### PR TITLE
chore(agentplugins): require npm trusted publishing

### DIFF
--- a/.github/workflows/agentplugins-npm-publish.yml
+++ b/.github/workflows/agentplugins-npm-publish.yml
@@ -128,6 +128,17 @@ jobs:
           export GIT_CONFIG_NOSYSTEM=1
           export GIT_TERMINAL_PROMPT=0
           printf '%s\n' 'registry=https://registry.npmjs.org/' > "${NPM_CONFIG_USERCONFIG}"
+          npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"
+          npm audit signatures --json --include-attestations > audit-signatures.json
+          jq -e --arg package "${NPM_PACKAGE}" --arg version "${version}" '
+            (.invalid | length) == 0 and
+            (.missing | length) == 0 and
+            ([.verified[] | select(
+              .name == $package and
+              .version == $version and
+              .attestations.provenance.predicateType == "https://slsa.dev/provenance/v1"
+            )] | length) == 1
+          ' audit-signatures.json
           run_agentplugins() {
             npm exec --yes --package="${NPM_PACKAGE}@${version}" -- agentplugins "$@"
           }

--- a/.github/workflows/agentplugins-npm-publish.yml
+++ b/.github/workflows/agentplugins-npm-publish.yml
@@ -6,11 +6,6 @@ on:
       tag:
         description: Existing immutable stable release tag
         required: true
-      bootstrap_publish:
-        description: One-time first publish with the protected NPM_TOKEN secret; must be false after trusted publishing is configured
-        required: true
-        type: boolean
-        default: false
 
 permissions:
   contents: read
@@ -41,8 +36,6 @@ jobs:
         env:
           TAG: ${{ inputs.tag }}
           READY: ${{ vars.NPM_AGENTPLUGINS_PUBLISH_READY }}
