### PR TITLE
fix(agentplugins): publish as universal-agent-plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,24 +15,29 @@ The honest promise is `one repo / many supported outputs`, not fake parity every
 
 ## Install Agent Plugins 1.0
 
-Want to use a plugin rather than author one? `agentplugins` is the standard-first
-installer built on this repository's lifecycle engine:
+Want to use a plugin rather than author one? `universal-agent-plugins` is the
+standard-first npm installer built on this repository's lifecycle engine:
 
 ```bash
-npx --yes agentplugins@0.1.0 add context7
+npx --yes universal-agent-plugins@0.1.1 add context7
 ```
 
 It reads the root `plugin.json` defined by Agent Plugins 1.0 and plans, prepares,
 or installs one explicit target at a time across Codex/ChatGPT, Cursor, GitHub
-Copilot/VS Code, and Kiro. The beta supports user scope; client-native limits are
+Copilot/VS Code, and Kiro. v0.1 supports user scope; client-native limits are
 reported before mutation. The first catalog contains [26 portable plugins](https://github.com/777genius/universal-agent-plugins).
 
 ```bash
-npx --yes agentplugins@0.1.0 add context7 --dry-run --target cursor
-npx --yes agentplugins@0.1.0 add context7 --target cursor --yes
+npx --yes universal-agent-plugins@0.1.1 add context7 --dry-run --target cursor
+npx --yes universal-agent-plugins@0.1.1 add context7 --target cursor --yes
 ```
 
-`agentplugins` is an independent community installer, not an official OpenAI
+Short names resolve through the pinned catalog, while a local directory or an
+exact GitHub source such as `owner/repo@ref//path/to/plugin` can install any
+valid Agent Plugins 1.0 package directly. The installed command is
+`agentplugins`.
+
+`universal-agent-plugins` is an independent community installer, not an official OpenAI
 CLI. OAuth and trust prompts remain under the user's client. Prepared,
 auth-pending, and manual-activation states are never labelled installed.
 

--- a/docs/agentplugins-release.md
+++ b/docs/agentplugins-release.md
@@ -1,4 +1,4 @@
-# Agentplugins 0.1.0 release
+# Agentplugins stable release
 
 This runbook is for maintainers. Do not create a release, publish npm, or change
 the `latest` dist-tag without explicit owner approval for that exact version.

--- a/npm/agentplugins/README.md
+++ b/npm/agentplugins/README.md
@@ -1,13 +1,13 @@
-# agentplugins
+# Universal Agent Plugins
 
 Install and manage portable Agent Plugins 1.0 packages across Codex/ChatGPT,
 Cursor, GitHub Copilot/VS Code, and Kiro.
 
 ```bash
-npx --yes agentplugins@0.1.0 add context7
+npx --yes universal-agent-plugins@0.1.1 add context7
 ```
 
-`agentplugins` is an independent community CLI built in
+`universal-agent-plugins` is an independent community CLI built in
 [`plugin-kit-ai`](https://github.com/777genius/plugin-kit-ai). It is not an
 official OpenAI or Agent Plugins project and is not affiliated with
 `sigilco/agentplugins` or `@agentplugins/cli`. Agent Plugins 1.0 defines the
@@ -20,22 +20,37 @@ tarball, then caches it under XDG Cache or LocalAppData. It never falls back to
 `latest` and never sends `GITHUB_TOKEN` to public downloads.
 
 ```bash
-npx --yes agentplugins@0.1.0 doctor
-npx --yes agentplugins@0.1.0 list
-npx --yes agentplugins@0.1.0 add context7 --dry-run --target cursor
-npx --yes agentplugins@0.1.0 add context7 --target cursor --yes
-npx --yes agentplugins@0.1.0 update context7 --target cursor --yes
-npx --yes agentplugins@0.1.0 remove context7 --target cursor --yes
+npx --yes universal-agent-plugins@0.1.1 doctor
+npx --yes universal-agent-plugins@0.1.1 list
+npx --yes universal-agent-plugins@0.1.1 add context7 --dry-run --target cursor
+npx --yes universal-agent-plugins@0.1.1 add context7 --target cursor --yes
+npx --yes universal-agent-plugins@0.1.1 update context7 --target cursor --yes
+npx --yes universal-agent-plugins@0.1.1 remove context7 --target cursor --yes
 ```
 
+Short names resolve through the pinned
+[`universal-agent-plugins`](https://github.com/777genius/universal-agent-plugins)
+catalog. You can also install a different valid Agent Plugins 1.0 package from
+a local directory or an exact GitHub source:
+
+```bash
+npx --yes universal-agent-plugins@0.1.1 add ./my-plugin --target cursor --yes
+npx --yes universal-agent-plugins@0.1.1 add owner/repo@commit//plugins/my-plugin --target cursor --yes
+```
+
+The package must have a root `plugin.json` using the supported Agent Plugins
+1.0 schema. Optional root `mcp.json` and `skills/*/SKILL.md` components are
+installed only where the selected client supports them. The downloaded binary
+and installed command remain `agentplugins`.
+
 Each mutation changes one selected client. `--yes` never means install
-everywhere. v0.1.0 supports user scope and reports whether a client can install
+everywhere. v0.1 supports user scope and reports whether a client can install
 automatically or requires manual activation. For older `plugin-kit-ai` installations, run the explicit migration
 before the first standard installation:
 
 ```bash
-npx --yes agentplugins@0.1.0 migrate-state --dry-run
-npx --yes agentplugins@0.1.0 migrate-state --yes
+npx --yes universal-agent-plugins@0.1.1 migrate-state --dry-run
+npx --yes universal-agent-plugins@0.1.1 migrate-state --yes
 ```
 
 The migration validates the complete State v2 result, creates a byte-for-byte

--- a/npm/agentplugins/package.json
+++ b/npm/agentplugins/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "agentplugins",
+  "name": "universal-agent-plugins",
   "version": "0.0.0-development",
-  "description": "Independent community installer and lifecycle manager for the Agent Plugins 1.0 standard",
+  "description": "Universal community installer and lifecycle manager for Agent Plugins 1.0",
   "license": "MIT",
   "homepage": "https://github.com/777genius/plugin-kit-ai#install-agent-plugins-10",
   "repository": {
@@ -14,6 +14,7 @@
   },
   "keywords": [
     "agent-plugins",
+    "universal-agent-plugins",
     "ai-agents",
     "codex",
     "cursor",

--- a/npm/agentplugins/test/bootstrap.test.js
+++ b/npm/agentplugins/test/bootstrap.test.js
@@ -20,11 +20,11 @@ async function fixturePackage(t, binary = BINARY) {
   t.after(() => fsp.rm(root, { recursive: true, force: true }));
   const platformInfo = detectPlatform("linux", "x64");
   const file = expectedAssetName(VERSION, platformInfo);
-  await fsp.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "agentplugins", version: VERSION }));
+  await fsp.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "universal-agent-plugins", version: VERSION }));
   await fsp.writeFile(path.join(root, "assets.json"), JSON.stringify({
     schema_version: 1,
     version: VERSION,
-    npm_package: "agentplugins",
+    npm_package: "universal-agent-plugins",
     repository: "777genius/plugin-kit-ai",
     tag: `agentplugins-v${VERSION}`,
     assets: {
@@ -152,7 +152,7 @@ test("development metadata cannot download a release binary", async (t) => {
   const packageRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "agentplugins-development-package-"));
   t.after(() => fsp.rm(packageRoot, { recursive: true, force: true }));
   await fsp.writeFile(path.join(packageRoot, "package.json"), JSON.stringify({
-    name: "agentplugins",
+    name: "universal-agent-plugins",
     version: "0.0.0-development"
   }));
   await fsp.writeFile(path.join(packageRoot, "assets.json"), "{}\n");

--- a/npm/agentplugins/test/stage-release.test.js
+++ b/npm/agentplugins/test/stage-release.test.js
@@ -17,7 +17,7 @@ test("release staging embeds every exact platform asset hash", async (t) => {
   await fsp.mkdir(packageRoot);
   await fsp.mkdir(assetsRoot);
   await fsp.writeFile(path.join(packageRoot, "package.json"), JSON.stringify({
-    name: "agentplugins",
+    name: "universal-agent-plugins",
     version: "0.0.0-development",
     bin: { agentplugins: "bin/agentplugins.js" }
   }));
@@ -28,7 +28,7 @@ test("release staging embeds every exact platform asset hash", async (t) => {
   }
   const manifest = stage(packageRoot, assetsRoot, version);
   assert.equal(manifest.version, version);
-  assert.equal(manifest.npm_package, "agentplugins");
+  assert.equal(manifest.npm_package, "universal-agent-plugins");
   assert.equal(Object.keys(manifest.assets).length, 6);
   for (const asset of Object.values(manifest.assets)) {
     assert.match(asset.sha256, /^[0-9a-f]{64}$/);
@@ -41,6 +41,7 @@ test("release staging embeds every exact platform asset hash", async (t) => {
 test("npm distribution name is independent from the agentplugins binary name", () => {
   for (const name of [
     "agentplugins",
+    "universal-agent-plugins",
     "agentplugins-cli",
     "@ilyazelenko/agentplugins",
     "@777genius/agentplugins"


### PR DESCRIPTION
## Summary

- rename the unscoped npm distribution to `universal-agent-plugins`
- keep the short `agentplugins` binary and verified release assets unchanged
- document catalog aliases and direct Agent Plugins 1.0 sources
- update npm fixtures and the stable release runbook

## Verification

- `make test-required`
- npm tests: 16/16
- disposable direct-source lifecycle: add, info, read-only doctor, remove
- local `npx universal-agent-plugins` binary resolution


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation and command examples for version 0.1.1.
  * Added guidance for user-scope, portable plugins, exact GitHub sources, and local installations.
  * Clarified catalog status, migration steps, supported schemas, and single-client updates.
  * Updated the release runbook for the stable release.

* **Package Updates**
  * Renamed the npm package to `universal-agent-plugins`; the installed command remains `agentplugins`.
  * Refreshed package metadata and release validation for the new package name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->