### PR TITLE
fix: update Go security toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: false
 
       - name: Run required lane

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
       - if: matrix.language == 'go'
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: false
 
       - uses: github/codeql-action/init@v4

--- a/.github/workflows/docs-canary.yml
+++ b/.github/workflows/docs-canary.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: false
 
       - name: Install pinned docs toolchain

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: false
 
       - name: Install landing toolchain

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: false
 
       - uses: actions/setup-python@v6

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: false
 
       - name: Run extended evidence lane

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: false
 
       - name: Run govulncheck

--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: false
 
       - name: Resolve stable tag

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: false
 
       - name: Run live evidence lane

--- a/.github/workflows/polyglot-smoke.yml
+++ b/.github/workflows/polyglot-smoke.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: false
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: false
 
       - uses: goreleaser/goreleaser-action@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Post-`v1.0.0` hardening on `main` continues here. The initial stable release was
 - Windows launcher validation now accepts extensionless configured entrypoints such as `./bin/x` when the generated launcher file is `./bin/x.cmd`
 - documentation now reflects post-`v1.0.0` contract status, the executable-ABI beta boundary, Windows runtime resolution rules, and the TypeScript-over-Node supported path
 - Go SDK module root moved from `sdk/plugin-kit-ai/` to `sdk/`, making `github.com/777genius/plugin-kit-ai/sdk@v1.0.4` the first truthful normal-module release; `v1.0.3` remains published but is known-bad for Go SDK consumption
-- maintainer-facing docs now distinguish monorepo Go `1.25.9` requirements from generated Go plugin projects that remain on Go `1.22+`, and the repository now ships root `LICENSE` and `SECURITY.md`
+- maintainer-facing docs now distinguish monorepo Go `1.25.10` requirements from generated Go plugin projects that remain on Go `1.22+`, and the repository now ships root `LICENSE` and `SECURITY.md`
 
 ## [1.0.0] - 2026-03-26
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 GOCACHE ?= /tmp/plugin-kit-ai-gocache
 export GOCACHE
 
-SECURITY_GOTOOLCHAIN ?= go1.25.9
+SECURITY_GOTOOLCHAIN ?= go1.25.10
 
 EXTENDED_TEST_ARGS ?=
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ For Codex lane selection, use [docs/CODEX_TARGET_BOUNDARY.md](docs/CODEX_TARGET_
 
 Requirements:
 
-- Go `1.25.9` for this monorepo workspace and its CI lanes
+- Go `1.25.10` for this monorepo workspace and its CI lanes
 - generated Go plugin projects created by `plugin-kit-ai init` remain on Go `1.22+`
 
 Common commands from repo root:

--- a/cli/plugin-kit-ai/README.md
+++ b/cli/plugin-kit-ai/README.md
@@ -89,7 +89,7 @@ go build -o bin/plugin-kit-ai ./cli/plugin-kit-ai/cmd/plugin-kit-ai
 
 Choose the lane that matches the delivery model you need today. Expand later from the same repo when the product needs more outputs.
 
-Maintainer note: building the checked-in monorepo workspace currently requires Go `1.25.9` for the CLI module and CI lanes. Generated Go plugin projects stay on the public Go SDK path with Go `1.22+`.
+Maintainer note: building the checked-in monorepo workspace currently requires Go `1.25.10` for the CLI module and CI lanes. Generated Go plugin projects stay on the public Go SDK path with Go `1.22+`.
 ## Fast Local Plugin
 
 For repo-local plugins where fast iteration matters more than packaged distribution:

--- a/cli/plugin-kit-ai/go.mod
+++ b/cli/plugin-kit-ai/go.mod
@@ -2,7 +2,7 @@ module github.com/777genius/plugin-kit-ai/cli
 
 go 1.23
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 replace github.com/777genius/plugin-kit-ai/sdk => ../../sdk
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/777genius/plugin-kit-ai
 
 go 1.22
 
-toolchain go1.25.9
+toolchain go1.25.10

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 go 1.23
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 use (
 	.

--- a/install/integrationctl/go.mod
+++ b/install/integrationctl/go.mod
@@ -2,7 +2,7 @@ module github.com/777genius/plugin-kit-ai/install/integrationctl
 
 go 1.23
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require gopkg.in/yaml.v3 v3.0.1
 

--- a/install/plugininstall/go.mod
+++ b/install/plugininstall/go.mod
@@ -2,4 +2,4 @@ module github.com/777genius/plugin-kit-ai/plugininstall
 
 go 1.22
 
-toolchain go1.25.9
+toolchain go1.25.10

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -2,4 +2,4 @@ module github.com/777genius/plugin-kit-ai/sdk
 
 go 1.22
 
-toolchain go1.25.9
+toolchain go1.25.10


### PR DESCRIPTION
<!-- review-router-summary:start -->
## Summary

- updates a GitHub Actions workflow
- touch 21 files (21 modified) with +21/-21 lines


<details>
<summary>📒 Files selected for processing (21)</summary>

* `.github/workflows/ci.yml`
* `.github/workflows/codeql.yml`
* `.github/workflows/docs-canary.yml`
* `.github/workflows/docs-pages.yml`
* `.github/workflows/docs.yml`
* `.github/workflows/extended.yml`
* `.github/workflows/govulncheck.yml`
* `.github/workflows/homebrew-tap.yml`
* `.github/workflows/live.yml`
* `.github/workflows/polyglot-smoke.yml`
* `.github/workflows/release-assets.yml`
* `CHANGELOG.md`
* `Makefile`
* `README.md`
* `cli/plugin-kit-ai/README.md`
* `cli/plugin-kit-ai/go.mod`
* `go.mod`
* `go.work`
* `install/integrationctl/go.mod`
* `install/plugininstall/go.mod`
* `sdk/go.mod`

</details>

<details>
<summary>📝 Walkthrough</summary>

## Walkthrough

This PR updates 21 files across 11 CI workflow, 5 configuration, 3 documentation, 2 source. The generated summary is based on the GitHub pull request file list and diff metadata, and the author's description above is preserved.

## Changes

| Cohort / File(s) | Summary |
|---|---|
| **CI workflow** <br> `.github/workflows/ci.yml`<br>`.github/workflows/codeql.yml`<br>`.github/workflows/docs-canary.yml`<br>`.github/workflows/docs-pages.yml`<br>`.github/workflows/docs.yml`<br>and 6 more | Updates a GitHub Actions workflow.<br>Also updates 8 more files.<br>Line stats: 11 modified; +11/-11. |
| **Configuration** <br> `cli/plugin-kit-ai/go.mod`<br>`go.mod`<br>`install/integrationctl/go.mod`<br>`install/plugininstall/go.mod`<br>`sdk/go.mod` | Updates project configuration.<br>Also updates 2 more files.<br>Line stats: 5 modified; +5/-5. |
| **Documentation** <br> `CHANGELOG.md`<br>`README.md`<br>`cli/plugin-kit-ai/README.md` | Updates documentation content.<br>Line stats: 3 modified; +3/-3. |
| **Source** <br> `Makefile`<br>`go.work` | Updates source implementation in Makefile.<br>Updates source implementation in go.<br>Line stats: 2 modified; +2/-2. |

</details>
<!-- review-router-summary:end -->