### PR TITLE
fix(website): update vulnerable dompurify override

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -10,7 +10,7 @@
   "pnpm": {
     "overrides": {
       "brace-expansion": "5.0.8",
-      "dompurify": "3.4.12",
+      "dompurify": "3.4.13",
       "lodash-es": "4.18.1",
       "uuid": "14.0.1"
     }

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   brace-expansion: 5.0.8
-  dompurify: 3.4.12
+  dompurify: 3.4.13
   lodash-es: 4.18.1
   uuid: 14.0.1
 
@@ -1227,8 +1227,8 @@ packages:
       dequal: 2.0.3
     dev: true
 
-  /dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  /dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
     optionalDependencies:
       '@types/trusted-types': 2.0.7
     dev: true
@@ -1547,7 +1547,7 @@ packages:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       es-toolkit: 1.50.0
       katex: 0.16.47
       khroma: 2.1.0


### PR DESCRIPTION
## Summary

- update the pinned DOMPurify override from 3.4.12 to 3.4.13
- regenerate the pnpm lockfile with the fixed release and integrity
- unblock Dependabot security updates for the website

## Verification

- frozen pnpm 8.15.1 install
- resolved Mermaid to DOMPurify 3.4.13
- full docs quality and production build gate
- git diff --check

## Release impact

Security-only website dependency fix. No Agent Plugins runtime or CLI behavior changes.