### PR TITLE
fix(agentplugins): isolate registry verification

### DIFF
--- a/.github/workflows/agentplugins-npm-publish.yml
+++ b/.github/workflows/agentplugins-npm-publish.yml
@@ -14,6 +14,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     environment: npm-agentplugins
+    outputs:
+      package_name: ${{ steps.publish-gate.outputs.package_name }}
     permissions:
       contents: read
       id-token: write
@@ -104,10 +106,25 @@ jobs:
       - name: Publish stable release with provenance
         working-directory: ${{ runner.temp }}/agentplugins-npm
         run: npm publish --access public --tag latest --provenance
+
+  verify:
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Install pinned npm with provenance verification support
+        run: npm install --global npm@12.0.2
       - name: Verify exact published stable lifecycle from a clean project
         env:
           TAG: ${{ inputs.tag }}
-          NPM_PACKAGE: ${{ steps.publish-gate.outputs.package_name }}
+          NPM_PACKAGE: ${{ needs.publish.outputs.package_name }}
         run: |
           version="${TAG#agentplugins-v}"
           project="${RUNNER_TEMP}/agentplugins-registry-smoke"
@@ -129,15 +146,16 @@ jobs:
           export GIT_TERMINAL_PROMPT=0
           printf '%s\n' 'registry=https://registry.npmjs.org/' > "${NPM_CONFIG_USERCONFIG}"
           available=false
-          for attempt in 1 2 3 4 5 6; do
-            published_version="$(npm view "${NPM_PACKAGE}@${version}" version 2>/dev/null || true)"
-            dist_tags="$(npm view "${NPM_PACKAGE}" dist-tags --json 2>/dev/null || true)"
+          max_attempts=30
+          for attempt in $(seq 1 "${max_attempts}"); do
+            published_version="$(npm view --prefer-online "${NPM_PACKAGE}@${version}" version 2>/dev/null || true)"
+            dist_tags="$(npm view --prefer-online "${NPM_PACKAGE}" dist-tags --json 2>/dev/null || true)"
             if [[ "${published_version}" = "${version}" ]] && \
               jq -e --arg version "${version}" '.latest == $version' <<<"${dist_tags}" >/dev/null 2>&1; then
               available=true
               break
             fi
-            echo "waiting for ${NPM_PACKAGE}@${version} registry propagation (${attempt}/6)" >&2
+            echo "waiting for ${NPM_PACKAGE}@${version} registry propagation (${attempt}/${max_attempts})" >&2
             sleep 10
           done
           test "${available}" = true

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Want to use a plugin rather than author one? `universal-agent-plugins` is the
 standard-first npm installer built on this repository's lifecycle engine:
 
 ```bash
-npx universal-agent-plugins@0.1.3 add context7
+npx universal-agent-plugins@0.1.4 add context7
 ```
 
 It reads the root `plugin.json` defined by Agent Plugins 1.0 and plans, prepares,
@@ -35,8 +35,8 @@ required client confirmation and receive an exact, path-specific next step in
 human-readable output.
 
 ```bash
-npx universal-agent-plugins@0.1.3 add context7 --dry-run --target cursor
-npx universal-agent-plugins@0.1.3 add context7 --target cursor
+npx universal-agent-plugins@0.1.4 add context7 --dry-run --target cursor
+npx universal-agent-plugins@0.1.4 add context7 --target cursor
 ```
 
 Short names resolve through the pinned catalog, while a local directory or an

--- a/docs/agentplugins-release.md
+++ b/docs/agentplugins-release.md
@@ -70,7 +70,9 @@ read-only `doctor`, no-change `update`, `remove`, and final absent-state
 verification in an isolated HOME.
 It must prove the `latest` dist-tag resolves to the exact published version and
 JSON output contains no absolute runner paths before the gate is returned to
-`false`.
+`false`. Registry verification runs as a separate job after publication, waits
+up to five minutes with online metadata refreshes, and can be retried without
+attempting to republish an immutable npm version.
 
 Never publish an empty placeholder, reuse a tag, overwrite release assets, or
 resolve a binary through an unpinned GitHub `latest` release.

--- a/npm/agentplugins/README.md
+++ b/npm/agentplugins/README.md
@@ -4,7 +4,7 @@ Install and manage portable Agent Plugins 1.0 packages across Codex/ChatGPT,
 Cursor, GitHub Copilot/VS Code, and Kiro.
 
 ```bash
-npx universal-agent-plugins@0.1.3 add context7
+npx universal-agent-plugins@0.1.4 add context7
 ```
 
 `universal-agent-plugins` is an independent community CLI built in
@@ -20,12 +20,12 @@ tarball, then caches it under XDG Cache or LocalAppData. It never falls back to
 `latest` and never sends `GITHUB_TOKEN` to public downloads.
 
 ```bash
-npx universal-agent-plugins@0.1.3 doctor
-npx universal-agent-plugins@0.1.3 list
-npx universal-agent-plugins@0.1.3 add context7 --dry-run --target cursor
-npx universal-agent-plugins@0.1.3 add context7 --target cursor
-npx universal-agent-plugins@0.1.3 update context7 --target cursor
-npx universal-agent-plugins@0.1.3 remove context7 --target cursor
+npx universal-agent-plugins@0.1.4 doctor
+npx universal-agent-plugins@0.1.4 list
+npx universal-agent-plugins@0.1.4 add context7 --dry-run --target cursor
+npx universal-agent-plugins@0.1.4 add context7 --target cursor
+npx universal-agent-plugins@0.1.4 update context7 --target cursor
+npx universal-agent-plugins@0.1.4 remove context7 --target cursor
 ```
 
 For GitHub Copilot CLI, `agentplugins` performs the native install, update, and
