### PR TITLE
feat(agentplugins): simplify confirmation UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Want to use a plugin rather than author one? `universal-agent-plugins` is the
 standard-first npm installer built on this repository's lifecycle engine:
 
 ```bash
-npx --yes universal-agent-plugins@0.1.1 add context7
+npx universal-agent-plugins@0.1.3 add context7
 ```
 
 It reads the root `plugin.json` defined by Agent Plugins 1.0 and plans, prepares,
@@ -35,8 +35,8 @@ required client confirmation and receive an exact, path-specific next step in
 human-readable output.
 
 ```bash
-npx --yes universal-agent-plugins@0.1.1 add context7 --dry-run --target cursor
-npx --yes universal-agent-plugins@0.1.1 add context7 --target cursor --yes
+npx universal-agent-plugins@0.1.3 add context7 --dry-run --target cursor
+npx universal-agent-plugins@0.1.3 add context7 --target cursor
 ```
 
 Short names resolve through the pinned catalog, while a local directory or an

--- a/cli/plugin-kit-ai/cmd/agentplugins/catalog-v1.json
+++ b/cli/plugin-kit-ai/cmd/agentplugins/catalog-v1.json
@@ -3,8 +3,8 @@
   "schema_version": 1,
   "catalog_version": "0.1.0",
   "repository": "777genius/universal-agent-plugins",
