### PR TITLE
fix(release): add verify-only npm recovery

### DIFF
--- a/.github/workflows/agentplugins-npm-publish.yml
+++ b/.github/workflows/agentplugins-npm-publish.yml
@@ -6,12 +6,18 @@ on:
       tag:
         description: Existing immutable stable release tag
         required: true
+      verify_only:
+        description: Verify an existing public version without publishing
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
 
 jobs:
   publish:
+    if: ${{ !inputs.verify_only }}
     runs-on: ubuntu-latest
     environment: npm-agentplugins
     outputs:
@@ -109,22 +115,43 @@ jobs:
 
   verify:
     needs: publish
+    if: ${{ always() && !cancelled() && (inputs.verify_only || needs.publish.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.tag }}
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
+      - name: Resolve immutable verification target
+        id: verify-target
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if [[ ! "${TAG}" =~ ^agentplugins-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "invalid agentplugins stable tag: ${TAG}" >&2
+            exit 1
+          fi
+          package_name="$(node -p 'require("./npm/agentplugins/package.json").name')"
+          package_name_length="$(printf '%s' "${package_name}" | wc -c | tr -d ' ')"
+          if [[ ! "${package_name}" =~ ^(@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$ ]] || [[ "${package_name_length}" -gt 214 ]]; then
+            echo "invalid npm package name in npm/agentplugins/package.json" >&2
+            exit 1
+          fi
+          echo "package_name=${package_name}" >> "${GITHUB_OUTPUT}"
       - name: Install pinned npm with provenance verification support
         run: npm install --global npm@12.0.2
       - name: Verify exact published stable lifecycle from a clean project
         env:
           TAG: ${{ inputs.tag }}
-          NPM_PACKAGE: ${{ needs.publish.outputs.package_name }}
+          NPM_PACKAGE: ${{ steps.verify-target.outputs.package_name }}
         run: |
           version="${TAG#agentplugins-v}"
           project="${RUNNER_TEMP}/agentplugins-registry-smoke"

--- a/docs/agentplugins-release.md
+++ b/docs/agentplugins-release.md
@@ -68,11 +68,16 @@ after an exact-version, scripts-disabled install verifies both the registry
 signature and SLSA provenance attestation. Only then may it run `add`, `info`,
 read-only `doctor`, no-change `update`, `remove`, and final absent-state
 verification in an isolated HOME.
-It must prove the `latest` dist-tag resolves to the exact published version and
-JSON output contains no absolute runner paths before the gate is returned to
-`false`. Registry verification runs as a separate job after publication, waits
-up to five minutes with online metadata refreshes, and can be retried without
-attempting to republish an immutable npm version.
+The publish-ready gate must be returned to `false` immediately after the publish
+job finishes, regardless of the verification result. Registry verification
+must still prove the `latest` dist-tag resolves to the exact published version
+and that JSON output contains no absolute runner paths. It runs as a separate
+job after publication, waits up to five minutes with online metadata refreshes,
+and can be retried without attempting to republish an immutable npm version.
+The same workflow can be dispatched with `verify_only=true` and the existing
+tag after publication. That mode skips the protected publish job entirely,
+does not require opening the publish-ready gate, and only runs the public
+registry and isolated lifecycle verification.
 
 Never publish an empty placeholder, reuse a tag, overwrite release assets, or
 resolve a binary through an unpinned GitHub `latest` release.

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -54,6 +54,7 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	}
 
 	for _, want := range []string{
+		"if: ${{ !inputs.verify_only }}",
 		"environment: npm-agentplugins",
 		"id-token: write",
 		`package_name="$(node -p 'require("./npm/agentplugins/package.json").name')"`,
@@ -68,7 +69,10 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	}
 	for _, want := range []string{
 		"needs: publish",
-		`NPM_PACKAGE: ${{ needs.publish.outputs.package_name }}`,
+		"always() && !cancelled() && (inputs.verify_only || needs.publish.result == 'success')",
+		`ref: ${{ inputs.tag }}`,
+		"Resolve immutable verification target",
+		`NPM_PACKAGE: ${{ steps.verify-target.outputs.package_name }}`,
 		`npm view --prefer-online "${NPM_PACKAGE}@${version}" version`,
 		`npm view --prefer-online "${NPM_PACKAGE}@latest" version`,
 		`[[ "${latest_version}" = "${version}" ]]`,
@@ -79,6 +83,8 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	} {
 		mustContain(t, npmVerifyJob, want)
 	}
+	mustContain(t, npmWorkflow, "verify_only:")
+	mustContain(t, npmWorkflow, "Verify an existing public version without publishing")
 	for _, unwanted := range []string{
 		"npm view agentplugins versions --json",
 		"npm view agentplugins version >/dev/null",
@@ -91,6 +97,9 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	}
 	mustNotContain(t, npmPublishJob, "Verify exact published stable lifecycle from a clean project")
 	mustNotContain(t, npmVerifyJob, "npm publish --access public --tag latest --provenance")
+	mustNotContain(t, npmVerifyJob, "environment: npm-agentplugins")
+	mustNotContain(t, npmVerifyJob, "id-token: write")
+	mustAppearBefore(t, npmVerifyJob, "Resolve immutable verification target", `npm view --prefer-online "${NPM_PACKAGE}@${version}" version`)
 	mustAppearBefore(t, npmVerifyJob, `npm view --prefer-online "${NPM_PACKAGE}@${version}" version`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
 	mustAppearBefore(t, npmVerifyJob, `npm view --prefer-online "${NPM_PACKAGE}@latest" version`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
 	mustAppearBefore(t, npmVerifyJob, `test "${available}" = true`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
@@ -112,6 +121,8 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		"publish through",
 		"GitHub OIDC with provenance",
 		"`latest` dist-tag resolves to the exact published version",
+		"returned to `false` immediately after the publish",
+		"dispatched with `verify_only=true`",
 	} {
 		mustContain(t, runbook, want)
 	}


### PR DESCRIPTION
Make post-publication verification genuinely retryable after workflow fixes.

The existing split publish/verify jobs prevent duplicate publication during a normal failed-job retry, but GitHub re-runs the original workflow SHA. If verifier code itself needs a fix, there was no safe way to run the corrected verifier against an immutable published version.

This adds a `verify_only` workflow input. In that mode:
- the protected publish job is skipped
- the publish-ready gate stays false
- no OIDC publish permission or npm environment is used
- package identity is resolved from the immutable release tag
- the public signature, SLSA provenance, and isolated add/info/doctor/update/remove lifecycle still run

The maintainer runbook and fail-closed contract test cover the recovery path.