@@ -40,8 +40,8 @@ catalog. You can also install a different valid Agent Plugins 1.0 package from
 a local directory or an exact GitHub source:
 
 ```bash
-npx universal-agent-plugins@0.1.3 add ./my-plugin --target cursor
-npx universal-agent-plugins@0.1.3 add owner/repo@commit//plugins/my-plugin --target cursor
+npx universal-agent-plugins@0.1.4 add ./my-plugin --target cursor
+npx universal-agent-plugins@0.1.4 add owner/repo@commit//plugins/my-plugin --target cursor
 ```
 
 The package must have a root `plugin.json` using the supported Agent Plugins
@@ -55,8 +55,8 @@ requires manual activation. For older `plugin-kit-ai` installations, run the
 explicit migration before the first standard installation:
 
 ```bash
-npx universal-agent-plugins@0.1.3 migrate-state --dry-run
-npx universal-agent-plugins@0.1.3 migrate-state
+npx universal-agent-plugins@0.1.4 migrate-state --dry-run
+npx universal-agent-plugins@0.1.4 migrate-state
 ```
 
 The migration validates the complete State v2 result, creates a byte-for-byte

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -11,6 +11,7 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	releaseWorkflow := readRepoFile(t, root, ".github", "workflows", "agentplugins-release.yml")
 	npmWorkflow := readRepoFile(t, root, ".github", "workflows", "agentplugins-npm-publish.yml")
 	npmPublishJob := yamlJob(t, npmWorkflow, "publish")
+	npmVerifyJob := yamlJob(t, npmWorkflow, "verify")
 	removedBoundaryScript := readRepoFile(t, root, "scripts", "check-removed-contract-boundary.sh")
 	runbook := readRepoFile(t, root, "docs", "agentplugins-release.md")
 
@@ -60,21 +61,23 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		`npm view "${package_name}" versions --json`,
 		"grep -q 'E404'",
 		"unable to prove whether ${package_name} already exists in npm",
-		`NPM_PACKAGE: ${{ steps.publish-gate.outputs.package_name }}`,
-		`npm view "${NPM_PACKAGE}@${version}" version`,
-		`npm view "${NPM_PACKAGE}" dist-tags --json`,
 		"npm publish --access public --tag latest --provenance",
 		"trusted publishing only supports existing packages",
-		".latest == $version",
 	} {
 		mustContain(t, npmPublishJob, want)
 	}
 	for _, want := range []string{
+		"needs: publish",
+		`NPM_PACKAGE: ${{ needs.publish.outputs.package_name }}`,
+		`npm view --prefer-online "${NPM_PACKAGE}@${version}" version`,
+		`npm view --prefer-online "${NPM_PACKAGE}" dist-tags --json`,
+		".latest == $version",
+		"max_attempts=30",
 		`npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`,
 		"npm audit signatures --json --include-attestations",
 		`.attestations.provenance.predicateType == "https://slsa.dev/provenance/v1"`,
 	} {
-		mustContain(t, npmPublishJob, want)
+		mustContain(t, npmVerifyJob, want)
 	}
 	for _, unwanted := range []string{
 		"npm view agentplugins versions --json",
@@ -84,14 +87,15 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		"NPM_TOKEN",
 		"NODE_AUTH_TOKEN",
 	} {
-		mustNotContain(t, npmPublishJob, unwanted)
+		mustNotContain(t, npmWorkflow, unwanted)
 	}
-	mustAppearBefore(t, npmPublishJob, "npm publish --access public --tag latest --provenance", "Verify exact published stable lifecycle from a clean project")
-	mustAppearBefore(t, npmPublishJob, `npm view "${NPM_PACKAGE}@${version}" version`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
-	mustAppearBefore(t, npmPublishJob, `npm view "${NPM_PACKAGE}" dist-tags --json`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
-	mustAppearBefore(t, npmPublishJob, `test "${available}" = true`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
-	mustAppearBefore(t, npmPublishJob, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`, "npm audit signatures --json --include-attestations")
-	mustAppearBefore(t, npmPublishJob, "npm audit signatures --json --include-attestations", "run_agentplugins version")
+	mustNotContain(t, npmPublishJob, "Verify exact published stable lifecycle from a clean project")
+	mustNotContain(t, npmVerifyJob, "npm publish --access public --tag latest --provenance")
+	mustAppearBefore(t, npmVerifyJob, `npm view --prefer-online "${NPM_PACKAGE}@${version}" version`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
+	mustAppearBefore(t, npmVerifyJob, `npm view --prefer-online "${NPM_PACKAGE}" dist-tags --json`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
+	mustAppearBefore(t, npmVerifyJob, `test "${available}" = true`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
+	mustAppearBefore(t, npmVerifyJob, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`, "npm audit signatures --json --include-attestations")
+	mustAppearBefore(t, npmVerifyJob, "npm audit signatures --json --include-attestations", "run_agentplugins version")
 
 	mustContain(t, removedBoundaryScript, "if command -v rg")
 	mustContain(t, removedBoundaryScript, "git grep --untracked --exclude-standard")


### PR DESCRIPTION
## Summary
- separate immutable npm publication from retryable registry verification
- wait up to five minutes and force online metadata refreshes
- keep lifecycle, signature, provenance, and latest-tag checks fail-closed
- prepare the 0.1.4 patch release

## Why
0.1.3 published successfully, but npm registry propagation exceeded the previous 60-second post-publish window. The separate verification job can be retried without attempting to overwrite an immutable npm version.

## Validation
- repository release contract suite
- agentplugins CLI tests
- npm bootstrap tests
- formatting and diff checks