### PR TITLE
feat(agentplugins): automate Copilot and VS Code plugin lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ or installs one explicit target at a time across Codex/ChatGPT, Cursor, GitHub
 Copilot/VS Code, and Kiro. v0.1 supports user scope; client-native limits are
 reported before mutation. The first catalog contains [26 portable plugins](https://github.com/777genius/universal-agent-plugins).
 
+When GitHub Copilot CLI is detected, `agentplugins` installs, updates, and
+removes the plugin automatically through a managed local marketplace. VS Code
+discovers that installation automatically, so selecting either Copilot or VS
+Code once is enough. Codex/ChatGPT and Kiro keep their
+required client confirmation and receive an exact, path-specific next step in
+human-readable output.
+
 ```bash
 npx --yes universal-agent-plugins@0.1.1 add context7 --dry-run --target cursor
 npx --yes universal-agent-plugins@0.1.1 add context7 --target cursor --yes
@@ -38,8 +45,8 @@ valid Agent Plugins 1.0 package directly. The installed command is
 `agentplugins`.
 
 `universal-agent-plugins` is an independent community installer, not an official OpenAI
-CLI. OAuth and trust prompts remain under the user's client. Prepared,
-auth-pending, and manual-activation states are never labelled installed.
+CLI. OAuth and required client confirmations remain under the user's client.
+Prepared, auth-pending, and manual-activation states are never labelled installed.
 
 This is separate from the `plugin-kit-ai` authoring flow below: `plugin.json`
 and legacy `plugin/plugin.yaml` are never merged or silently converted.

--- a/cli/plugin-kit-ai/cmd/agentplugins/main.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins/main.go
@@ -81,7 +81,7 @@ func run() error {
 		SourceResolver:  sourceadapter.Resolver{Runner: runner, DisableAliases: true},
 		PackageLoader:   loader.Loader{Registry: registry},
 		Stager:          providers.Stager{},
-		Activator:       providers.Activator{},
+		Activator:       providers.Activator{Runner: runner},
 		MutationLock:    processlock.Lock{Path: filepath.Join(dataRoot, "mutation.lock")},
 		HTTPClient:      hardenedHTTPClient(),
 		CatalogURL:      catalogURL,

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -194,6 +194,9 @@ func renderHumanPlan(writer io.Writer, envelope domain.PackageEnvelope, result u
 	for _, action := range result.Plan.UserActions {
 		_, _ = fmt.Fprintf(writer, "  Next: %s\n", action)
 	}
+	for _, action := range result.Plan.LocalActions {
+		_, _ = fmt.Fprintf(writer, "  Next: %s\n", action)
+	}
 	return nil
 }
 
@@ -225,6 +228,9 @@ func renderAddResult(writer io.Writer, format string, envelope domain.PackageEnv
 			_, _ = fmt.Fprintln(writer, "Package prepared. Activation is not complete yet.")
 		}
 		for _, action := range result.Activation.UserActions {
+			_, _ = fmt.Fprintf(writer, "Next: %s\n", action)
+		}
+		for _, action := range result.Activation.LocalActions {
 			_, _ = fmt.Fprintf(writer, "Next: %s\n", action)
 		}
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
@@ -414,6 +414,9 @@ func renderUpdateResult(writer io.Writer, format string, envelope domain.Package
 		for _, action := range result.Activation.UserActions {
 			_, _ = fmt.Fprintf(writer, "Next: %s\n", action)
 		}
+		for _, action := range result.Activation.LocalActions {
+			_, _ = fmt.Fprintf(writer, "Next: %s\n", action)
+		}
 	}
 	return nil
 }
@@ -437,12 +440,18 @@ func renderRemoveResult(writer io.Writer, format string, installation domain.Ins
 		for _, action := range result.Deactivation.UserActions {
 			_, _ = fmt.Fprintf(writer, "Next: %s\n", action)
 		}
+		for _, action := range result.Deactivation.LocalActions {
+			_, _ = fmt.Fprintf(writer, "Next: %s\n", action)
+		}
 		return nil
 	}
 	if result.Mutated {
 		_, _ = fmt.Fprintln(writer, "Removed the selected managed package.")
 	}
 	for _, action := range result.Deactivation.UserActions {
+		_, _ = fmt.Fprintf(writer, "Next: %s\n", action)
+	}
+	for _, action := range result.Deactivation.LocalActions {
 		_, _ = fmt.Fprintf(writer, "Next: %s\n", action)
 	}
 	return nil

--- a/install/integrationctl/agentplugins/domain/clients.go
+++ b/install/integrationctl/agentplugins/domain/clients.go
@@ -92,7 +92,10 @@ type DeliveryPlan struct {
 	PhysicalArtifactID string              `json:"physical_artifact_id"`
 	Components         []ComponentDecision `json:"components,omitempty"`
 	UserActions        []string            `json:"user_actions,omitempty"`
-	Warnings           []string            `json:"warnings,omitempty"`
+	// LocalActions can contain operational paths and are rendered only in
+	// human-readable output. They must never be emitted by the public JSON API.
+	LocalActions []string `json:"-"`
+	Warnings     []string `json:"warnings,omitempty"`
 	// TargetRoot and ActivePath are intentionally excluded from public JSON.
 	TargetAnchor string `json:"-"`
 	TargetRoot   string `json:"-"`
@@ -130,6 +133,8 @@ type ActivationRequest struct {
 	Client            DetectedClient `json:"client"`
 	Plan              DeliveryPlan   `json:"plan"`
 	Delivery          StagedDelivery `json:"delivery"`
+	DeclaredName      string         `json:"declared_name"`
+	Replacing         bool           `json:"replacing"`
 	Interactive       bool           `json:"interactive"`
 	BackendExecutable string         `json:"-"`
 }
@@ -140,6 +145,7 @@ type ActivationOutcome struct {
 	Policy         PolicyState         `json:"policy"`
 	Verification   VerificationState   `json:"verification"`
 	UserActions    []string            `json:"user_actions,omitempty"`
+	LocalActions   []string            `json:"-"`
 }
 
 type DeactivationRequest struct {
@@ -148,6 +154,8 @@ type DeactivationRequest struct {
 	CurrentActivation   ActivationState `json:"current_activation"`
 	Interactive         bool            `json:"interactive"`
 	ExternalUninstalled bool            `json:"external_uninstalled"`
+	Confirmed           bool            `json:"confirmed"`
+	PhysicalArtifactID  string          `json:"physical_artifact_id"`
 	BackendExecutable   string          `json:"-"`
 }
 
@@ -156,4 +164,5 @@ type DeactivationOutcome struct {
 	ArtifactRemovalAllowed  bool            `json:"artifact_removal_allowed"`
 	ExternalRemovalComplete bool            `json:"external_removal_complete"`
 	UserActions             []string        `json:"user_actions,omitempty"`
+	LocalActions            []string        `json:"-"`
 }

--- a/install/integrationctl/agentplugins/planner/planner.go
+++ b/install/integrationctl/agentplugins/planner/planner.go
@@ -85,20 +85,43 @@ func (planner Planner) Plan(
 		plan.Activation = domain.ActivationFailed
 		plan.Warnings = append(plan.Warnings, "no_supported_components")
 	}
+	if plan.Status != domain.PlanUnsupported && planner.hasNativeCopilotBackend(client) {
+		plan.Status = domain.PlanReady
+		plan.Activation = domain.ActivationPrepared
+	}
 
 	switch client.ClientID {
 	case domain.ClientCodex:
-		plan.UserActions = append(plan.UserActions, "install the prepared marketplace plugin in Codex or ChatGPT")
+		plan.UserActions = append(plan.UserActions, "finish installation in Codex or ChatGPT Plugins, then start a new session")
 	case domain.ClientCursor:
 		plan.UserActions = append(plan.UserActions, "reload Cursor, then verify the plugin appears before using its components")
 	case domain.ClientCopilot:
-		plan.UserActions = append(plan.UserActions, fmt.Sprintf("run `copilot plugin install %s` and review the trust prompt", plan.ActivePath))
+		if strings.TrimSpace(client.ExecutablePath) != "" {
+			plan.UserActions = append(plan.UserActions, "agentplugins will install and verify the plugin through GitHub Copilot CLI automatically")
+		} else {
+			plan.UserActions = append(plan.UserActions, "GitHub Copilot CLI is required for automatic activation")
+		}
 	case domain.ClientKiro:
-		plan.UserActions = append(plan.UserActions, "import the prepared folder with Kiro: Powers > Add Custom Power > Import from folder")
+		plan.UserActions = append(plan.UserActions, "finish the prepared Power installation in Kiro")
 	case domain.ClientVSCode:
-		plan.UserActions = append(plan.UserActions, fmt.Sprintf("open VS Code's Agent Plugins UI, import %s, then verify the plugin appears", plan.ActivePath))
+		if strings.TrimSpace(planner.Detected[domain.ClientCopilot].ExecutablePath) != "" {
+			plan.UserActions = append(plan.UserActions, "agentplugins will install through GitHub Copilot CLI; VS Code discovers it automatically")
+		} else {
+			plan.UserActions = append(plan.UserActions, "register the prepared local plugin in VS Code after installation")
+		}
 	}
 	return plan, nil
+}
+
+func (planner Planner) hasNativeCopilotBackend(client domain.DetectedClient) bool {
+	switch client.ClientID {
+	case domain.ClientCopilot:
+		return strings.TrimSpace(client.ExecutablePath) != ""
+	case domain.ClientVSCode:
+		return strings.TrimSpace(planner.Detected[domain.ClientCopilot].ExecutablePath) != ""
+	default:
+		return false
+	}
 }
 
 func (planner Planner) ResolveTarget(

--- a/install/integrationctl/agentplugins/planner/planner_test.go
+++ b/install/integrationctl/agentplugins/planner/planner_test.go
@@ -54,7 +54,7 @@ func TestPlannerUsesNativeCursorTargetAndDoesNotExposeItInJSON(t *testing.T) {
 	}
 }
 
-func TestPlannerKeepsVSCodeManualEvenWhenCopilotIsDetected(t *testing.T) {
+func TestPlannerPromotesVSCodeToReadyWhenCopilotIsDetected(t *testing.T) {
 	t.Parallel()
 	client := detectedClient(domain.ClientVSCode, filepath.Join(t.TempDir(), "Code", "User"))
 	withoutBridge := Planner{ManagedRoot: t.TempDir()}
@@ -77,8 +77,23 @@ func TestPlannerKeepsVSCodeManualEvenWhenCopilotIsDetected(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if bridged.Status != domain.PlanManualActivationRequired || bridged.PackageMode != domain.PackagePrepared || bridged.Activation != domain.ActivationManual {
+	if bridged.Status != domain.PlanReady || bridged.PackageMode != domain.PackagePrepared || bridged.Activation != domain.ActivationPrepared {
 		t.Fatalf("bridged plan = %+v", bridged)
+	}
+}
+
+func TestPlannerPromotesDetectedCopilotExecutableToReady(t *testing.T) {
+	t.Parallel()
+	client := detectedClient(domain.ClientCopilot, filepath.Join(t.TempDir(), ".copilot"))
+	client.ExecutablePath = "/test/bin/copilot"
+	plan, err := (Planner{ManagedRoot: t.TempDir()}).Plan(
+		context.Background(), testEnvelope(), client, domain.ScopeUser, "demo-0123456789ab",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Status != domain.PlanReady || plan.Activation != domain.ActivationPrepared {
+		t.Fatalf("plan = %+v", plan)
 	}
 }
 

--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/pathpolicy"
@@ -110,15 +111,15 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 		outcome.UserActions = append(outcome.UserActions, "finish installation in Codex or ChatGPT Plugins, then start a new session")
 		marketplace := managedMarketplaceName(request.Plan.PhysicalArtifactID)
 		outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf(
-			"Codex CLI: run `codex plugin marketplace add %q --json`, then `codex plugin add %q --json`; ChatGPT/Codex app: open Plugins > Personal and install %s",
-			request.Delivery.ActivePath, request.DeclaredName+"@"+marketplace, request.DeclaredName,
+			"Codex CLI: run `codex plugin marketplace add %s --json`, then `codex plugin add %s --json`; ChatGPT/Codex app: open Plugins > Personal and install %s",
+			shellQuoteForHint(request.Delivery.ActivePath), request.DeclaredName+"@"+marketplace, request.DeclaredName,
 		))
 		return outcome, nil
 	case domain.ClientKiro:
 		outcome.Activation = domain.ActivationManual
 		outcome.UserActions = append(outcome.UserActions, "finish the prepared Power installation in Kiro")
 		outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf(
-			"Kiro: Powers > Add Custom Power > Import power from a folder > select %q > Install",
+			"Kiro: Powers > Add Custom Power > Import power from a folder > select %s > Install",
 			request.Delivery.ActivePath,
 		))
 		return outcome, nil
@@ -211,4 +212,11 @@ func (activator Activator) runCopilotResult(ctx context.Context, executable stri
 func commandOutputContains(result legacyports.CommandResult, fragment string) bool {
 	output := string(result.Stdout) + "\n" + string(result.Stderr)
 	return strings.Contains(strings.ToLower(output), strings.ToLower(fragment))
+}
+
+func shellQuoteForHint(value string) string {
+	if runtime.GOOS == "windows" {
+		return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }

--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -4,12 +4,20 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/pathpolicy"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	legacyports "github.com/777genius/plugin-kit-ai/install/integrationctl/ports"
 )
 
-type Activator struct{}
+type CommandRunner interface {
+	Run(context.Context, legacyports.Command) (legacyports.CommandResult, error)
+}
+
+type Activator struct {
+	Runner CommandRunner
+}
 
 func (activator Activator) Deactivate(ctx context.Context, request domain.DeactivationRequest) (domain.DeactivationOutcome, error) {
 	if err := ctx.Err(); err != nil {
@@ -23,10 +31,31 @@ func (activator Activator) Deactivate(ctx context.Context, request domain.Deacti
 		return requireExternalUninstall(outcome, request.ExternalUninstalled, "uninstall the plugin in Codex or ChatGPT, then rerun remove with `--external-uninstalled` (also use the flag if it was never activated)"), nil
 	case domain.ClientKiro:
 		return requireExternalUninstall(outcome, request.ExternalUninstalled, "remove the custom Power in Kiro, then rerun remove with `--external-uninstalled` (also use the flag if it was never imported)"), nil
-	case domain.ClientCopilot:
-		return requireExternalUninstall(outcome, request.ExternalUninstalled, fmt.Sprintf("run `copilot plugin uninstall %s` in a terminal, then rerun remove with `--external-uninstalled` (also use the flag if it was never installed in the client)", request.DeclaredName)), nil
-	case domain.ClientVSCode:
-		return requireExternalUninstall(outcome, request.ExternalUninstalled, "remove the plugin through VS Code's Agent Plugins UI, then rerun remove with `--external-uninstalled` (also use the flag if it was never imported)"), nil
+	case domain.ClientCopilot, domain.ClientVSCode:
+		if request.ExternalUninstalled {
+			outcome.ExternalRemovalComplete = true
+			return outcome, nil
+		}
+		if strings.TrimSpace(request.BackendExecutable) == "" || activator.Runner == nil {
+			action := fmt.Sprintf("run `copilot plugin uninstall %s`, then rerun remove with `--external-uninstalled`", request.DeclaredName)
+			if request.Client.ClientID == domain.ClientVSCode {
+				action = "remove the plugin in VS Code, then rerun remove with `--external-uninstalled`"
+			}
+			return requireExternalUninstall(outcome, false, action), nil
+		}
+		if request.CurrentActivation != domain.ActivationActive {
+			action := fmt.Sprintf("verify `%s@%s` is absent from GitHub Copilot CLI, then rerun remove with `--external-uninstalled`", request.DeclaredName, managedMarketplaceName(request.PhysicalArtifactID))
+			return requireExternalUninstall(outcome, false, action), nil
+		}
+		if !request.Confirmed {
+			outcome.UserActions = append(outcome.UserActions, "agentplugins will uninstall the plugin from GitHub Copilot CLI and VS Code automatically")
+			return outcome, nil
+		}
+		if err := activator.deactivateCopilot(ctx, request); err != nil {
+			return outcome, err
+		}
+		outcome.ExternalRemovalComplete = true
+		return outcome, nil
 	default:
 		return domain.DeactivationOutcome{}, fmt.Errorf("unsupported deactivation client %q", request.Client.ClientID)
 	}
@@ -53,6 +82,9 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 	if request.Plan.ActivePath != request.Delivery.ActivePath {
 		return domain.ActivationOutcome{}, fmt.Errorf("activation artifact path mismatch")
 	}
+	if strings.TrimSpace(request.DeclaredName) == "" {
+		return domain.ActivationOutcome{}, fmt.Errorf("activation plugin name is required")
+	}
 	if err := pathpolicy.RequireContainedChild(request.Delivery.OwnedBase, request.Delivery.ActivePath); err != nil {
 		return domain.ActivationOutcome{}, fmt.Errorf("unsafe activation artifact: %w", err)
 	}
@@ -75,21 +107,108 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 		return outcome, nil
 	case domain.ClientCodex:
 		outcome.Activation = domain.ActivationManual
-		outcome.UserActions = append(outcome.UserActions, "install the prepared marketplace plugin in Codex or ChatGPT")
+		outcome.UserActions = append(outcome.UserActions, "finish installation in Codex or ChatGPT Plugins, then start a new session")
+		marketplace := managedMarketplaceName(request.Plan.PhysicalArtifactID)
+		outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf(
+			"Codex CLI: run `codex plugin marketplace add %q --json`, then `codex plugin add %q --json`; ChatGPT/Codex app: open Plugins > Personal and install %s",
+			request.Delivery.ActivePath, request.DeclaredName+"@"+marketplace, request.DeclaredName,
+		))
 		return outcome, nil
 	case domain.ClientKiro:
 		outcome.Activation = domain.ActivationManual
-		outcome.UserActions = append(outcome.UserActions, "import the prepared folder with Kiro: Powers > Add Custom Power > Import from folder")
+		outcome.UserActions = append(outcome.UserActions, "finish the prepared Power installation in Kiro")
+		outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf(
+			"Kiro: Powers > Add Custom Power > Import power from a folder > select %q > Install",
+			request.Delivery.ActivePath,
+		))
 		return outcome, nil
-	case domain.ClientCopilot:
-		outcome.Activation = domain.ActivationManual
-		outcome.UserActions = append(outcome.UserActions, fmt.Sprintf("run `copilot plugin install %s` in a terminal and review the client trust prompt", request.Delivery.ActivePath))
-		return outcome, nil
-	case domain.ClientVSCode:
-		outcome.Activation = domain.ActivationManual
-		outcome.UserActions = append(outcome.UserActions, fmt.Sprintf("open VS Code's Agent Plugins UI, import %s, then verify the plugin appears", request.Delivery.ActivePath))
+	case domain.ClientCopilot, domain.ClientVSCode:
+		if strings.TrimSpace(request.BackendExecutable) == "" || activator.Runner == nil {
+			outcome.Activation = domain.ActivationManual
+			if request.Client.ClientID == domain.ClientVSCode {
+				outcome.UserActions = append(outcome.UserActions, "register the prepared local plugin in VS Code")
+				outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf(
+					"VS Code: add %q to the `chat.pluginLocations` setting with value `true`, then reload VS Code",
+					request.Delivery.ActivePath,
+				))
+			} else {
+				outcome.UserActions = append(outcome.UserActions, "install GitHub Copilot CLI, then rerun `agentplugins update` for this plugin")
+			}
+			return outcome, nil
+		}
+		if err := activator.activateCopilot(ctx, request); err != nil {
+			return outcome, err
+		}
+		outcome.Activation = domain.ActivationActive
+		outcome.Verification = domain.VerificationInstalled
 		return outcome, nil
 	default:
 		return domain.ActivationOutcome{}, fmt.Errorf("unsupported activation client %q", request.Client.ClientID)
 	}
+}
+
+func (activator Activator) activateCopilot(ctx context.Context, request domain.ActivationRequest) error {
+	marketplace := managedMarketplaceName(request.Plan.PhysicalArtifactID)
+	if request.Replacing {
+		if err := activator.runCopilot(ctx, request.BackendExecutable, "plugin", "marketplace", "update", marketplace); err != nil {
+			if fallbackErr := activator.runCopilot(ctx, request.BackendExecutable, "plugin", "marketplace", "add", request.Delivery.ActivePath); fallbackErr != nil {
+				return fmt.Errorf("refresh managed Copilot marketplace: %v; fallback registration: %w", err, fallbackErr)
+			}
+		}
+		if err := activator.runCopilot(ctx, request.BackendExecutable, "plugin", "update", request.DeclaredName+"@"+marketplace); err == nil {
+			return nil
+		}
+	} else if err := activator.runCopilot(ctx, request.BackendExecutable, "plugin", "marketplace", "add", request.Delivery.ActivePath); err != nil {
+		if fallbackErr := activator.runCopilot(ctx, request.BackendExecutable, "plugin", "marketplace", "update", marketplace); fallbackErr != nil {
+			return fmt.Errorf("register managed Copilot marketplace: %v; fallback refresh: %w", err, fallbackErr)
+		}
+	}
+	pluginSpec := request.DeclaredName + "@" + marketplace
+	if err := activator.runCopilot(ctx, request.BackendExecutable, "plugin", "install", pluginSpec); err != nil {
+		if !request.Replacing {
+			_ = activator.runCopilot(ctx, request.BackendExecutable, "plugin", "marketplace", "remove", marketplace)
+		}
+		return err
+	}
+	return nil
+}
+
+func (activator Activator) deactivateCopilot(ctx context.Context, request domain.DeactivationRequest) error {
+	if strings.TrimSpace(request.PhysicalArtifactID) == "" {
+		return fmt.Errorf("managed Copilot marketplace identity is missing")
+	}
+	marketplace := managedMarketplaceName(request.PhysicalArtifactID)
+	uninstall, err := activator.runCopilotResult(ctx, request.BackendExecutable, "plugin", "uninstall", request.DeclaredName+"@"+marketplace)
+	if err != nil && !commandOutputContains(uninstall, "is not installed") {
+		return err
+	}
+	remove, err := activator.runCopilotResult(ctx, request.BackendExecutable, "plugin", "marketplace", "remove", marketplace)
+	if err != nil && !commandOutputContains(remove, "is not registered") {
+		return err
+	}
+	return nil
+}
+
+func (activator Activator) runCopilot(ctx context.Context, executable string, args ...string) error {
+	_, err := activator.runCopilotResult(ctx, executable, args...)
+	return err
+}
+
+func (activator Activator) runCopilotResult(ctx context.Context, executable string, args ...string) (legacyports.CommandResult, error) {
+	if activator.Runner == nil {
+		return legacyports.CommandResult{}, fmt.Errorf("GitHub Copilot CLI runner is unavailable")
+	}
+	result, err := activator.Runner.Run(ctx, legacyports.Command{Argv: append([]string{executable}, args...)})
+	if err != nil {
+		return result, fmt.Errorf("start GitHub Copilot CLI: %w", err)
+	}
+	if result.ExitCode != 0 {
+		return result, fmt.Errorf("GitHub Copilot CLI command failed with exit code %d", result.ExitCode)
+	}
+	return result, nil
+}
+
+func commandOutputContains(result legacyports.CommandResult, fragment string) bool {
+	output := string(result.Stdout) + "\n" + string(result.Stderr)
+	return strings.Contains(strings.ToLower(output), strings.ToLower(fragment))
 }

--- a/install/integrationctl/agentplugins/providers/activator_test.go
+++ b/install/integrationctl/agentplugins/providers/activator_test.go
@@ -2,56 +2,136 @@ package providers
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	legacyports "github.com/777genius/plugin-kit-ai/install/integrationctl/ports"
 )
 
-func TestActivatorKeepsCopilotManualEvenWhenCallerHasATerminal(t *testing.T) {
+type recordingRunner struct {
+	commands []legacyports.Command
+	run      func(legacyports.Command) legacyports.CommandResult
+}
+
+func (runner *recordingRunner) Run(_ context.Context, command legacyports.Command) (legacyports.CommandResult, error) {
+	runner.commands = append(runner.commands, command)
+	if runner.run != nil {
+		return runner.run(command), nil
+	}
+	return legacyports.CommandResult{}, nil
+}
+
+func TestActivatorInstallsCopilotAndVSCodeThroughManagedMarketplace(t *testing.T) {
 	t.Parallel()
-	for _, interactive := range []bool{false, true} {
-		request := activationRequest(t, domain.ClientCopilot)
-		request.Interactive = interactive
-		outcome, err := (Activator{}).Activate(context.Background(), request)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if outcome.Activation != domain.ActivationManual || outcome.Verification != domain.VerificationPackageValid {
-			t.Fatalf("outcome = %+v", outcome)
-		}
-		if len(outcome.UserActions) != 1 || !strings.Contains(outcome.UserActions[0], "copilot plugin install") {
-			t.Fatalf("actions = %+v", outcome.UserActions)
-		}
+	for _, client := range []domain.ClientID{domain.ClientCopilot, domain.ClientVSCode} {
+		client := client
+		t.Run(string(client), func(t *testing.T) {
+			runner := &recordingRunner{}
+			request := activationRequest(t, client)
+			request.BackendExecutable = "/test/bin/copilot"
+			outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if outcome.Activation != domain.ActivationActive || outcome.Verification != domain.VerificationInstalled || len(outcome.UserActions) != 0 {
+				t.Fatalf("outcome = %+v", outcome)
+			}
+			marketplace := managedMarketplaceName(request.Plan.PhysicalArtifactID)
+			want := [][]string{
+				{"/test/bin/copilot", "plugin", "marketplace", "add", request.Delivery.ActivePath},
+				{"/test/bin/copilot", "plugin", "install", "demo@" + marketplace},
+			}
+			if got := commandArgv(runner.commands); !reflect.DeepEqual(got, want) {
+				t.Fatalf("commands = %#v, want %#v", got, want)
+			}
+		})
 	}
 }
 
-func TestActivatorDoesNotOfferCopilotCommandForVSCodeOnlyTarget(t *testing.T) {
+func TestActivatorUpdateRecoversMissingMarketplaceAndPlugin(t *testing.T) {
 	t.Parallel()
-	request := activationRequest(t, domain.ClientVSCode)
-	outcome, err := (Activator{}).Activate(context.Background(), request)
+	runner := &recordingRunner{run: func(command legacyports.Command) legacyports.CommandResult {
+		joined := strings.Join(command.Argv, " ")
+		if strings.Contains(joined, "marketplace update") || strings.Contains(joined, "plugin update") {
+			return legacyports.CommandResult{ExitCode: 1, Stderr: []byte("missing")}
+		}
+		return legacyports.CommandResult{}
+	}}
+	request := activationRequest(t, domain.ClientCopilot)
+	request.BackendExecutable = "/test/bin/copilot"
+	request.Replacing = true
+	outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if outcome.Activation != domain.ActivationManual || len(outcome.UserActions) != 1 || strings.Contains(outcome.UserActions[0], "copilot plugin") || !strings.Contains(outcome.UserActions[0], "VS Code") {
+	if outcome.Activation != domain.ActivationActive {
 		t.Fatalf("outcome = %+v", outcome)
+	}
+	marketplace := managedMarketplaceName(request.Plan.PhysicalArtifactID)
+	want := [][]string{
+		{"/test/bin/copilot", "plugin", "marketplace", "update", marketplace},
+		{"/test/bin/copilot", "plugin", "marketplace", "add", request.Delivery.ActivePath},
+		{"/test/bin/copilot", "plugin", "update", "demo@" + marketplace},
+		{"/test/bin/copilot", "plugin", "install", "demo@" + marketplace},
+	}
+	if got := commandArgv(runner.commands); !reflect.DeepEqual(got, want) {
+		t.Fatalf("commands = %#v, want %#v", got, want)
 	}
 }
 
-func TestActivatorKeepsUIOnlyClientsInManualActivationState(t *testing.T) {
+func TestActivatorCleansNewMarketplaceWhenPluginInstallFails(t *testing.T) {
 	t.Parallel()
-	for _, client := range []domain.ClientID{domain.ClientCodex, domain.ClientKiro} {
-		request := activationRequest(t, client)
-		request.Interactive = true
-		outcome, err := (Activator{}).Activate(context.Background(), request)
-		if err != nil {
-			t.Fatal(err)
+	runner := &recordingRunner{run: func(command legacyports.Command) legacyports.CommandResult {
+		if strings.Contains(strings.Join(command.Argv, " "), "plugin install") {
+			return legacyports.CommandResult{ExitCode: 1, Stderr: []byte("install failed")}
 		}
-		if outcome.Activation != domain.ActivationManual {
-			t.Fatalf("client %s outcome = %+v", client, outcome)
-		}
+		return legacyports.CommandResult{}
+	}}
+	request := activationRequest(t, domain.ClientCopilot)
+	request.BackendExecutable = "/test/bin/copilot"
+	if _, err := (Activator{Runner: runner}).Activate(context.Background(), request); err == nil {
+		t.Fatal("failed install unexpectedly succeeded")
+	}
+	marketplace := managedMarketplaceName(request.Plan.PhysicalArtifactID)
+	want := [][]string{
+		{"/test/bin/copilot", "plugin", "marketplace", "add", request.Delivery.ActivePath},
+		{"/test/bin/copilot", "plugin", "install", "demo@" + marketplace},
+		{"/test/bin/copilot", "plugin", "marketplace", "remove", marketplace},
+	}
+	if got := commandArgv(runner.commands); !reflect.DeepEqual(got, want) {
+		t.Fatalf("commands = %#v, want %#v", got, want)
+	}
+}
+
+func TestActivatorUsesPathSpecificManualHintsWithoutLeakingThemToJSON(t *testing.T) {
+	t.Parallel()
+	for _, client := range []domain.ClientID{domain.ClientCodex, domain.ClientKiro, domain.ClientVSCode} {
+		client := client
+		t.Run(string(client), func(t *testing.T) {
+			request := activationRequest(t, client)
+			outcome, err := (Activator{}).Activate(context.Background(), request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if outcome.Activation != domain.ActivationManual || len(outcome.UserActions) != 1 || len(outcome.LocalActions) != 1 {
+				t.Fatalf("outcome = %+v", outcome)
+			}
+			if !strings.Contains(outcome.LocalActions[0], request.Delivery.ActivePath) {
+				t.Fatalf("local action = %q", outcome.LocalActions[0])
+			}
+			body, err := json.Marshal(outcome)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(body), request.Delivery.ActivePath) {
+				t.Fatalf("public JSON leaked local path: %s", body)
+			}
+		})
 	}
 }
 
@@ -67,44 +147,76 @@ func TestActivatorKeepsCursorManualUntilClientDiscoveryIsVerified(t *testing.T) 
 	}
 }
 
-func TestDeactivatorNeverRemovesCopilotPackageBeforeManualClientUninstall(t *testing.T) {
+func TestDeactivatorPreviewsThenRemovesNativeCopilotLifecycle(t *testing.T) {
 	t.Parallel()
-	for _, activation := range []domain.ActivationState{domain.ActivationManual, domain.ActivationActive} {
-		for _, interactive := range []bool{false, true} {
-			outcome, err := (Activator{}).Deactivate(context.Background(), domain.DeactivationRequest{
-				Client: domain.DetectedClient{ClientID: domain.ClientCopilot}, DeclaredName: "demo",
-				CurrentActivation: activation, Interactive: interactive,
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-			if outcome.ArtifactRemovalAllowed || outcome.Activation != domain.ActivationManual || outcome.ExternalRemovalComplete {
-				t.Fatalf("outcome = %+v", outcome)
-			}
-			if len(outcome.UserActions) != 1 || !strings.Contains(outcome.UserActions[0], "copilot plugin uninstall demo") {
-				t.Fatalf("actions = %+v", outcome.UserActions)
-			}
-		}
+	runner := &recordingRunner{}
+	request := domain.DeactivationRequest{
+		Client: domain.DetectedClient{ClientID: domain.ClientCopilot}, DeclaredName: "demo",
+		CurrentActivation: domain.ActivationActive, BackendExecutable: "/test/bin/copilot",
+		PhysicalArtifactID: "demo-0123456789ab",
+	}
+	preview, err := (Activator{Runner: runner}).Deactivate(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !preview.ArtifactRemovalAllowed || preview.ExternalRemovalComplete || len(runner.commands) != 0 {
+		t.Fatalf("preview = %+v, commands = %+v", preview, runner.commands)
+	}
+	request.Confirmed = true
+	outcome, err := (Activator{Runner: runner}).Deactivate(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.ArtifactRemovalAllowed || !outcome.ExternalRemovalComplete {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+	want := [][]string{
+		{"/test/bin/copilot", "plugin", "uninstall", "demo@" + managedMarketplaceName(request.PhysicalArtifactID)},
+		{"/test/bin/copilot", "plugin", "marketplace", "remove", managedMarketplaceName(request.PhysicalArtifactID)},
+	}
+	if got := commandArgv(runner.commands); !reflect.DeepEqual(got, want) {
+		t.Fatalf("commands = %#v, want %#v", got, want)
 	}
 }
 
-func TestDeactivatorAllowsCopiedArtifactRemovalAfterExplicitExternalUninstall(t *testing.T) {
+func TestDeactivatorTreatsAlreadyAbsentNativeObjectsAsRemoved(t *testing.T) {
 	t.Parallel()
-	for _, client := range []domain.ClientID{domain.ClientCodex, domain.ClientKiro, domain.ClientCopilot, domain.ClientVSCode} {
-		outcome, err := (Activator{}).Deactivate(context.Background(), domain.DeactivationRequest{
-			Client: domain.DetectedClient{ClientID: client}, DeclaredName: "demo",
-			CurrentActivation: domain.ActivationManual, ExternalUninstalled: true,
-		})
-		if err != nil {
-			t.Fatal(err)
+	runner := &recordingRunner{run: func(command legacyports.Command) legacyports.CommandResult {
+		if strings.Contains(strings.Join(command.Argv, " "), "marketplace remove") {
+			return legacyports.CommandResult{ExitCode: 1, Stderr: []byte(`Marketplace "demo" is not registered`)}
 		}
-		if !outcome.ArtifactRemovalAllowed || !outcome.ExternalRemovalComplete || len(outcome.UserActions) != 0 {
-			t.Fatalf("client %s outcome = %+v", client, outcome)
-		}
+		return legacyports.CommandResult{ExitCode: 1, Stderr: []byte(`Plugin "demo" is not installed`)}
+	}}
+	outcome, err := (Activator{Runner: runner}).Deactivate(context.Background(), domain.DeactivationRequest{
+		Client: domain.DetectedClient{ClientID: domain.ClientVSCode}, DeclaredName: "demo",
+		CurrentActivation: domain.ActivationActive, BackendExecutable: "/test/bin/copilot",
+		PhysicalArtifactID: "demo-0123456789ab", Confirmed: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.ArtifactRemovalAllowed || !outcome.ExternalRemovalComplete {
+		t.Fatalf("outcome = %+v", outcome)
 	}
 }
 
-func TestDeactivatorPreservesCopiedClientArtifactUntilExternalUninstallIsAcknowledged(t *testing.T) {
+func TestDeactivatorDoesNotClaimManualCopilotLifecycle(t *testing.T) {
+	t.Parallel()
+	runner := &recordingRunner{}
+	outcome, err := (Activator{Runner: runner}).Deactivate(context.Background(), domain.DeactivationRequest{
+		Client: domain.DetectedClient{ClientID: domain.ClientCopilot}, DeclaredName: "demo",
+		CurrentActivation: domain.ActivationManual, BackendExecutable: "/test/bin/copilot",
+		PhysicalArtifactID: "demo-0123456789ab", Confirmed: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.ArtifactRemovalAllowed || len(outcome.UserActions) != 1 || len(runner.commands) != 0 {
+		t.Fatalf("outcome = %+v, commands = %+v", outcome, runner.commands)
+	}
+}
+
+func TestDeactivatorPreservesManualClientArtifactsUntilAcknowledged(t *testing.T) {
 	t.Parallel()
 	for _, client := range []domain.ClientID{domain.ClientCodex, domain.ClientKiro, domain.ClientVSCode} {
 		outcome, err := (Activator{}).Deactivate(context.Background(), domain.DeactivationRequest{
@@ -131,10 +243,20 @@ func activationRequest(t *testing.T, client domain.ClientID) domain.ActivationRe
 		t.Fatal(err)
 	}
 	return domain.ActivationRequest{
-		Client: domain.DetectedClient{ClientID: client, Status: domain.DetectionDetected},
+		Client:       domain.DetectedClient{ClientID: client, Status: domain.DetectionDetected},
+		DeclaredName: "demo",
 		Plan: domain.DeliveryPlan{
-			ClientID: client, ActivePath: active, Authentication: domain.AuthenticationNotChecked,
+			ClientID: client, ActivePath: active, PhysicalArtifactID: "demo-0123456789ab",
+			Authentication: domain.AuthenticationNotChecked,
 		},
 		Delivery: domain.StagedDelivery{ClientID: client, OwnedBase: base, ActivePath: active},
 	}
+}
+
+func commandArgv(commands []legacyports.Command) [][]string {
+	result := make([][]string, 0, len(commands))
+	for _, command := range commands {
+		result = append(result, command.Argv)
+	}
+	return result
 }

--- a/install/integrationctl/agentplugins/providers/marketplaces.go
+++ b/install/integrationctl/agentplugins/providers/marketplaces.go
@@ -1,0 +1,67 @@
+package providers
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+func managedMarketplaceName(physicalArtifactID string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(physicalArtifactID)))
+	return "agentplugins-" + hex.EncodeToString(sum[:6])
+}
+
+func projectCopilotMarketplace(root string, envelope domain.PackageEnvelope, plan domain.DeliveryPlan) error {
+	version := strings.TrimSpace(envelope.Manifest.Version)
+	if version == "" {
+		version = "0.0.0"
+	}
+	description := strings.TrimSpace(envelope.Manifest.Description)
+	if description == "" {
+		description = "Managed Agent Plugin " + envelope.Manifest.Name
+	}
+	document := map[string]any{
+		"name":  managedMarketplaceName(plan.PhysicalArtifactID),
+		"owner": map[string]any{"name": "Agent Plugins CLI"},
+		"metadata": map[string]any{
+			"description": "Managed local marketplace for " + envelope.Manifest.Name,
+			"version":     version,
+		},
+		"plugins": []map[string]any{{
+			"name":        envelope.Manifest.Name,
+			"description": description,
+			"version":     version,
+			"source":      ".",
+		}},
+	}
+	if err := writeJSON(filepath.Join(root, ".github", "plugin", "marketplace.json"), document); err != nil {
+		return fmt.Errorf("write Copilot managed marketplace: %w", err)
+	}
+	return nil
+}
+
+func projectCodexMarketplace(root string, envelope domain.PackageEnvelope, plan domain.DeliveryPlan) error {
+	document := map[string]any{
+		"name": managedMarketplaceName(plan.PhysicalArtifactID),
+		"plugins": []map[string]any{{
+			"name": envelope.Manifest.Name,
+			"source": map[string]any{
+				"source": "local",
+				"path":   ".",
+			},
+			"policy": map[string]any{
+				"installation":   "AVAILABLE",
+				"authentication": "ON_INSTALL",
+			},
+			"category": "Productivity",
+		}},
+	}
+	if err := writeJSON(filepath.Join(root, ".agents", "plugins", "marketplace.json"), document); err != nil {
+		return fmt.Errorf("write Codex managed marketplace: %w", err)
+	}
+	return nil
+}

--- a/install/integrationctl/agentplugins/providers/marketplaces.go
+++ b/install/integrationctl/agentplugins/providers/marketplaces.go
@@ -51,7 +51,7 @@ func projectCodexMarketplace(root string, envelope domain.PackageEnvelope, plan 
 			"name": envelope.Manifest.Name,
 			"source": map[string]any{
 				"source": "local",
-				"path":   ".",
+				"path":   "./",
 			},
 			"policy": map[string]any{
 				"installation":   "AVAILABLE",

--- a/install/integrationctl/agentplugins/providers/stager.go
+++ b/install/integrationctl/agentplugins/providers/stager.go
@@ -122,6 +122,14 @@ func (stager Stager) Stage(
 		if err := projectOpenAI(stagingPath, envelope, plan, hints); err != nil {
 			return domain.StagedDelivery{}, err
 		}
+		if err := projectCodexMarketplace(stagingPath, envelope, plan); err != nil {
+			return domain.StagedDelivery{}, err
+		}
+	}
+	if plan.ClientID == domain.ClientCopilot || plan.ClientID == domain.ClientVSCode {
+		if err := projectCopilotMarketplace(stagingPath, envelope, plan); err != nil {
+			return domain.StagedDelivery{}, err
+		}
 	}
 	artifact, err := stager.SnapshotBuilder.Build(ctx, stagingPath)
 	if err != nil {

--- a/install/integrationctl/agentplugins/providers/stager_test.go
+++ b/install/integrationctl/agentplugins/providers/stager_test.go
@@ -53,7 +53,7 @@ func TestStagerBuildsOpenAIProjectionWithoutMutatingPortableSnapshot(t *testing.
 	}
 	plugins := codexMarketplace["plugins"].([]any)
 	source := plugins[0].(map[string]any)["source"].(map[string]any)
-	if source["source"] != "local" || source["path"] != "." {
+	if source["source"] != "local" || source["path"] != "./" {
 		t.Fatalf("Codex marketplace source = %+v", source)
 	}
 	standardMCP := readObject(t, filepath.Join(delivery.StagingPath, "mcp.json"))

--- a/install/integrationctl/agentplugins/providers/stager_test.go
+++ b/install/integrationctl/agentplugins/providers/stager_test.go
@@ -47,10 +47,44 @@ func TestStagerBuildsOpenAIProjectionWithoutMutatingPortableSnapshot(t *testing.
 	if notion["type"] != "http" || notion["oauth_resource"] != "https://mcp.notion.com" {
 		t.Fatalf("OpenAI MCP = %+v", notion)
 	}
+	codexMarketplace := readObject(t, filepath.Join(delivery.StagingPath, ".agents", "plugins", "marketplace.json"))
+	if codexMarketplace["name"] != managedMarketplaceName(plan.PhysicalArtifactID) {
+		t.Fatalf("Codex marketplace = %+v", codexMarketplace)
+	}
+	plugins := codexMarketplace["plugins"].([]any)
+	source := plugins[0].(map[string]any)["source"].(map[string]any)
+	if source["source"] != "local" || source["path"] != "." {
+		t.Fatalf("Codex marketplace source = %+v", source)
+	}
 	standardMCP := readObject(t, filepath.Join(delivery.StagingPath, "mcp.json"))
 	standardServers := standardMCP["mcpServers"].(map[string]any)
 	if _, exists := standardServers["broken"]; exists {
 		t.Fatal("invalid MCP server survived staging")
+	}
+}
+
+func TestStagerBuildsManagedCopilotMarketplaceForCopilotAndVSCode(t *testing.T) {
+	t.Parallel()
+	for _, client := range []domain.ClientID{domain.ClientCopilot, domain.ClientVSCode} {
+		client := client
+		t.Run(string(client), func(t *testing.T) {
+			envelope := stagingEnvelope(t)
+			plan := stagingPlan(t, client, domain.PackageNative)
+			delivery, err := (Stager{}).Stage(context.Background(), envelope, plan, "operation-"+string(client), domain.CompatibilityHints{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			marketplace := readObject(t, filepath.Join(delivery.StagingPath, ".github", "plugin", "marketplace.json"))
+			if marketplace["name"] != managedMarketplaceName(plan.PhysicalArtifactID) {
+				t.Fatalf("marketplace = %+v", marketplace)
+			}
+			plugins := marketplace["plugins"].([]any)
+			plugin := plugins[0].(map[string]any)
+			if plugin["name"] != "demo" || plugin["source"] != "." || plugin["version"] != "1.0.0" {
+				t.Fatalf("plugin entry = %+v", plugin)
+			}
+			assertMissing(t, filepath.Join(envelope.SnapshotRoot, ".github"))
+		})
 	}
 }
 

--- a/install/integrationctl/agentplugins/usecase/remove.go
+++ b/install/integrationctl/agentplugins/usecase/remove.go
@@ -65,6 +65,8 @@ func (service Service) Remove(ctx context.Context, input RemoveInput) (RemoveRes
 		Client: input.Client, DeclaredName: installation.DeclaredName,
 		CurrentActivation: client.Activation, Interactive: input.Interactive,
 		ExternalUninstalled: input.ExternalUninstalled,
+		Confirmed:           input.Confirmed && !input.DryRun,
+		PhysicalArtifactID:  client.PhysicalArtifact,
 		BackendExecutable:   input.BackendExecutable,
 	})
 	result.Deactivation = deactivation

--- a/install/integrationctl/agentplugins/usecase/service.go
+++ b/install/integrationctl/agentplugins/usecase/service.go
@@ -118,6 +118,11 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 	if err := rejectNativeNameCollision(state, installationID, input.Envelope.Manifest.Name, input.Client.ClientID); err != nil {
 		return result, err
 	}
+	if existing {
+		if err := rejectSharedCopilotBackendDuplicate(state.Installations[installationIndex], input.Client.ClientID); err != nil {
+			return result, err
+		}
+	}
 	clientBindingID := domain.ComputeClientBindingID(installationID, string(input.Client.ClientID), string(input.Scope), plan.ActivePath)
 	if existing {
 		if err := validatePackageTransition(state.Installations[installationIndex], input.Envelope); err != nil {
@@ -137,7 +142,7 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 		if err := service.verifyManagedTarget(ctx, input.Client, input.Scope, previousClient, "update"); err != nil {
 			return result, err
 		}
-		if packageRevisionMatches(previousClient.PackageRevision, input.Envelope) {
+		if packageRevisionMatches(previousClient.PackageRevision, input.Envelope) && lifecycleConverged(previousClient) {
 			result.NoChange = true
 			return result, nil
 		}
@@ -199,6 +204,7 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 			ClientID: delivery.ClientID, OwnedBase: delivery.OwnedBase, ActivePath: delivery.ActivePath,
 			ArtifactDigest: delivery.ArtifactDigest, NativeObjects: delivery.NativeObjects,
 		},
+		DeclaredName: input.Envelope.Manifest.Name, Replacing: replace,
 		Interactive: input.Interactive, BackendExecutable: input.BackendExecutable,
 	})
 	result.Activation = outcome
@@ -219,6 +225,13 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 		return result, activationErr
 	}
 	return result, nil
+}
+
+func lifecycleConverged(client domain.ClientBinding) bool {
+	if client.ClientID != string(domain.ClientCopilot) && client.ClientID != string(domain.ClientVSCode) {
+		return true
+	}
+	return client.Activation == domain.ActivationActive && client.Verification == domain.VerificationInstalled
 }
 
 func hasOAuthRequirement(envelope domain.PackageEnvelope, hints domain.CompatibilityHints) bool {
@@ -408,12 +421,34 @@ func rejectNativeNameCollision(state domain.StateFileV2, installationID, declare
 			continue
 		}
 		for _, client := range installation.Clients {
-			if client.ClientID == string(clientID) && client.Materialization != domain.MaterializationAbsent {
+			boundClientID := domain.ClientID(client.ClientID)
+			if sameNativeBackend(boundClientID, clientID) && client.Materialization != domain.MaterializationAbsent {
 				return fmt.Errorf("native client name collision for %q on %s; remove or rebind the existing source first", declaredName, clientID)
 			}
 		}
 	}
 	return nil
+}
+
+func rejectSharedCopilotBackendDuplicate(installation domain.Installation, requested domain.ClientID) error {
+	if !sameNativeBackend(requested, domain.ClientCopilot) {
+		return nil
+	}
+	for _, client := range installation.Clients {
+		bound := domain.ClientID(client.ClientID)
+		if bound != requested && sameNativeBackend(bound, requested) && client.Materialization != domain.MaterializationAbsent {
+			return fmt.Errorf("plugin is already installed through %s and is available in both GitHub Copilot CLI and VS Code", bound)
+		}
+	}
+	return nil
+}
+
+func sameNativeBackend(first, second domain.ClientID) bool {
+	if first == second {
+		return true
+	}
+	return (first == domain.ClientCopilot || first == domain.ClientVSCode) &&
+		(second == domain.ClientCopilot || second == domain.ClientVSCode)
 }
 
 func initialLifecycle(plan domain.DeliveryPlan) (domain.ActivationState, domain.VerificationState) {

--- a/install/integrationctl/agentplugins/usecase/service_test.go
+++ b/install/integrationctl/agentplugins/usecase/service_test.go
@@ -364,6 +364,48 @@ func TestUpdateReturnsNoChangeWithoutMutation(t *testing.T) {
 	}
 }
 
+func TestLifecycleConvergenceRetriesOnlyNativeCopilotBackends(t *testing.T) {
+	t.Parallel()
+	manual := domain.ClientBinding{Activation: domain.ActivationManual, Verification: domain.VerificationPackageValid}
+	for _, client := range []domain.ClientID{domain.ClientCursor, domain.ClientCodex, domain.ClientKiro} {
+		manual.ClientID = string(client)
+		if !lifecycleConverged(manual) {
+			t.Fatalf("manual lifecycle for %s should preserve normal no-change behavior", client)
+		}
+	}
+	for _, client := range []domain.ClientID{domain.ClientCopilot, domain.ClientVSCode} {
+		manual.ClientID = string(client)
+		if lifecycleConverged(manual) {
+			t.Fatalf("manual lifecycle for %s should retry native activation", client)
+		}
+		manual.Activation = domain.ActivationActive
+		manual.Verification = domain.VerificationInstalled
+		if !lifecycleConverged(manual) {
+			t.Fatalf("installed lifecycle for %s should be converged", client)
+		}
+		manual.Activation = domain.ActivationManual
+		manual.Verification = domain.VerificationPackageValid
+	}
+}
+
+func TestCopilotAndVSCodeShareOneNativeBackend(t *testing.T) {
+	t.Parallel()
+	installation := domain.Installation{Clients: map[string]domain.ClientBinding{
+		"copilot": {
+			ClientID: string(domain.ClientCopilot), Materialization: domain.MaterializationMaterialized,
+		},
+	}}
+	if err := rejectSharedCopilotBackendDuplicate(installation, domain.ClientVSCode); err == nil || !strings.Contains(err.Error(), "available in both") {
+		t.Fatalf("shared backend error = %v", err)
+	}
+	if err := rejectSharedCopilotBackendDuplicate(installation, domain.ClientCopilot); err != nil {
+		t.Fatalf("same target was rejected: %v", err)
+	}
+	if !sameNativeBackend(domain.ClientCopilot, domain.ClientVSCode) || sameNativeBackend(domain.ClientCursor, domain.ClientVSCode) {
+		t.Fatal("native backend family mapping is incorrect")
+	}
+}
+
 func TestMultiClientUpdateConvergesEachClientRevision(t *testing.T) {
 	t.Parallel()
 	service, store, cursor := serviceFixture(t)

--- a/npm/agentplugins/README.md
+++ b/npm/agentplugins/README.md
@@ -28,6 +28,12 @@ npx --yes universal-agent-plugins@0.1.1 update context7 --target cursor --yes
 npx --yes universal-agent-plugins@0.1.1 remove context7 --target cursor --yes
 ```
 
+For GitHub Copilot CLI, `agentplugins` performs the native install, update, and
+remove automatically through a managed local marketplace. VS Code discovers
+the same installation automatically, so selecting either target once is
+enough. Codex/ChatGPT and Kiro print one exact, path-specific next step when
+their client UI must finish the installation.
+
 Short names resolve through the pinned
 [`universal-agent-plugins`](https://github.com/777genius/universal-agent-plugins)
 catalog. You can also install a different valid Agent Plugins 1.0 package from
@@ -45,8 +51,9 @@ and installed command remain `agentplugins`.
 
 Each mutation changes one selected client. `--yes` never means install
 everywhere. v0.1 supports user scope and reports whether a client can install
-automatically or requires manual activation. For older `plugin-kit-ai` installations, run the explicit migration
-before the first standard installation:
+automatically or requires manual activation. For older `plugin-kit-ai`
+installations, run the explicit migration before the first standard
+installation:
 
 ```bash
 npx --yes universal-agent-plugins@0.1.1 migrate-state --dry-run


### PR DESCRIPTION
## Summary

- install, update, and remove Agent Plugins through the official GitHub Copilot CLI marketplace flow
- let VS Code reuse the same Copilot installation and prevent duplicate shared-backend bindings
- generate valid managed marketplace packages for Copilot and Codex
- print exact local next steps for Codex, ChatGPT, Kiro, and VS Code without leaking paths in JSON output
- keep preview and dry-run free of external client mutations

## Verification

- make test-required
- make generated-check
- make vet
- npm agentplugins tests and package contract tests
- isolated Copilot CLI 1.0.78 add, dry-run remove, remove, and shared-backend E2E
- isolated Codex CLI 0.144.1 marketplace add, plugin add, plugin remove, and marketplace remove E2E

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatically install, update, and remove GitHub Copilot CLI integrations through a managed local marketplace.
  - Detect Copilot installations and enable compatible VS Code setups automatically.
  - Support selecting Copilot and VS Code together while preventing conflicting installations.
  - Provide clearer activation, deactivation, confirmation, and recovery guidance.

- **Documentation**
  - Added setup and migration guidance for Copilot, VS Code, Codex/ChatGPT, and Kiro.
  - Clarified when manual client confirmation or path-specific follow-up steps are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->