### PR TITLE
fix(release): verify npm latest across npm 12 output changes

### DIFF
--- a/.github/workflows/agentplugins-npm-publish.yml
+++ b/.github/workflows/agentplugins-npm-publish.yml
@@ -149,9 +149,9 @@ jobs:
           max_attempts=30
           for attempt in $(seq 1 "${max_attempts}"); do
             published_version="$(npm view --prefer-online "${NPM_PACKAGE}@${version}" version 2>/dev/null || true)"
-            dist_tags="$(npm view --prefer-online "${NPM_PACKAGE}" dist-tags --json 2>/dev/null || true)"
+            latest_version="$(npm view --prefer-online "${NPM_PACKAGE}@latest" version 2>/dev/null || true)"
             if [[ "${published_version}" = "${version}" ]] && \
-              jq -e --arg version "${version}" '.latest == $version' <<<"${dist_tags}" >/dev/null 2>&1; then
+              [[ "${latest_version}" = "${version}" ]]; then
               available=true
               break
             fi

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -70,8 +70,8 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		"needs: publish",
 		`NPM_PACKAGE: ${{ needs.publish.outputs.package_name }}`,
 		`npm view --prefer-online "${NPM_PACKAGE}@${version}" version`,
-		`npm view --prefer-online "${NPM_PACKAGE}" dist-tags --json`,
-		".latest == $version",
+		`npm view --prefer-online "${NPM_PACKAGE}@latest" version`,
+		`[[ "${latest_version}" = "${version}" ]]`,
 		"max_attempts=30",
 		`npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`,
 		"npm audit signatures --json --include-attestations",
@@ -92,7 +92,7 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	mustNotContain(t, npmPublishJob, "Verify exact published stable lifecycle from a clean project")
 	mustNotContain(t, npmVerifyJob, "npm publish --access public --tag latest --provenance")
 	mustAppearBefore(t, npmVerifyJob, `npm view --prefer-online "${NPM_PACKAGE}@${version}" version`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
-	mustAppearBefore(t, npmVerifyJob, `npm view --prefer-online "${NPM_PACKAGE}" dist-tags --json`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
+	mustAppearBefore(t, npmVerifyJob, `npm view --prefer-online "${NPM_PACKAGE}@latest" version`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
 	mustAppearBefore(t, npmVerifyJob, `test "${available}" = true`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
 	mustAppearBefore(t, npmVerifyJob, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`, "npm audit signatures --json --include-attestations")
 	mustAppearBefore(t, npmVerifyJob, "npm audit signatures --json --include-attestations", "run_agentplugins version")


### PR DESCRIPTION
Fix the public registry verifier after the successful 0.1.4 publication.

npm 12 returns `npm view <package> dist-tags --json` as a singleton array, while npm 11 returns an object. The old jq expression therefore waited for all 30 retries even though 0.1.4 and the latest tag were public.

This checks `<package>@latest version` as a scalar instead. It proves the same invariant without depending on npm JSON response shape.

Verification:
- targeted release contract test passes
- exact npm 12.0.2 registry query returns 0.1.4
- no publication or lifecycle behavior changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package publication verification to more reliably confirm that the latest released version is available before publication is considered complete.

* **Tests**
  * Updated release verification checks to validate the latest version directly and maintain accurate ordering expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->