### PR TITLE
fix(release): wait for npm registry propagation

### DIFF
--- a/.github/workflows/agentplugins-npm-publish.yml
+++ b/.github/workflows/agentplugins-npm-publish.yml
@@ -128,6 +128,19 @@ jobs:
           export GIT_CONFIG_NOSYSTEM=1
           export GIT_TERMINAL_PROMPT=0
           printf '%s\n' 'registry=https://registry.npmjs.org/' > "${NPM_CONFIG_USERCONFIG}"
+          available=false
+          for attempt in 1 2 3 4 5 6; do
+            published_version="$(npm view "${NPM_PACKAGE}@${version}" version 2>/dev/null || true)"
+            dist_tags="$(npm view "${NPM_PACKAGE}" dist-tags --json 2>/dev/null || true)"
+            if [[ "${published_version}" = "${version}" ]] && \
+              jq -e --arg version "${version}" '.latest == $version' <<<"${dist_tags}" >/dev/null 2>&1; then
+              available=true
+              break
+            fi
+            echo "waiting for ${NPM_PACKAGE}@${version} registry propagation (${attempt}/6)" >&2
+            sleep 10
+          done
+          test "${available}" = true
           npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"
           npm audit signatures --json --include-attestations > audit-signatures.json
           jq -e --arg package "${NPM_PACKAGE}" --arg version "${version}" '
@@ -142,19 +155,7 @@ jobs:
           run_agentplugins() {
             npm exec --yes --package="${NPM_PACKAGE}@${version}" -- agentplugins "$@"
           }
-          available=false
-          for attempt in 1 2 3 4 5 6; do
-            if run_agentplugins version | grep -Fx "agentplugins ${version}"; then
-              dist_tags="$(npm view "${NPM_PACKAGE}" dist-tags --json)"
-              if jq -e --arg version "${version}" '.latest == $version' <<<"${dist_tags}" >/dev/null; then
-                available=true
-                break
-              fi
-            fi
-            echo "waiting for ${NPM_PACKAGE}@${version} registry propagation (${attempt}/6)" >&2
-            sleep 10
-          done
-          test "${available}" = true
+          run_agentplugins version | grep -Fx "agentplugins ${version}"
           run_agentplugins add context7 --target cursor --yes --format json > add.json
           jq -e '.schema_version == 1 and .command == "add" and .data.result.mutated == true' add.json
           run_agentplugins info context7 --format json > info.json

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -88,6 +88,8 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	}
 	mustAppearBefore(t, npmPublishJob, "npm publish --access public --tag latest --provenance", "Verify exact published stable lifecycle from a clean project")
 	mustAppearBefore(t, npmPublishJob, `npm view "${NPM_PACKAGE}@${version}" version`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
+	mustAppearBefore(t, npmPublishJob, `npm view "${NPM_PACKAGE}" dist-tags --json`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
+	mustAppearBefore(t, npmPublishJob, `test "${available}" = true`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
 	mustAppearBefore(t, npmPublishJob, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`, "npm audit signatures --json --include-attestations")
 	mustAppearBefore(t, npmPublishJob, "npm audit signatures --json --include-attestations", "run_agentplugins version")
 

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -61,6 +61,7 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		"grep -q 'E404'",
 		"unable to prove whether ${package_name} already exists in npm",
 		`NPM_PACKAGE: ${{ steps.publish-gate.outputs.package_name }}`,
+		`npm view "${NPM_PACKAGE}@${version}" version`,
 		`npm view "${NPM_PACKAGE}" dist-tags --json`,
 		"npm publish --access public --tag latest --provenance",
 		"trusted publishing only supports existing packages",
@@ -86,6 +87,7 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		mustNotContain(t, npmPublishJob, unwanted)
 	}
 	mustAppearBefore(t, npmPublishJob, "npm publish --access public --tag latest --provenance", "Verify exact published stable lifecycle from a clean project")
+	mustAppearBefore(t, npmPublishJob, `npm view "${NPM_PACKAGE}@${version}" version`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
 	mustAppearBefore(t, npmPublishJob, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`, "npm audit signatures --json --include-attestations")
 	mustAppearBefore(t, npmPublishJob, "npm audit signatures --json --include-attestations", "run_agentplugins version")
 


### PR DESCRIPTION
## Summary

- wait until the exact npm version and `latest` dist-tag are visible before the clean install
- keep signature, provenance, version, lifecycle, and path-leak checks unchanged
- protect every propagation gate with repository contract assertions

## Reason

The `0.1.2` package published successfully, but its post-publish smoke attempted `npm install` before registry propagation and produced a false red run. The package became available immediately afterward and passed the complete public lifecycle E2E.

## Verification

- [x] `go test ./repotests`
- [x] focused release contract test
- [x] CodeRabbit review finding addressed

## Release impact

- [x] no CLI or package behavior change
- [x] no version bump required
- [x] next npm release waits for registry propagation before install