-          BOOTSTRAP: ${{ inputs.bootstrap_publish }}
-          NPM_BOOTSTRAP_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           if [[ ! "${TAG}" =~ ^agentplugins-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "invalid agentplugins stable tag: ${TAG}" >&2
@@ -72,16 +65,9 @@ jobs:
             cat "${registry_error}" >&2
             exit 1
           fi
-          if [[ "${BOOTSTRAP}" = "true" ]]; then
-            test "${exists}" = "false"
-            test -n "${NPM_BOOTSTRAP_TOKEN}"
-            echo "mode=bootstrap" >> "${GITHUB_OUTPUT}"
-          else
-            if [[ "${exists}" != "true" ]]; then
-              echo "${package_name} does not exist yet; the first publish requires bootstrap_publish=true and the protected NPM_TOKEN secret" >&2
-              exit 1
-            fi
-            echo "mode=trusted" >> "${GITHUB_OUTPUT}"
+          if [[ "${exists}" != "true" ]]; then
+            echo "${package_name} does not exist yet; trusted publishing only supports existing packages" >&2
+            exit 1
           fi
       - name: Download and verify all release assets
         env:
@@ -117,8 +103,6 @@ jobs:
           AGENTPLUGINS_CACHE_DIR="${RUNNER_TEMP}/agentplugins-cache" node bin/agentplugins.js version | grep -Fx "agentplugins ${version}"
       - name: Publish stable release with provenance
         working-directory: ${{ runner.temp }}/agentplugins-npm
-        env:
-          NODE_AUTH_TOKEN: ${{ steps.publish-gate.outputs.mode == 'bootstrap' && secrets.NPM_TOKEN || '' }}
         run: npm publish --access public --tag latest --provenance
       - name: Verify exact published stable lifecycle from a clean project
         env:

--- a/docs/agentplugins-release.md
+++ b/docs/agentplugins-release.md
@@ -64,8 +64,10 @@ Use the same immutable asset workflow, temporarily open the publish-ready gate,
 then dispatch the npm workflow with the exact tag. Review and approve the
 `npm-agentplugins` environment deployment. The workflow must publish through
 GitHub OIDC with provenance and must pass the exact-version registry smoke
-through `add`, `info`, read-only `doctor`, no-change `update`, `remove`, and
-final absent-state verification in an isolated HOME.
+after an exact-version, scripts-disabled install verifies both the registry
+signature and SLSA provenance attestation. Only then may it run `add`, `info`,
+read-only `doctor`, no-change `update`, `remove`, and final absent-state
+verification in an isolated HOME.
 It must prove the `latest` dist-tag resolves to the exact published version and
 JSON output contains no absolute runner paths before the gate is returned to
 `false`.

--- a/docs/agentplugins-release.md
+++ b/docs/agentplugins-release.md
@@ -19,6 +19,9 @@ the `latest` dist-tag without explicit owner approval for that exact version.
   released catalog and its compiled SHA-256 pin matches.
 - `agentplugins-release` and `npm-agentplugins` require a reviewer and allow
   deployment only from `main`.
+- npm trusted publishing is bound to repository `777genius/plugin-kit-ai`,
+  workflow `agentplugins-npm-publish.yml`, environment `npm-agentplugins`, and
+  the `npm publish` permission.
 - `NPM_AGENTPLUGINS_PUBLISH_READY` stays `false` until the exact publish is
   approved.
 
@@ -43,40 +46,29 @@ project is tagged.
 The workflow refuses an existing release instead of replacing immutable
 assets.
 
-## First npm publication
+## Bootstrap publication record
 
-The first publication cannot use npm trusted publishing because the package
-does not exist yet.
+`universal-agent-plugins@0.1.1` completed the one-time bootstrap publication.
+Its exact registry tarball, provenance, clean-project lifecycle, and attestation
+were verified before trusted publishing was enabled. The short-lived bootstrap
+credential was then removed from both GitHub and npm, and package access was
+changed to disallow bypass-2FA tokens.
 
-1. Add a short-lived granular `NPM_TOKEN` only to the protected
-   `npm-agentplugins` environment.
-2. Set `NPM_AGENTPLUGINS_PUBLISH_READY=true` only after the GitHub assets pass
-   verification.
-3. Dispatch `Agentplugins NPM Publish` with the exact tag and
-   `bootstrap_publish=true`.
-4. Review the exact tag and approve the `npm-agentplugins` deployment.
-5. Confirm the registry preflight succeeds. Only an npm `E404` is accepted as
-   proof that the package does not exist; network, authentication, and other
-   registry errors fail closed.
-6. Confirm the workflow stages the exact npm package, verifies all embedded
-   platform hashes, runs its tests, and exercises the verified release binary.
-7. Confirm the post-publish clean-project smoke runs the exact registry version
-   through `add`, `info`, read-only `doctor`, no-change `update`, `remove`, and
-   final absent-state verification in an isolated HOME. It must prove the
-   `latest` dist-tag resolves to the exact published version and JSON output
-   contains no absolute runner paths.
-8. Immediately set `NPM_AGENTPLUGINS_PUBLISH_READY=false` and remove the
-   bootstrap token.
-9. Configure npm trusted publishing for repository
-   `777genius/plugin-kit-ai` and workflow
-   `.github/workflows/agentplugins-npm-publish.yml`.
+Do not add a bootstrap token back to the workflow. If the package disappears
+from npm, the registry preflight must fail closed instead of attempting to
+recreate it.
 
 ## Later stable publications
 
 Use the same immutable asset workflow, temporarily open the publish-ready gate,
-then dispatch the npm workflow with `bootstrap_publish=false`. The workflow must
-publish through GitHub OIDC with provenance and must pass the exact-version
-registry smoke before the gate is returned to `false`.
+then dispatch the npm workflow with the exact tag. Review and approve the
+`npm-agentplugins` environment deployment. The workflow must publish through
+GitHub OIDC with provenance and must pass the exact-version registry smoke
+through `add`, `info`, read-only `doctor`, no-change `update`, `remove`, and
+final absent-state verification in an isolated HOME.
+It must prove the `latest` dist-tag resolves to the exact published version and
+JSON output contains no absolute runner paths before the gate is returned to
+`false`.
 
 Never publish an empty placeholder, reuse a tag, overwrite release assets, or
 resolve a binary through an unpinned GitHub `latest` release.

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -10,6 +10,7 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	makefile := readRepoFile(t, root, "Makefile")
 	releaseWorkflow := readRepoFile(t, root, ".github", "workflows", "agentplugins-release.yml")
 	npmWorkflow := readRepoFile(t, root, ".github", "workflows", "agentplugins-npm-publish.yml")
+	npmPublishJob := yamlJob(t, npmWorkflow, "publish")
 	removedBoundaryScript := readRepoFile(t, root, "scripts", "check-removed-contract-boundary.sh")
 	runbook := readRepoFile(t, root, "docs", "agentplugins-release.md")
 
@@ -65,15 +66,28 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		"trusted publishing only supports existing packages",
 		".latest == $version",
 	} {
-		mustContain(t, npmWorkflow, want)
+		mustContain(t, npmPublishJob, want)
 	}
-	mustNotContain(t, npmWorkflow, "npm view agentplugins versions --json")
-	mustNotContain(t, npmWorkflow, "npm view agentplugins version >/dev/null")
-	mustNotContain(t, npmWorkflow, "--tag beta")
-	mustNotContain(t, npmWorkflow, "bootstrap_publish")
-	mustNotContain(t, npmWorkflow, "NPM_TOKEN")
-	mustNotContain(t, npmWorkflow, "NODE_AUTH_TOKEN")
-	mustAppearBefore(t, npmWorkflow, "npm publish --access public --tag latest --provenance", "Verify exact published stable lifecycle from a clean project")
+	for _, want := range []string{
+		`npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`,
+		"npm audit signatures --json --include-attestations",
+		`.attestations.provenance.predicateType == "https://slsa.dev/provenance/v1"`,
+	} {
+		mustContain(t, npmPublishJob, want)
+	}
+	for _, unwanted := range []string{
+		"npm view agentplugins versions --json",
+		"npm view agentplugins version >/dev/null",
+		"--tag beta",
+		"bootstrap_publish",
+		"NPM_TOKEN",
+		"NODE_AUTH_TOKEN",
+	} {
+		mustNotContain(t, npmPublishJob, unwanted)
+	}
+	mustAppearBefore(t, npmPublishJob, "npm publish --access public --tag latest --provenance", "Verify exact published stable lifecycle from a clean project")
+	mustAppearBefore(t, npmPublishJob, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`, "npm audit signatures --json --include-attestations")
+	mustAppearBefore(t, npmPublishJob, "npm audit signatures --json --include-attestations", "run_agentplugins version")
 
 	mustContain(t, removedBoundaryScript, "if command -v rg")
 	mustContain(t, removedBoundaryScript, "git grep --untracked --exclude-standard")
@@ -102,4 +116,24 @@ func mustAppearBefore(t *testing.T, text, first, second string) {
 	if firstIndex < 0 || secondIndex < 0 || firstIndex >= secondIndex {
 		t.Fatalf("expected %q to appear before %q", first, second)
 	}
+}
+
+func yamlJob(t *testing.T, workflow, name string) string {
+	t.Helper()
+	marker := "\n  " + name + ":\n"
+	start := strings.Index(workflow, marker)
+	if start < 0 {
+		t.Fatalf("missing workflow job %q", name)
+	}
+
+	lines := strings.SplitAfter(workflow[start+1:], "\n")
+	var job strings.Builder
+	for index, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if index > 0 && strings.HasPrefix(line, "  ") && !strings.HasPrefix(line, "    ") && strings.HasSuffix(trimmed, ":") {
+			break
+		}
+		job.WriteString(line)
+	}
+	return job.String()
 }

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -52,6 +52,8 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	}
 
 	for _, want := range []string{
+		"environment: npm-agentplugins",
+		"id-token: write",
 		`package_name="$(node -p 'require("./npm/agentplugins/package.json").name')"`,
 		`test "$(node -p 'require("./npm/agentplugins/package.json").bin.agentplugins')" = "bin/agentplugins.js"`,
 		`npm view "${package_name}" versions --json`,
@@ -60,6 +62,7 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		`NPM_PACKAGE: ${{ steps.publish-gate.outputs.package_name }}`,
 		`npm view "${NPM_PACKAGE}" dist-tags --json`,
 		"npm publish --access public --tag latest --provenance",
+		"trusted publishing only supports existing packages",
 		".latest == $version",
 	} {
 		mustContain(t, npmWorkflow, want)
@@ -67,6 +70,9 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	mustNotContain(t, npmWorkflow, "npm view agentplugins versions --json")
 	mustNotContain(t, npmWorkflow, "npm view agentplugins version >/dev/null")
 	mustNotContain(t, npmWorkflow, "--tag beta")
+	mustNotContain(t, npmWorkflow, "bootstrap_publish")
+	mustNotContain(t, npmWorkflow, "NPM_TOKEN")
+	mustNotContain(t, npmWorkflow, "NODE_AUTH_TOKEN")
 	mustAppearBefore(t, npmWorkflow, "npm publish --access public --tag latest --provenance", "Verify exact published stable lifecycle from a clean project")
 
 	mustContain(t, removedBoundaryScript, "if command -v rg")
@@ -78,8 +84,11 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		"`release-manifest.json` before creating the public release",
 		"requires a merged pull request into",
 		"Repository settings are not treated as the release proof",
-		"Only an npm `E404` is accepted as",
-		"proof that the package does not exist",
+		"short-lived bootstrap",
+		"disallow bypass-2FA tokens",
+		"Do not add a bootstrap token back",
+		"publish through",
+		"GitHub OIDC with provenance",
 		"`latest` dist-tag resolves to the exact published version",
 	} {
 		mustContain(t, runbook, want)


### PR DESCRIPTION
## Summary

- remove the one-time npm token bootstrap path
- require the existing package and GitHub OIDC trusted publishing
- record the completed bootstrap and token cleanup in the release runbook
- fail the release contract if token-based publishing is reintroduced

## Verification

- `go test -count=1 ./repotests -run TestAgentpluginsReleaseContractsStayFailClosed`
- exact npm registry lifecycle passed for `universal-agent-plugins@0.1.1`
- `npm audit signatures` verified the registry signature and provenance attestation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * npm packages must already exist before publishing; first-time bootstrap publishing is no longer supported.
  * Releases now use trusted publishing with GitHub OIDC provenance instead of long-lived npm tokens.
  * Publishing requires the approved workflow, deployment environment, and exact release tag.

* **Documentation**
  * Updated release guidance with trusted publishing requirements and post-release registry verification steps.

* **Tests**
  * Added checks to ensure release workflows and documentation follow the trusted publishing model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->