-  "revision": "e201a0a1f8b3894862f69267e14994b2d9f7fd51",
-  "published_at": "2026-08-08T08:00:00Z",
+  "revision": "85bdea44799f2970c20b51d675f6d365fee3dbef",
+  "published_at": "2026-08-08T18:46:47Z",
   "plugins": [
     {
       "name": "agent-code-navigator",
@@ -12,7 +12,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/agent-code-navigator",
-      "tree_digest": "sha256:ba782f20aefdd62fad2dd03fe07e22996bff468a21f5823fd1b0eafca49f48ee",
+      "tree_digest": "sha256:9ea3846fd168322f46da9397ee2c6068eb53cebfca6903d0c3db256d77e38175",
       "manifest_digest": "sha256:675fb48dff9431f75e2986211039b3bfb04860a84d6a5bd157b9658514a2394e",
       "components": [
         "skills"
@@ -51,7 +51,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/atlassian",
-      "tree_digest": "sha256:4a183e1d387a8f8958923432f260a052bbf6f49cd0426f0a42e0417d9b1043b7",
+      "tree_digest": "sha256:17266edb0d757c14adc0c3ba07cbfc8a1b5b648f292b1ea799ad087df9a3b3af",
       "manifest_digest": "sha256:e83ade754f1251554622e4b48d596ebf72510bd7292b19a7793df4de8e546d04",
       "components": [
         "mcp"
@@ -90,7 +90,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/chrome-devtools",
-      "tree_digest": "sha256:4977d4092f34d54268c8d599b67754f494d718409fa9c9f2e410518570bb9267",
+      "tree_digest": "sha256:ef9f503ec6a6d34f36fb13ee17376c69f578be15896aa49fdd4c5164925f297d",
       "manifest_digest": "sha256:e7d43a8e39b0e83f2c05777e297f6a3884002dc2601d70528b55a44132db8091",
       "components": [
         "mcp"
@@ -129,7 +129,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/cloudflare",
-      "tree_digest": "sha256:ba8db74355175406e6131f221d6f1b2df2d74109913832a04496c7498d486008",
+      "tree_digest": "sha256:dc93797949592c138bda0592d13a09b9d07158e333a9df2c4beaec7d568a3f75",
       "manifest_digest": "sha256:9bec7cfed2ecb217145c2a02658296670a328416566433518b4da0246e91d382",
       "components": [
         "mcp"
@@ -168,7 +168,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/cloudflare-bindings",
-      "tree_digest": "sha256:2b296eada51f082946de68fe9f38b4a899abbf9951ad9f45a654ec150cf379ce",
+      "tree_digest": "sha256:833653c9b11a8242a7f0e115b2d101feb595937c4fde93708f5471cabcfcc8b6",
       "manifest_digest": "sha256:6b945cf035f784216e71425cf7b6ca477b27a2069d2580e9713a65f5ec2ca0bf",
       "components": [
         "mcp"
@@ -207,7 +207,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/cloudflare-docs",
-      "tree_digest": "sha256:88d31b33a6169f7f55d5f9c0feea162e39a0ba8d227bd1bd85f89390ab288318",
+      "tree_digest": "sha256:d2a0a22ababf569198a742c18ede0fe6037f7a0bc49f2d674d936310cf057ff5",
       "manifest_digest": "sha256:6b575562e527194ccd31238fde8c5f764409ecc98e211e92dfb81455eef88bdd",
       "components": [
         "mcp"
@@ -246,7 +246,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/cloudflare-observability",
-      "tree_digest": "sha256:513def2899e3ce12ac8d6834b608f1d045a027f7ea1eab18e8f7b02c3ab98b58",
+      "tree_digest": "sha256:5a4dcb7e0de469cffad69b223c0ce95e6fae3760c3796e0391768838d1c7d676",
       "manifest_digest": "sha256:41573bb020202619d72fe2cbbf35c56cb5ed4b885b17867ffd2e4a74ebcb5064",
       "components": [
         "mcp"
@@ -285,7 +285,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/cloudflare-radar",
-      "tree_digest": "sha256:2c1cf647e3504a7c8d502b2438543246d32cfce371c80c425678421477ec050d",
+      "tree_digest": "sha256:765aad1d8742a4f9c74662f67d696d94a0ce6e3ff1214b22e2abaa81868a540c",
       "manifest_digest": "sha256:cf94d10bad7d902f4ed171d2363854fb93409ac79a1c5e02d152be6448d66fc2",
       "components": [
         "mcp"
@@ -324,7 +324,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/context7",
-      "tree_digest": "sha256:0efc3edefc3add644a4384159f7d8979e42adfe1fa635661331385f6eec4aba3",
+      "tree_digest": "sha256:e4f1a4cd941b03743869a94ecafe6a1aded9c991c5c09eceffdcb708dfc953de",
       "manifest_digest": "sha256:341c54728c2f50d3876b12a6e94ba06751c94d2be215037846d06f93a018434e",
       "components": [
         "mcp"
@@ -363,7 +363,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/docker-hub",
-      "tree_digest": "sha256:0d37034973c15a6bcd06dd76d64430c722cf3affbafa63a650a3409da7c16e55",
+      "tree_digest": "sha256:5f7a893b6368ecd82195907e091ac63ea7288247a609fd5cea4b8b5c6ef6b69d",
       "manifest_digest": "sha256:413347fe45d0dbcbd5b4d5cf88eb7e0ec5c0cd080486ea4cb8c3f61f0bd7a95d",
       "components": [
         "mcp"
@@ -402,7 +402,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/figma",
-      "tree_digest": "sha256:08c71c3f67c4be21da8a38c193640f23c6957a3e1f9a5286ef8c23d2546ae971",
+      "tree_digest": "sha256:5e5ce333c6f213970d0c92196b596eb1a0705ce7a76fdc93c60c143b53b1d20d",
       "manifest_digest": "sha256:67fbfd8062a7f3d965ee63cc68f392a6afb1e8861e3bcc5fe1f70e7e9fadabba",
       "components": [
         "mcp"
@@ -446,7 +446,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/firebase",
-      "tree_digest": "sha256:52472451dd010bae37f2c93422e63a4ef5c1f3db4885ae2783c11bd6ceea1f65",
+      "tree_digest": "sha256:e5d1c691e4a409b7297b53fee6581850c4fc9adff1b261cda7976e5b02ceee97",
       "manifest_digest": "sha256:9883d7c5b0472304f799df862f52d3cdae3120b3324633d6a58fceceb78da7b7",
       "components": [
         "mcp"
@@ -485,7 +485,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/github",
-      "tree_digest": "sha256:9c86bcb4418dc653aa7a37478cc871c0738d6817269f67472ee6b78504bed7c3",
+      "tree_digest": "sha256:c0ac7e6b561ea073ad174aa9e127841d6c8878e604fde861d0fbd0d6a2960865",
       "manifest_digest": "sha256:091e37c5f33c0a92f77070cfcb1b03759b2637927281c04d989e6c8fef888cae",
       "components": [
         "mcp"
@@ -529,7 +529,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/gitlab",
-      "tree_digest": "sha256:6f28455dff4f677b25731368e87b55a90cebda85ceddfcdd3f7b36b2bdcfb95a",
+      "tree_digest": "sha256:0495772011f6a810fe89876f5970c7bbc5142fffb873b2fee65b4de0573f8177",
       "manifest_digest": "sha256:1a181fab20d9520f5f006f4237e88d67cf58d29b9994dbc45ee4c80d2474e080",
       "components": [
         "mcp"
@@ -568,7 +568,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/greptile",
-      "tree_digest": "sha256:3c5431043ff6ff579ae3546619dcaf30d29d69e0f52063690e4e94551e249934",
+      "tree_digest": "sha256:d5ae01ce0f88f6a0e74ae1374fc8762f2180550916314f30e6e1e2c3ee149da3",
       "manifest_digest": "sha256:05b29500564aede5274a6d21c0cf5bb4727e995045b04de170913b7ef2ae07bb",
       "components": [
         "mcp"
@@ -607,7 +607,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/heroku",
-      "tree_digest": "sha256:2687e36cf49889ba81e8cef79a9bdd3f107628b67c9851832a572174954e1de7",
+      "tree_digest": "sha256:f05e7b102072a201cd2b4ff82300bedb0a863f279a4cb7f315b0b8ee077dcb66",
       "manifest_digest": "sha256:5b7c088e290ed04b0eafe0275dc806e7c2153dd7cbe6b74d1c5f1d2961e9355a",
       "components": [
         "mcp"
@@ -646,7 +646,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/hubspot-crm",
-      "tree_digest": "sha256:d1732d392ffac4b2a2042f74a3ccb34379ce7ec6debeb7e82a0451ea50472adf",
+      "tree_digest": "sha256:5ec6335b78a6b97fab797c5302722b2e911fd67a10ef169c5c844d34f3ca3396",
       "manifest_digest": "sha256:20334e86a1b599d2759e04bfaef37dc2ddb7f6b0f3994b5d66d4eca12fbec941",
       "components": [
         "mcp"
@@ -685,7 +685,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/hubspot-developer",
-      "tree_digest": "sha256:bb570b3ec8d7fa6abd480a058650407a14c80d7d795449804a7d01f4afe9ad79",
+      "tree_digest": "sha256:721ac10f15755591601eb13819620be582da922225469e952e6cc8a7585e854f",
       "manifest_digest": "sha256:257a75ed2e473945a26afa102152f866bd8269bb41c998f6d87fbdf43ed1a6b9",
       "components": [
         "mcp"
@@ -724,7 +724,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/linear",
-      "tree_digest": "sha256:2744fa84a26fbabbc178abb0691ff85c659a41175ac1fd032d0eef1d7c16c3f3",
+      "tree_digest": "sha256:b443c5b4a6cc11be57f7bac9de744066846276d4cd5922bd02818d8a76afb2d4",
       "manifest_digest": "sha256:0b8ed223c21d206d802130ace7219b5c78af1903675640cc77f5195e4f86ef70",
       "components": [
         "mcp"
@@ -768,7 +768,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/neon",
-      "tree_digest": "sha256:38fe4225cf86e8c88665334ccc6e9e84b3ac8880ffae0edff94a12dcb4890137",
+      "tree_digest": "sha256:980b66094b63f3ec073864db27a3f0b40d497917487dbc2f594bad46fadf12ef",
       "manifest_digest": "sha256:6787894c7d3e033db05deee5e36358caf387493a98a78716d6db4b343e9c0698",
       "components": [
         "mcp"
@@ -807,7 +807,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/notion",
-      "tree_digest": "sha256:404ddfde0a2d08c4d28ad6511616954d0ae2f6259093658a9e3b0e842f106a83",
+      "tree_digest": "sha256:73b180af71006641968249c81795b4315a380f589d90f9943d894297e09a0c4d",
       "manifest_digest": "sha256:bbab30a4f062218d7a5fce2f6c818680d3c7adfaebdbaa3e523e15942a2f57e5",
       "components": [
         "mcp"
@@ -851,7 +851,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/sentry",
-      "tree_digest": "sha256:77a6245be9cb7b704e7fa4e31a7b60d185fdd67fc9a9dbf10226d0b33a27f9bb",
+      "tree_digest": "sha256:f05770b0d784df29d25f5f5365687301085086730d817fa7a064876dead80f54",
       "manifest_digest": "sha256:7606b1f8af700ea76590f0ae586ff8586f4dc370f536ceedbeab8d934494e42e",
       "components": [
         "mcp"
@@ -890,7 +890,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/statsig",
-      "tree_digest": "sha256:77ca245f2184f64b709d001255abcd461c5fc71ad81ff739df56b5d45641af6e",
+      "tree_digest": "sha256:a51a09363253f4c8a593fef01b6816ae7efc953bfd23661a0a4417374fe34e4e",
       "manifest_digest": "sha256:5100526dca8f8e53e42d1d53f8acc1879ea8a2d8b0982df3f00be5e95bf3e465",
       "components": [
         "mcp"
@@ -929,7 +929,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/stripe",
-      "tree_digest": "sha256:627d2b176da1d722f494b1d40a2a6c5fbcd5030ea948423a787f1b7cfcc329fa",
+      "tree_digest": "sha256:68471c6c4fe88b35c3ea9eaff5d80b2d0b9a643db1e1458c95433e65b182a7f0",
       "manifest_digest": "sha256:e70885fda5a4ce50c302891229e204bbf22904ec3f227670e5916d69f9b8b80d",
       "components": [
         "mcp"
@@ -968,7 +968,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/supabase",
-      "tree_digest": "sha256:e35779973c44d94b315e57e1a61f91922a181319a9af9fd7f65eda44eae23080",
+      "tree_digest": "sha256:e5c7a17e9dae43f15224243d75e58ed6b18c386f22ad7f264e047c557796278e",
       "manifest_digest": "sha256:bb0672e8cd411b1c8e0872a5f7f0abc95f9c68f008802d42a2cd16a689deeb11",
       "components": [
         "mcp"
@@ -1007,7 +1007,7 @@
       "agent_plugins_schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       "minimum_cli_version": "0.1.0",
       "source_path": "plugins/vercel",
-      "tree_digest": "sha256:9e5cbaf441c338e1ea30f6b93b7173d8d6e1057ec0d2821209f5f8921c81fb10",
+      "tree_digest": "sha256:2a1560a7c24263b2ca9176d4a3a1d2fc9443ac539a9bc852ef7d767a386ea4ff",
       "manifest_digest": "sha256:23f7cd28573c4ab10943178db05a47f2af3639518a334449c23d89b19562ef74",
       "components": [
         "mcp"

--- a/cli/plugin-kit-ai/cmd/agentplugins/main.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins/main.go
@@ -30,7 +30,7 @@ import (
 var (
 	version              = "0.1.0-development"
 	defaultCatalogURL    = ""
-	defaultCatalogDigest = "sha256:5578f1d46dd22cd68da233ab7c38e353955b285dc4be3bff5006bdfbb8436f03"
+	defaultCatalogDigest = "sha256:b1e3efcdc7bd3fc5cc64c959f96964818b1cbfd815cbd125045c02757c767c30"
 	//go:embed catalog-v1.json
 	embeddedCatalog []byte
 )

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -24,6 +24,18 @@ import (
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/usecase"
 )
 
+func TestHelpKeepsAutomationConfirmationFlagOutOfUserFlow(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, nil)
+	stdout, _, err := fixture.execute(true, "--help")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stdout, "--yes") {
+		t.Fatalf("user-facing help exposed the automation-only flag: %s", stdout)
+	}
+}
+
 func TestAddListAndInfoProduceVersionedPathRedactedJSON(t *testing.T) {
 	t.Parallel()
 	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})

--- a/cli/plugin-kit-ai/internal/agentpluginscli/root.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/root.go
@@ -23,6 +23,7 @@ func NewRoot(app App) *cobra.Command {
 	flags.StringVar(&opts.scope, "scope", "user", "installation scope: user or project")
 	flags.BoolVar(&opts.dryRun, "dry-run", false, "show the exact plan without changes")
 	flags.BoolVar(&opts.yes, "yes", false, "confirm this selected target without installing everywhere")
+	_ = flags.MarkHidden("yes")
 	flags.StringVar(&opts.format, "format", "human", "output format: human or json")
 	flags.BoolVar(&opts.noColor, "no-color", false, "disable color output")
 

--- a/npm/agentplugins/README.md
+++ b/npm/agentplugins/README.md
@@ -4,7 +4,7 @@ Install and manage portable Agent Plugins 1.0 packages across Codex/ChatGPT,
 Cursor, GitHub Copilot/VS Code, and Kiro.
 
 ```bash
-npx --yes universal-agent-plugins@0.1.1 add context7
+npx universal-agent-plugins@0.1.3 add context7
 ```
 
 `universal-agent-plugins` is an independent community CLI built in
@@ -20,12 +20,12 @@ tarball, then caches it under XDG Cache or LocalAppData. It never falls back to
 `latest` and never sends `GITHUB_TOKEN` to public downloads.
 
 ```bash
-npx --yes universal-agent-plugins@0.1.1 doctor
-npx --yes universal-agent-plugins@0.1.1 list
-npx --yes universal-agent-plugins@0.1.1 add context7 --dry-run --target cursor
-npx --yes universal-agent-plugins@0.1.1 add context7 --target cursor --yes
-npx --yes universal-agent-plugins@0.1.1 update context7 --target cursor --yes
-npx --yes universal-agent-plugins@0.1.1 remove context7 --target cursor --yes
+npx universal-agent-plugins@0.1.3 doctor
+npx universal-agent-plugins@0.1.3 list
+npx universal-agent-plugins@0.1.3 add context7 --dry-run --target cursor
+npx universal-agent-plugins@0.1.3 add context7 --target cursor
+npx universal-agent-plugins@0.1.3 update context7 --target cursor
+npx universal-agent-plugins@0.1.3 remove context7 --target cursor
 ```
 
 For GitHub Copilot CLI, `agentplugins` performs the native install, update, and
@@ -40,8 +40,8 @@ catalog. You can also install a different valid Agent Plugins 1.0 package from
 a local directory or an exact GitHub source:
 
 ```bash
-npx --yes universal-agent-plugins@0.1.1 add ./my-plugin --target cursor --yes
-npx --yes universal-agent-plugins@0.1.1 add owner/repo@commit//plugins/my-plugin --target cursor --yes
+npx universal-agent-plugins@0.1.3 add ./my-plugin --target cursor
+npx universal-agent-plugins@0.1.3 add owner/repo@commit//plugins/my-plugin --target cursor
 ```
 
 The package must have a root `plugin.json` using the supported Agent Plugins
@@ -49,15 +49,14 @@ The package must have a root `plugin.json` using the supported Agent Plugins
 installed only where the selected client supports them. The downloaded binary
 and installed command remain `agentplugins`.
 
-Each mutation changes one selected client. `--yes` never means install
-everywhere. v0.1 supports user scope and reports whether a client can install
-automatically or requires manual activation. For older `plugin-kit-ai`
-installations, run the explicit migration before the first standard
-installation:
+Each mutation changes one selected client and asks before changing it. v0.1
+supports user scope and reports whether a client can install automatically or
+requires manual activation. For older `plugin-kit-ai` installations, run the
+explicit migration before the first standard installation:
 
 ```bash
-npx --yes universal-agent-plugins@0.1.1 migrate-state --dry-run
-npx --yes universal-agent-plugins@0.1.1 migrate-state --yes
+npx universal-agent-plugins@0.1.3 migrate-state --dry-run
+npx universal-agent-plugins@0.1.3 migrate-state
 ```
 
 The migration validates the complete State v2 result, creates a byte-for-byte


### PR DESCRIPTION
## Summary
- remove `--yes` from every public agentplugins command example
- keep interactive plan confirmation as the default safety boundary
- hide the automation-only flag from normal help output
- update npm-facing examples for the 0.1.3 patch release

## Validation
- agentplugins CLI tests
- npm bootstrap tests
- formatting and diff checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation and migration examples to use version 0.1.3.
  * Simplified commands by removing unnecessary automatic-confirmation options.
  * Clarified separate preview and installation steps for cursor setup.
* **User Experience**
  * The `--help` output now omits the automation-only `--yes` option.
  * Standard changes prompt for confirmation before applying updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->