### PR TITLE
fix(agentplugins): decouple npm distribution name

### DIFF
--- a/.github/workflows/agentplugins-npm-publish.yml
+++ b/.github/workflows/agentplugins-npm-publish.yml
@@ -54,13 +54,21 @@ jobs:
           test "${head_commit}" = "$(git rev-parse refs/remotes/origin/main)"
           test "${head_commit}" = "$(git rev-list -n 1 "${TAG}")"
           echo "commit=${head_commit}" >> "${GITHUB_OUTPUT}"
+          package_name="$(node -p 'require("./npm/agentplugins/package.json").name')"
+          package_name_length="$(printf '%s' "${package_name}" | wc -c | tr -d ' ')"
+          if [[ ! "${package_name}" =~ ^(@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$ ]] || [[ "${package_name_length}" -gt 214 ]]; then
+            echo "invalid npm package name in npm/agentplugins/package.json" >&2
+            exit 1
+          fi
+          test "$(node -p 'require("./npm/agentplugins/package.json").bin.agentplugins')" = "bin/agentplugins.js"
+          echo "package_name=${package_name}" >> "${GITHUB_OUTPUT}"
           registry_error="${RUNNER_TEMP}/agentplugins-npm-view.err"
-          if npm view agentplugins versions --json >/dev/null 2>"${registry_error}"; then
+          if npm view "${package_name}" versions --json >/dev/null 2>"${registry_error}"; then
             exists=true
           elif grep -q 'E404' "${registry_error}"; then
             exists=false
           else
-            echo "unable to prove whether agentplugins already exists in npm" >&2
+            echo "unable to prove whether ${package_name} already exists in npm" >&2
             cat "${registry_error}" >&2
             exit 1
           fi
@@ -70,7 +78,7 @@ jobs:
             echo "mode=bootstrap" >> "${GITHUB_OUTPUT}"
           else
             if [[ "${exists}" != "true" ]]; then
-              echo "agentplugins does not exist yet; the first publish requires bootstrap_publish=true and the protected NPM_TOKEN secret" >&2
+              echo "${package_name} does not exist yet; the first publish requires bootstrap_publish=true and the protected NPM_TOKEN secret" >&2
               exit 1
             fi
             echo "mode=trusted" >> "${GITHUB_OUTPUT}"
@@ -115,6 +123,7 @@ jobs:
       - name: Verify exact published stable lifecycle from a clean project
         env:
           TAG: ${{ inputs.tag }}
+          NPM_PACKAGE: ${{ steps.publish-gate.outputs.package_name }}
         run: |
           version="${TAG#agentplugins-v}"
           project="${RUNNER_TEMP}/agentplugins-registry-smoke"
@@ -136,18 +145,18 @@ jobs:
           export GIT_TERMINAL_PROMPT=0
           printf '%s\n' 'registry=https://registry.npmjs.org/' > "${NPM_CONFIG_USERCONFIG}"
           run_agentplugins() {
-            npm exec --yes --package="agentplugins@${version}" -- agentplugins "$@"
+            npm exec --yes --package="${NPM_PACKAGE}@${version}" -- agentplugins "$@"
           }
           available=false
           for attempt in 1 2 3 4 5 6; do
             if run_agentplugins version | grep -Fx "agentplugins ${version}"; then
-              dist_tags="$(npm view agentplugins dist-tags --json)"
+              dist_tags="$(npm view "${NPM_PACKAGE}" dist-tags --json)"
               if jq -e --arg version "${version}" '.latest == $version' <<<"${dist_tags}" >/dev/null; then
                 available=true
                 break
               fi
             fi
-            echo "waiting for agentplugins@${version} registry propagation (${attempt}/6)" >&2
+            echo "waiting for ${NPM_PACKAGE}@${version} registry propagation (${attempt}/6)" >&2
             sleep 10
           done
           test "${available}" = true

--- a/npm/agentplugins/lib/bootstrap.js
+++ b/npm/agentplugins/lib/bootstrap.js
@@ -25,6 +25,9 @@ function loadRelease(packageRoot, platformInfo) {
   if (manifest.schema_version !== 1 || manifest.version !== version) {
     throw new Error("npm version and embedded binary manifest do not match");
   }
+  if (manifest.npm_package !== pkg.name) {
+    throw new Error("npm package name and embedded binary manifest do not match");
+  }
   if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(String(manifest.repository || ""))) {
     throw new Error("embedded binary repository is invalid");
   }

--- a/npm/agentplugins/scripts/stage-release.js
+++ b/npm/agentplugins/scripts/stage-release.js
@@ -8,6 +8,7 @@ const path = require("node:path");
 const { detectPlatform, expectedAssetName } = require("../lib/platform");
 
 const VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+const NPM_PACKAGE_NAME = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/;
 const PLATFORMS = [
   ["darwin", "x64"],
   ["darwin", "arm64"],
@@ -21,15 +22,24 @@ function sha256(file) {
   return crypto.createHash("sha256").update(fs.readFileSync(file)).digest("hex");
 }
 
+function validatePackageMetadata(pkg) {
+  const packageName = String(pkg.name || "").trim();
+  if (!NPM_PACKAGE_NAME.test(packageName) || packageName.length > 214) {
+    throw new Error("staged npm package name is invalid");
+  }
+  if (!pkg.bin || pkg.bin.agentplugins !== "bin/agentplugins.js") {
+    throw new Error("staged npm package must expose the agentplugins binary");
+  }
+  return packageName;
+}
+
 function stage(packageRoot, assetRoot, version) {
   if (!VERSION.test(version)) {
     throw new Error(`invalid release version: ${version}`);
   }
   const pkgPath = path.join(packageRoot, "package.json");
   const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
-  if (pkg.name !== "agentplugins") {
-    throw new Error("staged npm package name must be agentplugins");
-  }
+  const packageName = validatePackageMetadata(pkg);
   pkg.version = version;
   fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
   const assets = {};
@@ -46,6 +56,7 @@ function stage(packageRoot, assetRoot, version) {
   const manifest = {
     schema_version: 1,
     version,
+    npm_package: packageName,
     repository: "777genius/plugin-kit-ai",
     tag: `agentplugins-v${version}`,
     assets
@@ -72,4 +83,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { stage };
+module.exports = { stage, validatePackageMetadata };

--- a/npm/agentplugins/scripts/stage-release.js
+++ b/npm/agentplugins/scripts/stage-release.js
@@ -23,10 +23,11 @@ function sha256(file) {
 }
 
 function validatePackageMetadata(pkg) {
-  const packageName = String(pkg.name || "").trim();
-  if (!NPM_PACKAGE_NAME.test(packageName) || packageName.length > 214) {
+  if (!pkg || typeof pkg !== "object" || typeof pkg.name !== "string" ||
+      !NPM_PACKAGE_NAME.test(pkg.name) || pkg.name.length > 214) {
     throw new Error("staged npm package name is invalid");
   }
+  const packageName = pkg.name;
   if (!pkg.bin || pkg.bin.agentplugins !== "bin/agentplugins.js") {
     throw new Error("staged npm package must expose the agentplugins binary");
   }

--- a/npm/agentplugins/test/bootstrap.test.js
+++ b/npm/agentplugins/test/bootstrap.test.js
@@ -24,6 +24,7 @@ async function fixturePackage(t, binary = BINARY) {
   await fsp.writeFile(path.join(root, "assets.json"), JSON.stringify({
     schema_version: 1,
     version: VERSION,
+    npm_package: "agentplugins",
     repository: "777genius/plugin-kit-ai",
     tag: `agentplugins-v${VERSION}`,
     assets: {
@@ -158,6 +159,16 @@ test("development metadata cannot download a release binary", async (t) => {
   assert.throws(
     () => loadRelease(packageRoot, detectPlatform("linux", "x64")),
     /development npm package/
+  );
+});
+
+test("embedded release manifest is pinned to the npm distribution name", async (t) => {
+  const fixture = await fixturePackage(t);
+  const pkgPath = path.join(fixture.root, "package.json");
+  await fsp.writeFile(pkgPath, JSON.stringify({ name: "agentplugins-cli", version: VERSION }));
+  assert.throws(
+    () => loadRelease(fixture.root, detectPlatform("linux", "x64")),
+    /npm package name and embedded binary manifest do not match/
   );
 });
 

--- a/npm/agentplugins/test/stage-release.test.js
+++ b/npm/agentplugins/test/stage-release.test.js
@@ -53,10 +53,12 @@ test("npm distribution name is independent from the agentplugins binary name", (
 });
 
 test("release staging rejects unsafe package metadata", () => {
-  assert.throws(
-    () => validatePackageMetadata({ name: "AgentPlugins", bin: { agentplugins: "bin/agentplugins.js" } }),
-    /package name is invalid/
-  );
+  for (const name of ["AgentPlugins", " agentplugins ", 123, null]) {
+    assert.throws(
+      () => validatePackageMetadata({ name, bin: { agentplugins: "bin/agentplugins.js" } }),
+      /package name is invalid/
+    );
+  }
   assert.throws(
     () => validatePackageMetadata({ name: "agentplugins-cli", bin: { other: "bin/agentplugins.js" } }),
     /must expose the agentplugins binary/

--- a/npm/agentplugins/test/stage-release.test.js
+++ b/npm/agentplugins/test/stage-release.test.js
@@ -7,7 +7,7 @@ const path = require("node:path");
 const test = require("node:test");
 
 const { detectPlatform, expectedAssetName } = require("../lib/platform");
-const { stage } = require("../scripts/stage-release");
+const { stage, validatePackageMetadata } = require("../scripts/stage-release");
 
 test("release staging embeds every exact platform asset hash", async (t) => {
   const root = await fsp.mkdtemp(path.join(os.tmpdir(), "agentplugins-stage-"));
@@ -16,7 +16,11 @@ test("release staging embeds every exact platform asset hash", async (t) => {
   const assetsRoot = path.join(root, "assets");
   await fsp.mkdir(packageRoot);
   await fsp.mkdir(assetsRoot);
-  await fsp.writeFile(path.join(packageRoot, "package.json"), JSON.stringify({ name: "agentplugins", version: "0.0.0-development" }));
+  await fsp.writeFile(path.join(packageRoot, "package.json"), JSON.stringify({
+    name: "agentplugins",
+    version: "0.0.0-development",
+    bin: { agentplugins: "bin/agentplugins.js" }
+  }));
   const version = "0.1.0";
   for (const [platform, arch] of [["darwin", "x64"], ["darwin", "arm64"], ["linux", "x64"], ["linux", "arm64"], ["win32", "x64"], ["win32", "arm64"]]) {
     const info = detectPlatform(platform, arch);
@@ -24,6 +28,7 @@ test("release staging embeds every exact platform asset hash", async (t) => {
   }
   const manifest = stage(packageRoot, assetsRoot, version);
   assert.equal(manifest.version, version);
+  assert.equal(manifest.npm_package, "agentplugins");
   assert.equal(Object.keys(manifest.assets).length, 6);
   for (const asset of Object.values(manifest.assets)) {
     assert.match(asset.sha256, /^[0-9a-f]{64}$/);
@@ -31,4 +36,29 @@ test("release staging embeds every exact platform asset hash", async (t) => {
   }
   const pkg = JSON.parse(await fsp.readFile(path.join(packageRoot, "package.json"), "utf8"));
   assert.equal(pkg.version, version);
+});
+
+test("npm distribution name is independent from the agentplugins binary name", () => {
+  for (const name of [
+    "agentplugins",
+    "agentplugins-cli",
+    "@ilyazelenko/agentplugins",
+    "@777genius/agentplugins"
+  ]) {
+    assert.equal(validatePackageMetadata({
+      name,
+      bin: { agentplugins: "bin/agentplugins.js" }
+    }), name);
+  }
+});
+
+test("release staging rejects unsafe package metadata", () => {
+  assert.throws(
+    () => validatePackageMetadata({ name: "AgentPlugins", bin: { agentplugins: "bin/agentplugins.js" } }),
+    /package name is invalid/
+  );
+  assert.throws(
+    () => validatePackageMetadata({ name: "agentplugins-cli", bin: { other: "bin/agentplugins.js" } }),
+    /must expose the agentplugins binary/
+  );
 });

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -52,15 +52,19 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	}
 
 	for _, want := range []string{
-		"npm view agentplugins versions --json",
+		`package_name="$(node -p 'require("./npm/agentplugins/package.json").name')"`,
+		`test "$(node -p 'require("./npm/agentplugins/package.json").bin.agentplugins')" = "bin/agentplugins.js"`,
+		`npm view "${package_name}" versions --json`,
 		"grep -q 'E404'",
-		"unable to prove whether agentplugins already exists in npm",
-		"npm view agentplugins dist-tags --json",
+		"unable to prove whether ${package_name} already exists in npm",
+		`NPM_PACKAGE: ${{ steps.publish-gate.outputs.package_name }}`,
+		`npm view "${NPM_PACKAGE}" dist-tags --json`,
 		"npm publish --access public --tag latest --provenance",
 		".latest == $version",
 	} {
 		mustContain(t, npmWorkflow, want)
 	}
+	mustNotContain(t, npmWorkflow, "npm view agentplugins versions --json")
 	mustNotContain(t, npmWorkflow, "npm view agentplugins version >/dev/null")
 	mustNotContain(t, npmWorkflow, "--tag beta")
 	mustAppearBefore(t, npmWorkflow, "npm publish --access public --tag latest --provenance", "Verify exact published stable lifecycle from a clean project")


### PR DESCRIPTION
## Context

The first agentplugins 0.1.0 npm publish was rejected by the registry because the unscoped name is too similar to the existing agent-plugins package. No npm package was created.

## Change

- derive registry preflight and exact-version smoke from package.json
- keep the public binary and product name agentplugins
- pin the npm distribution name into the embedded release manifest
- reject unsafe package metadata or a missing agentplugins binary mapping
- cover unscoped and scoped distribution candidates

This PR intentionally does not choose or publish a replacement npm name. The protected publish gate is false and the bootstrap secret has been removed.

## Verification

- npm test: 16/16
- npm pack --dry-run --ignore-scripts
- workflow YAML parse
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved npm package validation during release staging and publishing.
  * Prevented releases when package metadata, embedded manifests, or executable entries are inconsistent.
  * Improved error messages and verification for package names and distribution tags.

* **Tests**
  * Added coverage for valid package configurations and mismatched metadata.
  * Expanded release staging and bootstrap verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->