### PR TITLE
docs: simplify npm installer examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Want to use a plugin rather than author one? `universal-agent-plugins` is the
 standard-first npm installer built on this repository's lifecycle engine:
 
 ```bash
-npx universal-agent-plugins@0.1.4 add context7
+npx universal-agent-plugins add context7
 ```
 
 It reads the root `plugin.json` defined by Agent Plugins 1.0 and plans, prepares,
@@ -35,8 +35,8 @@ required client confirmation and receive an exact, path-specific next step in
 human-readable output.
 
 ```bash
-npx universal-agent-plugins@0.1.4 add context7 --dry-run --target cursor
-npx universal-agent-plugins@0.1.4 add context7 --target cursor
+npx universal-agent-plugins add context7 --dry-run --target cursor
+npx universal-agent-plugins add context7 --target cursor
 ```
 
 Short names resolve through the pinned catalog, while a local directory or an

--- a/npm/agentplugins/README.md
+++ b/npm/agentplugins/README.md
@@ -4,7 +4,7 @@ Install and manage portable Agent Plugins 1.0 packages across Codex/ChatGPT,
 Cursor, GitHub Copilot/VS Code, and Kiro.
 
 ```bash
-npx universal-agent-plugins@0.1.4 add context7
+npx universal-agent-plugins add context7
 ```
 
 `universal-agent-plugins` is an independent community CLI built in
@@ -20,12 +20,12 @@ tarball, then caches it under XDG Cache or LocalAppData. It never falls back to
 `latest` and never sends `GITHUB_TOKEN` to public downloads.
 
 ```bash
-npx universal-agent-plugins@0.1.4 doctor
-npx universal-agent-plugins@0.1.4 list
-npx universal-agent-plugins@0.1.4 add context7 --dry-run --target cursor
-npx universal-agent-plugins@0.1.4 add context7 --target cursor
-npx universal-agent-plugins@0.1.4 update context7 --target cursor
-npx universal-agent-plugins@0.1.4 remove context7 --target cursor
+npx universal-agent-plugins doctor
+npx universal-agent-plugins list
+npx universal-agent-plugins add context7 --dry-run --target cursor
+npx universal-agent-plugins add context7 --target cursor
+npx universal-agent-plugins update context7 --target cursor
+npx universal-agent-plugins remove context7 --target cursor
 ```
 
 For GitHub Copilot CLI, `agentplugins` performs the native install, update, and
@@ -40,8 +40,8 @@ catalog. You can also install a different valid Agent Plugins 1.0 package from
 a local directory or an exact GitHub source:
 
 ```bash
-npx universal-agent-plugins@0.1.4 add ./my-plugin --target cursor
-npx universal-agent-plugins@0.1.4 add owner/repo@commit//plugins/my-plugin --target cursor
+npx universal-agent-plugins add ./my-plugin --target cursor
+npx universal-agent-plugins add owner/repo@commit//plugins/my-plugin --target cursor
 ```
 
 The package must have a root `plugin.json` using the supported Agent Plugins
@@ -55,8 +55,8 @@ requires manual activation. For older `plugin-kit-ai` installations, run the
 explicit migration before the first standard installation:
 
 ```bash
-npx universal-agent-plugins@0.1.4 migrate-state --dry-run
-npx universal-agent-plugins@0.1.4 migrate-state
+npx universal-agent-plugins migrate-state --dry-run
+npx universal-agent-plugins migrate-state
 ```
 
 The migration validates the complete State v2 result, creates a byte-for-byte

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -128,6 +128,18 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	}
 }
 
+func TestAgentpluginsReadmesUseUnversionedNpxExamples(t *testing.T) {
+	root := RepoRoot(t)
+	for _, path := range [][]string{
+		{"README.md"},
+		{"npm", "agentplugins", "README.md"},
+	} {
+		readme := readRepoFile(t, root, path...)
+		mustContain(t, readme, "npx universal-agent-plugins add context7")
+		mustNotContain(t, readme, "npx universal-agent-plugins@")
+	}
+}
+
 func mustAppearBefore(t *testing.T, text, first, second string) {
 	t.Helper()
 	firstIndex := strings.Index(text, first)


### PR DESCRIPTION
Keep CLI examples copy-ready and versionless:

```bash
npx universal-agent-plugins add context7
```

This updates both the repository README and the npm package README, including lifecycle, local package, GitHub source, and state migration examples.

A repository contract test now rejects `npx universal-agent-plugins@<version>` in either public README while keeping release records versioned where reproducibility requires it.

Targeted repository tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command examples to use the unversioned `universal-agent-plugins` package name.
  * Removed explicit package version references from installation, lifecycle, source installation, and migration examples.

* **Tests**
  * Added validation to ensure README examples consistently use unversioned commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->