### PR TITLE
feat(agentplugins): harden lifecycle and release E2E

### DIFF
--- a/.github/workflows/agentplugins-npm-publish.yml
+++ b/.github/workflows/agentplugins-npm-publish.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   release-identity:
+    if: ${{ !inputs.verify_only }}
     runs-on: ubuntu-24.04
     outputs:
       commit: ${{ steps.identity.outputs.commit }}
@@ -43,6 +44,7 @@ jobs:
 
   platform-proof:
     needs: release-identity
+    if: ${{ !inputs.verify_only }}
     uses: ./.github/workflows/agentplugins-platform-proof.yml
     permissions:
       contents: read
@@ -172,7 +174,7 @@ jobs:
         run: npm publish --access public --tag latest --provenance "${TARBALL}"
 
   verify:
-    needs: [publish, platform-proof]
+    needs: publish
     if: ${{ always() && !cancelled() && (inputs.verify_only || needs.publish.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/agentplugins-npm-publish.yml
+++ b/.github/workflows/agentplugins-npm-publish.yml
@@ -271,7 +271,9 @@ jobs:
           }
           run_agentplugins version | grep -Fx "agentplugins ${version}"
           run_agentplugins add "${synthetic}" --target cursor --yes --format json > add.json
-          jq -e '.schema_version == 1 and .command == "add" and .data.result.mutated == true' add.json
+          jq -e '.schema_version == 1 and .command == "add" and .data.result.mutated == true and .data.result.activation.authentication == "not_checked"' add.json
+          run_agentplugins add "${synthetic}" --target cursor --yes --activation-complete --auth-complete --format json > complete.json
+          jq -e '.schema_version == 1 and .command == "add" and .data.result.mutated == true and .data.result.activation.activation_attested == true and .data.result.activation.authentication_attested == true' complete.json
           run_agentplugins info registry-proof-synthetic --format json > info.json
           jq -e '.schema_version == 1 and .command == "info" and .data.name == "registry-proof-synthetic"' info.json
           state_before_doctor="$(sha256sum "${AGENTPLUGINS_HOME}/state-v2.json")"
@@ -285,7 +287,7 @@ jobs:
           jq -e '.schema_version == 1 and .command == "remove" and .data.result.mutated == true' remove.json
           run_agentplugins info registry-proof-synthetic --format json > removed.json
           jq -e '.data.clients as $clients | ($clients | length) == 1 and $clients[0].materialization == "absent"' removed.json
-          if grep -F "${RUNNER_TEMP}" add.json info.json doctor.json update.json remove.json removed.json; then
+          if grep -F "${RUNNER_TEMP}" add.json complete.json info.json doctor.json update.json remove.json removed.json; then
             echo "agentplugins JSON output leaked an absolute runner path" >&2
             exit 1
           fi

--- a/.github/workflows/agentplugins-npm-publish.yml
+++ b/.github/workflows/agentplugins-npm-publish.yml
@@ -272,9 +272,9 @@ jobs:
             npm exec --yes --package="${NPM_PACKAGE}@${version}" -- agentplugins "$@"
           }
           run_agentplugins version | grep -Fx "agentplugins ${version}"
-          run_agentplugins add "${synthetic}" --target cursor --yes --format json > add.json
+          run_agentplugins add "${synthetic}" --target cursor --format json > add.json
           jq -e '.schema_version == 1 and .command == "add" and .data.result.mutated == true and .data.result.activation.authentication == "not_checked"' add.json
-          run_agentplugins add "${synthetic}" --target cursor --yes --activation-complete --auth-complete --format json > complete.json
+          run_agentplugins add "${synthetic}" --target cursor --activation-complete --auth-complete --format json > complete.json
           jq -e '.schema_version == 1 and .command == "add" and .data.result.mutated == true and .data.result.activation.activation_attested == true and .data.result.activation.authentication_attested == true' complete.json
           run_agentplugins info registry-proof-synthetic --format json > info.json
           jq -e '.schema_version == 1 and .command == "info" and .data.name == "registry-proof-synthetic"' info.json
@@ -283,9 +283,9 @@ jobs:
           state_after_doctor="$(sha256sum "${AGENTPLUGINS_HOME}/state-v2.json")"
           test "${state_before_doctor}" = "${state_after_doctor}"
           jq -e '.schema_version == 1 and .command == "doctor" and .data.read_only == true' doctor.json
-          run_agentplugins update registry-proof-synthetic --target cursor --yes --format json > update.json
+          run_agentplugins update registry-proof-synthetic --target cursor --format json > update.json
           jq -e '.schema_version == 1 and .command == "update" and .data.result.no_change == true and .data.result.mutated == false' update.json
-          run_agentplugins remove registry-proof-synthetic --target cursor --yes --format json > remove.json
+          run_agentplugins remove registry-proof-synthetic --target cursor --format json > remove.json
           jq -e '.schema_version == 1 and .command == "remove" and .data.result.mutated == true' remove.json
           run_agentplugins info registry-proof-synthetic --format json > removed.json
           jq -e '.data.clients as $clients | ($clients | length) == 1 and $clients[0].materialization == "absent"' removed.json

--- a/.github/workflows/agentplugins-npm-publish.yml
+++ b/.github/workflows/agentplugins-npm-publish.yml
@@ -16,7 +16,44 @@ permissions:
   contents: read
 
 jobs:
+  release-identity:
+    runs-on: ubuntu-24.04
+    outputs:
+      commit: ${{ steps.identity.outputs.commit }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ inputs.tag }}
+      - name: Freeze exact release identity
+        id: identity
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if [[ ! "${TAG}" =~ ^agentplugins-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "invalid agentplugins stable tag: ${TAG}" >&2
+            exit 1
+          fi
+          git fetch --force origin main:refs/remotes/origin/main
+          commit="$(git rev-parse HEAD)"
+          test "${commit}" = "$(git rev-parse refs/remotes/origin/main)"
+          test "${commit}" = "$(git rev-list -n 1 "${TAG}")"
+          echo "commit=${commit}" >> "${GITHUB_OUTPUT}"
+
+  platform-proof:
+    needs: release-identity
+    uses: ./.github/workflows/agentplugins-platform-proof.yml
+    permissions:
+      contents: read
+      attestations: read
+    with:
+      tag: ${{ inputs.tag }}
+      expected_commit: ${{ needs.release-identity.outputs.commit }}
+      allow_legacy_manifest: false
+
   publish:
+    needs: [release-identity, platform-proof]
     if: ${{ !inputs.verify_only }}
     runs-on: ubuntu-latest
     environment: npm-agentplugins
@@ -52,6 +89,8 @@ jobs:
           test "${READY}" = "true"
           git fetch --force origin main:refs/remotes/origin/main
           head_commit="$(git rev-parse HEAD)"
+          test "${head_commit}" = "${{ needs.release-identity.outputs.commit }}"
+          test "${{ needs.platform-proof.outputs.gate_eligible }}" = "true"
           test "${head_commit}" = "$(git rev-parse refs/remotes/origin/main)"
           test "${head_commit}" = "$(git rev-list -n 1 "${TAG}")"
           echo "commit=${head_commit}" >> "${GITHUB_OUTPUT}"
@@ -85,36 +124,55 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/agentplugins-assets"
           gh release download "${TAG}" --repo "${GITHUB_REPOSITORY}" --dir "${RUNNER_TEMP}/agentplugins-assets"
           cd "${RUNNER_TEMP}/agentplugins-assets"
-          test "$(find . -maxdepth 1 -type f -name 'agentplugins_*' | wc -l | tr -d ' ')" = 6
-          sha256sum --check checksums.txt
-          test "$(jq -r '.schema_version' release-manifest.json)" = "1"
-          test "$(jq -r '.tag' release-manifest.json)" = "${TAG}"
-          test "$(jq -r '.commit' release-manifest.json)" = "${{ steps.publish-gate.outputs.commit }}"
+          node "${GITHUB_WORKSPACE}/npm/agentplugins/scripts/release-assets.js" verify \
+            "${PWD}" "${TAG}" "${{ steps.publish-gate.outputs.commit }}"
           for asset in agentplugins_* checksums.txt release-manifest.json; do
             gh attestation verify "${asset}" \
               --repo "${GITHUB_REPOSITORY}" \
               --signer-workflow "github.com/${GITHUB_REPOSITORY}/.github/workflows/agentplugins-release.yml" \
               --source-digest "${{ steps.publish-gate.outputs.commit }}"
           done
-      - name: Stage exact npm package with embedded platform hashes
+      - name: Download exact six-platform-tested npm tarball
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.platform-proof.outputs.tarball_artifact }}
+          path: ${{ runner.temp }}/agentplugins-tested-package
+      - name: Revalidate exact tested tarball publication identity
         env:
           TAG: ${{ inputs.tag }}
+          TARBALL_FILE: ${{ needs.platform-proof.outputs.tarball_file }}
+          EXPECTED_PACKAGE: ${{ needs.platform-proof.outputs.package_name }}
         run: |
           version="${TAG#agentplugins-v}"
-          stage="${RUNNER_TEMP}/agentplugins-npm"
-          mkdir -p "${stage}"
-          cp -R npm/agentplugins/. "${stage}/"
-          node npm/agentplugins/scripts/stage-release.js "${stage}" "${RUNNER_TEMP}/agentplugins-assets" "${version}"
-          cd "${stage}"
-          npm test
-          npm pack --dry-run --ignore-scripts
-          AGENTPLUGINS_CACHE_DIR="${RUNNER_TEMP}/agentplugins-cache" node bin/agentplugins.js version | grep -Fx "agentplugins ${version}"
+          tarball="${RUNNER_TEMP}/agentplugins-tested-package/${TARBALL_FILE}"
+          test -s "${tarball}"
+          install_root="${RUNNER_TEMP}/agentplugins-publish-inspection"
+          npm install --prefix "${install_root}" --ignore-scripts --no-audit --no-fund --save-exact "${tarball}"
+          package_root="${install_root}/node_modules/${EXPECTED_PACKAGE}"
+          test "$(node -p 'require(process.argv[1]).version' "${package_root}/package.json")" = "${version}"
+          test "$(node -p 'require(process.argv[1]).name' "${package_root}/package.json")" = "${EXPECTED_PACKAGE}"
+          test "$(node -p 'require(process.argv[1]).bin.agentplugins' "${package_root}/package.json")" = "bin/agentplugins.js"
+          test "$(node -p 'Boolean(require(process.argv[1]).scripts?.preinstall || require(process.argv[1]).scripts?.install || require(process.argv[1]).scripts?.postinstall)' "${package_root}/package.json")" = "false"
+          node -e '
+            const fs = require("node:fs");
+            const npmAssets = JSON.parse(fs.readFileSync(process.argv[1]));
+            const release = JSON.parse(fs.readFileSync(process.argv[2]));
+            if (npmAssets.version !== release.version || npmAssets.tag !== release.tag) throw new Error("npm manifest identity mismatch");
+            for (const [key, asset] of Object.entries(release.assets)) {
+              const pin = npmAssets.assets?.[key];
+              if (!pin || pin.file !== asset.file || pin.sha256 !== asset.sha256 || pin.size !== asset.size) {
+                throw new Error(`npm asset pin mismatch: ${key}`);
+              }
+            }
+            if (Object.keys(npmAssets.assets || {}).length !== 6) throw new Error("npm manifest target count mismatch");
+          ' "${package_root}/assets.json" "${RUNNER_TEMP}/agentplugins-tested-package/verified-release.json"
       - name: Publish stable release with provenance
-        working-directory: ${{ runner.temp }}/agentplugins-npm
-        run: npm publish --access public --tag latest --provenance
+        env:
+          TARBALL: ${{ runner.temp }}/agentplugins-tested-package/${{ needs.platform-proof.outputs.tarball_file }}
+        run: npm publish --access public --tag latest --provenance "${TARBALL}"
 
   verify:
-    needs: publish
+    needs: [publish, platform-proof]
     if: ${{ always() && !cancelled() && (inputs.verify_only || needs.publish.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -157,6 +215,15 @@ jobs:
           project="${RUNNER_TEMP}/agentplugins-registry-smoke"
           test_home="${project}/home"
           mkdir -p "${project}" "${test_home}/.cursor" "${project}/tmp"
+          synthetic="${project}/synthetic-plugin"
+          mkdir -p "${synthetic}"
+          printf '%s\n' \
+            '{' \
+            '  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",' \
+            '  "name": "registry-proof-synthetic",' \
+            '  "version": "1.0.0",' \
+            '  "description": "Synthetic package used only by isolated registry CI"' \
+            '}' > "${synthetic}/plugin.json"
           cd "${project}" || exit 1
           npm init -y >/dev/null
           export HOME="${test_home}"
@@ -201,20 +268,20 @@ jobs:
             npm exec --yes --package="${NPM_PACKAGE}@${version}" -- agentplugins "$@"
           }
           run_agentplugins version | grep -Fx "agentplugins ${version}"
-          run_agentplugins add context7 --target cursor --yes --format json > add.json
+          run_agentplugins add "${synthetic}" --target cursor --yes --format json > add.json
           jq -e '.schema_version == 1 and .command == "add" and .data.result.mutated == true' add.json
-          run_agentplugins info context7 --format json > info.json
-          jq -e '.schema_version == 1 and .command == "info" and .data.name == "context7"' info.json
+          run_agentplugins info registry-proof-synthetic --format json > info.json
+          jq -e '.schema_version == 1 and .command == "info" and .data.name == "registry-proof-synthetic"' info.json
           state_before_doctor="$(sha256sum "${AGENTPLUGINS_HOME}/state-v2.json")"
-          run_agentplugins doctor context7 --format json > doctor.json
+          run_agentplugins doctor registry-proof-synthetic --format json > doctor.json
           state_after_doctor="$(sha256sum "${AGENTPLUGINS_HOME}/state-v2.json")"
           test "${state_before_doctor}" = "${state_after_doctor}"
           jq -e '.schema_version == 1 and .command == "doctor" and .data.read_only == true' doctor.json
-          run_agentplugins update context7 --target cursor --yes --format json > update.json
+          run_agentplugins update registry-proof-synthetic --target cursor --yes --format json > update.json
           jq -e '.schema_version == 1 and .command == "update" and .data.result.no_change == true and .data.result.mutated == false' update.json
-          run_agentplugins remove context7 --target cursor --yes --format json > remove.json
+          run_agentplugins remove registry-proof-synthetic --target cursor --yes --format json > remove.json
           jq -e '.schema_version == 1 and .command == "remove" and .data.result.mutated == true' remove.json
-          run_agentplugins info context7 --format json > removed.json
+          run_agentplugins info registry-proof-synthetic --format json > removed.json
           jq -e '.data.clients as $clients | ($clients | length) == 1 and $clients[0].materialization == "absent"' removed.json
           if grep -F "${RUNNER_TEMP}" add.json info.json doctor.json update.json remove.json removed.json; then
             echo "agentplugins JSON output leaked an absolute runner path" >&2

--- a/.github/workflows/agentplugins-npm-publish.yml
+++ b/.github/workflows/agentplugins-npm-publish.yml
@@ -36,10 +36,10 @@ jobs:
             echo "invalid agentplugins stable tag: ${TAG}" >&2
             exit 1
           fi
-          git fetch --force origin main:refs/remotes/origin/main
+          git fetch --force origin main:refs/remotes/origin/main "refs/tags/${TAG}:refs/tags/${TAG}"
           commit="$(git rev-parse HEAD)"
           test "${commit}" = "$(git rev-parse refs/remotes/origin/main)"
-          test "${commit}" = "$(git rev-list -n 1 "${TAG}")"
+          test "${commit}" = "$(git rev-list -n 1 "refs/tags/${TAG}")"
           echo "commit=${commit}" >> "${GITHUB_OUTPUT}"
 
   platform-proof:
@@ -89,12 +89,12 @@ jobs:
             exit 1
           fi
           test "${READY}" = "true"
-          git fetch --force origin main:refs/remotes/origin/main
+          git fetch --force origin main:refs/remotes/origin/main "refs/tags/${TAG}:refs/tags/${TAG}"
           head_commit="$(git rev-parse HEAD)"
           test "${head_commit}" = "${{ needs.release-identity.outputs.commit }}"
           test "${{ needs.platform-proof.outputs.gate_eligible }}" = "true"
           test "${head_commit}" = "$(git rev-parse refs/remotes/origin/main)"
-          test "${head_commit}" = "$(git rev-list -n 1 "${TAG}")"
+          test "${head_commit}" = "$(git rev-list -n 1 "refs/tags/${TAG}")"
           echo "commit=${head_commit}" >> "${GITHUB_OUTPUT}"
           package_name="$(node -p 'require("./npm/agentplugins/package.json").name')"
           package_name_length="$(printf '%s' "${package_name}" | wc -c | tr -d ' ')"
@@ -199,6 +199,8 @@ jobs:
             echo "invalid agentplugins stable tag: ${TAG}" >&2
             exit 1
           fi
+          git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
+          test "$(git rev-parse HEAD)" = "$(git rev-list -n 1 "refs/tags/${TAG}")"
           package_name="$(node -p 'require("./npm/agentplugins/package.json").name')"
           package_name_length="$(printf '%s' "${package_name}" | wc -c | tr -d ' ')"
           if [[ ! "${package_name}" =~ ^(@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$ ]] || [[ "${package_name_length}" -gt 214 ]]; then

--- a/.github/workflows/agentplugins-npm-publish.yml
+++ b/.github/workflows/agentplugins-npm-publish.yml
@@ -31,6 +31,8 @@ jobs:
         id: identity
         env:
           TAG: ${{ inputs.tag }}
+          WORKFLOW_COMMIT: ${{ github.sha }}
+          WORKFLOW_REF: ${{ github.ref }}
         run: |
           if [[ ! "${TAG}" =~ ^agentplugins-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "invalid agentplugins stable tag: ${TAG}" >&2
@@ -38,6 +40,11 @@ jobs:
           fi
           git fetch --force origin main:refs/remotes/origin/main "refs/tags/${TAG}:refs/tags/${TAG}"
           commit="$(git rev-parse HEAD)"
+          test "${WORKFLOW_REF}" = "refs/heads/main"
+          if [[ "${WORKFLOW_COMMIT}" != "${commit}" ]]; then
+            echo "npm publish workflow source does not match the exact tagged main commit" >&2
+            exit 1
+          fi
           test "${commit}" = "$(git rev-parse refs/remotes/origin/main)"
           test "${commit}" = "$(git rev-list -n 1 "refs/tags/${TAG}")"
           echo "commit=${commit}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/agentplugins-platform-proof.yml
+++ b/.github/workflows/agentplugins-platform-proof.yml
@@ -16,6 +16,15 @@ on:
         required: false
         default: false
         type: boolean
+      require_draft:
+        description: Require the exact release to remain a non-public draft during proof
+        required: false
+        default: false
+        type: boolean
+      expected_asset_set_digest:
+        description: Optional SHA-256 of checksums.txt frozen by the draft staging job
+        required: false
+        type: string
   workflow_call:
     inputs:
       tag:
@@ -31,6 +40,16 @@ on:
         required: false
         default: false
         type: boolean
+      require_draft:
+        description: Require the exact release to remain a non-public draft during proof
+        required: false
+        default: false
+        type: boolean
+      expected_asset_set_digest:
+        description: Optional SHA-256 of checksums.txt frozen by the calling workflow
+        required: false
+        default: ""
+        type: string
     outputs:
       commit:
         description: Verified release commit
@@ -90,6 +109,8 @@ jobs:
           TAG: ${{ inputs.tag }}
           EXPECTED_COMMIT: ${{ inputs.expected_commit }}
           ALLOW_LEGACY: ${{ inputs.allow_legacy_manifest }}
+          REQUIRE_DRAFT: ${{ inputs.require_draft }}
+          EXPECTED_ASSET_SET_DIGEST: ${{ inputs.expected_asset_set_digest }}
         run: |
           if [[ ! "${TAG}" =~ ^agentplugins-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "invalid agentplugins stable tag: ${TAG}" >&2
@@ -103,7 +124,28 @@ jobs:
           version="${TAG#agentplugins-v}"
           assets="${RUNNER_TEMP}/agentplugins-release-${version}"
           mkdir -p "${assets}"
+          release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}")"
+          if [[ "${REQUIRE_DRAFT}" = "true" ]]; then
+            jq -e --arg tag "${TAG}" --arg commit "${commit}" \
+              '.draft == true and .prerelease == false and .tag_name == $tag and .target_commitish == $commit' \
+              <<<"${release_json}" >/dev/null || {
+                echo "platform proof requires the exact release to remain a non-public draft" >&2
+                exit 1
+              }
+          else
+            jq -e --arg tag "${TAG}" '.draft == false and .tag_name == $tag' <<<"${release_json}" >/dev/null || {
+              echo "platform proof requires an existing public release" >&2
+              exit 1
+            }
+          fi
           gh release download "${TAG}" --repo "${GITHUB_REPOSITORY}" --dir "${assets}"
+          if [[ -n "${EXPECTED_ASSET_SET_DIGEST}" ]]; then
+            [[ "${EXPECTED_ASSET_SET_DIGEST}" =~ ^[0-9a-f]{64}$ ]] || {
+              echo "invalid expected release asset-set digest" >&2
+              exit 1
+            }
+            test "$(sha256sum "${assets}/checksums.txt" | cut -d ' ' -f 1)" = "${EXPECTED_ASSET_SET_DIGEST}"
+          fi
           policy=()
           if [[ "${ALLOW_LEGACY}" = "true" ]]; then
             policy=(allow-legacy-v1)
@@ -202,3 +244,11 @@ jobs:
           path: ${{ runner.temp }}/agentplugins-proof-${{ matrix.target }}.json
           if-no-files-found: warn
           retention-days: 7
+
+  proof-complete:
+    name: Aggregate all six native platform proofs
+    needs: [prepare, native-runtime]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Confirm native matrix aggregation
+        run: test "${{ needs.native-runtime.result }}" = "success"

--- a/.github/workflows/agentplugins-platform-proof.yml
+++ b/.github/workflows/agentplugins-platform-proof.yml
@@ -8,8 +8,8 @@ on:
         required: true
         type: string
       expected_commit:
-        description: Optional exact 40-character release commit (required by publish callers)
-        required: false
+        description: Exact lowercase 40-character release commit
+        required: true
         type: string
       allow_legacy_manifest:
         description: Audit a schema-v1 historical release; never eligible as an npm publish gate
@@ -78,6 +78,11 @@ jobs:
   prepare:
     name: Verify release and pack exact npm tarball
     runs-on: ubuntu-24.04
+    permissions:
+      # GitHub only exposes draft releases and their assets to tokens with push
+      # access; scope that elevated contents permission to this job alone.
+      contents: write
+      attestations: read
     outputs:
       commit: ${{ steps.prepare.outputs.commit }}
       version: ${{ steps.prepare.outputs.version }}
@@ -116,11 +121,15 @@ jobs:
             echo "invalid agentplugins stable tag: ${TAG}" >&2
             exit 1
           fi
+          if [[ ! "${EXPECTED_COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "expected_commit must be an exact lowercase 40-character commit" >&2
+            exit 1
+          fi
           commit="$(git -C release-source rev-parse HEAD)"
           git -C release-source fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
           tag_commit="$(git -C release-source rev-list -n 1 "refs/tags/${TAG}")"
           test "${tag_commit}" = "${commit}"
-          if [[ -n "${EXPECTED_COMMIT}" ]] && [[ "${commit}" != "${EXPECTED_COMMIT}" ]]; then
+          if [[ "${commit}" != "${EXPECTED_COMMIT}" ]]; then
             echo "release tag commit does not match the caller's frozen commit" >&2
             exit 1
           fi
@@ -264,5 +273,58 @@ jobs:
     needs: [prepare, native-runtime]
     runs-on: ubuntu-24.04
     steps:
-      - name: Confirm native matrix aggregation
-        run: test "${{ needs.native-runtime.result }}" = "success"
+      - name: Download all native platform proofs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: agentplugins-native-proof-*
+          path: ${{ runner.temp }}/agentplugins-native-proofs
+      - name: Validate exactly one proof for every native target
+        env:
+          EXPECTED_VERSION: ${{ needs.prepare.outputs.version }}
+        shell: bash
+        run: |
+          root="${RUNNER_TEMP}/agentplugins-native-proofs"
+          proofs=()
+          while IFS= read -r -d '' proof; do
+            proofs+=("${proof}")
+          done < <(find "${root}" -type f -name '*.json' -print0)
+          if [[ "${#proofs[@]}" -ne 6 ]]; then
+            echo "expected exactly six machine-readable platform proofs, found ${#proofs[@]}" >&2
+            exit 1
+          fi
+          for spec in \
+            "darwin-amd64 false" \
+            "darwin-arm64 true" \
+            "linux-amd64 true" \
+            "linux-arm64 false" \
+            "windows-amd64 true" \
+            "windows-arm64 false"; do
+            read -r target lifecycle <<<"${spec}"
+            matches=()
+            while IFS= read -r -d '' proof; do
+              matches+=("${proof}")
+            done < <(find "${root}" -type f -name "agentplugins-proof-${target}.json" -print0)
+            if [[ "${#matches[@]}" -ne 1 ]]; then
+              echo "expected exactly one machine-readable proof for ${target}, found ${#matches[@]}" >&2
+              exit 1
+            fi
+            jq -e \
+              --arg target "${target}" \
+              --arg version "${EXPECTED_VERSION}" \
+              --argjson lifecycle "${lifecycle}" \
+              '.schema_version == 1 and
+               .target == $target and
+               .release_version == $version and
+               .execution == "native-runtime-e2e" and
+               .proofs.npm_install_ignore_scripts == true and
+               .proofs.launcher_cold_bootstrap == true and
+               .proofs.embedded_sha256_and_size == true and
+               .proofs.released_binary_executed == true and
+               .proofs.version == true and
+               .proofs.list == true and
+               .proofs.doctor_read_only == true and
+               .proofs.synthetic_add_dry_run == true and
+               .proofs.warm_cache == true and
+               .proofs.isolated_add_update_remove == $lifecycle' \
+              "${matches[0]}" >/dev/null
+          done

--- a/.github/workflows/agentplugins-platform-proof.yml
+++ b/.github/workflows/agentplugins-platform-proof.yml
@@ -25,6 +25,10 @@ on:
         description: Optional SHA-256 of checksums.txt frozen by the draft staging job
         required: false
         type: string
+      release_assets_artifact:
+        description: Same-run artifact containing caller-staged draft assets
+        required: false
+        type: string
   workflow_call:
     inputs:
       tag:
@@ -47,6 +51,11 @@ on:
         type: boolean
       expected_asset_set_digest:
         description: Optional SHA-256 of checksums.txt frozen by the calling workflow
+        required: false
+        default: ""
+        type: string
+      release_assets_artifact:
+        description: Same-run artifact containing caller-staged draft assets
         required: false
         default: ""
         type: string
@@ -79,9 +88,7 @@ jobs:
     name: Verify release and pack exact npm tarball
     runs-on: ubuntu-24.04
     permissions:
-      # GitHub only exposes draft releases and their assets to tokens with push
-      # access; scope that elevated contents permission to this job alone.
-      contents: write
+      contents: read
       attestations: read
     outputs:
       commit: ${{ steps.prepare.outputs.commit }}
@@ -107,6 +114,12 @@ jobs:
         with:
           node-version: 22
           package-manager-cache: false
+      - name: Download caller-staged draft assets
+        if: ${{ inputs.release_assets_artifact != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.release_assets_artifact }}
+          path: ${{ runner.temp }}/agentplugins-release-assets
       - name: Verify immutable release identity, assets, and attestations
         id: prepare
         env:
@@ -116,6 +129,7 @@ jobs:
           ALLOW_LEGACY: ${{ inputs.allow_legacy_manifest }}
           REQUIRE_DRAFT: ${{ inputs.require_draft }}
           EXPECTED_ASSET_SET_DIGEST: ${{ inputs.expected_asset_set_digest }}
+          RELEASE_ASSETS_ARTIFACT: ${{ inputs.release_assets_artifact }}
         run: |
           if [[ ! "${TAG}" =~ ^agentplugins-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "invalid agentplugins stable tag: ${TAG}" >&2
@@ -136,32 +150,31 @@ jobs:
           version="${TAG#agentplugins-v}"
           assets="${RUNNER_TEMP}/agentplugins-release-${version}"
           mkdir -p "${assets}"
-          owner="${GITHUB_REPOSITORY%%/*}"
-          repository="${GITHUB_REPOSITORY#*/}"
-          release_query='query($owner:String!,$name:String!,$tag:String!){repository(owner:$owner,name:$name){release(tagName:$tag){isDraft isPrerelease tagName}}}'
-          release_json="$(gh api graphql -f query="${release_query}" -F owner="${owner}" -F name="${repository}" -F tag="${TAG}")" || {
-            echo "failed to look up release ${TAG}" >&2
-            exit 1
-          }
-          release_json="$(jq -c '.data.repository.release' <<<"${release_json}")"
-          if [[ "${release_json}" = "null" ]]; then
-            echo "release ${TAG} was not found" >&2
-            exit 1
-          fi
-          if [[ "${REQUIRE_DRAFT}" = "true" ]]; then
-            jq -e --arg tag "${TAG}" \
-              '.isDraft == true and .isPrerelease == false and .tagName == $tag' \
-              <<<"${release_json}" >/dev/null || {
-                echo "platform proof requires the exact release to remain a non-public draft" >&2
-                exit 1
-              }
+          if [[ -n "${RELEASE_ASSETS_ARTIFACT}" ]]; then
+            if [[ "${REQUIRE_DRAFT}" != "true" ]]; then
+              echo "caller-staged assets are only valid for draft proof" >&2
+              exit 1
+            fi
+            cp -R "${RUNNER_TEMP}/agentplugins-release-assets/." "${assets}/"
           else
+            if [[ "${REQUIRE_DRAFT}" = "true" ]]; then
+              echo "draft proof requires caller-staged release assets" >&2
+              exit 1
+            fi
+            owner="${GITHUB_REPOSITORY%%/*}"
+            repository="${GITHUB_REPOSITORY#*/}"
+            release_query='query($owner:String!,$name:String!,$tag:String!){repository(owner:$owner,name:$name){release(tagName:$tag){isDraft isPrerelease tagName}}}'
+            release_json="$(gh api graphql -f query="${release_query}" -F owner="${owner}" -F name="${repository}" -F tag="${TAG}")" || {
+              echo "failed to look up release ${TAG}" >&2
+              exit 1
+            }
+            release_json="$(jq -c '.data.repository.release' <<<"${release_json}")"
             jq -e --arg tag "${TAG}" '.isDraft == false and .isPrerelease == false and .tagName == $tag' <<<"${release_json}" >/dev/null || {
               echo "platform proof requires an existing public release" >&2
               exit 1
             }
+            gh release download "${TAG}" --repo "${GITHUB_REPOSITORY}" --dir "${assets}"
           fi
-          gh release download "${TAG}" --repo "${GITHUB_REPOSITORY}" --dir "${assets}"
           if [[ -n "${EXPECTED_ASSET_SET_DIGEST}" ]]; then
             [[ "${EXPECTED_ASSET_SET_DIGEST}" =~ ^[0-9a-f]{64}$ ]] || {
               echo "invalid expected release asset-set digest" >&2

--- a/.github/workflows/agentplugins-platform-proof.yml
+++ b/.github/workflows/agentplugins-platform-proof.yml
@@ -78,6 +78,9 @@ on:
       gate_eligible:
         description: Whether the release uses the strict publish-gate manifest
         value: ${{ jobs.prepare.outputs.gate_eligible }}
+      bootstrap_mode:
+        description: Exact cold-bootstrap evidence source used by native jobs
+        value: ${{ jobs.prepare.outputs.bootstrap_mode }}
 
 permissions:
   contents: read
@@ -97,18 +100,20 @@ jobs:
       tarball_artifact: ${{ steps.prepare.outputs.tarball_artifact }}
       tarball_file: ${{ steps.prepare.outputs.tarball_file }}
       gate_eligible: ${{ steps.prepare.outputs.gate_eligible }}
+      bootstrap_mode: ${{ steps.prepare.outputs.bootstrap_mode }}
     steps:
       - name: Check out platform proof tools
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          ref: ${{ inputs.expected_commit }}
           path: proof-tools
       - name: Check out exact release source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
-          ref: ${{ inputs.tag }}
+          ref: ${{ inputs.expected_commit }}
           path: release-source
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -130,6 +135,7 @@ jobs:
           REQUIRE_DRAFT: ${{ inputs.require_draft }}
           EXPECTED_ASSET_SET_DIGEST: ${{ inputs.expected_asset_set_digest }}
           RELEASE_ASSETS_ARTIFACT: ${{ inputs.release_assets_artifact }}
+          WORKFLOW_COMMIT: ${{ github.sha }}
         run: |
           if [[ ! "${TAG}" =~ ^agentplugins-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "invalid agentplugins stable tag: ${TAG}" >&2
@@ -139,6 +145,14 @@ jobs:
             echo "expected_commit must be an exact lowercase 40-character commit" >&2
             exit 1
           fi
+          if [[ "${WORKFLOW_COMMIT}" != "${EXPECTED_COMMIT}" ]]; then
+            if [[ "${ALLOW_LEGACY}" = "true" ]]; then
+              echo "historical audit must be dispatched with --ref ${TAG}; the platform-proof workflow must exist at that exact tag" >&2
+            fi
+            echo "platform proof workflow source does not match the frozen release commit" >&2
+            exit 1
+          fi
+          test "$(git -C proof-tools rev-parse HEAD)" = "${EXPECTED_COMMIT}"
           commit="$(git -C release-source rev-parse HEAD)"
           git -C release-source fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
           tag_commit="$(git -C release-source rev-list -n 1 "refs/tags/${TAG}")"
@@ -207,19 +221,30 @@ jobs:
           package_name="$(node -p 'require(process.argv[1]).name' "${stage}/package.json")"
           tarball_artifact="agentplugins-npm-${version}"
           gate_eligible="$(jq -r '.gate_eligible' "${RUNNER_TEMP}/verified-release.json")"
+          bootstrap_mode="public_release_download"
+          if [[ -n "${RELEASE_ASSETS_ARTIFACT}" ]]; then
+            bootstrap_mode="local_frozen_asset"
+          fi
           echo "commit=${commit}" >> "${GITHUB_OUTPUT}"
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
           echo "package_name=${package_name}" >> "${GITHUB_OUTPUT}"
           echo "tarball_artifact=${tarball_artifact}" >> "${GITHUB_OUTPUT}"
           echo "tarball_file=${tarball_file}" >> "${GITHUB_OUTPUT}"
           echo "gate_eligible=${gate_eligible}" >> "${GITHUB_OUTPUT}"
-          cp "${tarball}" "${RUNNER_TEMP}/${tarball_file}"
+          echo "bootstrap_mode=${bootstrap_mode}" >> "${GITHUB_OUTPUT}"
+          proof_bundle="${RUNNER_TEMP}/agentplugins-proof-bundle"
+          mkdir -p "${proof_bundle}"
+          cp "${tarball}" "${proof_bundle}/${tarball_file}"
+          cp "${RUNNER_TEMP}/verified-release.json" "${proof_bundle}/verified-release.json"
+          if [[ "${bootstrap_mode}" = "local_frozen_asset" ]]; then
+            mkdir -p "${proof_bundle}/release-assets"
+            cp "${assets}"/agentplugins_* "${assets}/checksums.txt" "${assets}/release-manifest.json" \
+              "${proof_bundle}/release-assets/"
+          fi
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:
           name: ${{ steps.prepare.outputs.tarball_artifact }}
-          path: |
-            ${{ runner.temp }}/${{ steps.prepare.outputs.tarball_file }}
-            ${{ runner.temp }}/verified-release.json
+          path: ${{ runner.temp }}/agentplugins-proof-bundle/
           if-no-files-found: error
           retention-days: 7
 
@@ -255,6 +280,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          ref: ${{ inputs.expected_commit }}
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
@@ -266,12 +292,21 @@ jobs:
       - name: Run native npm launcher and released binary proof
         shell: bash
         run: |
+          test "$(git rev-parse HEAD)" = "${{ inputs.expected_commit }}"
+          release_assets="-"
+          if [[ "${{ needs.prepare.outputs.bootstrap_mode }}" = "local_frozen_asset" ]]; then
+            release_assets="${{ runner.temp }}/agentplugins-proof-package/release-assets"
+            test -d "${release_assets}"
+          fi
           node npm/agentplugins/scripts/platform-proof.js \
             "${{ runner.temp }}/agentplugins-proof-package/${{ needs.prepare.outputs.tarball_file }}" \
             "${{ needs.prepare.outputs.version }}" \
             "${{ matrix.target }}" \
             "${{ matrix.lifecycle }}" \
-            "${{ runner.temp }}/agentplugins-proof-${{ matrix.target }}.json"
+            "${{ runner.temp }}/agentplugins-proof-${{ matrix.target }}.json" \
+            "${{ inputs.expected_commit }}" \
+            "${{ needs.prepare.outputs.bootstrap_mode }}" \
+            "${release_assets}"
       - name: Upload machine-readable native proof
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
@@ -294,6 +329,7 @@ jobs:
       - name: Validate exactly one proof for every native target
         env:
           EXPECTED_VERSION: ${{ needs.prepare.outputs.version }}
+          EXPECTED_BOOTSTRAP_MODE: ${{ needs.prepare.outputs.bootstrap_mode }}
         shell: bash
         run: |
           root="${RUNNER_TEMP}/agentplugins-native-proofs"
@@ -324,13 +360,17 @@ jobs:
             jq -e \
               --arg target "${target}" \
               --arg version "${EXPECTED_VERSION}" \
+              --arg bootstrap_mode "${EXPECTED_BOOTSTRAP_MODE}" \
               --argjson lifecycle "${lifecycle}" \
               '.schema_version == 1 and
                .target == $target and
                .release_version == $version and
                .execution == "native-runtime-e2e" and
+               .bootstrap_source == $bootstrap_mode and
                .proofs.npm_install_ignore_scripts == true and
                .proofs.launcher_cold_bootstrap == true and
+               .proofs.local_frozen_asset_bootstrap == ($bootstrap_mode == "local_frozen_asset") and
+               .proofs.anonymous_public_release_download == ($bootstrap_mode == "public_release_download") and
                .proofs.embedded_sha256_and_size == true and
                .proofs.released_binary_executed == true and
                .proofs.version == true and
@@ -338,6 +378,7 @@ jobs:
                .proofs.doctor_read_only == true and
                .proofs.synthetic_add_dry_run == true and
                .proofs.warm_cache == true and
+               .proofs.warm_cache_without_proof_source == true and
                .proofs.isolated_add_update_remove == $lifecycle' \
               "${matches[0]}" >/dev/null
           done

--- a/.github/workflows/agentplugins-platform-proof.yml
+++ b/.github/workflows/agentplugins-platform-proof.yml
@@ -1,0 +1,204 @@
+name: Agentplugins Platform Proof
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Exact released tag to audit, for example agentplugins-v0.1.4
+        required: true
+        type: string
+      expected_commit:
+        description: Optional exact 40-character release commit (required by publish callers)
+        required: false
+        type: string
+      allow_legacy_manifest:
+        description: Audit a schema-v1 historical release; never eligible as an npm publish gate
+        required: false
+        default: false
+        type: boolean
+  workflow_call:
+    inputs:
+      tag:
+        description: Exact released stable tag
+        required: true
+        type: string
+      expected_commit:
+        description: Exact 40-character release commit
+        required: true
+        type: string
+      allow_legacy_manifest:
+        description: Audit-only compatibility for historical schema-v1 manifests
+        required: false
+        default: false
+        type: boolean
+    outputs:
+      commit:
+        description: Verified release commit
+        value: ${{ jobs.prepare.outputs.commit }}
+      version:
+        description: Verified release version
+        value: ${{ jobs.prepare.outputs.version }}
+      package_name:
+        description: Exact npm distribution name
+        value: ${{ jobs.prepare.outputs.package_name }}
+      tarball_artifact:
+        description: Artifact containing the exact tested npm tarball
+        value: ${{ jobs.prepare.outputs.tarball_artifact }}
+      tarball_file:
+        description: Filename of the exact tested npm tarball
+        value: ${{ jobs.prepare.outputs.tarball_file }}
+      gate_eligible:
+        description: Whether the release uses the strict publish-gate manifest
+        value: ${{ jobs.prepare.outputs.gate_eligible }}
+
+permissions:
+  contents: read
+  attestations: read
+
+jobs:
+  prepare:
+    name: Verify release and pack exact npm tarball
+    runs-on: ubuntu-24.04
+    outputs:
+      commit: ${{ steps.prepare.outputs.commit }}
+      version: ${{ steps.prepare.outputs.version }}
+      package_name: ${{ steps.prepare.outputs.package_name }}
+      tarball_artifact: ${{ steps.prepare.outputs.tarball_artifact }}
+      tarball_file: ${{ steps.prepare.outputs.tarball_file }}
+      gate_eligible: ${{ steps.prepare.outputs.gate_eligible }}
+    steps:
+      - name: Check out platform proof tools
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          path: proof-tools
+      - name: Check out exact release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ inputs.tag }}
+          path: release-source
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          package-manager-cache: false
+      - name: Verify immutable release identity, assets, and attestations
+        id: prepare
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          ALLOW_LEGACY: ${{ inputs.allow_legacy_manifest }}
+        run: |
+          if [[ ! "${TAG}" =~ ^agentplugins-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "invalid agentplugins stable tag: ${TAG}" >&2
+            exit 1
+          fi
+          commit="$(git -C release-source rev-parse HEAD)"
+          if [[ -n "${EXPECTED_COMMIT}" ]] && [[ "${commit}" != "${EXPECTED_COMMIT}" ]]; then
+            echo "release tag commit does not match the caller's frozen commit" >&2
+            exit 1
+          fi
+          version="${TAG#agentplugins-v}"
+          assets="${RUNNER_TEMP}/agentplugins-release-${version}"
+          mkdir -p "${assets}"
+          gh release download "${TAG}" --repo "${GITHUB_REPOSITORY}" --dir "${assets}"
+          policy=()
+          if [[ "${ALLOW_LEGACY}" = "true" ]]; then
+            policy=(allow-legacy-v1)
+          fi
+          node proof-tools/npm/agentplugins/scripts/release-assets.js verify \
+            "${assets}" "${TAG}" "${commit}" "${policy[@]}" > "${RUNNER_TEMP}/verified-release.json"
+          for asset in "${assets}"/agentplugins_* "${assets}/checksums.txt" "${assets}/release-manifest.json"; do
+            gh attestation verify "${asset}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --signer-workflow "github.com/${GITHUB_REPOSITORY}/.github/workflows/agentplugins-release.yml" \
+              --source-digest "${commit}"
+          done
+          stage="${RUNNER_TEMP}/agentplugins-npm-${version}"
+          mkdir -p "${stage}"
+          cp -R release-source/npm/agentplugins/. "${stage}/"
+          node proof-tools/npm/agentplugins/scripts/stage-release.js \
+            "${stage}" "${assets}" "${version}" "${commit}" "${policy[@]}"
+          (cd "${stage}" && npm test && npm pack --dry-run --ignore-scripts)
+          pack_json="$(cd "${stage}" && npm pack --ignore-scripts --json)"
+          tarball_file="$(jq -er 'if length == 1 then .[0].filename else error("expected one npm tarball") end' <<<"${pack_json}")"
+          tarball="${stage}/${tarball_file}"
+          test -s "${tarball}"
+          package_name="$(node -p 'require(process.argv[1]).name' "${stage}/package.json")"
+          tarball_artifact="agentplugins-npm-${version}"
+          gate_eligible="$(jq -r '.gate_eligible' "${RUNNER_TEMP}/verified-release.json")"
+          echo "commit=${commit}" >> "${GITHUB_OUTPUT}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "package_name=${package_name}" >> "${GITHUB_OUTPUT}"
+          echo "tarball_artifact=${tarball_artifact}" >> "${GITHUB_OUTPUT}"
+          echo "tarball_file=${tarball_file}" >> "${GITHUB_OUTPUT}"
+          echo "gate_eligible=${gate_eligible}" >> "${GITHUB_OUTPUT}"
+          cp "${tarball}" "${RUNNER_TEMP}/${tarball_file}"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: ${{ steps.prepare.outputs.tarball_artifact }}
+          path: |
+            ${{ runner.temp }}/${{ steps.prepare.outputs.tarball_file }}
+            ${{ runner.temp }}/verified-release.json
+          if-no-files-found: error
+          retention-days: 7
+
+  native-runtime:
+    name: native runtime E2E (${{ matrix.target }})
+    needs: prepare
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: darwin-amd64
+            runner: macos-15-intel
+            lifecycle: false
+          - target: darwin-arm64
+            runner: macos-15
+            lifecycle: true
+          - target: linux-amd64
+            runner: ubuntu-24.04
+            lifecycle: true
+          - target: linux-arm64
+            runner: ubuntu-24.04-arm
+            lifecycle: false
+          - target: windows-amd64
+            runner: windows-2025
+            lifecycle: true
+          - target: windows-arm64
+            runner: windows-11-arm
+            lifecycle: false
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Check out platform proof harness
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          package-manager-cache: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.prepare.outputs.tarball_artifact }}
+          path: ${{ runner.temp }}/agentplugins-proof-package
+      - name: Run native npm launcher and released binary proof
+        shell: bash
+        run: |
+          node npm/agentplugins/scripts/platform-proof.js \
+            "${{ runner.temp }}/agentplugins-proof-package/${{ needs.prepare.outputs.tarball_file }}" \
+            "${{ needs.prepare.outputs.version }}" \
+            "${{ matrix.target }}" \
+            "${{ matrix.lifecycle }}" \
+            "${{ runner.temp }}/agentplugins-proof-${{ matrix.target }}.json"
+      - name: Upload machine-readable native proof
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: agentplugins-native-proof-${{ matrix.target }}
+          path: ${{ runner.temp }}/agentplugins-proof-${{ matrix.target }}.json
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/agentplugins-platform-proof.yml
+++ b/.github/workflows/agentplugins-platform-proof.yml
@@ -117,6 +117,9 @@ jobs:
             exit 1
           fi
           commit="$(git -C release-source rev-parse HEAD)"
+          git -C release-source fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
+          tag_commit="$(git -C release-source rev-list -n 1 "refs/tags/${TAG}")"
+          test "${tag_commit}" = "${commit}"
           if [[ -n "${EXPECTED_COMMIT}" ]] && [[ "${commit}" != "${EXPECTED_COMMIT}" ]]; then
             echo "release tag commit does not match the caller's frozen commit" >&2
             exit 1
@@ -124,16 +127,27 @@ jobs:
           version="${TAG#agentplugins-v}"
           assets="${RUNNER_TEMP}/agentplugins-release-${version}"
           mkdir -p "${assets}"
-          release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}")"
+          owner="${GITHUB_REPOSITORY%%/*}"
+          repository="${GITHUB_REPOSITORY#*/}"
+          release_query='query($owner:String!,$name:String!,$tag:String!){repository(owner:$owner,name:$name){release(tagName:$tag){isDraft isPrerelease tagName}}}'
+          release_json="$(gh api graphql -f query="${release_query}" -F owner="${owner}" -F name="${repository}" -F tag="${TAG}")" || {
+            echo "failed to look up release ${TAG}" >&2
+            exit 1
+          }
+          release_json="$(jq -c '.data.repository.release' <<<"${release_json}")"
+          if [[ "${release_json}" = "null" ]]; then
+            echo "release ${TAG} was not found" >&2
+            exit 1
+          fi
           if [[ "${REQUIRE_DRAFT}" = "true" ]]; then
-            jq -e --arg tag "${TAG}" --arg commit "${commit}" \
-              '.draft == true and .prerelease == false and .tag_name == $tag and .target_commitish == $commit' \
+            jq -e --arg tag "${TAG}" \
+              '.isDraft == true and .isPrerelease == false and .tagName == $tag' \
               <<<"${release_json}" >/dev/null || {
                 echo "platform proof requires the exact release to remain a non-public draft" >&2
                 exit 1
               }
           else
-            jq -e --arg tag "${TAG}" '.draft == false and .tag_name == $tag' <<<"${release_json}" >/dev/null || {
+            jq -e --arg tag "${TAG}" '.isDraft == false and .isPrerelease == false and .tagName == $tag' <<<"${release_json}" >/dev/null || {
               echo "platform proof requires an existing public release" >&2
               exit 1
             }

--- a/.github/workflows/agentplugins-release.yml
+++ b/.github/workflows/agentplugins-release.yml
@@ -33,6 +33,8 @@ jobs:
         id: identity
         env:
           TAG: ${{ inputs.tag }}
+          WORKFLOW_COMMIT: ${{ github.sha }}
+          WORKFLOW_REF: ${{ github.ref }}
         run: |
           if [[ ! "${TAG}" =~ ^agentplugins-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "invalid agentplugins stable tag: ${TAG}" >&2
@@ -40,6 +42,11 @@ jobs:
           fi
           git fetch --force origin main:refs/remotes/origin/main "refs/tags/${TAG}:refs/tags/${TAG}"
           head_commit="$(git rev-parse HEAD)"
+          test "${WORKFLOW_REF}" = "refs/heads/main"
+          if [[ "${WORKFLOW_COMMIT}" != "${head_commit}" ]]; then
+            echo "release workflow source does not match the exact tagged main commit" >&2
+            exit 1
+          fi
           test "${head_commit}" = "$(git rev-parse refs/remotes/origin/main)"
           test "${head_commit}" = "$(git rev-list -n 1 "refs/tags/${TAG}")"
           echo "commit=${head_commit}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/agentplugins-release.yml
+++ b/.github/workflows/agentplugins-release.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: agentplugins-release-${{ inputs.tag }}
+  cancel-in-progress: false
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -149,10 +153,12 @@ jobs:
           if-no-files-found: error
           retention-days: 3
 
-  publish-assets:
+  stage-draft:
     needs: [validate, build]
     runs-on: ubuntu-latest
     environment: agentplugins-release
+    outputs:
+      asset_set_digest: ${{ steps.draft.outputs.asset_set_digest }}
     permissions:
       contents: write
       id-token: write
@@ -170,6 +176,7 @@ jobs:
           merge-multiple: true
           path: ${{ runner.temp }}/agentplugins-assets
       - name: Prepare immutable stable assets
+        id: draft
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ inputs.tag }}
@@ -182,9 +189,28 @@ jobs:
             prepare "${PWD}" "${TAG}" "${FROZEN_COMMIT}"
           node "${GITHUB_WORKSPACE}/npm/agentplugins/scripts/release-assets.js" \
             verify "${PWD}" "${TAG}" "${FROZEN_COMMIT}"
-          if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-            echo "release ${TAG} already exists; refusing to overwrite immutable assets" >&2
-            exit 1
+          echo "asset_set_digest=$(sha256sum checksums.txt | cut -d ' ' -f 1)" >> "${GITHUB_OUTPUT}"
+          if release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" 2>/dev/null)"; then
+            jq -e --arg tag "${TAG}" --arg commit "${FROZEN_COMMIT}" \
+              '.draft == true and .prerelease == false and .tag_name == $tag and .target_commitish == $commit' \
+              <<<"${release_json}" >/dev/null || {
+                echo "release ${TAG} already exists but is not the exact resumable draft; refusing to overwrite immutable assets" >&2
+                exit 1
+              }
+            existing="${RUNNER_TEMP}/existing-agentplugins-assets"
+            mkdir -p "${existing}"
+            gh release download "${TAG}" --repo "${GITHUB_REPOSITORY}" --dir "${existing}"
+            node "${GITHUB_WORKSPACE}/npm/agentplugins/scripts/release-assets.js" \
+              verify "${existing}" "${TAG}" "${FROZEN_COMMIT}"
+            for asset in agentplugins_* checksums.txt release-manifest.json; do
+              cmp -- "${asset}" "${existing}/${asset}" || {
+                echo "existing draft asset differs from the frozen build: ${asset}" >&2
+                exit 1
+              }
+            done
+            echo "existing=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "existing=false" >> "${GITHUB_OUTPUT}"
           fi
       - uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
@@ -192,22 +218,24 @@ jobs:
             ${{ runner.temp }}/agentplugins-assets/agentplugins_*
             ${{ runner.temp }}/agentplugins-assets/checksums.txt
             ${{ runner.temp }}/agentplugins-assets/release-manifest.json
-      - name: Publish attested immutable stable assets
+      - name: Create non-public immutable draft
+        if: ${{ steps.draft.outputs.existing != 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ inputs.tag }}
         working-directory: ${{ runner.temp }}/agentplugins-assets
         run: |
           if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-            echo "release ${TAG} already exists; refusing to overwrite immutable assets" >&2
+            echo "release ${TAG} appeared concurrently; refusing to overwrite immutable assets" >&2
             exit 1
           fi
           gh release create "${TAG}" agentplugins_* checksums.txt release-manifest.json \
             --repo "${GITHUB_REPOSITORY}" --verify-tag \
+            --target "${{ needs.validate.outputs.commit }}" --draft \
             --title "Agentplugins ${TAG#agentplugins-v}" --generate-notes
 
   platform-proof:
-    needs: [validate, publish-assets]
+    needs: [validate, stage-draft]
     uses: ./.github/workflows/agentplugins-platform-proof.yml
     permissions:
       contents: read
@@ -216,3 +244,50 @@ jobs:
       tag: ${{ inputs.tag }}
       expected_commit: ${{ needs.validate.outputs.commit }}
       allow_legacy_manifest: false
+      require_draft: true
+      expected_asset_set_digest: ${{ needs.stage-draft.outputs.asset_set_digest }}
+
+  promote-release:
+    needs: [validate, stage-draft, platform-proof]
+    runs-on: ubuntu-latest
+    environment: agentplugins-release
+    permissions:
+      contents: write
+      attestations: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ needs.validate.outputs.commit }}
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          package-manager-cache: false
+      - name: Reverify exact draft and promote only after all native proofs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+          FROZEN_COMMIT: ${{ needs.validate.outputs.commit }}
+          EXPECTED_ASSET_SET_DIGEST: ${{ needs.stage-draft.outputs.asset_set_digest }}
+        run: |
+          release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}")"
+          jq -e --arg tag "${TAG}" --arg commit "${FROZEN_COMMIT}" \
+            '.draft == true and .prerelease == false and .tag_name == $tag and .target_commitish == $commit' \
+            <<<"${release_json}" >/dev/null || {
+              echo "release is no longer the exact non-public draft proven by this run" >&2
+              exit 1
+            }
+          assets="${RUNNER_TEMP}/agentplugins-promote-assets"
+          mkdir -p "${assets}"
+          gh release download "${TAG}" --repo "${GITHUB_REPOSITORY}" --dir "${assets}"
+          node npm/agentplugins/scripts/release-assets.js verify "${assets}" "${TAG}" "${FROZEN_COMMIT}"
+          test "$(sha256sum "${assets}/checksums.txt" | cut -d ' ' -f 1)" = "${EXPECTED_ASSET_SET_DIGEST}"
+          for asset in "${assets}"/agentplugins_* "${assets}/checksums.txt" "${assets}/release-manifest.json"; do
+            gh attestation verify "${asset}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --signer-workflow "github.com/${GITHUB_REPOSITORY}/.github/workflows/agentplugins-release.yml" \
+              --source-digest "${FROZEN_COMMIT}"
+          done
+          gh release edit "${TAG}" --repo "${GITHUB_REPOSITORY}" --draft=false
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \
+            --jq 'select(.draft == false and .prerelease == false) | .tag_name' | grep -Fx -- "${TAG}"

--- a/.github/workflows/agentplugins-release.yml
+++ b/.github/workflows/agentplugins-release.yml
@@ -38,10 +38,10 @@ jobs:
             echo "invalid agentplugins stable tag: ${TAG}" >&2
             exit 1
           fi
-          git fetch --force origin main:refs/remotes/origin/main
+          git fetch --force origin main:refs/remotes/origin/main "refs/tags/${TAG}:refs/tags/${TAG}"
           head_commit="$(git rev-parse HEAD)"
           test "${head_commit}" = "$(git rev-parse refs/remotes/origin/main)"
-          test "${head_commit}" = "$(git rev-list -n 1 "${TAG}")"
+          test "${head_commit}" = "$(git rev-list -n 1 "refs/tags/${TAG}")"
           echo "commit=${head_commit}" >> "${GITHUB_OUTPUT}"
       - name: Verify merged PR and required commit evidence
         env:
@@ -184,15 +184,23 @@ jobs:
         working-directory: ${{ runner.temp }}/agentplugins-assets
         run: |
           git -C "${GITHUB_WORKSPACE}" fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
-          test "$(git -C "${GITHUB_WORKSPACE}" rev-list -n 1 "${TAG}")" = "${FROZEN_COMMIT}"
+          test "$(git -C "${GITHUB_WORKSPACE}" rev-list -n 1 "refs/tags/${TAG}")" = "${FROZEN_COMMIT}"
           node "${GITHUB_WORKSPACE}/npm/agentplugins/scripts/release-assets.js" \
             prepare "${PWD}" "${TAG}" "${FROZEN_COMMIT}"
           node "${GITHUB_WORKSPACE}/npm/agentplugins/scripts/release-assets.js" \
             verify "${PWD}" "${TAG}" "${FROZEN_COMMIT}"
           echo "asset_set_digest=$(sha256sum checksums.txt | cut -d ' ' -f 1)" >> "${GITHUB_OUTPUT}"
-          if release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" 2>/dev/null)"; then
-            jq -e --arg tag "${TAG}" --arg commit "${FROZEN_COMMIT}" \
-              '.draft == true and .prerelease == false and .tag_name == $tag and .target_commitish == $commit' \
+          owner="${GITHUB_REPOSITORY%%/*}"
+          repository="${GITHUB_REPOSITORY#*/}"
+          release_query='query($owner:String!,$name:String!,$tag:String!){repository(owner:$owner,name:$name){release(tagName:$tag){isDraft isPrerelease tagName}}}'
+          release_response="$(gh api graphql -f query="${release_query}" -F owner="${owner}" -F name="${repository}" -F tag="${TAG}")" || {
+            echo "failed to look up existing release ${TAG}" >&2
+            exit 1
+          }
+          release_json="$(jq -c '.data.repository.release' <<<"${release_response}")"
+          if [[ "${release_json}" != "null" ]]; then
+            jq -e --arg tag "${TAG}" \
+              '.isDraft == true and .isPrerelease == false and .tagName == $tag' \
               <<<"${release_json}" >/dev/null || {
                 echo "release ${TAG} already exists but is not the exact resumable draft; refusing to overwrite immutable assets" >&2
                 exit 1
@@ -225,7 +233,14 @@ jobs:
           TAG: ${{ inputs.tag }}
         working-directory: ${{ runner.temp }}/agentplugins-assets
         run: |
-          if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+          owner="${GITHUB_REPOSITORY%%/*}"
+          repository="${GITHUB_REPOSITORY#*/}"
+          release_query='query($owner:String!,$name:String!,$tag:String!){repository(owner:$owner,name:$name){release(tagName:$tag){tagName}}}'
+          release_response="$(gh api graphql -f query="${release_query}" -F owner="${owner}" -F name="${repository}" -F tag="${TAG}")" || {
+            echo "failed to recheck release ${TAG} before creation" >&2
+            exit 1
+          }
+          if [[ "$(jq -c '.data.repository.release' <<<"${release_response}")" != "null" ]]; then
             echo "release ${TAG} appeared concurrently; refusing to overwrite immutable assets" >&2
             exit 1
           fi
@@ -270,9 +285,22 @@ jobs:
           FROZEN_COMMIT: ${{ needs.validate.outputs.commit }}
           EXPECTED_ASSET_SET_DIGEST: ${{ needs.stage-draft.outputs.asset_set_digest }}
         run: |
-          release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}")"
-          jq -e --arg tag "${TAG}" --arg commit "${FROZEN_COMMIT}" \
-            '.draft == true and .prerelease == false and .tag_name == $tag and .target_commitish == $commit' \
+          git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
+          test "$(git rev-list -n 1 "refs/tags/${TAG}")" = "${FROZEN_COMMIT}"
+          owner="${GITHUB_REPOSITORY%%/*}"
+          repository="${GITHUB_REPOSITORY#*/}"
+          release_query='query($owner:String!,$name:String!,$tag:String!){repository(owner:$owner,name:$name){release(tagName:$tag){isDraft isPrerelease tagName}}}'
+          release_response="$(gh api graphql -f query="${release_query}" -F owner="${owner}" -F name="${repository}" -F tag="${TAG}")" || {
+            echo "failed to look up release ${TAG} immediately before promotion" >&2
+            exit 1
+          }
+          release_json="$(jq -c '.data.repository.release' <<<"${release_response}")"
+          [[ "${release_json}" != "null" ]] || {
+            echo "release ${TAG} was not found immediately before promotion" >&2
+            exit 1
+          }
+          jq -e --arg tag "${TAG}" \
+            '.isDraft == true and .isPrerelease == false and .tagName == $tag' \
             <<<"${release_json}" >/dev/null || {
               echo "release is no longer the exact non-public draft proven by this run" >&2
               exit 1

--- a/.github/workflows/agentplugins-release.yml
+++ b/.github/workflows/agentplugins-release.yml
@@ -159,6 +159,7 @@ jobs:
     environment: agentplugins-release
     outputs:
       asset_set_digest: ${{ steps.draft.outputs.asset_set_digest }}
+      assets_artifact: ${{ steps.draft.outputs.assets_artifact }}
     permissions:
       contents: write
       id-token: write
@@ -190,6 +191,7 @@ jobs:
           node "${GITHUB_WORKSPACE}/npm/agentplugins/scripts/release-assets.js" \
             verify "${PWD}" "${TAG}" "${FROZEN_COMMIT}"
           echo "asset_set_digest=$(sha256sum checksums.txt | cut -d ' ' -f 1)" >> "${GITHUB_OUTPUT}"
+          echo "assets_artifact=agentplugins-draft-assets-${FROZEN_COMMIT}" >> "${GITHUB_OUTPUT}"
           owner="${GITHUB_REPOSITORY%%/*}"
           repository="${GITHUB_REPOSITORY#*/}"
           release_query='query($owner:String!,$name:String!,$tag:String!){repository(owner:$owner,name:$name){release(tagName:$tag){isDraft isPrerelease tagName}}}'
@@ -248,13 +250,22 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" --verify-tag \
             --target "${{ needs.validate.outputs.commit }}" --draft \
             --title "Agentplugins ${TAG#agentplugins-v}" --generate-notes
+      - name: Share frozen draft assets with the read-only proof workflow
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: ${{ steps.draft.outputs.assets_artifact }}
+          path: |
+            ${{ runner.temp }}/agentplugins-assets/agentplugins_*
+            ${{ runner.temp }}/agentplugins-assets/checksums.txt
+            ${{ runner.temp }}/agentplugins-assets/release-manifest.json
+          if-no-files-found: error
+          retention-days: 7
 
   platform-proof:
     needs: [validate, stage-draft]
     uses: ./.github/workflows/agentplugins-platform-proof.yml
     permissions:
-      # Draft release assets require push-level repository access.
-      contents: write
+      contents: read
       attestations: read
     with:
       tag: ${{ inputs.tag }}
@@ -262,6 +273,7 @@ jobs:
       allow_legacy_manifest: false
       require_draft: true
       expected_asset_set_digest: ${{ needs.stage-draft.outputs.asset_set_digest }}
+      release_assets_artifact: ${{ needs.stage-draft.outputs.assets_artifact }}
 
   promote-release:
     needs: [validate, stage-draft, platform-proof]

--- a/.github/workflows/agentplugins-release.yml
+++ b/.github/workflows/agentplugins-release.yml
@@ -253,7 +253,8 @@ jobs:
     needs: [validate, stage-draft]
     uses: ./.github/workflows/agentplugins-platform-proof.yml
     permissions:
-      contents: read
+      # Draft release assets require push-level repository access.
+      contents: write
       attestations: read
     with:
       tag: ${{ inputs.tag }}

--- a/.github/workflows/agentplugins-release.yml
+++ b/.github/workflows/agentplugins-release.yml
@@ -176,12 +176,12 @@ jobs:
           FROZEN_COMMIT: ${{ needs.validate.outputs.commit }}
         working-directory: ${{ runner.temp }}/agentplugins-assets
         run: |
-          test "$(find . -maxdepth 1 -type f -name 'agentplugins_*' | wc -l | tr -d ' ')" = 6
           git -C "${GITHUB_WORKSPACE}" fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
           test "$(git -C "${GITHUB_WORKSPACE}" rev-list -n 1 "${TAG}")" = "${FROZEN_COMMIT}"
-          jq -n --arg tag "${TAG}" --arg commit "${FROZEN_COMMIT}" \
-            '{schema_version: 1, tag: $tag, commit: $commit}' > release-manifest.json
-          sha256sum agentplugins_* release-manifest.json > checksums.txt
+          node "${GITHUB_WORKSPACE}/npm/agentplugins/scripts/release-assets.js" \
+            prepare "${PWD}" "${TAG}" "${FROZEN_COMMIT}"
+          node "${GITHUB_WORKSPACE}/npm/agentplugins/scripts/release-assets.js" \
+            verify "${PWD}" "${TAG}" "${FROZEN_COMMIT}"
           if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
             echo "release ${TAG} already exists; refusing to overwrite immutable assets" >&2
             exit 1
@@ -205,3 +205,14 @@ jobs:
           gh release create "${TAG}" agentplugins_* checksums.txt release-manifest.json \
             --repo "${GITHUB_REPOSITORY}" --verify-tag \
             --title "Agentplugins ${TAG#agentplugins-v}" --generate-notes
+
+  platform-proof:
+    needs: [validate, publish-assets]
+    uses: ./.github/workflows/agentplugins-platform-proof.yml
+    permissions:
+      contents: read
+      attestations: read
+    with:
+      tag: ${{ inputs.tag }}
+      expected_commit: ${{ needs.validate.outputs.commit }}
+      allow_legacy_manifest: false

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -188,8 +188,16 @@ func renderHumanPlan(writer io.Writer, envelope domain.PackageEnvelope, result u
 	_, _ = fmt.Fprintf(writer, "Target: %s\n", result.Plan.ClientID)
 	_, _ = fmt.Fprintf(writer, "Package: %s\n", result.Plan.PackageMode)
 	_, _ = fmt.Fprintf(writer, "Result: %s\n", result.Plan.Status)
+	_, _ = fmt.Fprintf(writer, "Authentication: %s\n", result.Plan.Authentication)
+	_, _ = fmt.Fprintf(writer, "Verification: %s\n", result.Plan.Verification)
 	for _, component := range result.Plan.Components {
 		_, _ = fmt.Fprintf(writer, "  - %s %s: %s\n", component.Kind, component.Name, component.Support)
+	}
+	for _, diagnostic := range result.Plan.Diagnostics {
+		_, _ = fmt.Fprintf(writer, "  Warning: %s: %s\n", diagnostic.Code, diagnostic.Message)
+	}
+	for _, warning := range result.Plan.Warnings {
+		_, _ = fmt.Fprintf(writer, "  Warning: %s\n", warning)
 	}
 	for _, action := range result.Plan.UserActions {
 		_, _ = fmt.Fprintf(writer, "  Planned action: %s\n", action)

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -1,7 +1,6 @@
 package agentpluginscli
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -30,7 +29,7 @@ func newAddCommand(app App, opts *options) *cobra.Command {
 		},
 	}
 	command.Flags().BoolVar(&activationComplete, "activation-complete", false, "attest that manual client activation is complete")
-	command.Flags().BoolVar(&authComplete, "auth-complete", false, "attest that pending client authentication is complete")
+	command.Flags().BoolVar(&authComplete, "auth-complete", false, "attest that required authentication is complete or none is required after review")
 	return command
 }
 
@@ -82,25 +81,22 @@ func runAdd(ctx context.Context, cmd *cobra.Command, app App, opts *options, sou
 			return err
 		}
 	}
+	freshInstall := planned.Activation.Activation == ""
+	if !freshInstall && opts.format == "human" && app.Terminal && !opts.yes && !activationComplete && !authComplete {
+		if err := renderAddResult(cmd.OutOrStdout(), opts.format, loaded.envelope, planned, false); err != nil {
+			return err
+		}
+		return resumeInteractiveLifecycle(ctx, cmd, service, input, loaded.envelope, planned)
+	}
 	confirmed := opts.yes
 	if !confirmed && opts.format == "human" && app.Terminal {
 		prompt := "Apply this plan? [y/N]"
-		if planned.Activation.Activation == domain.ActivationManual {
-			prompt = "Have you completed manual activation and verified the plugin is enabled in the client? [y/N]"
-		} else if planned.Activation.Authentication == domain.AuthenticationPending && planned.Activation.Activation == domain.ActivationActive {
-			prompt = "Have you completed authentication in the client? [y/N]"
+		if !freshInstall {
+			prompt = "Apply these explicit lifecycle attestations? [y/N]"
 		}
 		confirmed, err = promptYesNo(cmd.InOrStdin(), cmd.OutOrStdout(), prompt)
 		if err != nil {
 			return err
-		}
-		if confirmed && planned.Activation.Activation == domain.ActivationManual {
-			input.ActivationComplete = true
-			if planned.Activation.Authentication == domain.AuthenticationPending {
-				input.AuthComplete = true
-			}
-		} else if confirmed && planned.Activation.Authentication == domain.AuthenticationPending && planned.Activation.Activation == domain.ActivationActive {
-			input.AuthComplete = true
 		}
 	}
 	if !confirmed {
@@ -117,7 +113,65 @@ func runAdd(ctx context.Context, cmd *cobra.Command, app App, opts *options, sou
 	if renderErr := renderAddResult(cmd.OutOrStdout(), opts.format, loaded.envelope, result, false); renderErr != nil && err == nil {
 		err = renderErr
 	}
+	if err == nil && freshInstall && opts.format == "human" && app.Terminal && !opts.yes {
+		return resumeInteractiveLifecycle(ctx, cmd, service, input, loaded.envelope, result)
+	}
 	return err
+}
+
+func resumeInteractiveLifecycle(
+	ctx context.Context,
+	cmd *cobra.Command,
+	service usecase.Service,
+	input usecase.AddInput,
+	envelope domain.PackageEnvelope,
+	current usecase.AddResult,
+) error {
+	if current.Activation.Activation != domain.ActivationActive || current.Activation.Verification != domain.VerificationInstalled {
+		complete, err := promptYesNo(cmd.InOrStdin(), cmd.OutOrStdout(), "Have you completed activation and verified the plugin is enabled in the client? [y/N]")
+		if err != nil {
+			return err
+		}
+		if !complete {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Activation remains unconfirmed. Rerun add when it is complete.")
+			return nil
+		}
+		resume := input
+		resume.Confirmed = true
+		resume.InstallationID = current.InstallationID
+		resume.ActivationComplete = true
+		resume.AuthComplete = false
+		current, err = service.Add(ctx, resume)
+		if err != nil {
+			return err
+		}
+	}
+
+	if current.Activation.Authentication == domain.AuthenticationPending || current.Activation.Authentication == domain.AuthenticationNotChecked {
+		complete, err := promptYesNo(cmd.InOrStdin(), cmd.OutOrStdout(), "Have you completed required authentication, or reviewed the package and confirmed none is required? [y/N]")
+		if err != nil {
+			return err
+		}
+		if !complete {
+			if current.Activation.ActivationAttested {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Activation is user-attested. Authentication remains unconfirmed; rerun add after completing or reviewing it.")
+			} else {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Authentication remains unconfirmed. Rerun add after completing or reviewing it.")
+			}
+			return nil
+		}
+		resume := input
+		resume.Confirmed = true
+		resume.InstallationID = current.InstallationID
+		resume.ActivationComplete = false
+		resume.AuthComplete = true
+		current, err = service.Add(ctx, resume)
+		if err != nil {
+			return err
+		}
+	}
+
+	return renderAddResult(cmd.OutOrStdout(), "human", envelope, current, false)
 }
 
 func selectClient(
@@ -157,7 +211,7 @@ func selectClient(
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %d. %s\n", index+1, client.DisplayName)
 	}
 	_, _ = fmt.Fprint(cmd.OutOrStdout(), "Choose one target: ")
-	line, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
+	line, err := readInputLine(cmd.InOrStdin())
 	if err != nil && err != io.EOF {
 		return domain.DetectedClient{}, detectedMap, err
 	}
@@ -194,12 +248,29 @@ func backendExecutable(selected domain.DetectedClient, clients map[domain.Client
 
 func promptYesNo(reader io.Reader, writer io.Writer, prompt string) (bool, error) {
 	_, _ = fmt.Fprint(writer, prompt+" ")
-	line, err := bufio.NewReader(reader).ReadString('\n')
+	line, err := readInputLine(reader)
 	if err != nil && err != io.EOF {
 		return false, err
 	}
 	answer := strings.ToLower(strings.TrimSpace(line))
 	return answer == "y" || answer == "yes", nil
+}
+
+func readInputLine(reader io.Reader) (string, error) {
+	var line strings.Builder
+	var buffer [1]byte
+	for {
+		read, err := reader.Read(buffer[:])
+		if read > 0 {
+			if buffer[0] == '\n' {
+				return line.String(), nil
+			}
+			line.WriteByte(buffer[0])
+		}
+		if err != nil {
+			return line.String(), err
+		}
+	}
 }
 
 func renderHumanPlan(writer io.Writer, envelope domain.PackageEnvelope, result usecase.AddResult) error {
@@ -246,7 +317,7 @@ func renderAddResult(writer io.Writer, format string, envelope domain.PackageEnv
 	}
 	if result.Mutated && fullyInstalled(result.Activation) {
 		if result.Activation.ActivationAttested || result.Activation.AuthenticationAttested {
-			_, _ = fmt.Fprintln(writer, "Lifecycle marked complete from your explicit confirmation; client observation was not available for the attested phase.")
+			_, _ = fmt.Fprintln(writer, "Lifecycle is user-attested for the explicitly confirmed phase; it was not observed from the client.")
 		} else {
 			_, _ = fmt.Fprintln(writer, "Installed and verified for the selected client.")
 		}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -17,7 +17,8 @@ import (
 )
 
 func newAddCommand(app App, opts *options) *cobra.Command {
-	return &cobra.Command{
+	var activationComplete, authComplete bool
+	command := &cobra.Command{
 		Use:   "add <name-or-source>",
 		Short: "Plan and install one Agent Plugins 1.0 package",
 		Args:  cobra.ExactArgs(1),
@@ -25,12 +26,15 @@ func newAddCommand(app App, opts *options) *cobra.Command {
 			if err := validateCommonOptions(opts); err != nil {
 				return err
 			}
-			return runAdd(cmd.Context(), cmd, app, opts, args[0])
+			return runAdd(cmd.Context(), cmd, app, opts, args[0], activationComplete, authComplete)
 		},
 	}
+	command.Flags().BoolVar(&activationComplete, "activation-complete", false, "attest that manual client activation is complete")
+	command.Flags().BoolVar(&authComplete, "auth-complete", false, "attest that pending client authentication is complete")
+	return command
 }
 
-func runAdd(ctx context.Context, cmd *cobra.Command, app App, opts *options, source string) error {
+func runAdd(ctx context.Context, cmd *cobra.Command, app App, opts *options, source string, activationComplete, authComplete bool) error {
 	writeProgress(app, opts.format, "Resolving and validating Agent Plugin...")
 	loaded, err := app.loadPackage(ctx, source)
 	if err != nil {
@@ -64,6 +68,7 @@ func runAdd(ctx context.Context, cmd *cobra.Command, app App, opts *options, sou
 		Envelope: loaded.envelope, Client: selected, Scope: domain.InstallScope(opts.scope),
 		DryRun: opts.dryRun, Confirmed: false, Interactive: app.Terminal,
 		Hints: loaded.hints, BackendExecutable: backendExecutable(selected, detectedMap),
+		ActivationComplete: activationComplete, AuthComplete: authComplete,
 	}
 	planned, err := service.Add(ctx, input)
 	if err != nil {
@@ -79,9 +84,23 @@ func runAdd(ctx context.Context, cmd *cobra.Command, app App, opts *options, sou
 	}
 	confirmed := opts.yes
 	if !confirmed && opts.format == "human" && app.Terminal {
-		confirmed, err = promptYesNo(cmd.InOrStdin(), cmd.OutOrStdout(), "Apply this plan? [y/N]")
+		prompt := "Apply this plan? [y/N]"
+		if planned.Activation.Activation == domain.ActivationManual {
+			prompt = "Have you completed manual activation and verified the plugin is enabled in the client? [y/N]"
+		} else if planned.Activation.Authentication == domain.AuthenticationPending && planned.Activation.Activation == domain.ActivationActive {
+			prompt = "Have you completed authentication in the client? [y/N]"
+		}
+		confirmed, err = promptYesNo(cmd.InOrStdin(), cmd.OutOrStdout(), prompt)
 		if err != nil {
 			return err
+		}
+		if confirmed && planned.Activation.Activation == domain.ActivationManual {
+			input.ActivationComplete = true
+			if planned.Activation.Authentication == domain.AuthenticationPending {
+				input.AuthComplete = true
+			}
+		} else if confirmed && planned.Activation.Authentication == domain.AuthenticationPending && planned.Activation.Activation == domain.ActivationActive {
+			input.AuthComplete = true
 		}
 	}
 	if !confirmed {
@@ -226,7 +245,11 @@ func renderAddResult(writer io.Writer, format string, envelope domain.PackageEnv
 		return nil
 	}
 	if result.Mutated && fullyInstalled(result.Activation) {
-		_, _ = fmt.Fprintln(writer, "Installed and verified for the selected client.")
+		if result.Activation.ActivationAttested || result.Activation.AuthenticationAttested {
+			_, _ = fmt.Fprintln(writer, "Lifecycle marked complete from your explicit confirmation; client observation was not available for the attested phase.")
+		} else {
+			_, _ = fmt.Fprintln(writer, "Installed and verified for the selected client.")
+		}
 		return nil
 	}
 	if result.Mutated {
@@ -236,12 +259,14 @@ func renderAddResult(writer io.Writer, format string, envelope domain.PackageEnv
 			} else {
 				_, _ = fmt.Fprintln(writer, "Package prepared. Authentication and client activation are pending.")
 			}
+		} else if result.Activation.Authentication == domain.AuthenticationNotChecked && result.Activation.Activation == domain.ActivationActive {
+			_, _ = fmt.Fprintln(writer, "Package materialized and client activation verified. Authentication requirements have not been checked.")
 		} else {
 			_, _ = fmt.Fprintln(writer, "Package prepared. Activation is not complete yet.")
 		}
-		if action := nextLifecycleAction(result); action != "" {
-			_, _ = fmt.Fprintf(writer, "Next: %s\n", action)
-		}
+	}
+	if action := nextLifecycleAction(result); action != "" && !fullyInstalled(result.Activation) {
+		_, _ = fmt.Fprintf(writer, "Next: %s\n", action)
 	}
 	return nil
 }
@@ -258,6 +283,12 @@ func nextLifecycleAction(result usecase.AddResult) string {
 			return fmt.Sprintf("%s; complete authentication, then rerun add to verify activation and authentication", action)
 		}
 		return fmt.Sprintf("complete authentication for the prepared package at %s, then rerun add to verify activation and authentication", result.Plan.ActivePath)
+	}
+	if result.Activation.Authentication == domain.AuthenticationNotChecked {
+		if action != "" {
+			return action + "; verify this plugin's authentication requirements before using it"
+		}
+		return "verify this plugin's authentication requirements before using it"
 	}
 	if action != "" {
 		return action

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -248,7 +248,9 @@ func backendExecutable(selected domain.DetectedClient, clients map[domain.Client
 }
 
 func promptYesNo(reader io.Reader, writer io.Writer, prompt string) (bool, error) {
-	_, _ = fmt.Fprint(writer, prompt+" ")
+	if _, err := fmt.Fprint(writer, prompt+" "); err != nil {
+		return false, err
+	}
 	line, err := readInputLine(reader)
 	if err != nil && err != io.EOF {
 		return false, err

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -129,10 +129,6 @@ func resumeInteractiveLifecycle(
 	current usecase.AddResult,
 ) error {
 	if current.Activation.Activation != domain.ActivationActive || current.Activation.Verification != domain.VerificationInstalled {
-		if cliClientVerifierAvailable(input, current.Plan) {
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Client verification must return recognized positive evidence. Inspect the plugin manually, update the client if its output format is unsupported, then rerun add.")
-			return nil
-		}
 		complete, err := promptYesNo(cmd.InOrStdin(), cmd.OutOrStdout(), "Have you completed activation and verified the plugin is enabled in the client? [y/N]")
 		if err != nil {
 			return err
@@ -177,28 +173,6 @@ func resumeInteractiveLifecycle(
 	}
 
 	return renderAddResult(cmd.OutOrStdout(), "human", envelope, current, false)
-}
-
-func cliClientVerifierAvailable(input usecase.AddInput, plan domain.DeliveryPlan) bool {
-	if strings.TrimSpace(input.BackendExecutable) == "" {
-		return false
-	}
-	switch input.Client.ClientID {
-	case domain.ClientCodex, domain.ClientCopilot, domain.ClientVSCode:
-		return true
-	case domain.ClientKiro:
-		if !strings.Contains(strings.ToLower(input.BackendExecutable), "kiro") || len(plan.Components) == 0 {
-			return false
-		}
-		for _, component := range plan.Components {
-			if component.Support == domain.SupportUnsupported || component.Kind != domain.ComponentMCPServer {
-				return false
-			}
-		}
-		return true
-	default:
-		return false
-	}
 }
 
 func selectClient(

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -46,12 +46,12 @@ func runAdd(ctx context.Context, cmd *cobra.Command, app App, opts *options, sou
 	if err != nil {
 		return fmt.Errorf("detect AI clients: %w", err)
 	}
+	if !opts.dryRun && automatedMutation(app, opts) && strings.TrimSpace(opts.target) == "" {
+		return fmt.Errorf("automated installation requires --target")
+	}
 	selected, detectedMap, err := selectClient(cmd, app, opts, clients)
 	if err != nil {
 		return err
-	}
-	if !opts.dryRun && !app.Terminal && (strings.TrimSpace(opts.target) == "" || !opts.yes) {
-		return fmt.Errorf("non-interactive installation requires both --target and --yes")
 	}
 	planner := clientplanner.Planner{ManagedRoot: app.ManagedRoot, Detected: detectedMap}
 	service := usecase.Service{
@@ -89,7 +89,7 @@ func runAdd(ctx context.Context, cmd *cobra.Command, app App, opts *options, sou
 		}
 		return resumeInteractiveLifecycle(ctx, cmd, service, input, loaded.envelope, planned)
 	}
-	confirmed := opts.yes
+	confirmed := mutationConfirmed(app, opts)
 	if !confirmed && opts.format == "human" && app.Terminal {
 		prompt := "Apply this plan? [y/N]"
 		if !freshInstall {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -68,6 +68,7 @@ func runAdd(ctx context.Context, cmd *cobra.Command, app App, opts *options, sou
 		DryRun: opts.dryRun, Confirmed: false, Interactive: app.Terminal,
 		Hints: loaded.hints, BackendExecutable: backendExecutable(selected, detectedMap),
 		ActivationComplete: activationComplete, AuthComplete: authComplete,
+		PersistAuthoritativeObservations: true,
 	}
 	planned, err := service.Add(ctx, input)
 	if err != nil {
@@ -128,6 +129,10 @@ func resumeInteractiveLifecycle(
 	current usecase.AddResult,
 ) error {
 	if current.Activation.Activation != domain.ActivationActive || current.Activation.Verification != domain.VerificationInstalled {
+		if cliClientVerifierAvailable(input, current.Plan) {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Client verification must return recognized positive evidence. Inspect the plugin manually, update the client if its output format is unsupported, then rerun add.")
+			return nil
+		}
 		complete, err := promptYesNo(cmd.InOrStdin(), cmd.OutOrStdout(), "Have you completed activation and verified the plugin is enabled in the client? [y/N]")
 		if err != nil {
 			return err
@@ -172,6 +177,28 @@ func resumeInteractiveLifecycle(
 	}
 
 	return renderAddResult(cmd.OutOrStdout(), "human", envelope, current, false)
+}
+
+func cliClientVerifierAvailable(input usecase.AddInput, plan domain.DeliveryPlan) bool {
+	if strings.TrimSpace(input.BackendExecutable) == "" {
+		return false
+	}
+	switch input.Client.ClientID {
+	case domain.ClientCodex, domain.ClientCopilot, domain.ClientVSCode:
+		return true
+	case domain.ClientKiro:
+		if !strings.Contains(strings.ToLower(input.BackendExecutable), "kiro") || len(plan.Components) == 0 {
+			return false
+		}
+		for _, component := range plan.Components {
+			if component.Support == domain.SupportUnsupported || component.Kind != domain.ComponentMCPServer {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
 }
 
 func selectClient(

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -69,8 +69,8 @@ func runAdd(ctx context.Context, cmd *cobra.Command, app App, opts *options, sou
 	if err != nil {
 		return err
 	}
-	if opts.dryRun {
-		return renderAddResult(cmd.OutOrStdout(), opts.format, loaded.envelope, planned, true)
+	if opts.dryRun || planned.NoChange {
+		return renderAddResult(cmd.OutOrStdout(), opts.format, loaded.envelope, planned, opts.dryRun)
 	}
 	if opts.format == "human" {
 		if err := renderHumanPlan(cmd.OutOrStdout(), loaded.envelope, planned); err != nil {
@@ -151,7 +151,7 @@ func selectClient(
 
 func normalizeTarget(value string) domain.ClientID {
 	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "chatgpt", "openai", "codex":
+	case "openai", "codex":
 		return domain.ClientCodex
 	case "cursor":
 		return domain.ClientCursor
@@ -192,10 +192,10 @@ func renderHumanPlan(writer io.Writer, envelope domain.PackageEnvelope, result u
 		_, _ = fmt.Fprintf(writer, "  - %s %s: %s\n", component.Kind, component.Name, component.Support)
 	}
 	for _, action := range result.Plan.UserActions {
-		_, _ = fmt.Fprintf(writer, "  Next: %s\n", action)
+		_, _ = fmt.Fprintf(writer, "  Planned action: %s\n", action)
 	}
 	for _, action := range result.Plan.LocalActions {
-		_, _ = fmt.Fprintf(writer, "  Next: %s\n", action)
+		_, _ = fmt.Fprintf(writer, "  Planned action: %s\n", action)
 	}
 	return nil
 }
@@ -213,6 +213,10 @@ func renderAddResult(writer io.Writer, format string, envelope domain.PackageEnv
 	if dryRun {
 		return renderHumanPlan(writer, envelope, result)
 	}
+	if result.NoChange {
+		_, _ = fmt.Fprintln(writer, "Already installed and lifecycle verification is complete. No changes made.")
+		return nil
+	}
 	if result.Mutated && fullyInstalled(result.Activation) {
 		_, _ = fmt.Fprintln(writer, "Installed and verified for the selected client.")
 		return nil
@@ -227,14 +231,30 @@ func renderAddResult(writer io.Writer, format string, envelope domain.PackageEnv
 		} else {
 			_, _ = fmt.Fprintln(writer, "Package prepared. Activation is not complete yet.")
 		}
-		for _, action := range result.Activation.UserActions {
-			_, _ = fmt.Fprintf(writer, "Next: %s\n", action)
-		}
-		for _, action := range result.Activation.LocalActions {
+		if action := nextLifecycleAction(result); action != "" {
 			_, _ = fmt.Fprintf(writer, "Next: %s\n", action)
 		}
 	}
 	return nil
+}
+
+func nextLifecycleAction(result usecase.AddResult) string {
+	action := ""
+	if len(result.Activation.LocalActions) > 0 {
+		action = result.Activation.LocalActions[0]
+	} else if len(result.Activation.UserActions) > 0 {
+		action = result.Activation.UserActions[0]
+	}
+	if result.Activation.Authentication == domain.AuthenticationPending {
+		if action != "" {
+			return fmt.Sprintf("%s; complete authentication, then rerun add to verify activation and authentication", action)
+		}
+		return fmt.Sprintf("complete authentication for the prepared package at %s, then rerun add to verify activation and authentication", result.Plan.ActivePath)
+	}
+	if action != "" {
+		return action
+	}
+	return "start a new client session and verify the plugin is available"
 }
 
 func fullyInstalled(outcome domain.ActivationOutcome) bool {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/binding.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/binding.go
@@ -50,9 +50,6 @@ func runBindingChange(
 	selector, source string,
 ) error {
 	commandName := bindingCommandName(mode)
-	if !opts.dryRun && !app.Terminal && !opts.yes {
-		return fmt.Errorf("non-interactive %s requires --yes", commandName)
-	}
 	writeProgress(app, opts.format, "Resolving and validating the proposed Agent Plugin binding...")
 	loaded, err := app.loadPackage(ctx, source)
 	if err != nil {
@@ -83,7 +80,7 @@ func runBindingChange(
 	if opts.format == "human" {
 		renderHumanBindingPlan(cmd.OutOrStdout(), planned.Plan)
 	}
-	confirmed := opts.yes
+	confirmed := mutationConfirmed(app, opts)
 	if !confirmed && opts.format == "human" && app.Terminal {
 		confirmed, err = promptYesNo(cmd.InOrStdin(), cmd.OutOrStdout(), "Apply this binding change? [y/N]")
 		if err != nil {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -163,7 +163,7 @@ func TestDoctorDiagnosesManagedDirectoryChangesWithRecovery(t *testing.T) {
 			if finding.InstallationName != "demo" || finding.InstallationID == "" || finding.ClientID != "cursor" {
 				t.Fatalf("managed finding scope = %+v", finding)
 			}
-			if finding.RecoveryAction != "run `agentplugins repair demo --target cursor`" {
+			if finding.RecoveryAction != "run `agentplugins repair "+finding.InstallationID+" --target cursor`" {
 				t.Fatalf("managed finding recovery = %q", finding.RecoveryAction)
 			}
 		}
@@ -175,9 +175,9 @@ func TestDoctorDiagnosesManagedDirectoryChangesWithRecovery(t *testing.T) {
 
 func TestDoctorRecoveryIncludesProjectScopeAndExactTarget(t *testing.T) {
 	t.Parallel()
-	installation := domain.Installation{DeclaredName: "demo"}
+	installation := domain.Installation{InstallationID: "00000000-0000-4000-8000-000000000001", DeclaredName: "demo"}
 	binding := domain.ClientBinding{ClientID: "cursor", Scope: string(domain.ScopeProject)}
-	if got := repairAction(installation, binding); got != "run `agentplugins repair demo --target cursor --scope project`" {
+	if got := repairAction(installation, binding); got != "run `agentplugins repair 00000000-0000-4000-8000-000000000001 --target cursor --scope project`" {
 		t.Fatalf("project repair action = %q", got)
 	}
 }

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/ports"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/usecase"
+	legacyports "github.com/777genius/plugin-kit-ai/install/integrationctl/ports"
 )
 
 func TestHelpKeepsAutomationConfirmationFlagOutOfUserFlow(t *testing.T) {
@@ -171,6 +172,46 @@ func TestDoctorDiagnosesManagedDirectoryChangesWithRecovery(t *testing.T) {
 	if !found {
 		t.Fatalf("managed integrity finding missing: %+v", output.Data.Findings)
 	}
+}
+
+func TestDoctorBlocksRepairForExcludedOwnershipMarker(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	plugin := writeCLIPlugin(t)
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor", "--yes"); err != nil {
+		t.Fatal(err)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding := onlyCLIClient(state.Installations[0])
+	if err := os.Mkdir(filepath.Join(binding.TargetLocator, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, err := fixture.execute(false, "doctor", state.Installations[0].InstallationID, "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output struct {
+		Data struct {
+			Findings []doctorFinding `json:"findings"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatal(err)
+	}
+	for _, finding := range output.Data.Findings {
+		if finding.Code != "excluded_ownership_marker" {
+			continue
+		}
+		if finding.Status != "unknown" || finding.InstallationID != state.Installations[0].InstallationID ||
+			!strings.Contains(finding.RecoveryAction, "manually review and remove") || strings.Contains(finding.RecoveryAction, "agentplugins repair") {
+			t.Fatalf("excluded marker finding = %+v", finding)
+		}
+		return
+	}
+	t.Fatalf("excluded ownership marker finding missing: %+v", output.Data.Findings)
 }
 
 func TestDoctorRecoveryIncludesProjectScopeAndExactTarget(t *testing.T) {
@@ -418,6 +459,103 @@ func TestCLICompletionFlagsRequirePriorMaterialization(t *testing.T) {
 	_, _, err := fixture.execute(false, "add", plugin, "--target", "cursor", "--yes", "--activation-complete", "--auth-complete")
 	if err == nil || !strings.Contains(err.Error(), "already materialized") {
 		t.Fatalf("fresh completion error = %v", err)
+	}
+}
+
+func TestCLIAddAndUpdatePersistConvergedNegativeObservationBeforeConfirmation(t *testing.T) {
+	t.Parallel()
+	client := fixtureClient(t, domain.ClientCopilot)
+	client.ExecutablePath = "/test/bin/copilot"
+	fixture := newCLIFixture(t, []domain.DetectedClient{client})
+	plugin := writeCLIPlugin(t)
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "copilot", "--yes"); err != nil {
+		t.Fatal(err)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptCount := len(onlyCLIClient(state.Installations[0]).Receipts)
+
+	for _, command := range []string{"add", "update"} {
+		for _, yes := range []bool{false, true} {
+			state, err = fixture.store.Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			for key, binding := range state.Installations[0].Clients {
+				binding.Activation = domain.ActivationActive
+				binding.Authentication = domain.AuthenticationNotRequired
+				binding.Verification = domain.VerificationInstalled
+				state.Installations[0].Clients[key] = binding
+			}
+			if err := fixture.store.Save(state); err != nil {
+				t.Fatal(err)
+			}
+			observer := &cliObservedActivator{outcome: domain.ActivationOutcome{
+				Activation: domain.ActivationFailed, Authentication: domain.AuthenticationNotRequired,
+				Policy: domain.PolicyAllowed, Verification: domain.VerificationFailed, AuthoritativeObservation: true,
+			}, err: errors.New("recognized negative client evidence")}
+			fixture.app.Activator = observer
+			selector := plugin
+			if command == "update" {
+				selector = "demo"
+			}
+			args := []string{command, selector, "--target", "copilot"}
+			if yes {
+				args = append(args, "--yes")
+			}
+			stdout, _, commandErr := fixture.execute(true, args...)
+			if commandErr == nil || !strings.Contains(commandErr.Error(), "recognized negative client evidence") {
+				t.Fatalf("%s yes=%t error=%v output=%q", command, yes, commandErr, stdout)
+			}
+			if observer.calls != 1 || strings.Contains(stdout, "Apply this") {
+				t.Fatalf("%s yes=%t verifier calls=%d output=%q", command, yes, observer.calls, stdout)
+			}
+			state, err = fixture.store.Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			binding := onlyCLIClient(state.Installations[0])
+			if binding.Activation != domain.ActivationFailed || binding.Verification != domain.VerificationFailed || len(binding.Receipts) != receiptCount {
+				t.Fatalf("%s yes=%t state=%+v", command, yes, binding)
+			}
+		}
+	}
+}
+
+func TestInteractiveUnknownCopilotOutputDoesNotPromptUnusableAttestation(t *testing.T) {
+	t.Parallel()
+	client := fixtureClient(t, domain.ClientCopilot)
+	client.ExecutablePath = "/test/bin/copilot"
+	fixture := newCLIFixture(t, []domain.DetectedClient{client})
+	runner := &cliCommandRunner{}
+	fixture.app.Activator = providers.Activator{Runner: runner}
+	plugin := writeCLIPlugin(t)
+	stdout, _, err := fixture.executeInput(true, "y\n", "add", plugin, "--target", "copilot")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runner.calls == 0 || !strings.Contains(stdout, "output contract was not recognized") {
+		t.Fatalf("unknown-output path did not execute verifier or show recovery: calls=%d output=%q", runner.calls, stdout)
+	}
+	if strings.Contains(stdout, "Have you completed activation") {
+		t.Fatalf("unknown observable output prompted an unusable attestation: %q", stdout)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding := onlyCLIClient(state.Installations[0])
+	if binding.Activation != domain.ActivationManual || binding.Verification != domain.VerificationPackageValid {
+		t.Fatalf("unknown output state = %+v", binding)
+	}
+	stdout, _, err = fixture.executeInput(true, "", "add", plugin, "--target", "copilot")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stdout, "Have you completed activation") || !strings.Contains(stdout, "update the client if its output format is unsupported") {
+		t.Fatalf("repeated unknown-output recovery = %q", stdout)
 	}
 }
 
@@ -783,6 +921,28 @@ func (stager failingVerifyStager) Verify(context.Context, string, string) error 
 
 type cliLegacyLifecycleStub struct {
 	exists bool
+}
+
+type cliObservedActivator struct {
+	outcome domain.ActivationOutcome
+	err     error
+	calls   int
+}
+
+func (activator *cliObservedActivator) Activate(context.Context, domain.ActivationRequest) (domain.ActivationOutcome, error) {
+	activator.calls++
+	return activator.outcome, activator.err
+}
+
+func (*cliObservedActivator) Deactivate(context.Context, domain.DeactivationRequest) (domain.DeactivationOutcome, error) {
+	return domain.DeactivationOutcome{}, errors.New("unexpected deactivation")
+}
+
+type cliCommandRunner struct{ calls int }
+
+func (runner *cliCommandRunner) Run(context.Context, legacyports.Command) (legacyports.CommandResult, error) {
+	runner.calls++
+	return legacyports.CommandResult{}, nil
 }
 
 func (stub *cliLegacyLifecycleStub) Exists(context.Context, string) (bool, error) {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -136,6 +136,39 @@ func TestHumanCodexFlowNeverClaimsPreparedPackageIsInstalled(t *testing.T) {
 	if !strings.Contains(stdout, "Package prepared") || strings.Contains(stdout, "Installed and verified") {
 		t.Fatalf("human output overclaimed activation: %s", stdout)
 	}
+	if strings.Count(stdout, "Next:") != 1 || !strings.Contains(stdout, fixture.root) || !strings.Contains(stdout, "verify") {
+		t.Fatalf("human output must contain one path-bearing verification step: %s", stdout)
+	}
+}
+
+func TestRepeatedAddResumesManualLifecycleWithoutAnotherReceipt(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	plugin := writeCLIPlugin(t)
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor", "--yes"); err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, err := fixture.execute(false, "add", plugin, "--target", "cursor", "--yes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(stdout, "Next:") != 1 || !strings.Contains(stdout, "verify") || !strings.Contains(stdout, "plugins/local") {
+		t.Fatalf("resume output = %q", stdout)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipts := onlyCLIClient(state.Installations[0]).Receipts; len(receipts) != 1 {
+		t.Fatalf("resume created another materialization receipt: %+v", receipts)
+	}
+}
+
+func TestChatGPTTargetIsNotAliasedToCodexCLI(t *testing.T) {
+	t.Parallel()
+	if got := normalizeTarget("chatgpt"); got == domain.ClientCodex {
+		t.Fatalf("ChatGPT GUI target was aliased to Codex CLI: %s", got)
+	}
 }
 
 func TestHumanOutputNeverCallsAuthPendingPackageInstalled(t *testing.T) {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -336,6 +336,63 @@ func TestRepeatedAddResumesManualLifecycleWithoutAnotherReceipt(t *testing.T) {
 	}
 }
 
+func TestInitialInteractiveAddPromptsForApplyBeforeLifecycle(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	plugin := writeCLIPlugin(t)
+	stdout, _, err := fixture.executeInput(true, "n\n", "add", plugin, "--target", "cursor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "Apply this plan? [y/N]") || strings.Contains(stdout, "Have you completed activation") || strings.Contains(stdout, "authentication, or reviewed") {
+		t.Fatalf("initial prompt order = %q", stdout)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Installations) != 0 {
+		t.Fatalf("declined plan materialized state: %+v", state)
+	}
+}
+
+func TestInteractiveActivationYesAuthNoKeepsIndependentResumableState(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	plugin := writeCLIPlugin(t)
+	stdout, _, err := fixture.executeInput(true, "y\ny\nn\n", "add", plugin, "--target", "cursor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	apply := strings.Index(stdout, "Apply this plan? [y/N]")
+	activation := strings.Index(stdout, "Have you completed activation")
+	auth := strings.Index(stdout, "Have you completed required authentication")
+	if apply < 0 || activation <= apply || auth <= activation {
+		t.Fatalf("interactive prompt order = %q", stdout)
+	}
+	if strings.Count(stdout, "Next:") != 1 || !strings.Contains(stdout, "Activation is user-attested") {
+		t.Fatalf("interactive next action or attestation output = %q", stdout)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding := onlyCLIClient(state.Installations[0])
+	if binding.Activation != domain.ActivationActive || binding.Verification != domain.VerificationInstalled || binding.Authentication != domain.AuthenticationNotChecked {
+		t.Fatalf("declined auth state = %+v", binding)
+	}
+}
+
+func TestCLICompletionFlagsRequirePriorMaterialization(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	plugin := writeCLIPlugin(t)
+	_, _, err := fixture.execute(false, "add", plugin, "--target", "cursor", "--yes", "--activation-complete", "--auth-complete")
+	if err == nil || !strings.Contains(err.Error(), "already materialized") {
+		t.Fatalf("fresh completion error = %v", err)
+	}
+}
+
 func TestRepairExplicitlyRestoresMissingManagedDirectory(t *testing.T) {
 	t.Parallel()
 	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
@@ -660,9 +717,13 @@ func newCLIFixture(t *testing.T, clients []domain.DetectedClient) cliFixture {
 }
 
 func (fixture cliFixture) execute(terminal bool, args ...string) (string, string, error) {
+	return fixture.executeInput(terminal, "", args...)
+}
+
+func (fixture cliFixture) executeInput(terminal bool, input string, args ...string) (string, string, error) {
 	var stdout, stderr bytes.Buffer
 	app := fixture.app
-	app.Input = strings.NewReader("")
+	app.Input = strings.NewReader(input)
 	app.Output = &stdout
 	app.ErrorOutput = &stderr
 	app.Terminal = terminal

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -98,6 +98,44 @@ func TestAutomatedAddRequiresExplicitTargetButNotYes(t *testing.T) {
 	}
 }
 
+func TestTTYYesNeverBypassesExplicitStandardTargetGuards(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	plugin := writeCLIPlugin(t)
+	if _, _, err := fixture.execute(true, "add", plugin, "--yes"); err == nil || !strings.Contains(err.Error(), "requires --target") {
+		t.Fatalf("TTY add --yes missing-target error = %v", err)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Installations) != 0 {
+		t.Fatalf("TTY add --yes without target mutated state: %+v", state)
+	}
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor"); err != nil {
+		t.Fatal(err)
+	}
+	for name, args := range map[string][]string{
+		"update": {"update", "demo", "--yes"},
+		"remove": {"remove", "demo", "--yes"},
+		"repair": {"repair", "demo", "--yes"},
+	} {
+		name, args := name, args
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := fixture.execute(true, args...); err == nil || !strings.Contains(err.Error(), "requires --target") {
+				t.Fatalf("TTY %s --yes missing-target error = %v", name, err)
+			}
+		})
+	}
+	state, err = fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binding := onlyCLIClient(state.Installations[0]); binding.Materialization != domain.MaterializationMaterialized || len(binding.Receipts) != 1 {
+		t.Fatalf("TTY --yes without target mutated standard lifecycle state: %+v", binding)
+	}
+}
+
 func TestDryRunAndDoctorAreStrictlyReadOnly(t *testing.T) {
 	t.Parallel()
 	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
@@ -975,6 +1013,9 @@ func TestLegacyRemovalRequiresExplicitAllTargetAndReconcilesV2(t *testing.T) {
 	}}}
 	if err := fixture.store.Save(state); err != nil {
 		t.Fatal(err)
+	}
+	if _, _, err := fixture.execute(true, "remove", "legacy-demo", "--yes"); err == nil || !strings.Contains(err.Error(), "legacy-all") {
+		t.Fatalf("unsafe legacy TTY --yes removal error = %v", err)
 	}
 	if _, _, err := fixture.execute(false, "remove", "legacy-demo"); err == nil || !strings.Contains(err.Error(), "legacy-all") {
 		t.Fatalf("unsafe legacy non-TTY removal error = %v", err)

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -173,6 +173,34 @@ func TestDoctorDiagnosesManagedDirectoryChangesWithRecovery(t *testing.T) {
 	}
 }
 
+func TestDoctorRecoveryIncludesProjectScopeAndExactTarget(t *testing.T) {
+	t.Parallel()
+	installation := domain.Installation{DeclaredName: "demo"}
+	binding := domain.ClientBinding{ClientID: "cursor", Scope: string(domain.ScopeProject)}
+	if got := repairAction(installation, binding); got != "run `agentplugins repair demo --target cursor --scope project`" {
+		t.Fatalf("project repair action = %q", got)
+	}
+}
+
+func TestRepairSourcePinsSelectedClientRevision(t *testing.T) {
+	t.Parallel()
+	installation := domain.Installation{Source: domain.SourceBinding{
+		Repository: "acme/plugins", PackageSubpath: "plugins/demo", ResolvedRevision: "moving-head",
+	}}
+	binding := domain.ClientBinding{PackageRevision: &domain.ClientPackageRevision{ResolvedRevision: "client-commit"}}
+	got, err := repairSource(installation, binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "github:acme/plugins@client-commit//plugins/demo" {
+		t.Fatalf("repair source = %q", got)
+	}
+	binding.PackageRevision.ResolvedRevision = ""
+	if _, err := repairSource(installation, binding); err == nil || !strings.Contains(err.Error(), "moving source") {
+		t.Fatalf("unpinned repair error = %v", err)
+	}
+}
+
 func TestDoctorScopesPendingRecoveryAndRendersIdentity(t *testing.T) {
 	t.Parallel()
 	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
@@ -412,7 +440,7 @@ func TestRepairExplicitlyRestoresMissingManagedDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(stdout, "repaired from the resolved source") {
+	if !strings.Contains(stdout, "repaired from the exact installed revision") {
 		t.Fatalf("repair output = %q", stdout)
 	}
 	if _, err := os.Stat(filepath.Join(target, "plugin.json")); err != nil {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -790,14 +790,21 @@ func TestHumanOutputNeverCallsAuthPendingPackageInstalled(t *testing.T) {
 	}
 }
 
-func TestMultipleDetectedClientsAreNeverSelectedByYesAlone(t *testing.T) {
+func TestTTYYesWithMultipleDetectedClientsRequiresExplicitTarget(t *testing.T) {
 	t.Parallel()
 	fixture := newCLIFixture(t, []domain.DetectedClient{
 		fixtureClient(t, domain.ClientCursor), fixtureClient(t, domain.ClientCodex),
 	})
 	plugin := writeCLIPlugin(t)
-	if _, _, err := fixture.execute(true, "add", plugin, "--yes"); err == nil || !strings.Contains(err.Error(), "choose exactly one") {
-		t.Fatalf("multiple-client error = %v", err)
+	if _, _, err := fixture.execute(true, "add", plugin, "--yes"); err == nil || !strings.Contains(err.Error(), "requires --target") {
+		t.Fatalf("missing-target error = %v", err)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Installations) != 0 {
+		t.Fatalf("TTY --yes without an explicit target mutated state: %+v", state)
 	}
 }
 

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -159,10 +160,140 @@ func TestDoctorDiagnosesManagedDirectoryChangesWithRecovery(t *testing.T) {
 		}
 		if finding.Code == "managed_directory_changed" {
 			found = true
+			if finding.InstallationName != "demo" || finding.InstallationID == "" || finding.ClientID != "cursor" {
+				t.Fatalf("managed finding scope = %+v", finding)
+			}
+			if finding.RecoveryAction != "run `agentplugins repair demo --target cursor`" {
+				t.Fatalf("managed finding recovery = %q", finding.RecoveryAction)
+			}
 		}
 	}
 	if !found {
 		t.Fatalf("managed integrity finding missing: %+v", output.Data.Findings)
+	}
+}
+
+func TestDoctorScopesPendingRecoveryAndRendersIdentity(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	plugin := writeCLIPlugin(t)
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor", "--yes"); err != nil {
+		t.Fatal(err)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, binding := range state.Installations[0].Clients {
+		binding.Authentication = domain.AuthenticationPending
+		state.Installations[0].Clients[key] = binding
+	}
+	if err := fixture.store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, err := fixture.execute(false, "doctor", "demo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	installationID := state.Installations[0].InstallationID
+	for _, expected := range []string{
+		"Installation: demo (" + installationID + ")",
+		"Client: cursor",
+		"complete the displayed external activation step, then rerun the same `agentplugins add ... --target cursor` command",
+		"complete the displayed external authentication step, then rerun the same `agentplugins add ... --target cursor` command",
+	} {
+		if !strings.Contains(stdout, expected) {
+			t.Fatalf("doctor output omitted %q:\n%s", expected, stdout)
+		}
+	}
+	if strings.Contains(stdout, "then rerun doctor") {
+		t.Fatalf("pending lifecycle recovery incorrectly recommends doctor:\n%s", stdout)
+	}
+}
+
+func TestDoctorBlocksAutomaticMutationForMissingPhysicalIdentity(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	plugin := writeCLIPlugin(t)
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor", "--yes"); err != nil {
+		t.Fatal(err)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, binding := range state.Installations[0].Clients {
+		binding.PhysicalArtifact = ""
+		state.Installations[0].Clients[key] = binding
+	}
+	findings := doctorFindings(context.Background(), fixture.app, fixture.app.Detector.(staticDetector).clients, state, nil, &state.Installations[0])
+	var found doctorFinding
+	for _, finding := range findings {
+		if finding.Code == "managed_target_unverifiable" {
+			found = finding
+		}
+	}
+	if found.Code == "" || !strings.Contains(found.RecoveryAction, "automatic mutation is intentionally blocked") {
+		t.Fatalf("missing identity recovery = %+v", findings)
+	}
+	if strings.Contains(found.RecoveryAction, "update") || strings.Contains(found.RecoveryAction, "remove") {
+		t.Fatalf("blocked identity recovery invented a refusing mutation: %+v", found)
+	}
+}
+
+func TestDoctorDoesNotRequireCopilotCLIForVSCodeBinding(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientVSCode)})
+	plugin := writeCLIPlugin(t)
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "vscode", "--yes"); err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, err := fixture.execute(false, "doctor", "demo", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stdout, "copilot_cli_missing") {
+		t.Fatalf("VS Code binding incorrectly required Copilot CLI: %s", stdout)
+	}
+}
+
+func TestDoctorDoesNotCallVerifierFailureChangedContent(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	plugin := writeCLIPlugin(t)
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor", "--yes"); err != nil {
+		t.Fatal(err)
+	}
+	fixture.app.Stager = failingVerifyStager{err: errors.New("temporary verifier unavailable")}
+	stdout, _, err := fixture.execute(false, "doctor", "demo", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "managed_integrity_check_failed") || strings.Contains(stdout, "managed_directory_changed") {
+		t.Fatalf("verification infrastructure error was mislabeled: %s", stdout)
+	}
+}
+
+func TestDoctorSkipsClientWarningsForAbsentBinding(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	plugin := writeCLIPlugin(t)
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor", "--yes"); err != nil {
+		t.Fatal(err)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, binding := range state.Installations[0].Clients {
+		binding.Materialization = domain.MaterializationAbsent
+		state.Installations[0].Clients[key] = binding
+	}
+	findings := doctorFindings(context.Background(), fixture.app, nil, state, nil, &state.Installations[0])
+	for _, finding := range findings {
+		if finding.ClientID != "" {
+			t.Fatalf("absent binding produced client finding: %+v", finding)
+		}
 	}
 }
 
@@ -543,6 +674,22 @@ func (fixture cliFixture) execute(terminal bool, args ...string) (string, string
 
 type staticDetector struct {
 	clients []domain.DetectedClient
+}
+
+type failingVerifyStager struct {
+	err error
+}
+
+func (failingVerifyStager) Stage(context.Context, domain.PackageEnvelope, domain.DeliveryPlan, string, domain.CompatibilityHints) (domain.StagedDelivery, error) {
+	return domain.StagedDelivery{}, errors.New("unexpected stage")
+}
+
+func (failingVerifyStager) Discard(context.Context, domain.StagedDelivery) error {
+	return errors.New("unexpected discard")
+}
+
+func (stager failingVerifyStager) Verify(context.Context, string, string) error {
+	return stager.err
 }
 
 type cliLegacyLifecycleStub struct {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -125,6 +125,47 @@ func TestDryRunAndDoctorAreStrictlyReadOnly(t *testing.T) {
 	}
 }
 
+func TestDoctorDiagnosesManagedDirectoryChangesWithRecovery(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	plugin := writeCLIPlugin(t)
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor", "--yes", "--format", "json"); err != nil {
+		t.Fatal(err)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding := onlyCLIClient(state.Installations[0])
+	if err := os.WriteFile(filepath.Join(binding.TargetLocator, "unexpected.txt"), []byte("tampered"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, err := fixture.execute(false, "doctor", "demo", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output struct {
+		Data struct {
+			Findings []doctorFinding `json:"findings"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, finding := range output.Data.Findings {
+		if finding.Status == "degraded" && finding.RecoveryAction == "" {
+			t.Fatalf("degraded finding has no recovery: %+v", finding)
+		}
+		if finding.Code == "managed_directory_changed" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("managed integrity finding missing: %+v", output.Data.Findings)
+	}
+}
+
 func TestHumanCodexFlowNeverClaimsPreparedPackageIsInstalled(t *testing.T) {
 	t.Parallel()
 	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCodex)})

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -205,6 +205,33 @@ func TestRepeatedAddResumesManualLifecycleWithoutAnotherReceipt(t *testing.T) {
 	}
 }
 
+func TestRepairExplicitlyRestoresMissingManagedDirectory(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	plugin := writeCLIPlugin(t)
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor", "--yes"); err != nil {
+		t.Fatal(err)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := onlyCLIClient(state.Installations[0]).TargetLocator
+	if err := os.RemoveAll(target); err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, err := fixture.execute(false, "repair", "demo", "--target", "cursor", "--yes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "repaired from the resolved source") {
+		t.Fatalf("repair output = %q", stdout)
+	}
+	if _, err := os.Stat(filepath.Join(target, "plugin.json")); err != nil {
+		t.Fatalf("repaired package: %v", err)
+	}
+}
+
 func TestChatGPTTargetIsNotAliasedToCodexCLI(t *testing.T) {
 	t.Parallel()
 	if got := normalizeTarget("chatgpt"); got == domain.ClientCodex {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -176,42 +176,51 @@ func TestDoctorDiagnosesManagedDirectoryChangesWithRecovery(t *testing.T) {
 
 func TestDoctorBlocksRepairForExcludedOwnershipMarker(t *testing.T) {
 	t.Parallel()
-	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
-	plugin := writeCLIPlugin(t)
-	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor", "--yes"); err != nil {
-		t.Fatal(err)
+	for _, marker := range []string{".git", ".plugin-kit-ai.lock"} {
+		t.Run(marker, func(t *testing.T) {
+			fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+			plugin := writeCLIPlugin(t)
+			if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor", "--yes"); err != nil {
+				t.Fatal(err)
+			}
+			state, err := fixture.store.Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			binding := onlyCLIClient(state.Installations[0])
+			markerPath := filepath.Join(binding.TargetLocator, marker)
+			if marker == ".git" {
+				if err := os.Mkdir(markerPath, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := os.WriteFile(markerPath, []byte("excluded"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			stdout, _, err := fixture.execute(false, "doctor", state.Installations[0].InstallationID, "--format", "json")
+			if err != nil {
+				t.Fatal(err)
+			}
+			var output struct {
+				Data struct {
+					Findings []doctorFinding `json:"findings"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+				t.Fatal(err)
+			}
+			for _, finding := range output.Data.Findings {
+				if finding.Code != "excluded_ownership_marker" {
+					continue
+				}
+				if finding.Status != "unknown" || finding.InstallationID != state.Installations[0].InstallationID ||
+					!strings.Contains(finding.RecoveryAction, "manually review and remove") || strings.Contains(finding.RecoveryAction, "agentplugins repair") {
+					t.Fatalf("excluded marker finding = %+v", finding)
+				}
+				return
+			}
+			t.Fatalf("excluded ownership marker finding missing: %+v", output.Data.Findings)
+		})
 	}
-	state, err := fixture.store.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-	binding := onlyCLIClient(state.Installations[0])
-	if err := os.Mkdir(filepath.Join(binding.TargetLocator, ".git"), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	stdout, _, err := fixture.execute(false, "doctor", state.Installations[0].InstallationID, "--format", "json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	var output struct {
-		Data struct {
-			Findings []doctorFinding `json:"findings"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
-		t.Fatal(err)
-	}
-	for _, finding := range output.Data.Findings {
-		if finding.Code != "excluded_ownership_marker" {
-			continue
-		}
-		if finding.Status != "unknown" || finding.InstallationID != state.Installations[0].InstallationID ||
-			!strings.Contains(finding.RecoveryAction, "manually review and remove") || strings.Contains(finding.RecoveryAction, "agentplugins repair") {
-			t.Fatalf("excluded marker finding = %+v", finding)
-		}
-		return
-	}
-	t.Fatalf("excluded ownership marker finding missing: %+v", output.Data.Findings)
 }
 
 func TestDoctorRecoveryIncludesProjectScopeAndExactTarget(t *testing.T) {
@@ -524,7 +533,7 @@ func TestCLIAddAndUpdatePersistConvergedNegativeObservationBeforeConfirmation(t 
 	}
 }
 
-func TestInteractiveUnknownCopilotOutputDoesNotPromptUnusableAttestation(t *testing.T) {
+func TestInteractiveUnknownCopilotOutputReverifiesBeforeAttestation(t *testing.T) {
 	t.Parallel()
 	client := fixtureClient(t, domain.ClientCopilot)
 	client.ExecutablePath = "/test/bin/copilot"
@@ -532,30 +541,56 @@ func TestInteractiveUnknownCopilotOutputDoesNotPromptUnusableAttestation(t *test
 	runner := &cliCommandRunner{}
 	fixture.app.Activator = providers.Activator{Runner: runner}
 	plugin := writeCLIPlugin(t)
-	stdout, _, err := fixture.executeInput(true, "y\n", "add", plugin, "--target", "copilot")
+	stdout, _, err := fixture.executeInput(true, "y\ny\nn\n", "add", plugin, "--target", "copilot")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if runner.calls == 0 || !strings.Contains(stdout, "output contract was not recognized") {
 		t.Fatalf("unknown-output path did not execute verifier or show recovery: calls=%d output=%q", runner.calls, stdout)
 	}
-	if strings.Contains(stdout, "Have you completed activation") {
-		t.Fatalf("unknown observable output prompted an unusable attestation: %q", stdout)
+	if !strings.Contains(stdout, "Have you completed activation") || !strings.Contains(stdout, "Activation is user-attested") {
+		t.Fatalf("unknown observable output did not complete usable attestation flow: %q", stdout)
 	}
 	state, err := fixture.store.Load()
 	if err != nil {
 		t.Fatal(err)
 	}
 	binding := onlyCLIClient(state.Installations[0])
-	if binding.Activation != domain.ActivationManual || binding.Verification != domain.VerificationPackageValid {
-		t.Fatalf("unknown output state = %+v", binding)
+	if binding.Activation != domain.ActivationActive || binding.Verification != domain.VerificationInstalled {
+		t.Fatalf("attested output state = %+v", binding)
 	}
-	stdout, _, err = fixture.executeInput(true, "", "add", plugin, "--target", "copilot")
-	if err != nil {
-		t.Fatal(err)
+	if runner.calls != 4 {
+		t.Fatalf("runner calls = %d, want 4 (activation commands plus retry verifier)", runner.calls)
 	}
-	if strings.Contains(stdout, "Have you completed activation") || !strings.Contains(stdout, "update the client if its output format is unsupported") {
-		t.Fatalf("repeated unknown-output recovery = %q", stdout)
+}
+
+func TestInteractiveUnknownRetryRecognizedNegativeFailsClosed(t *testing.T) {
+	t.Parallel()
+	client := fixtureClient(t, domain.ClientCopilot)
+	client.ExecutablePath = "/test/bin/copilot"
+	fixture := newCLIFixture(t, []domain.DetectedClient{client})
+	runner := &cliCommandRunner{run: func(call int, command legacyports.Command) legacyports.CommandResult {
+		if strings.HasSuffix(strings.Join(command.Argv, " "), "plugin list") && call >= 4 {
+			return legacyports.CommandResult{Stdout: []byte("Installed plugins:\n  No plugins installed.")}
+		}
+		return legacyports.CommandResult{}
+	}}
+	fixture.app.Activator = providers.Activator{Runner: runner}
+	plugin := writeCLIPlugin(t)
+	stdout, _, err := fixture.executeInput(true, "y\ny\n", "add", plugin, "--target", "copilot")
+	if err == nil || !strings.Contains(err.Error(), "recognized negative client evidence") {
+		t.Fatalf("retry err=%v output=%q", err, stdout)
+	}
+	if runner.calls != 4 {
+		t.Fatalf("runner calls = %d, want 4", runner.calls)
+	}
+	state, loadErr := fixture.store.Load()
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	binding := onlyCLIClient(state.Installations[0])
+	if binding.Activation != domain.ActivationFailed || binding.Verification != domain.VerificationFailed {
+		t.Fatalf("recognized negative retry state = %+v", binding)
 	}
 }
 
@@ -938,10 +973,16 @@ func (*cliObservedActivator) Deactivate(context.Context, domain.DeactivationRequ
 	return domain.DeactivationOutcome{}, errors.New("unexpected deactivation")
 }
 
-type cliCommandRunner struct{ calls int }
+type cliCommandRunner struct {
+	calls int
+	run   func(int, legacyports.Command) legacyports.CommandResult
+}
 
-func (runner *cliCommandRunner) Run(context.Context, legacyports.Command) (legacyports.CommandResult, error) {
+func (runner *cliCommandRunner) Run(_ context.Context, command legacyports.Command) (legacyports.CommandResult, error) {
 	runner.calls++
+	if runner.run != nil {
+		return runner.run(runner.calls, command), nil
+	}
 	return legacyports.CommandResult{}, nil
 }
 

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -335,6 +336,28 @@ func TestDoctorDoesNotRequireCopilotCLIForVSCodeBinding(t *testing.T) {
 	}
 }
 
+func TestDoctorDoesNotReportMissingCopilotCLIWhenCopilotIsNotVisible(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCopilot)})
+	plugin := writeCLIPlugin(t)
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "copilot", "--yes"); err != nil {
+		t.Fatal(err)
+	}
+	fixture.app.Detector = staticDetector{}
+	var stdout, stderr bytes.Buffer
+	app := fixture.app
+	app.Output = &stdout
+	app.ErrorOutput = &stderr
+	command := NewRoot(app)
+	command.SetArgs([]string{"doctor", "demo", "--format", "json"})
+	if err := command.ExecuteContext(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), "client_not_visible") || strings.Contains(stdout.String(), "copilot_cli_missing") {
+		t.Fatalf("invisible Copilot findings = %s", stdout.String())
+	}
+}
+
 func TestDoctorDoesNotCallVerifierFailureChangedContent(t *testing.T) {
 	t.Parallel()
 	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
@@ -621,6 +644,94 @@ func TestRepairExplicitlyRestoresMissingManagedDirectory(t *testing.T) {
 	}
 }
 
+func TestInteractiveRepairUsesOneReaderForTargetAndConfirmation(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{
+		fixtureClient(t, domain.ClientCodex),
+		fixtureClient(t, domain.ClientCursor),
+	})
+	plugin := writeCLIPlugin(t)
+	for _, target := range []string{"codex", "cursor"} {
+		if _, _, err := fixture.execute(false, "add", plugin, "--target", target, "--yes"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var codexTarget string
+	for _, binding := range state.Installations[0].Clients {
+		if binding.ClientID == string(domain.ClientCodex) {
+			codexTarget = binding.TargetLocator
+		}
+	}
+	if err := os.RemoveAll(codexTarget); err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, err := fixture.executeInput(true, "1\ny\n", "repair", "demo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "Choose one target:") || !strings.Contains(stdout, "Repair the managed package") {
+		t.Fatalf("repair prompts = %q", stdout)
+	}
+	if _, err := os.Stat(filepath.Join(codexTarget, "plugin.json")); err != nil {
+		t.Fatalf("selected target was not repaired: %v", err)
+	}
+}
+
+func TestDeclinedJSONRepairEmitsOneValidEnvelope(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	plugin := writeCLIPlugin(t)
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor", "--yes"); err != nil {
+		t.Fatal(err)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := onlyCLIClient(state.Installations[0]).TargetLocator
+	if err := os.RemoveAll(target); err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, err := fixture.execute(true, "repair", "demo", "--target", "cursor", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertVersionedJSON(t, stdout, "repair")
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Fatalf("declined repair changed target: %v", err)
+	}
+}
+
+func TestRepairReturnsOutputErrors(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	plugin := writeCLIPlugin(t)
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor", "--yes"); err != nil {
+		t.Fatal(err)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(onlyCLIClient(state.Installations[0]).TargetLocator); err != nil {
+		t.Fatal(err)
+	}
+	app := fixture.app
+	app.Input = strings.NewReader("n\n")
+	app.Output = alwaysErrorWriter{}
+	app.ErrorOutput = io.Discard
+	app.Terminal = true
+	command := NewRoot(app)
+	command.SetArgs([]string{"repair", "demo", "--target", "cursor"})
+	if err := command.ExecuteContext(context.Background()); err == nil || !strings.Contains(err.Error(), "synthetic output failure") {
+		t.Fatalf("repair output error = %v", err)
+	}
+}
+
 func TestChatGPTTargetIsNotAliasedToCodexCLI(t *testing.T) {
 	t.Parallel()
 	if got := normalizeTarget("chatgpt"); got == domain.ClientCodex {
@@ -890,6 +1001,12 @@ type cliFixture struct {
 	app        App
 	store      statev2.Store
 	operations string
+}
+
+type alwaysErrorWriter struct{}
+
+func (alwaysErrorWriter) Write([]byte) (int, error) {
+	return 0, errors.New("synthetic output failure")
 }
 
 func newCLIFixture(t *testing.T, clients []domain.DetectedClient) cliFixture {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -43,7 +43,7 @@ func TestAddListAndInfoProduceVersionedPathRedactedJSON(t *testing.T) {
 	t.Parallel()
 	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
 	plugin := writeCLIPlugin(t)
-	stdout, _, err := fixture.execute(false, "add", plugin, "--target", "cursor", "--yes", "--format", "json")
+	stdout, _, err := fixture.execute(false, "add", plugin, "--target", "cursor", "--format", "json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,29 +77,24 @@ func TestAddListAndInfoProduceVersionedPathRedactedJSON(t *testing.T) {
 	}
 }
 
-func TestNonInteractiveAddRequiresOneExplicitTargetAndYes(t *testing.T) {
+func TestAutomatedAddRequiresExplicitTargetButNotYes(t *testing.T) {
 	t.Parallel()
 	fixture := newCLIFixture(t, []domain.DetectedClient{
 		fixtureClient(t, domain.ClientCursor), fixtureClient(t, domain.ClientCodex),
 	})
 	plugin := writeCLIPlugin(t)
-	for name, args := range map[string][]string{
-		"missing_target": {"add", plugin, "--yes"},
-		"missing_yes":    {"add", plugin, "--target", "cursor"},
-	} {
-		name, args := name, args
-		t.Run(name, func(t *testing.T) {
-			if _, _, err := fixture.execute(false, args...); err == nil {
-				t.Fatal("unsafe non-interactive add succeeded")
-			}
-			state, err := fixture.store.Load()
-			if err != nil {
-				t.Fatal(err)
-			}
-			if len(state.Installations) != 0 {
-				t.Fatalf("state mutated: %+v", state)
-			}
-		})
+	if _, _, err := fixture.execute(false, "add", plugin); err == nil || !strings.Contains(err.Error(), "requires --target") {
+		t.Fatalf("missing-target error = %v", err)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Installations) != 0 {
+		t.Fatalf("missing-target command mutated state: %+v", state)
+	}
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor"); err != nil {
+		t.Fatalf("explicit-target add without --yes failed: %v", err)
 	}
 }
 
@@ -132,7 +127,7 @@ func TestDoctorDiagnosesManagedDirectoryChangesWithRecovery(t *testing.T) {
 	t.Parallel()
 	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
 	plugin := writeCLIPlugin(t)
-	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor", "--yes", "--format", "json"); err != nil {
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor", "--format", "json"); err != nil {
 		t.Fatal(err)
 	}
 	state, err := fixture.store.Load()
@@ -256,7 +251,7 @@ func TestDoctorScopesPendingRecoveryAndRendersIdentity(t *testing.T) {
 	t.Parallel()
 	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
 	plugin := writeCLIPlugin(t)
-	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor", "--yes"); err != nil {
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor"); err != nil {
 		t.Fatal(err)
 	}
 	state, err := fixture.store.Load()
@@ -632,7 +627,7 @@ func TestRepairExplicitlyRestoresMissingManagedDirectory(t *testing.T) {
 	if err := os.RemoveAll(target); err != nil {
 		t.Fatal(err)
 	}
-	stdout, _, err := fixture.execute(false, "repair", "demo", "--target", "cursor", "--yes")
+	stdout, _, err := fixture.execute(false, "repair", "demo", "--target", "cursor")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -681,11 +676,11 @@ func TestInteractiveRepairUsesOneReaderForTargetAndConfirmation(t *testing.T) {
 	}
 }
 
-func TestDeclinedJSONRepairEmitsOneValidEnvelope(t *testing.T) {
+func TestJSONRepairAutoConfirmsWithoutYes(t *testing.T) {
 	t.Parallel()
 	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
 	plugin := writeCLIPlugin(t)
-	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor", "--yes"); err != nil {
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor"); err != nil {
 		t.Fatal(err)
 	}
 	state, err := fixture.store.Load()
@@ -701,8 +696,8 @@ func TestDeclinedJSONRepairEmitsOneValidEnvelope(t *testing.T) {
 		t.Fatal(err)
 	}
 	assertVersionedJSON(t, stdout, "repair")
-	if _, err := os.Stat(target); !os.IsNotExist(err) {
-		t.Fatalf("declined repair changed target: %v", err)
+	if _, err := os.Stat(filepath.Join(target, "plugin.json")); err != nil {
+		t.Fatalf("JSON repair without --yes did not restore target: %v", err)
 	}
 }
 
@@ -783,7 +778,7 @@ func TestUpdateAndRemoveCompleteLifecycleWithVersionedRedactedJSON(t *testing.T)
 	if err := os.WriteFile(manifest, []byte(strings.Replace(string(body), `"version": "1.0.0"`, `"version": "2.0.0"`, 1)), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	stdout, _, err := fixture.execute(false, "update", "demo", "--target", "cursor", "--yes", "--format", "json")
+	stdout, _, err := fixture.execute(false, "update", "demo", "--target", "cursor", "--format", "json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -799,7 +794,7 @@ func TestUpdateAndRemoveCompleteLifecycleWithVersionedRedactedJSON(t *testing.T)
 	if state.Installations[0].Package.Version != "2.0.0" || len(binding.Receipts) != 2 {
 		t.Fatalf("updated state = %+v", state.Installations[0])
 	}
-	stdout, _, err = fixture.execute(false, "remove", "demo", "--target", "cursor", "--yes", "--format", "json")
+	stdout, _, err = fixture.execute(false, "remove", "demo", "--target", "cursor", "--format", "json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -817,18 +812,16 @@ func TestUpdateAndRemoveCompleteLifecycleWithVersionedRedactedJSON(t *testing.T)
 	}
 }
 
-func TestNonInteractiveUpdateAndRemoveRequireExplicitTargetAndYes(t *testing.T) {
+func TestAutomatedUpdateAndRemoveRequireExplicitTargetButNotYes(t *testing.T) {
 	t.Parallel()
 	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
 	plugin := writeCLIPlugin(t)
-	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor", "--yes"); err != nil {
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor"); err != nil {
 		t.Fatal(err)
 	}
 	for name, args := range map[string][]string{
-		"update_missing_target": {"update", "demo", "--yes"},
-		"update_missing_yes":    {"update", "demo", "--target", "cursor"},
-		"remove_missing_target": {"remove", "demo", "--yes"},
-		"remove_missing_yes":    {"remove", "demo", "--target", "cursor"},
+		"update_missing_target": {"update", "demo"},
+		"remove_missing_target": {"remove", "demo"},
 	} {
 		name, args := name, args
 		t.Run(name, func(t *testing.T) {
@@ -844,6 +837,12 @@ func TestNonInteractiveUpdateAndRemoveRequireExplicitTargetAndYes(t *testing.T) 
 	if binding := onlyCLIClient(state.Installations[0]); binding.Materialization != domain.MaterializationMaterialized || len(binding.Receipts) != 1 {
 		t.Fatalf("unsafe command mutated state: %+v", binding)
 	}
+	if _, _, err := fixture.execute(false, "update", "demo", "--target", "cursor"); err != nil {
+		t.Fatalf("explicit-target update without --yes failed: %v", err)
+	}
+	if _, _, err := fixture.execute(false, "remove", "demo", "--target", "cursor"); err != nil {
+		t.Fatalf("explicit-target remove without --yes failed: %v", err)
+	}
 }
 
 func TestRebindIsPlanFirstAndRequiresRemovedTargets(t *testing.T) {
@@ -851,7 +850,7 @@ func TestRebindIsPlanFirstAndRequiresRemovedTargets(t *testing.T) {
 	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
 	first := writeCLIPlugin(t)
 	second := writeCLIPlugin(t)
-	if _, _, err := fixture.execute(false, "add", first, "--target", "cursor", "--yes"); err != nil {
+	if _, _, err := fixture.execute(false, "add", first, "--target", "cursor"); err != nil {
 		t.Fatal(err)
 	}
 	stdout, _, err := fixture.execute(false, "rebind", "demo", second, "--dry-run", "--format", "json")
@@ -862,13 +861,13 @@ func TestRebindIsPlanFirstAndRequiresRemovedTargets(t *testing.T) {
 	if strings.Contains(stdout, fixture.root) {
 		t.Fatalf("rebind plan leaked sandbox path: %s", stdout)
 	}
-	if _, _, err := fixture.execute(false, "rebind", "demo", second, "--yes"); err == nil || !strings.Contains(err.Error(), "blocked") {
+	if _, _, err := fixture.execute(false, "rebind", "demo", second); err == nil || !strings.Contains(err.Error(), "blocked") {
 		t.Fatalf("materialized rebind error = %v", err)
 	}
-	if _, _, err := fixture.execute(false, "remove", "demo", "--target", "cursor", "--yes"); err != nil {
+	if _, _, err := fixture.execute(false, "remove", "demo", "--target", "cursor"); err != nil {
 		t.Fatal(err)
 	}
-	stdout, _, err = fixture.execute(false, "rebind", "demo", second, "--yes", "--format", "json")
+	stdout, _, err = fixture.execute(false, "rebind", "demo", second, "--format", "json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -942,7 +941,7 @@ func TestMigrateStateIsExplicitPlanFirstAndPathRedacted(t *testing.T) {
 	if _, err := os.Stat(fixture.store.Path); !os.IsNotExist(err) {
 		t.Fatalf("dry-run created state v2: %v", err)
 	}
-	stdout, _, err = fixture.execute(false, "migrate-state", "--yes", "--format", "json")
+	stdout, _, err = fixture.execute(false, "migrate-state", "--format", "json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -977,10 +976,10 @@ func TestLegacyRemovalRequiresExplicitAllTargetAndReconcilesV2(t *testing.T) {
 	if err := fixture.store.Save(state); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := fixture.execute(false, "remove", "legacy-demo", "--yes"); err == nil || !strings.Contains(err.Error(), "legacy-all") {
+	if _, _, err := fixture.execute(false, "remove", "legacy-demo"); err == nil || !strings.Contains(err.Error(), "legacy-all") {
 		t.Fatalf("unsafe legacy non-TTY removal error = %v", err)
 	}
-	stdout, _, err := fixture.execute(false, "remove", "legacy-demo", "--target", "legacy-all", "--yes", "--format", "json")
+	stdout, _, err := fixture.execute(false, "remove", "legacy-demo", "--target", "legacy-all", "--format", "json")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
@@ -56,14 +56,6 @@ func runRepair(ctx context.Context, cmd *cobra.Command, app App, opts *options, 
 	if installation.NeedsRebind || installation.Package.LoaderKind != domain.LoaderKindAgentPlugins {
 		return fmt.Errorf("repair requires a bound Agent Plugins installation")
 	}
-	writeProgress(app, opts.format, "Resolving and validating the original Agent Plugin source...")
-	loaded, err := app.loadPackage(ctx, updateSource(installation))
-	if err != nil {
-		return err
-	}
-	if loaded.cleanup != nil {
-		defer loaded.cleanup()
-	}
 	clients, err := app.Detector.Detect(ctx)
 	if err != nil {
 		return fmt.Errorf("detect AI clients: %w", err)
@@ -71,6 +63,22 @@ func runRepair(ctx context.Context, cmd *cobra.Command, app App, opts *options, 
 	selected, detectedMap, err := selectBoundClient(cmd, app, opts, installation, clients, true)
 	if err != nil {
 		return err
+	}
+	binding, err := selectedRepairBinding(installation, selected.ClientID, domain.InstallScope(opts.scope))
+	if err != nil {
+		return err
+	}
+	source, err := repairSource(installation, binding)
+	if err != nil {
+		return err
+	}
+	writeProgress(app, opts.format, "Resolving and validating the exact installed Agent Plugin revision...")
+	loaded, err := app.loadPackage(ctx, source)
+	if err != nil {
+		return err
+	}
+	if loaded.cleanup != nil {
+		defer loaded.cleanup()
 	}
 	if err := requireNonInteractiveMutation(app, opts, "repair"); err != nil && !opts.dryRun {
 		return err
@@ -88,7 +96,7 @@ func runRepair(ctx context.Context, cmd *cobra.Command, app App, opts *options, 
 	}
 	confirmed := opts.yes
 	if !confirmed && opts.format == "human" && app.Terminal {
-		confirmed, err = promptYesNo(cmd.InOrStdin(), cmd.OutOrStdout(), "Replace the damaged managed directory from the resolved package source? [y/N]")
+		confirmed, err = promptYesNo(cmd.InOrStdin(), cmd.OutOrStdout(), "Repair the managed package and its recorded verification state? [y/N]")
 		if err != nil {
 			return err
 		}
@@ -119,11 +127,15 @@ func renderRepairResult(writer io.Writer, format string, installation domain.Ins
 		return nil
 	}
 	if dryRun {
-		_, _ = fmt.Fprintln(writer, "Managed package is missing or modified and can be transactionally repaired. No changes made.")
+		_, _ = fmt.Fprintln(writer, "The managed package or its recorded verification state can be safely repaired. No changes made.")
 		return nil
 	}
 	if result.Mutated {
-		_, _ = fmt.Fprintln(writer, "Managed package repaired from the resolved source; existing lifecycle state was preserved.")
+		if result.Receipt.OperationID == "" {
+			_, _ = fmt.Fprintln(writer, "Managed package digest reverified and recorded lifecycle state corrected; no external client mutation was attempted.")
+		} else {
+			_, _ = fmt.Fprintln(writer, "Managed package repaired from the exact installed revision and its package digest verified; external client activation and authentication were not reverified.")
+		}
 	}
 	return nil
 }
@@ -396,6 +408,44 @@ func updateSource(installation domain.Installation) string {
 		return value
 	}
 	return installation.Source.CanonicalSource
+}
+
+func selectedRepairBinding(installation domain.Installation, clientID domain.ClientID, scope domain.InstallScope) (domain.ClientBinding, error) {
+	var matches []domain.ClientBinding
+	for _, binding := range installation.Clients {
+		if binding.ClientID == string(clientID) && binding.Scope == string(scope) && binding.Materialization != domain.MaterializationAbsent {
+			matches = append(matches, binding)
+		}
+	}
+	if len(matches) != 1 {
+		return domain.ClientBinding{}, fmt.Errorf("repair requires exactly one bound target for %s in %s scope", clientID, scope)
+	}
+	return matches[0], nil
+}
+
+func repairSource(installation domain.Installation, binding domain.ClientBinding) (string, error) {
+	canonical := strings.TrimSpace(installation.Source.CanonicalSource)
+	if installation.Source.Repository == "" && filepath.IsAbs(canonical) {
+		return canonical, nil
+	}
+	revision := ""
+	if binding.PackageRevision != nil {
+		revision = strings.TrimSpace(binding.PackageRevision.ResolvedRevision)
+	}
+	if revision == "" {
+		return "", fmt.Errorf("the selected client binding has no exact resolved revision; refusing repair from a moving source")
+	}
+	if repository := strings.TrimSpace(installation.Source.Repository); repository != "" {
+		value := "github:" + repository + "@" + revision
+		if subpath := strings.TrimSpace(installation.Source.PackageSubpath); subpath != "" {
+			value += "//" + subpath
+		}
+		return value, nil
+	}
+	if canonical != "" {
+		return canonical + "#" + revision, nil
+	}
+	return "", fmt.Errorf("the selected client binding source cannot be reconstructed safely")
 }
 
 func requireNonInteractiveMutation(app App, opts *options, action string) error {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
@@ -181,7 +181,8 @@ func runUpdate(ctx context.Context, cmd *cobra.Command, app App, opts *options, 
 	input := usecase.AddInput{
 		Envelope: loaded.envelope, Client: selected, Scope: domain.InstallScope(opts.scope),
 		DryRun: opts.dryRun, Interactive: app.Terminal, Hints: loaded.hints,
-		BackendExecutable: backendExecutable(selected, detectedMap),
+		BackendExecutable:                backendExecutable(selected, detectedMap),
+		PersistAuthoritativeObservations: true,
 	}
 	planned, err := service.Update(ctx, input)
 	if err != nil {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
@@ -462,12 +462,12 @@ func requireNonInteractiveMutation(app App, opts *options, action string) error 
 	return fmt.Errorf("automated %s requires --target", action)
 }
 
-// automatedMutation identifies invocations where prompting is unavailable or
-// would break the machine-readable JSON contract. These flows still require
-// every command-specific selector/target guard, but an explicit --yes is not
-// part of the public UX contract.
+// automatedMutation identifies invocations where prompting is unavailable,
+// would break the machine-readable JSON contract, or was explicitly bypassed
+// with the hidden compatibility flag. These flows still require every
+// command-specific selector/target guard.
 func automatedMutation(app App, opts *options) bool {
-	return !app.Terminal || opts.format == "json"
+	return !app.Terminal || opts.format == "json" || opts.yes
 }
 
 func mutationConfirmed(app App, opts *options) bool {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
@@ -411,10 +411,7 @@ func renderUpdateResult(writer io.Writer, format string, envelope domain.Package
 		} else {
 			_, _ = fmt.Fprintln(writer, "Package updated. Activation is not complete yet.")
 		}
-		for _, action := range result.Activation.UserActions {
-			_, _ = fmt.Fprintf(writer, "Next: %s\n", action)
-		}
-		for _, action := range result.Activation.LocalActions {
+		if action := nextLifecycleAction(result); action != "" {
 			_, _ = fmt.Fprintf(writer, "Next: %s\n", action)
 		}
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
@@ -45,6 +45,7 @@ func newRepairCommand(app App, opts *options) *cobra.Command {
 }
 
 func runRepair(ctx context.Context, cmd *cobra.Command, app App, opts *options, selector string) error {
+	stdin := bufio.NewReader(cmd.InOrStdin())
 	state, err := app.StateStore.Load()
 	if err != nil {
 		return err
@@ -60,7 +61,7 @@ func runRepair(ctx context.Context, cmd *cobra.Command, app App, opts *options, 
 	if err != nil {
 		return fmt.Errorf("detect AI clients: %w", err)
 	}
-	selected, detectedMap, err := selectBoundClient(cmd, app, opts, installation, clients, true)
+	selected, detectedMap, err := selectBoundClient(cmd, app, opts, installation, clients, true, stdin)
 	if err != nil {
 		return err
 	}
@@ -96,14 +97,17 @@ func runRepair(ctx context.Context, cmd *cobra.Command, app App, opts *options, 
 	}
 	confirmed := opts.yes
 	if !confirmed && opts.format == "human" && app.Terminal {
-		confirmed, err = promptYesNo(cmd.InOrStdin(), cmd.OutOrStdout(), "Repair the managed package and its recorded verification state? [y/N]")
+		confirmed, err = promptYesNo(stdin, cmd.OutOrStdout(), "Repair the managed package and its recorded verification state? [y/N]")
 		if err != nil {
 			return err
 		}
 	}
 	if !confirmed {
-		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No changes made.")
-		return nil
+		if opts.format == "json" {
+			return renderRepairResult(cmd.OutOrStdout(), opts.format, installation, planned, false)
+		}
+		_, err = fmt.Fprintln(cmd.OutOrStdout(), "No changes made.")
+		return err
 	}
 	input.Confirmed = true
 	result, repairErr := service.Repair(ctx, input)
@@ -123,18 +127,20 @@ func renderRepairResult(writer io.Writer, format string, installation domain.Ins
 		return writeJSONOutput(writer, "repair", data)
 	}
 	if result.NoChange {
-		_, _ = fmt.Fprintln(writer, "Managed package digest is valid. No repair was needed.")
-		return nil
+		_, err := fmt.Fprintln(writer, "Managed package digest is valid. No repair was needed.")
+		return err
 	}
 	if dryRun {
-		_, _ = fmt.Fprintln(writer, "The managed package or its recorded verification state can be safely repaired. No changes made.")
-		return nil
+		_, err := fmt.Fprintln(writer, "The managed package or its recorded verification state can be safely repaired. No changes made.")
+		return err
 	}
 	if result.Mutated {
 		if result.Receipt.OperationID == "" {
-			_, _ = fmt.Fprintln(writer, "Managed package digest reverified and recorded lifecycle state corrected; no external client mutation was attempted.")
+			_, err := fmt.Fprintln(writer, "Managed package digest reverified and recorded lifecycle state corrected; no external client mutation was attempted.")
+			return err
 		} else {
-			_, _ = fmt.Fprintln(writer, "Managed package repaired from the exact installed revision and its package digest verified; external client activation and authentication were not reverified.")
+			_, err := fmt.Fprintln(writer, "Managed package repaired from the exact installed revision and its package digest verified; external client activation and authentication were not reverified.")
+			return err
 		}
 	}
 	return nil
@@ -170,7 +176,7 @@ func runUpdate(ctx context.Context, cmd *cobra.Command, app App, opts *options, 
 	if err != nil {
 		return fmt.Errorf("detect AI clients: %w", err)
 	}
-	selected, detectedMap, err := selectBoundClient(cmd, app, opts, installation, clients, true)
+	selected, detectedMap, err := selectBoundClient(cmd, app, opts, installation, clients, true, cmd.InOrStdin())
 	if err != nil {
 		return err
 	}
@@ -251,7 +257,7 @@ func runRemove(ctx context.Context, cmd *cobra.Command, app App, opts *options, 
 	if err != nil {
 		return fmt.Errorf("detect AI clients: %w", err)
 	}
-	selected, detectedMap, err := selectBoundClient(cmd, app, opts, installation, clients, false)
+	selected, detectedMap, err := selectBoundClient(cmd, app, opts, installation, clients, false, cmd.InOrStdin())
 	if err != nil {
 		return err
 	}
@@ -463,6 +469,7 @@ func selectBoundClient(
 	installation domain.Installation,
 	clients []domain.DetectedClient,
 	requireDetected bool,
+	reader io.Reader,
 ) (domain.DetectedClient, map[domain.ClientID]domain.DetectedClient, error) {
 	detectedMap := make(map[domain.ClientID]domain.DetectedClient, len(clients))
 	for _, client := range clients {
@@ -506,17 +513,23 @@ func selectBoundClient(
 	if !app.Terminal || opts.yes || opts.format == "json" {
 		return domain.DetectedClient{}, detectedMap, fmt.Errorf("plugin has multiple installed targets; choose exactly one with --target")
 	}
-	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Installed targets:")
+	if _, err := fmt.Fprintln(cmd.OutOrStdout(), "Installed targets:"); err != nil {
+		return domain.DetectedClient{}, detectedMap, err
+	}
 	for index, clientID := range ids {
 		client := detectedMap[clientID]
 		display := client.DisplayName
 		if display == "" {
 			display = string(clientID)
 		}
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %d. %s\n", index+1, display)
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  %d. %s\n", index+1, display); err != nil {
+			return domain.DetectedClient{}, detectedMap, err
+		}
 	}
-	_, _ = fmt.Fprint(cmd.OutOrStdout(), "Choose one target: ")
-	line, readErr := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
+	if _, err := fmt.Fprint(cmd.OutOrStdout(), "Choose one target: "); err != nil {
+		return domain.DetectedClient{}, detectedMap, err
+	}
+	line, readErr := readInputLine(reader)
 	if readErr != nil && readErr != io.EOF {
 		return domain.DetectedClient{}, detectedMap, readErr
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
@@ -95,7 +95,7 @@ func runRepair(ctx context.Context, cmd *cobra.Command, app App, opts *options, 
 	if opts.dryRun || planned.NoChange {
 		return renderRepairResult(cmd.OutOrStdout(), opts.format, installation, planned, opts.dryRun)
 	}
-	confirmed := opts.yes
+	confirmed := mutationConfirmed(app, opts)
 	if !confirmed && opts.format == "human" && app.Terminal {
 		confirmed, err = promptYesNo(stdin, cmd.OutOrStdout(), "Repair the managed package and its recorded verification state? [y/N]")
 		if err != nil {
@@ -202,7 +202,7 @@ func runUpdate(ctx context.Context, cmd *cobra.Command, app App, opts *options, 
 			return err
 		}
 	}
-	confirmed := opts.yes
+	confirmed := mutationConfirmed(app, opts)
 	if !confirmed && opts.format == "human" && app.Terminal {
 		confirmed, err = promptYesNo(cmd.InOrStdin(), cmd.OutOrStdout(), "Apply this update? [y/N]")
 		if err != nil {
@@ -291,7 +291,7 @@ func runRemove(ctx context.Context, cmd *cobra.Command, app App, opts *options, 
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Target: %s\n", selected.ClientID)
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Result: managed package and its lifecycle binding will be removed")
 	}
-	confirmed := opts.yes
+	confirmed := mutationConfirmed(app, opts)
 	if !confirmed && opts.format == "human" && app.Terminal {
 		confirmed, err = promptYesNo(cmd.InOrStdin(), cmd.OutOrStdout(), "Remove this target? [y/N]")
 		if err != nil {
@@ -321,8 +321,8 @@ func runLegacyRemove(ctx context.Context, cmd *cobra.Command, app App, opts *opt
 	if target := strings.TrimSpace(opts.target); target != "" && target != "legacy-all" {
 		return fmt.Errorf("legacy removal is integration-wide; use --target legacy-all after reviewing every target")
 	}
-	if !opts.dryRun && !app.Terminal && (opts.target != "legacy-all" || !opts.yes) {
-		return fmt.Errorf("non-interactive legacy removal requires --target legacy-all and --yes")
+	if !opts.dryRun && automatedMutation(app, opts) && strings.TrimSpace(opts.target) != "legacy-all" {
+		return fmt.Errorf("automated legacy removal requires --target legacy-all")
 	}
 	service := usecase.Service{
 		StateStore: app.StateStore, Legacy: app.LegacyLifecycle, LegacyLock: app.LegacyStateLock, Lock: app.MutationLock,
@@ -339,7 +339,7 @@ func runLegacyRemove(ctx context.Context, cmd *cobra.Command, app App, opts *opt
 	if opts.format == "human" {
 		renderLegacyRemovePlan(cmd.OutOrStdout(), planned)
 	}
-	confirmed := opts.yes
+	confirmed := mutationConfirmed(app, opts)
 	if !confirmed && opts.format == "human" && app.Terminal {
 		confirmed, err = promptYesNo(cmd.InOrStdin(), cmd.OutOrStdout(), "Remove every legacy target listed above? [y/N]")
 		if err != nil {
@@ -456,10 +456,22 @@ func repairSource(installation domain.Installation, binding domain.ClientBinding
 }
 
 func requireNonInteractiveMutation(app App, opts *options, action string) error {
-	if app.Terminal || (strings.TrimSpace(opts.target) != "" && opts.yes) {
+	if !automatedMutation(app, opts) || strings.TrimSpace(opts.target) != "" {
 		return nil
 	}
-	return fmt.Errorf("non-interactive %s requires both --target and --yes", action)
+	return fmt.Errorf("automated %s requires --target", action)
+}
+
+// automatedMutation identifies invocations where prompting is unavailable or
+// would break the machine-readable JSON contract. These flows still require
+// every command-specific selector/target guard, but an explicit --yes is not
+// part of the public UX contract.
+func automatedMutation(app App, opts *options) bool {
+	return !app.Terminal || opts.format == "json"
+}
+
+func mutationConfirmed(app App, opts *options) bool {
+	return opts.yes || automatedMutation(app, opts)
 }
 
 func selectBoundClient(

--- a/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
@@ -31,6 +31,103 @@ func newUpdateCommand(app App, opts *options) *cobra.Command {
 	}
 }
 
+func newRepairCommand(app App, opts *options) *cobra.Command {
+	return &cobra.Command{
+		Use: "repair <name-or-installation-id>", Short: "Explicitly restore a missing or modified managed package",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateCommonOptions(opts); err != nil {
+				return err
+			}
+			return runRepair(cmd.Context(), cmd, app, opts, args[0])
+		},
+	}
+}
+
+func runRepair(ctx context.Context, cmd *cobra.Command, app App, opts *options, selector string) error {
+	state, err := app.StateStore.Load()
+	if err != nil {
+		return err
+	}
+	installation, err := selectInstallation(state, selector)
+	if err != nil {
+		return err
+	}
+	if installation.NeedsRebind || installation.Package.LoaderKind != domain.LoaderKindAgentPlugins {
+		return fmt.Errorf("repair requires a bound Agent Plugins installation")
+	}
+	writeProgress(app, opts.format, "Resolving and validating the original Agent Plugin source...")
+	loaded, err := app.loadPackage(ctx, updateSource(installation))
+	if err != nil {
+		return err
+	}
+	if loaded.cleanup != nil {
+		defer loaded.cleanup()
+	}
+	clients, err := app.Detector.Detect(ctx)
+	if err != nil {
+		return fmt.Errorf("detect AI clients: %w", err)
+	}
+	selected, detectedMap, err := selectBoundClient(cmd, app, opts, installation, clients, true)
+	if err != nil {
+		return err
+	}
+	if err := requireNonInteractiveMutation(app, opts, "repair"); err != nil && !opts.dryRun {
+		return err
+	}
+	service := lifecycleService(app, detectedMap)
+	input := usecase.AddInput{Envelope: loaded.envelope, Client: selected, Scope: domain.InstallScope(opts.scope), DryRun: opts.dryRun,
+		InstallationID: installation.InstallationID, Interactive: app.Terminal, Hints: loaded.hints,
+		BackendExecutable: backendExecutable(selected, detectedMap)}
+	planned, err := service.Repair(ctx, input)
+	if err != nil {
+		return err
+	}
+	if opts.dryRun || planned.NoChange {
+		return renderRepairResult(cmd.OutOrStdout(), opts.format, installation, planned, opts.dryRun)
+	}
+	confirmed := opts.yes
+	if !confirmed && opts.format == "human" && app.Terminal {
+		confirmed, err = promptYesNo(cmd.InOrStdin(), cmd.OutOrStdout(), "Replace the damaged managed directory from the resolved package source? [y/N]")
+		if err != nil {
+			return err
+		}
+	}
+	if !confirmed {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No changes made.")
+		return nil
+	}
+	input.Confirmed = true
+	result, repairErr := service.Repair(ctx, input)
+	if renderErr := renderRepairResult(cmd.OutOrStdout(), opts.format, installation, result, false); renderErr != nil && repairErr == nil {
+		repairErr = renderErr
+	}
+	return repairErr
+}
+
+func renderRepairResult(writer io.Writer, format string, installation domain.Installation, result usecase.AddResult, dryRun bool) error {
+	data := struct {
+		Plugin string            `json:"plugin"`
+		DryRun bool              `json:"dry_run"`
+		Result usecase.AddResult `json:"result"`
+	}{installation.DeclaredName, dryRun, result}
+	if format == "json" {
+		return writeJSONOutput(writer, "repair", data)
+	}
+	if result.NoChange {
+		_, _ = fmt.Fprintln(writer, "Managed package digest is valid. No repair was needed.")
+		return nil
+	}
+	if dryRun {
+		_, _ = fmt.Fprintln(writer, "Managed package is missing or modified and can be transactionally repaired. No changes made.")
+		return nil
+	}
+	if result.Mutated {
+		_, _ = fmt.Fprintln(writer, "Managed package repaired from the resolved source; existing lifecycle state was preserved.")
+	}
+	return nil
+}
+
 func runUpdate(ctx context.Context, cmd *cobra.Command, app App, opts *options, selector string) error {
 	state, err := app.StateStore.Load()
 	if err != nil {
@@ -408,12 +505,14 @@ func renderUpdateResult(writer io.Writer, format string, envelope domain.Package
 			} else {
 				_, _ = fmt.Fprintln(writer, "Package updated. Authentication and client activation are pending.")
 			}
+		} else if result.Activation.Authentication == domain.AuthenticationNotChecked && result.Activation.Activation == domain.ActivationActive {
+			_, _ = fmt.Fprintln(writer, "Package updated and client activation verified. Authentication requirements have not been checked.")
 		} else {
 			_, _ = fmt.Fprintln(writer, "Package updated. Activation is not complete yet.")
 		}
-		if action := nextLifecycleAction(result); action != "" {
-			_, _ = fmt.Fprintf(writer, "Next: %s\n", action)
-		}
+	}
+	if action := nextLifecycleAction(result); action != "" && !fullyInstalled(result.Activation) {
+		_, _ = fmt.Fprintf(writer, "Next: %s\n", action)
 	}
 	return nil
 }

--- a/cli/plugin-kit-ai/internal/agentpluginscli/read.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/read.go
@@ -2,9 +2,11 @@ package agentpluginscli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -42,11 +44,14 @@ type publicInstallation struct {
 }
 
 type doctorFinding struct {
-	Status         string `json:"status"`
-	Code           string `json:"code"`
-	Subject        string `json:"subject,omitempty"`
-	Message        string `json:"message"`
-	RecoveryAction string `json:"recovery_action,omitempty"`
+	Status           string `json:"status"`
+	Code             string `json:"code"`
+	Subject          string `json:"subject,omitempty"`
+	InstallationName string `json:"installation_name,omitempty"`
+	InstallationID   string `json:"installation_id,omitempty"`
+	ClientID         string `json:"client_id,omitempty"`
+	Message          string `json:"message"`
+	RecoveryAction   string `json:"recovery_action,omitempty"`
 }
 
 type supportedClient struct {
@@ -170,6 +175,12 @@ func runDoctor(ctx context.Context, cmd *cobra.Command, app App, opts *options, 
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Open recovery operations: %d\n", report.OpenOperationCount)
 	for _, finding := range report.Findings {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  [%s] %s: %s\n", finding.Status, finding.Code, finding.Message)
+		if finding.InstallationID != "" {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "    Installation: %s (%s)\n", finding.InstallationName, finding.InstallationID)
+		}
+		if finding.ClientID != "" {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "    Client: %s\n", finding.ClientID)
+		}
 		if finding.RecoveryAction != "" {
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "    Recovery: %s\n", finding.RecoveryAction)
 		}
@@ -211,65 +222,44 @@ func doctorFindings(ctx context.Context, app App, detected []domain.DetectedClie
 		installations = []domain.Installation{*selected}
 	}
 	for _, installation := range installations {
-		for _, diagnostic := range installation.Package.Diagnostics {
-			status := string(diagnostic.Severity)
-			if diagnostic.Severity == domain.SeverityError {
-				status = "degraded"
-			}
-			findings = append(findings, doctorFinding{Status: status, Code: diagnostic.Code, Subject: installation.DeclaredName, Message: diagnostic.Message, RecoveryAction: "review the package diagnostic and update the package after correcting the indicated item"})
-		}
-		if evidence := installation.Package.CatalogEvidence; evidence != nil {
-			clientIDs := make([]string, 0, len(evidence.Compatibility))
-			for clientID := range evidence.Compatibility {
-				clientIDs = append(clientIDs, clientID)
-			}
-			sort.Strings(clientIDs)
-			for _, clientID := range clientIDs {
-				compatibility := evidence.Compatibility[clientID]
-				if compatibility.Verification == "schema_only" || compatibility.Verification == "not_tested" {
-					findings = append(findings, doctorFinding{Status: "warning", Code: "catalog_" + compatibility.Verification, Subject: clientID, Message: "catalog compatibility has limited runtime verification", RecoveryAction: "verify the plugin in this client before relying on it"})
-				}
-			}
-		}
 		if installation.NeedsRebind {
-			findings = append(findings, degradedFinding("source_rebind_required", installation.DeclaredName, "the source identity needs an explicit rebind", "remove the old binding or run the explicit rebind workflow before updating"))
+			findings = append(findings, scopedFinding("degraded", "source_rebind_required", installation, "", "the source identity needs an explicit rebind", "automatic mutation is intentionally blocked; recover the original source identity and review an explicit rebind against the recorded installation"))
 		}
 		for _, binding := range installation.Clients {
 			if binding.Materialization == domain.MaterializationAbsent {
 				continue
 			}
 			if _, supported := clientplanner.Capabilities(domain.ClientID(binding.ClientID)); !supported {
-				findings = append(findings, degradedFinding("unsupported_client_binding", binding.ClientID, "the tracked binding names an unsupported client", "remove this stale binding and add the plugin to a supported client"))
+				findings = append(findings, scopedFinding("degraded", "unsupported_client_binding", installation, binding.ClientID, "the tracked binding names an unsupported client", blockedStateRecovery))
 				continue
 			}
 			client, visible := detectedByID[binding.ClientID]
 			if !visible || client.Status != domain.DetectionDetected {
-				findings = append(findings, degradedFinding("client_not_visible", binding.ClientID, "the package is tracked but no current client visibility evidence was detected", "install or launch the client so its CLI, desktop application, or configuration directory is visible, then rerun doctor"))
+				findings = append(findings, scopedFinding("degraded", "client_not_visible", installation, binding.ClientID, "the package is tracked but no current client visibility evidence was detected", "install or launch the client so its CLI, desktop application, or configuration directory is visible, then rerun doctor"))
+			}
+			if binding.ClientID == string(domain.ClientCopilot) && strings.TrimSpace(client.ExecutablePath) == "" {
+				findings = append(findings, scopedFinding("degraded", "copilot_cli_missing", installation, binding.ClientID, "GitHub Copilot CLI is unavailable for automatic Copilot activation", "install GitHub Copilot CLI, ensure copilot is on PATH, and rerun doctor"))
 			}
 			switch binding.Activation {
 			case domain.ActivationManual, domain.ActivationPrepared:
-				findings = append(findings, degradedFinding("activation_pending", binding.ClientID, "client activation is not complete", "open the selected client, finish plugin activation, and then rerun doctor"))
+				findings = append(findings, scopedFinding("degraded", "activation_pending", installation, binding.ClientID, "client activation is not complete", fmt.Sprintf("complete the displayed external activation step, then rerun the same `agentplugins add ... --target %s` command", binding.ClientID)))
 			case domain.ActivationFailed:
-				findings = append(findings, degradedFinding("activation_failed", binding.ClientID, "client activation failed", "retry the plugin update for this client after resolving the client-reported activation error"))
+				findings = append(findings, scopedFinding("degraded", "activation_failed", installation, binding.ClientID, "client activation failed", fmt.Sprintf("resolve the client-reported activation error, then rerun the same `agentplugins add ... --target %s` command", binding.ClientID)))
 			}
 			switch binding.Authentication {
 			case domain.AuthenticationPending:
-				findings = append(findings, degradedFinding("authentication_pending", binding.ClientID, "plugin authentication is pending", "complete authentication in the selected client and rerun doctor"))
+				findings = append(findings, scopedFinding("degraded", "authentication_pending", installation, binding.ClientID, "plugin authentication is pending", fmt.Sprintf("complete the displayed external authentication step, then rerun the same `agentplugins add ... --target %s` command", binding.ClientID)))
 			case domain.AuthenticationFailed:
-				findings = append(findings, degradedFinding("authentication_failed", binding.ClientID, "plugin authentication failed", "reauthorize the plugin in the selected client and rerun doctor"))
+				findings = append(findings, scopedFinding("degraded", "authentication_failed", installation, binding.ClientID, "plugin authentication failed", fmt.Sprintf("reauthorize the plugin in the selected client, then rerun the same `agentplugins add ... --target %s` command", binding.ClientID)))
 			case domain.AuthenticationNotChecked:
-				findings = append(findings, doctorFinding{Status: "unknown", Code: "authentication_not_checked", Subject: binding.ClientID, Message: "authentication requirements have not been verified", RecoveryAction: "check the package's authentication instructions and verify access in the selected client"})
+				findings = append(findings, scopedFinding("unknown", "authentication_not_checked", installation, binding.ClientID, "authentication requirements have not been verified", "check the package's authentication instructions and verify access in the selected client"))
 			}
 			if binding.Materialization == domain.MaterializationDegraded || binding.Verification == domain.VerificationFailed {
-				findings = append(findings, degradedFinding("installation_verification_failed", binding.ClientID, "the managed package is marked degraded or failed verification", "run plugin update for this client to rebuild and verify the managed package"))
+				findings = append(findings, scopedFinding("degraded", "installation_verification_failed", installation, binding.ClientID, "the managed package is marked degraded or failed verification", repairAction(installation, binding)))
 			}
-			findings = append(findings, checkManagedIntegrity(ctx, app, client, binding)...)
-		}
-	}
-	if requiresCopilotRuntime(installations) {
-		copilot, ok := detectedByID[string(domain.ClientCopilot)]
-		if !ok || strings.TrimSpace(copilot.ExecutablePath) == "" {
-			findings = append(findings, degradedFinding("copilot_cli_missing", "runtime", "GitHub Copilot CLI is unavailable for automatic Copilot/VS Code activation", "install GitHub Copilot CLI, ensure copilot is on PATH, and rerun doctor"))
+			if visible && client.Status == domain.DetectionDetected {
+				findings = append(findings, checkManagedIntegrity(ctx, app, client, installation, binding)...)
+			}
 		}
 	}
 	if len(findings) == 0 {
@@ -278,17 +268,19 @@ func doctorFindings(ctx context.Context, app App, detected []domain.DetectedClie
 	return findings
 }
 
-func checkManagedIntegrity(ctx context.Context, app App, client domain.DetectedClient, binding domain.ClientBinding) []doctorFinding {
+const blockedStateRecovery = "automatic mutation is intentionally blocked; restore state-v2.json from a trusted backup that matches the managed source, or recover and review the original source and binding metadata"
+
+func checkManagedIntegrity(ctx context.Context, app App, client domain.DetectedClient, installation domain.Installation, binding domain.ClientBinding) []doctorFinding {
 	if binding.Materialization != domain.MaterializationMaterialized || strings.TrimSpace(binding.TargetLocator) == "" {
 		return nil
 	}
 	physicalID := strings.TrimSpace(binding.PhysicalArtifact)
 	if physicalID == "" {
-		return []doctorFinding{degradedFinding("managed_target_unverifiable", binding.ClientID, "the managed target has no physical artifact identity", "run plugin update for this client to rebuild its managed target metadata")}
+		return []doctorFinding{scopedFinding("degraded", "managed_target_unverifiable", installation, binding.ClientID, "the managed target has no physical artifact identity", blockedStateRecovery)}
 	}
 	target, err := (clientplanner.Planner{ManagedRoot: app.ManagedRoot}).ResolveTarget(ctx, client, domain.InstallScope(binding.Scope), physicalID)
 	if err != nil || filepath.Clean(target.ActivePath) != filepath.Clean(binding.TargetLocator) {
-		return []doctorFinding{degradedFinding("managed_target_mismatch", binding.ClientID, "the recorded managed target does not match the current safe client target", "do not modify the recorded path; remove the stale binding and add the plugin again for this client")}
+		return []doctorFinding{scopedFinding("degraded", "managed_target_mismatch", installation, binding.ClientID, "the recorded managed target does not match the current safe client target", blockedStateRecovery)}
 	}
 	expected := ""
 	sequence := 0
@@ -299,23 +291,27 @@ func checkManagedIntegrity(ctx context.Context, app App, client domain.DetectedC
 		}
 	}
 	if expected == "" || app.Stager == nil {
-		return []doctorFinding{{Status: "unknown", Code: "managed_integrity_not_checked", Subject: binding.ClientID, Message: "managed-directory integrity evidence is unavailable", RecoveryAction: "run plugin update for this client to create fresh integrity evidence"}}
+		return []doctorFinding{scopedFinding("unknown", "managed_integrity_not_checked", installation, binding.ClientID, "managed-directory integrity evidence is unavailable", repairAction(installation, binding))}
 	}
 	if err := app.Stager.Verify(ctx, target.ActivePath, expected); err != nil {
-		return []doctorFinding{degradedFinding("managed_directory_changed", binding.ClientID, "the managed package directory is missing or differs from its recorded digest", "run plugin update for this client to restore the managed directory")}
+		if errors.Is(err, os.ErrNotExist) || strings.Contains(err.Error(), "artifact digest mismatch") || strings.Contains(err.Error(), "excluded ownership marker") {
+			return []doctorFinding{scopedFinding("degraded", "managed_directory_changed", installation, binding.ClientID, "the managed package directory is missing or differs from its recorded digest", repairAction(installation, binding))}
+		}
+		return []doctorFinding{scopedFinding("unknown", "managed_integrity_check_failed", installation, binding.ClientID, "managed-directory integrity could not be checked because verification infrastructure failed", "retry doctor after resolving the filesystem or temporary verification error")}
 	}
 	return nil
 }
 
-func requiresCopilotRuntime(installations []domain.Installation) bool {
-	for _, installation := range installations {
-		for _, binding := range installation.Clients {
-			if binding.Materialization != domain.MaterializationAbsent && (binding.ClientID == string(domain.ClientCopilot) || binding.ClientID == string(domain.ClientVSCode)) {
-				return true
-			}
-		}
+func scopedFinding(status, code string, installation domain.Installation, clientID, message, action string) doctorFinding {
+	return doctorFinding{
+		Status: status, Code: code, InstallationName: installation.DeclaredName,
+		InstallationID: installation.InstallationID, ClientID: clientID,
+		Message: message, RecoveryAction: action,
 	}
-	return false
+}
+
+func repairAction(installation domain.Installation, binding domain.ClientBinding) string {
+	return fmt.Sprintf("run `agentplugins repair %s --target %s`", installation.DeclaredName, binding.ClientID)
 }
 
 func degradedFinding(code, subject, message, action string) doctorFinding {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/read.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/read.go
@@ -295,7 +295,10 @@ func checkManagedIntegrity(ctx context.Context, app App, client domain.DetectedC
 	}
 	if err := app.Stager.Verify(ctx, target.ActivePath, expected); err != nil {
 		var verification *ports.VerificationError
-		if errors.As(err, &verification) && (verification.Kind == ports.VerificationAbsent || verification.Kind == ports.VerificationDigestMismatch) || strings.Contains(err.Error(), "excluded ownership marker") {
+		if errors.As(err, &verification) && verification.Kind == ports.VerificationExcludedMarker {
+			return []doctorFinding{scopedFinding("unknown", "excluded_ownership_marker", installation, binding.ClientID, "the managed package contains an ownership marker excluded from digest verification", "manually review and remove the excluded ownership marker, then rerun doctor; automatic repair is intentionally blocked")}
+		}
+		if errors.As(err, &verification) && (verification.Kind == ports.VerificationAbsent || verification.Kind == ports.VerificationDigestMismatch) {
 			return []doctorFinding{scopedFinding("degraded", "managed_directory_changed", installation, binding.ClientID, "the managed package directory is missing or differs from its recorded digest", repairAction(installation, binding))}
 		}
 		return []doctorFinding{scopedFinding("unknown", "managed_integrity_check_failed", installation, binding.ClientID, "managed-directory integrity could not be checked because verification infrastructure failed", "retry doctor after resolving the filesystem or temporary verification error")}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/read.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/read.go
@@ -242,15 +242,15 @@ func doctorFindings(ctx context.Context, app App, detected []domain.DetectedClie
 			}
 			switch binding.Activation {
 			case domain.ActivationManual, domain.ActivationPrepared:
-				findings = append(findings, scopedFinding("degraded", "activation_pending", installation, binding.ClientID, "client activation is not complete", fmt.Sprintf("complete the displayed external activation step, then rerun the same `agentplugins add ... --target %s` command", binding.ClientID)))
+				findings = append(findings, scopedFinding("degraded", "activation_pending", installation, binding.ClientID, "client activation is not complete", fmt.Sprintf("complete the displayed external activation step, then rerun the same `agentplugins add ... --target %s%s` command", binding.ClientID, doctorScopeFlag(binding))))
 			case domain.ActivationFailed:
-				findings = append(findings, scopedFinding("degraded", "activation_failed", installation, binding.ClientID, "client activation failed", fmt.Sprintf("resolve the client-reported activation error, then rerun the same `agentplugins add ... --target %s` command", binding.ClientID)))
+				findings = append(findings, scopedFinding("degraded", "activation_failed", installation, binding.ClientID, "client activation failed", fmt.Sprintf("resolve the client-reported activation error, then rerun the same `agentplugins add ... --target %s%s` command", binding.ClientID, doctorScopeFlag(binding))))
 			}
 			switch binding.Authentication {
 			case domain.AuthenticationPending:
-				findings = append(findings, scopedFinding("degraded", "authentication_pending", installation, binding.ClientID, "plugin authentication is pending", fmt.Sprintf("complete the displayed external authentication step, then rerun the same `agentplugins add ... --target %s` command", binding.ClientID)))
+				findings = append(findings, scopedFinding("degraded", "authentication_pending", installation, binding.ClientID, "plugin authentication is pending", fmt.Sprintf("complete the displayed external authentication step, then rerun the same `agentplugins add ... --target %s%s` command", binding.ClientID, doctorScopeFlag(binding))))
 			case domain.AuthenticationFailed:
-				findings = append(findings, scopedFinding("degraded", "authentication_failed", installation, binding.ClientID, "plugin authentication failed", fmt.Sprintf("reauthorize the plugin in the selected client, then rerun the same `agentplugins add ... --target %s` command", binding.ClientID)))
+				findings = append(findings, scopedFinding("degraded", "authentication_failed", installation, binding.ClientID, "plugin authentication failed", fmt.Sprintf("reauthorize the plugin in the selected client, then rerun the same `agentplugins add ... --target %s%s` command", binding.ClientID, doctorScopeFlag(binding))))
 			case domain.AuthenticationNotChecked:
 				findings = append(findings, scopedFinding("unknown", "authentication_not_checked", installation, binding.ClientID, "authentication requirements have not been verified", "check the package's authentication instructions and verify access in the selected client"))
 			}
@@ -311,7 +311,14 @@ func scopedFinding(status, code string, installation domain.Installation, client
 }
 
 func repairAction(installation domain.Installation, binding domain.ClientBinding) string {
-	return fmt.Sprintf("run `agentplugins repair %s --target %s`", installation.DeclaredName, binding.ClientID)
+	return fmt.Sprintf("run `agentplugins repair %s --target %s%s`", installation.DeclaredName, binding.ClientID, doctorScopeFlag(binding))
+}
+
+func doctorScopeFlag(binding domain.ClientBinding) string {
+	if binding.Scope == string(domain.ScopeProject) {
+		return " --scope project"
+	}
+	return ""
 }
 
 func degradedFinding(code, subject, message, action string) doctorFinding {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/read.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/read.go
@@ -237,7 +237,7 @@ func doctorFindings(ctx context.Context, app App, detected []domain.DetectedClie
 			if !visible || client.Status != domain.DetectionDetected {
 				findings = append(findings, scopedFinding("degraded", "client_not_visible", installation, binding.ClientID, "the package is tracked but no current client visibility evidence was detected", "install or launch the client so its CLI, desktop application, or configuration directory is visible, then rerun doctor"))
 			}
-			if binding.ClientID == string(domain.ClientCopilot) && strings.TrimSpace(client.ExecutablePath) == "" {
+			if visible && client.Status == domain.DetectionDetected && binding.ClientID == string(domain.ClientCopilot) && strings.TrimSpace(client.ExecutablePath) == "" {
 				findings = append(findings, scopedFinding("degraded", "copilot_cli_missing", installation, binding.ClientID, "GitHub Copilot CLI is unavailable for automatic Copilot activation", "install GitHub Copilot CLI, ensure copilot is on PATH, and rerun doctor"))
 			}
 			switch binding.Activation {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/read.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/read.go
@@ -9,7 +9,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/dirswap"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	clientplanner "github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/planner"
 	"github.com/spf13/cobra"
 )
 
@@ -37,6 +39,19 @@ type publicInstallation struct {
 	Source         string         `json:"source"`
 	NeedsRebind    bool           `json:"needs_rebind,omitempty"`
 	Clients        []publicClient `json:"clients"`
+}
+
+type doctorFinding struct {
+	Status         string `json:"status"`
+	Code           string `json:"code"`
+	Subject        string `json:"subject,omitempty"`
+	Message        string `json:"message"`
+	RecoveryAction string `json:"recovery_action,omitempty"`
+}
+
+type supportedClient struct {
+	ClientID    domain.ClientID    `json:"client_id"`
+	PackageMode domain.PackageMode `json:"package_mode"`
 }
 
 func newListCommand(app App, opts *options) *cobra.Command {
@@ -123,11 +138,16 @@ func runDoctor(ctx context.Context, cmd *cobra.Command, app App, opts *options, 
 	}
 	report := struct {
 		ReadOnly           bool                   `json:"read_only"`
+		ToolVersion        string                 `json:"tool_version"`
+		SupportedClients   []supportedClient      `json:"supported_clients"`
 		Clients            []publicDetectedClient `json:"clients"`
 		InstallationCount  int                    `json:"installation_count"`
 		OpenOperationCount int                    `json:"open_operation_count"`
 		Installation       *publicInstallation    `json:"installation,omitempty"`
-	}{ReadOnly: true, Clients: publicClients, InstallationCount: len(publicInstallations(state, false)), OpenOperationCount: len(open)}
+		Findings           []doctorFinding        `json:"findings"`
+	}{ReadOnly: true, ToolVersion: normalizedToolVersion(app.Version), SupportedClients: doctorSupportedClients(), Clients: publicClients,
+		InstallationCount: len(publicInstallations(state, false)), OpenOperationCount: len(open)}
+	selected := (*domain.Installation)(nil)
 	if len(args) == 1 {
 		installation, err := selectInstallation(state, args[0])
 		if err != nil {
@@ -135,20 +155,171 @@ func runDoctor(ctx context.Context, cmd *cobra.Command, app App, opts *options, 
 		}
 		value := publicInstallationView(installation, true)
 		report.Installation = &value
+		selected = &installation
 	}
+	report.Findings = doctorFindings(ctx, app, clients, state, open, selected)
 	if opts.format == "json" {
 		return writeJSONOutput(cmd.OutOrStdout(), "doctor", report)
 	}
 	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "agentplugins doctor (read-only)")
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Tool version: %s\n", report.ToolVersion)
 	for _, client := range clients {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s: %s\n", client.DisplayName, client.Status)
 	}
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Tracked installations: %d\n", report.InstallationCount)
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Open recovery operations: %d\n", report.OpenOperationCount)
+	for _, finding := range report.Findings {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  [%s] %s: %s\n", finding.Status, finding.Code, finding.Message)
+		if finding.RecoveryAction != "" {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "    Recovery: %s\n", finding.RecoveryAction)
+		}
+	}
 	if report.Installation != nil {
 		return renderInstallation(cmd.OutOrStdout(), *report.Installation)
 	}
 	return nil
+}
+
+func normalizedToolVersion(version string) string {
+	if version = strings.TrimSpace(version); version != "" {
+		return version
+	}
+	return "development"
+}
+
+func doctorSupportedClients() []supportedClient {
+	ids := []domain.ClientID{domain.ClientCodex, domain.ClientCursor, domain.ClientCopilot, domain.ClientVSCode, domain.ClientKiro}
+	result := make([]supportedClient, 0, len(ids))
+	for _, id := range ids {
+		capabilities, _ := clientplanner.Capabilities(id)
+		result = append(result, supportedClient{ClientID: id, PackageMode: capabilities.PackageMode})
+	}
+	return result
+}
+
+func doctorFindings(ctx context.Context, app App, detected []domain.DetectedClient, state domain.StateFileV2, open []dirswap.Receipt, selected *domain.Installation) []doctorFinding {
+	var findings []doctorFinding
+	detectedByID := make(map[string]domain.DetectedClient, len(detected))
+	for _, client := range detected {
+		detectedByID[string(client.ClientID)] = client
+	}
+	if len(open) > 0 {
+		findings = append(findings, degradedFinding("open_recovery_operations", "operations", "an interrupted managed-directory operation requires recovery", "rerun the intended add, update, or remove command to perform transactional recovery"))
+	}
+	installations := state.Installations
+	if selected != nil {
+		installations = []domain.Installation{*selected}
+	}
+	for _, installation := range installations {
+		for _, diagnostic := range installation.Package.Diagnostics {
+			status := string(diagnostic.Severity)
+			if diagnostic.Severity == domain.SeverityError {
+				status = "degraded"
+			}
+			findings = append(findings, doctorFinding{Status: status, Code: diagnostic.Code, Subject: installation.DeclaredName, Message: diagnostic.Message, RecoveryAction: "review the package diagnostic and update the package after correcting the indicated item"})
+		}
+		if evidence := installation.Package.CatalogEvidence; evidence != nil {
+			clientIDs := make([]string, 0, len(evidence.Compatibility))
+			for clientID := range evidence.Compatibility {
+				clientIDs = append(clientIDs, clientID)
+			}
+			sort.Strings(clientIDs)
+			for _, clientID := range clientIDs {
+				compatibility := evidence.Compatibility[clientID]
+				if compatibility.Verification == "schema_only" || compatibility.Verification == "not_tested" {
+					findings = append(findings, doctorFinding{Status: "warning", Code: "catalog_" + compatibility.Verification, Subject: clientID, Message: "catalog compatibility has limited runtime verification", RecoveryAction: "verify the plugin in this client before relying on it"})
+				}
+			}
+		}
+		if installation.NeedsRebind {
+			findings = append(findings, degradedFinding("source_rebind_required", installation.DeclaredName, "the source identity needs an explicit rebind", "remove the old binding or run the explicit rebind workflow before updating"))
+		}
+		for _, binding := range installation.Clients {
+			if binding.Materialization == domain.MaterializationAbsent {
+				continue
+			}
+			if _, supported := clientplanner.Capabilities(domain.ClientID(binding.ClientID)); !supported {
+				findings = append(findings, degradedFinding("unsupported_client_binding", binding.ClientID, "the tracked binding names an unsupported client", "remove this stale binding and add the plugin to a supported client"))
+				continue
+			}
+			client, visible := detectedByID[binding.ClientID]
+			if !visible || client.Status != domain.DetectionDetected {
+				findings = append(findings, degradedFinding("client_not_visible", binding.ClientID, "the package is tracked but no current client visibility evidence was detected", "install or launch the client so its CLI, desktop application, or configuration directory is visible, then rerun doctor"))
+			}
+			switch binding.Activation {
+			case domain.ActivationManual, domain.ActivationPrepared:
+				findings = append(findings, degradedFinding("activation_pending", binding.ClientID, "client activation is not complete", "open the selected client, finish plugin activation, and then rerun doctor"))
+			case domain.ActivationFailed:
+				findings = append(findings, degradedFinding("activation_failed", binding.ClientID, "client activation failed", "retry the plugin update for this client after resolving the client-reported activation error"))
+			}
+			switch binding.Authentication {
+			case domain.AuthenticationPending:
+				findings = append(findings, degradedFinding("authentication_pending", binding.ClientID, "plugin authentication is pending", "complete authentication in the selected client and rerun doctor"))
+			case domain.AuthenticationFailed:
+				findings = append(findings, degradedFinding("authentication_failed", binding.ClientID, "plugin authentication failed", "reauthorize the plugin in the selected client and rerun doctor"))
+			case domain.AuthenticationNotChecked:
+				findings = append(findings, doctorFinding{Status: "unknown", Code: "authentication_not_checked", Subject: binding.ClientID, Message: "authentication requirements have not been verified", RecoveryAction: "check the package's authentication instructions and verify access in the selected client"})
+			}
+			if binding.Materialization == domain.MaterializationDegraded || binding.Verification == domain.VerificationFailed {
+				findings = append(findings, degradedFinding("installation_verification_failed", binding.ClientID, "the managed package is marked degraded or failed verification", "run plugin update for this client to rebuild and verify the managed package"))
+			}
+			findings = append(findings, checkManagedIntegrity(ctx, app, client, binding)...)
+		}
+	}
+	if requiresCopilotRuntime(installations) {
+		copilot, ok := detectedByID[string(domain.ClientCopilot)]
+		if !ok || strings.TrimSpace(copilot.ExecutablePath) == "" {
+			findings = append(findings, degradedFinding("copilot_cli_missing", "runtime", "GitHub Copilot CLI is unavailable for automatic Copilot/VS Code activation", "install GitHub Copilot CLI, ensure copilot is on PATH, and rerun doctor"))
+		}
+	}
+	if len(findings) == 0 {
+		findings = append(findings, doctorFinding{Status: "healthy", Code: "no_degradation_detected", Message: "no tracked degradation was detected"})
+	}
+	return findings
+}
+
+func checkManagedIntegrity(ctx context.Context, app App, client domain.DetectedClient, binding domain.ClientBinding) []doctorFinding {
+	if binding.Materialization != domain.MaterializationMaterialized || strings.TrimSpace(binding.TargetLocator) == "" {
+		return nil
+	}
+	physicalID := strings.TrimSpace(binding.PhysicalArtifact)
+	if physicalID == "" {
+		return []doctorFinding{degradedFinding("managed_target_unverifiable", binding.ClientID, "the managed target has no physical artifact identity", "run plugin update for this client to rebuild its managed target metadata")}
+	}
+	target, err := (clientplanner.Planner{ManagedRoot: app.ManagedRoot}).ResolveTarget(ctx, client, domain.InstallScope(binding.Scope), physicalID)
+	if err != nil || filepath.Clean(target.ActivePath) != filepath.Clean(binding.TargetLocator) {
+		return []doctorFinding{degradedFinding("managed_target_mismatch", binding.ClientID, "the recorded managed target does not match the current safe client target", "do not modify the recorded path; remove the stale binding and add the plugin again for this client")}
+	}
+	expected := ""
+	sequence := 0
+	for _, receipt := range binding.Receipts {
+		if receipt.Sequence >= sequence && strings.TrimSpace(receipt.AfterDigest) != "" {
+			sequence = receipt.Sequence
+			expected = receipt.AfterDigest
+		}
+	}
+	if expected == "" || app.Stager == nil {
+		return []doctorFinding{{Status: "unknown", Code: "managed_integrity_not_checked", Subject: binding.ClientID, Message: "managed-directory integrity evidence is unavailable", RecoveryAction: "run plugin update for this client to create fresh integrity evidence"}}
+	}
+	if err := app.Stager.Verify(ctx, target.ActivePath, expected); err != nil {
+		return []doctorFinding{degradedFinding("managed_directory_changed", binding.ClientID, "the managed package directory is missing or differs from its recorded digest", "run plugin update for this client to restore the managed directory")}
+	}
+	return nil
+}
+
+func requiresCopilotRuntime(installations []domain.Installation) bool {
+	for _, installation := range installations {
+		for _, binding := range installation.Clients {
+			if binding.Materialization != domain.MaterializationAbsent && (binding.ClientID == string(domain.ClientCopilot) || binding.ClientID == string(domain.ClientVSCode)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func degradedFinding(code, subject, message, action string) doctorFinding {
+	return doctorFinding{Status: "degraded", Code: code, Subject: subject, Message: message, RecoveryAction: action}
 }
 
 func newVersionCommand(app App, opts *options) *cobra.Command {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/read.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/read.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -14,6 +13,7 @@ import (
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/dirswap"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 	clientplanner "github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/planner"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/ports"
 	"github.com/spf13/cobra"
 )
 
@@ -294,7 +294,8 @@ func checkManagedIntegrity(ctx context.Context, app App, client domain.DetectedC
 		return []doctorFinding{scopedFinding("unknown", "managed_integrity_not_checked", installation, binding.ClientID, "managed-directory integrity evidence is unavailable", repairAction(installation, binding))}
 	}
 	if err := app.Stager.Verify(ctx, target.ActivePath, expected); err != nil {
-		if errors.Is(err, os.ErrNotExist) || strings.Contains(err.Error(), "artifact digest mismatch") || strings.Contains(err.Error(), "excluded ownership marker") {
+		var verification *ports.VerificationError
+		if errors.As(err, &verification) && (verification.Kind == ports.VerificationAbsent || verification.Kind == ports.VerificationDigestMismatch) || strings.Contains(err.Error(), "excluded ownership marker") {
 			return []doctorFinding{scopedFinding("degraded", "managed_directory_changed", installation, binding.ClientID, "the managed package directory is missing or differs from its recorded digest", repairAction(installation, binding))}
 		}
 		return []doctorFinding{scopedFinding("unknown", "managed_integrity_check_failed", installation, binding.ClientID, "managed-directory integrity could not be checked because verification infrastructure failed", "retry doctor after resolving the filesystem or temporary verification error")}
@@ -311,7 +312,7 @@ func scopedFinding(status, code string, installation domain.Installation, client
 }
 
 func repairAction(installation domain.Installation, binding domain.ClientBinding) string {
-	return fmt.Sprintf("run `agentplugins repair %s --target %s%s`", installation.DeclaredName, binding.ClientID, doctorScopeFlag(binding))
+	return fmt.Sprintf("run `agentplugins repair %s --target %s%s`", installation.InstallationID, binding.ClientID, doctorScopeFlag(binding))
 }
 
 func doctorScopeFlag(binding domain.ClientBinding) string {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/root.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/root.go
@@ -29,6 +29,7 @@ func NewRoot(app App) *cobra.Command {
 
 	root.AddCommand(newAddCommand(app, opts))
 	root.AddCommand(newUpdateCommand(app, opts))
+	root.AddCommand(newRepairCommand(app, opts))
 	root.AddCommand(newRemoveCommand(app, opts))
 	root.AddCommand(newMigrateFormatCommand(app, opts))
 	root.AddCommand(newMigrateStateCommand(app, opts))

--- a/cli/plugin-kit-ai/internal/agentpluginscli/source.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/source.go
@@ -89,8 +89,22 @@ func (app App) loadPackage(ctx context.Context, raw string) (loadedPackage, erro
 		if envelope.TreeDigest != catalogResolution.Entry.TreeDigest || envelope.ManifestDigest != catalogResolution.Entry.ManifestDigest {
 			return fail(fmt.Errorf("catalog package digest mismatch"))
 		}
+		evidence := catalogResolution.Evidence
+		evidence.Compatibility = cloneCatalogCompatibility(evidence.Compatibility)
+		envelope.CatalogEvidence = &evidence
 	}
 	return loadedPackage{envelope: envelope, hints: hints, cleanup: cleanup}, nil
+}
+
+func cloneCatalogCompatibility(source map[string]domain.CatalogCompatibility) map[string]domain.CatalogCompatibility {
+	if len(source) == 0 {
+		return nil
+	}
+	result := make(map[string]domain.CatalogCompatibility, len(source))
+	for client, compatibility := range source {
+		result[client] = compatibility
+	}
+	return result
 }
 
 func (app App) resolveCatalogName(ctx context.Context, name string) (domain.CatalogResolution, error) {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/state_migration.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/state_migration.go
@@ -35,13 +35,10 @@ func runMigrateState(ctx context.Context, cmd *cobra.Command, app App, opts *opt
 	if opts.dryRun {
 		return renderStateMigration(cmd.OutOrStdout(), opts.format, plan, statemigration.Report{}, true)
 	}
-	if !app.Terminal && !opts.yes {
-		return fmt.Errorf("non-interactive state migration requires --yes")
-	}
 	if opts.format == "human" {
 		renderStateMigrationPlan(cmd.OutOrStdout(), plan)
 	}
-	confirmed := opts.yes
+	confirmed := mutationConfirmed(app, opts)
 	if !confirmed && opts.format == "human" && app.Terminal {
 		confirmed, err = promptYesNo(cmd.InOrStdin(), cmd.OutOrStdout(), "Create a backup and migrate this state? [y/N]")
 		if err != nil {

--- a/docs/agentplugins-release.md
+++ b/docs/agentplugins-release.md
@@ -75,9 +75,11 @@ and that JSON output contains no absolute runner paths. It runs as a separate
 job after publication, waits up to five minutes with online metadata refreshes,
 and can be retried without attempting to republish an immutable npm version.
 The same workflow can be dispatched with `verify_only=true` and the existing
-tag after publication. That mode skips the protected publish job entirely,
-does not require opening the publish-ready gate, and only runs the public
-registry and isolated lifecycle verification.
+historical tag after publication. That mode skips release identity,
+schema-v2 six-platform proof, and the protected publish job entirely; it does
+not require the tag to point to current `main` or require opening the
+publish-ready gate, and only runs public registry, provenance, and isolated
+lifecycle verification.
 
 Never publish an empty placeholder, reuse a tag, overwrite release assets, or
 resolve a binary through an unpinned GitHub `latest` release.

--- a/docs/agentplugins-release.md
+++ b/docs/agentplugins-release.md
@@ -18,7 +18,9 @@ the `latest` dist-tag without explicit owner approval for that exact version.
 - The catalog embedded in the `agentplugins` binary is byte-identical to that
   released catalog and its compiled SHA-256 pin matches.
 - `agentplugins-release` and `npm-agentplugins` require a reviewer and allow
-  deployment only from `main`.
+  deployment only from `main`. Dispatch both workflows from the exact `main`
+  commit referenced by the release tag; their source-commit guards reject a
+  newer or older workflow revision.
 - npm trusted publishing is bound to repository `777genius/plugin-kit-ai`,
   workflow `agentplugins-npm-publish.yml`, environment `npm-agentplugins`, and
   the `npm publish` permission.
@@ -39,9 +41,13 @@ project is tagged.
    environment deployment.
 4. Confirm the workflow attests all six binaries, `checksums.txt`, and
    `release-manifest.json` before creating the non-public draft.
-5. Confirm the authenticated platform-proof workflow downloads that exact
-   draft and succeeds on all six native targets. Until the matrix aggregates
-   successfully, no public GitHub Release may exist.
+5. Confirm the read-only platform-proof workflow receives the same-run frozen
+   asset artifact and succeeds on all six native targets. For a draft it cold
+   bootstraps the npm launcher from the exact local asset only after matching
+   the embedded filename, size, and SHA-256; no GitHub token reaches the
+   launcher or released binary. It then proves a warm-cache invocation with
+   the local proof source removed. Until the matrix aggregates successfully,
+   no public GitHub Release may exist.
 6. After all six proofs are green, approve the promotion deployment. Confirm
    it reverifies the draft identity, manifest, assets, and attestations.
    It promotes that exact draft only after all six native platform proofs succeed.
@@ -57,6 +63,11 @@ non-public. Fix the proof defect and rerun the same tag to resume. If draft
 creation itself was interrupted and left an incomplete or non-matching draft,
 an owner must verify that it was never public, delete only that draft release
 (not the tag), and rerun. Never edit or replace assets in place.
+
+For a schema-v1 historical platform audit, dispatch `Agentplugins Platform
+Proof` with `--ref <exact-tag>` and `allow_legacy_manifest=true`. The workflow
+must already exist at that tag, and its source SHA must equal the audited tag
+commit; current `main` is never allowed to impersonate a historical harness.
 
 ## Bootstrap publication record
 
@@ -80,6 +91,8 @@ after an exact-version, scripts-disabled install verifies both the registry
 signature and SLSA provenance attestation. Only then may it run `add`, `info`,
 read-only `doctor`, no-change `update`, `remove`, and final absent-state
 verification in an isolated HOME.
+The public-release platform proof uses a cold cache without the local draft
+override and therefore proves the normal anonymous GitHub release download.
 The publish-ready gate must be returned to `false` immediately after the publish
 job finishes, regardless of the verification result. Registry verification
 must still prove the `latest` dist-tag resolves to the exact published version

--- a/docs/agentplugins-release.md
+++ b/docs/agentplugins-release.md
@@ -38,13 +38,25 @@ project is tagged.
 3. Review the frozen commit and approve the `agentplugins-release`
    environment deployment.
 4. Confirm the workflow attests all six binaries, `checksums.txt`, and
-   `release-manifest.json` before creating the public release.
-5. Verify the release contains six platform binaries, `checksums.txt`, and
-   `release-manifest.json`.
-6. Verify GitHub attestations before allowing npm publication.
+   `release-manifest.json` before creating the non-public draft.
+5. Confirm the authenticated platform-proof workflow downloads that exact
+   draft and succeeds on all six native targets. Until the matrix aggregates
+   successfully, no public GitHub Release may exist.
+6. After all six proofs are green, approve the promotion deployment. Confirm
+   it reverifies the draft identity, manifest, assets, and attestations.
+   It promotes that exact draft only after all six native platform proofs succeed.
+7. Verify the resulting public release contains six platform binaries,
+   `checksums.txt`, and `release-manifest.json`, and verify GitHub attestations
+   before allowing npm publication.
 
-The workflow refuses an existing release instead of replacing immutable
-assets.
+The workflow rejects every existing public release. A rerun accepts an existing
+draft only when its tag, frozen commit, draft status, complete asset set, and
+every asset byte exactly match the rebuilt release; it never uploads over an
+existing asset. A failed native proof intentionally leaves that exact draft
+non-public. Fix the proof defect and rerun the same tag to resume. If draft
+creation itself was interrupted and left an incomplete or non-matching draft,
+an owner must verify that it was never public, delete only that draft release
+(not the tag), and rerun. Never edit or replace assets in place.
 
 ## Bootstrap publication record
 

--- a/install/integrationctl/agentplugins/adapters/catalog/catalog.go
+++ b/install/integrationctl/agentplugins/adapters/catalog/catalog.go
@@ -75,7 +75,20 @@ func (loaded Loaded) Resolve(name string) (domain.CatalogResolution, error) {
 		Entry:           entry,
 		SourceReference: fmt.Sprintf("%s@%s//%s", loaded.Catalog.Repository, loaded.Catalog.Revision, entry.SourcePath),
 		CatalogDigest:   loaded.Digest,
-		Hints:           domain.CompatibilityHints{OpenAIMCPAuth: cloneAuthHints(entry.OpenAIMCPAuth)},
+		Hints: domain.CompatibilityHints{
+			Compatibility: cloneCompatibility(entry.Compatibility),
+			OpenAIMCPAuth: cloneAuthHints(entry.OpenAIMCPAuth),
+		},
+		Evidence: domain.CatalogEvidence{
+			SchemaVersion:      loaded.Catalog.SchemaVersion,
+			CatalogVersion:     loaded.Catalog.CatalogVersion,
+			Repository:         loaded.Catalog.Repository,
+			Revision:           loaded.Catalog.Revision,
+			Digest:             loaded.Digest,
+			MinimumCLIVersion:  entry.MinimumCLIVersion,
+			AgentPluginsSchema: entry.AgentPluginsSchema,
+			Compatibility:      cloneCompatibility(entry.Compatibility),
+		},
 	}, nil
 }
 
@@ -178,8 +191,21 @@ func validVerificationCompatibility(value string) bool {
 	return oneOf(value, "tested", "schema_only", "not_tested")
 }
 
-func validAuthCompatibility(value string) bool {
-	return oneOf(value, "not_required", "required", "unknown")
+func validAuthCompatibility(value domain.AuthenticationRequirement) bool {
+	return value == domain.AuthenticationRequirementNotRequired ||
+		value == domain.AuthenticationRequirementRequired ||
+		value == domain.AuthenticationRequirementUnknown
+}
+
+func cloneCompatibility(source map[string]domain.CatalogCompatibility) map[string]domain.CatalogCompatibility {
+	if len(source) == 0 {
+		return nil
+	}
+	result := make(map[string]domain.CatalogCompatibility, len(source))
+	for key, value := range source {
+		result[key] = value
+	}
+	return result
 }
 
 func oneOf(value string, allowed ...string) bool {

--- a/install/integrationctl/agentplugins/adapters/catalog/catalog.go
+++ b/install/integrationctl/agentplugins/adapters/catalog/catalog.go
@@ -27,6 +27,14 @@ var (
 	namePattern       = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]{0,63}$`)
 )
 
+var requiredCompatibility = map[string]string{
+	string(domain.ClientCodex):   "projected",
+	string(domain.ClientCursor):  "native",
+	string(domain.ClientCopilot): "native",
+	string(domain.ClientVSCode):  "prepared",
+	string(domain.ClientKiro):    "native",
+}
+
 type Loader struct {
 	CurrentCLIVersion string
 }
@@ -150,10 +158,23 @@ func validatePlugin(plugin domain.CatalogPlugin) error {
 		}
 		components[component] = struct{}{}
 	}
-	for client, compatibility := range plugin.Compatibility {
-		if strings.TrimSpace(client) == "" || !validPackageCompatibility(compatibility.Package) ||
+	if len(plugin.Compatibility) != len(requiredCompatibility) {
+		return fmt.Errorf("plugin %q compatibility must contain exactly codex, cursor, copilot, vscode, and kiro", plugin.Name)
+	}
+	var authentication domain.AuthenticationRequirement
+	for client, expectedPackage := range requiredCompatibility {
+		compatibility, ok := plugin.Compatibility[client]
+		if !ok {
+			return fmt.Errorf("plugin %q compatibility is missing %q", plugin.Name, client)
+		}
+		if compatibility.Package != expectedPackage ||
 			!validVerificationCompatibility(compatibility.Verification) || !validAuthCompatibility(compatibility.Authentication) {
 			return fmt.Errorf("plugin %q has invalid compatibility for %q", plugin.Name, client)
+		}
+		if authentication == "" {
+			authentication = compatibility.Authentication
+		} else if compatibility.Authentication != authentication {
+			return fmt.Errorf("plugin %q must use one consistent authentication requirement for every client", plugin.Name)
 		}
 	}
 	for server, hint := range plugin.OpenAIMCPAuth {
@@ -181,10 +202,6 @@ func validateSourcePath(value string) error {
 		return fmt.Errorf("path is not normalized")
 	}
 	return nil
-}
-
-func validPackageCompatibility(value string) bool {
-	return oneOf(value, "native", "projected", "prepared", "unsupported")
 }
 
 func validVerificationCompatibility(value string) bool {

--- a/install/integrationctl/agentplugins/adapters/catalog/catalog_test.go
+++ b/install/integrationctl/agentplugins/adapters/catalog/catalog_test.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"os"
 	"strings"
 	"testing"
 
@@ -81,6 +82,50 @@ func TestCatalogEnforcesMinimumCLIVersionAtResolution(t *testing.T) {
 	}
 }
 
+func TestCatalogRejectsAnyCompatibilityMatrixDeviation(t *testing.T) {
+	t.Parallel()
+	tests := map[string]string{
+		"omission":       `,"kiro":{"package":"native","verification":"tested","authentication":"not_required"}`,
+		"extra":          `"kiro":{"package":"native","verification":"tested","authentication":"not_required"}`,
+		"mode":           `"vscode":{"package":"prepared"`,
+		"authentication": `"vscode":{"package":"prepared","verification":"tested","authentication":"not_required"}`,
+	}
+	for name, fragment := range tests {
+		name, fragment := name, fragment
+		t.Run(name, func(t *testing.T) {
+			body := string(validCatalog())
+			switch name {
+			case "omission":
+				body = strings.Replace(body, fragment, "", 1)
+			case "extra":
+				body = strings.Replace(body, fragment, fragment+`,"typo":{"package":"native","verification":"tested","authentication":"not_required"}`, 1)
+			case "mode":
+				body = strings.Replace(body, fragment, `"vscode":{"package":"native"`, 1)
+			case "authentication":
+				body = strings.Replace(body, fragment, `"vscode":{"package":"prepared","verification":"tested","authentication":"required"}`, 1)
+			}
+			if _, err := (Loader{CurrentCLIVersion: "0.1.0"}).Load([]byte(body), ""); err == nil {
+				t.Fatal("invalid compatibility matrix accepted")
+			}
+		})
+	}
+}
+
+func TestEmbeddedCatalogAllEntriesUseExactCompatibilityMatrix(t *testing.T) {
+	t.Parallel()
+	body, err := os.ReadFile("../../../../../cli/plugin-kit-ai/cmd/agentplugins/catalog-v1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := (Loader{CurrentCLIVersion: "0.1.4"}).Load(body, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Catalog.Plugins) != 26 {
+		t.Fatalf("embedded package count = %d, want 26", len(loaded.Catalog.Plugins))
+	}
+}
+
 func validCatalog() []byte {
 	return []byte(`{
   "$schema": "https://github.com/777genius/universal-agent-plugins/schemas/catalog-v1.schema.json",
@@ -98,7 +143,7 @@ func validCatalog() []byte {
     "tree_digest": "` + digest("a") + `",
     "manifest_digest": "` + digest("b") + `",
     "components": ["mcp"],
-    "compatibility": {"cursor": {"package":"native","verification":"tested","authentication":"not_required"}},
+    "compatibility": {"codex":{"package":"projected","verification":"tested","authentication":"not_required"},"cursor":{"package":"native","verification":"tested","authentication":"not_required"},"copilot":{"package":"native","verification":"tested","authentication":"not_required"},"vscode":{"package":"prepared","verification":"tested","authentication":"not_required"},"kiro":{"package":"native","verification":"tested","authentication":"not_required"}},
     "openai_mcp_auth": {"context7": {"bearer_token_env_var":"CONTEXT7_API_KEY"}}
   }]
 }`)
@@ -109,6 +154,6 @@ func digest(value string) string {
 }
 
 func conflictCatalog() []byte {
-	duplicate := `, {"name":"context7","version":"1.0.0","agent_plugins_schema":"https://agent-plugins.org/schemas/1.0.0/plugin.schema.json","minimum_cli_version":"0.1.0","source_path":"plugins/context7-copy","tree_digest":"` + digest("c") + `","manifest_digest":"` + digest("b") + `","components":["mcp"],"compatibility":{}}`
+	duplicate := `, {"name":"context7","version":"1.0.0","agent_plugins_schema":"https://agent-plugins.org/schemas/1.0.0/plugin.schema.json","minimum_cli_version":"0.1.0","source_path":"plugins/context7-copy","tree_digest":"` + digest("c") + `","manifest_digest":"` + digest("b") + `","components":["mcp"],"compatibility":{"codex":{"package":"projected","verification":"tested","authentication":"not_required"},"cursor":{"package":"native","verification":"tested","authentication":"not_required"},"copilot":{"package":"native","verification":"tested","authentication":"not_required"},"vscode":{"package":"prepared","verification":"tested","authentication":"not_required"},"kiro":{"package":"native","verification":"tested","authentication":"not_required"}}}`
 	return []byte(strings.Replace(string(validCatalog()), "  }]\n}", "  }"+duplicate+"]\n}", 1))
 }

--- a/install/integrationctl/agentplugins/adapters/catalog/catalog_test.go
+++ b/install/integrationctl/agentplugins/adapters/catalog/catalog_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/hex"
 	"strings"
 	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 )
 
 func TestCatalogLoadsStrictPinnedIndexAndResolvesExactSource(t *testing.T) {
@@ -26,6 +28,17 @@ func TestCatalogLoadsStrictPinnedIndexAndResolvesExactSource(t *testing.T) {
 	}
 	if resolved.Hints.OpenAIMCPAuth["context7"].BearerTokenEnvVar != "CONTEXT7_API_KEY" {
 		t.Fatalf("hints = %+v", resolved.Hints)
+	}
+	compatibility := resolved.Hints.Compatibility["cursor"]
+	if compatibility.Authentication != "not_required" || compatibility.Package != "native" {
+		t.Fatalf("generic compatibility = %+v", resolved.Hints.Compatibility)
+	}
+	if resolved.Evidence.SchemaVersion != 1 || resolved.Evidence.CatalogVersion != "0.1.0" || resolved.Evidence.Compatibility["cursor"].Authentication != "not_required" {
+		t.Fatalf("catalog evidence = %+v", resolved.Evidence)
+	}
+	resolved.Hints.Compatibility["cursor"] = domain.CatalogCompatibility{}
+	if resolved.Evidence.Compatibility["cursor"].Package != "native" {
+		t.Fatal("resolution hints alias immutable catalog evidence")
 	}
 }
 

--- a/install/integrationctl/agentplugins/adapters/clientdetect/detector.go
+++ b/install/integrationctl/agentplugins/adapters/clientdetect/detector.go
@@ -20,18 +20,31 @@ type Detector struct {
 	GOOS                  string
 	Environment           map[string]string
 	SystemApplicationsDir string
+	WindowsProgramFiles   []string
+	LinuxApplicationDirs  []string
 	LookPath              func(string) (string, error)
 	Lstat                 func(string) (fs.FileInfo, error)
 }
 
 func NewOS(homeDir string) Detector {
+	environment := environmentSnapshot()
+	xdgApplications := ""
+	if root := strings.TrimSpace(environment["XDG_DATA_HOME"]); root != "" {
+		xdgApplications = filepath.Join(root, "applications")
+	}
 	return Detector{
 		HomeDir:               homeDir,
 		GOOS:                  runtime.GOOS,
-		Environment:           environmentSnapshot(),
+		Environment:           environment,
 		SystemApplicationsDir: "/Applications",
-		LookPath:              exec.LookPath,
-		Lstat:                 os.Lstat,
+		WindowsProgramFiles:   compactPaths(environment["ProgramFiles"], environment["ProgramW6432"], environment["ProgramFiles(x86)"]),
+		LinuxApplicationDirs: compactPaths(
+			xdgApplications,
+			filepath.Join(homeDir, ".local", "share", "applications"),
+			"/usr/local/share/applications", "/usr/share/applications",
+		),
+		LookPath: exec.LookPath,
+		Lstat:    os.Lstat,
 	}
 }
 
@@ -69,8 +82,10 @@ func (detector Detector) detectCodex() domain.DetectedClient {
 		)
 	} else if detector.GOOS == "windows" {
 		surfaces = append(surfaces,
-			detector.windowsAppSurface("chatgpt_desktop", filepath.Join("Microsoft", "WindowsApps", "ChatGPT.exe")),
+			detector.windowsAppSurface("chatgpt_desktop", filepath.Join("Microsoft", "WindowsApps", "ChatGPT.exe"), filepath.Join("WindowsApps", "ChatGPT.exe")),
 		)
+	} else if detector.GOOS == "linux" {
+		surfaces = append(surfaces, detector.linuxDesktopSurface("codex_desktop", "codex.desktop", "chatgpt.desktop"))
 	}
 	return detected(domain.ClientCodex, "OpenAI Codex / ChatGPT", configRoot, detector.lookup("codex"), surfaces)
 }
@@ -84,7 +99,9 @@ func (detector Detector) detectCursor() domain.DetectedClient {
 	if detector.GOOS == "darwin" {
 		surfaces = append(surfaces, detector.appSurface("cursor_desktop", "Cursor.app"))
 	} else if detector.GOOS == "windows" {
-		surfaces = append(surfaces, detector.windowsAppSurface("cursor_desktop", filepath.Join("Programs", "cursor", "Cursor.exe")))
+		surfaces = append(surfaces, detector.windowsAppSurface("cursor_desktop", filepath.Join("Programs", "cursor", "Cursor.exe"), filepath.Join("Cursor", "Cursor.exe")))
+	} else if detector.GOOS == "linux" {
+		surfaces = append(surfaces, detector.linuxDesktopSurface("cursor_desktop", "cursor.desktop"))
 	}
 	return detected(domain.ClientCursor, "Cursor", configRoot, detector.lookup("cursor"), surfaces)
 }
@@ -107,7 +124,9 @@ func (detector Detector) detectVSCode() domain.DetectedClient {
 	if detector.GOOS == "darwin" {
 		surfaces = append(surfaces, detector.appSurface("vscode_desktop", "Visual Studio Code.app"))
 	} else if detector.GOOS == "windows" {
-		surfaces = append(surfaces, detector.windowsAppSurface("vscode_desktop", filepath.Join("Programs", "Microsoft VS Code", "Code.exe")))
+		surfaces = append(surfaces, detector.windowsAppSurface("vscode_desktop", filepath.Join("Programs", "Microsoft VS Code", "Code.exe"), filepath.Join("Microsoft VS Code", "Code.exe")))
+	} else if detector.GOOS == "linux" {
+		surfaces = append(surfaces, detector.linuxDesktopSurface("vscode_desktop", "code.desktop", "visual-studio-code.desktop"))
 	}
 	return detected(domain.ClientVSCode, "Visual Studio Code", configRoot, detector.lookup("code"), surfaces)
 }
@@ -124,7 +143,9 @@ func (detector Detector) detectKiro() domain.DetectedClient {
 	if detector.GOOS == "darwin" {
 		surfaces = append(surfaces, detector.appSurface("kiro_desktop", "Kiro.app"))
 	} else if detector.GOOS == "windows" {
-		surfaces = append(surfaces, detector.windowsAppSurface("kiro_desktop", filepath.Join("Programs", "Kiro", "Kiro.exe")))
+		surfaces = append(surfaces, detector.windowsAppSurface("kiro_desktop", filepath.Join("Programs", "Kiro", "Kiro.exe"), filepath.Join("Kiro", "Kiro.exe")))
+	} else if detector.GOOS == "linux" {
+		surfaces = append(surfaces, detector.linuxDesktopSurface("kiro_desktop", "kiro.desktop"))
 	}
 	return detected(domain.ClientKiro, "Kiro", configRoot, firstPath(kiroCLI, legacyCLI), surfaces)
 }
@@ -169,13 +190,33 @@ func (detector Detector) appSurface(id, appName string) domain.ClientSurface {
 	return domain.ClientSurface{ID: id}
 }
 
-func (detector Detector) windowsAppSurface(id, relativePath string) domain.ClientSurface {
-	root := strings.TrimSpace(detector.Environment["LOCALAPPDATA"])
-	if root == "" {
-		return domain.ClientSurface{ID: id}
+func (detector Detector) windowsAppSurface(id, userRelativePath, systemRelativePath string) domain.ClientSurface {
+	paths := []string{}
+	if root := strings.TrimSpace(detector.Environment["LOCALAPPDATA"]); root != "" {
+		paths = append(paths, filepath.Join(root, userRelativePath))
 	}
-	detected := detector.realFile(filepath.Join(root, relativePath))
-	return domain.ClientSurface{ID: id, Detected: detected, Evidence: evidence(detected, "application_installation")}
+	for _, root := range detector.WindowsProgramFiles {
+		if strings.TrimSpace(root) != "" {
+			paths = append(paths, filepath.Join(root, systemRelativePath))
+		}
+	}
+	for _, path := range paths {
+		if detector.realFile(path) {
+			return domain.ClientSurface{ID: id, Detected: true, Evidence: "application_installation"}
+		}
+	}
+	return domain.ClientSurface{ID: id}
+}
+
+func (detector Detector) linuxDesktopSurface(id string, filenames ...string) domain.ClientSurface {
+	for _, root := range detector.LinuxApplicationDirs {
+		for _, filename := range filenames {
+			if detector.realFile(filepath.Join(root, filename)) {
+				return domain.ClientSurface{ID: id, Detected: true, Evidence: "desktop_entry"}
+			}
+		}
+	}
+	return domain.ClientSurface{ID: id}
 }
 
 func (detector Detector) lookup(binary string) string {
@@ -238,12 +279,30 @@ func evidence(ok bool, value string) string {
 
 func environmentSnapshot() map[string]string {
 	values := map[string]string{}
-	for _, name := range []string{"APPDATA", "LOCALAPPDATA", "XDG_CONFIG_HOME"} {
+	for _, name := range []string{"APPDATA", "LOCALAPPDATA", "ProgramFiles", "ProgramW6432", "ProgramFiles(x86)", "XDG_CONFIG_HOME", "XDG_DATA_HOME"} {
 		if value, ok := os.LookupEnv(name); ok {
 			values[name] = value
 		}
 	}
 	return values
+}
+
+func compactPaths(paths ...string) []string {
+	result := make([]string, 0, len(paths))
+	seen := map[string]struct{}{}
+	for _, path := range paths {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		clean := filepath.Clean(path)
+		if _, ok := seen[clean]; ok {
+			continue
+		}
+		seen[clean] = struct{}{}
+		result = append(result, clean)
+	}
+	return result
 }
 
 func IsNotFound(err error) bool {

--- a/install/integrationctl/agentplugins/adapters/clientdetect/detector.go
+++ b/install/integrationctl/agentplugins/adapters/clientdetect/detector.go
@@ -32,6 +32,10 @@ func NewOS(homeDir string) Detector {
 	if root := strings.TrimSpace(environment["XDG_DATA_HOME"]); root != "" {
 		xdgApplications = filepath.Join(root, "applications")
 	}
+	userApplications := ""
+	if root := strings.TrimSpace(homeDir); root != "" {
+		userApplications = filepath.Join(root, ".local", "share", "applications")
+	}
 	return Detector{
 		HomeDir:               homeDir,
 		GOOS:                  runtime.GOOS,
@@ -40,7 +44,7 @@ func NewOS(homeDir string) Detector {
 		WindowsProgramFiles:   compactPaths(environment["ProgramFiles"], environment["ProgramW6432"], environment["ProgramFiles(x86)"]),
 		LinuxApplicationDirs: compactPaths(
 			xdgApplications,
-			filepath.Join(homeDir, ".local", "share", "applications"),
+			userApplications,
 			"/usr/local/share/applications", "/usr/share/applications",
 		),
 		LookPath: exec.LookPath,

--- a/install/integrationctl/agentplugins/adapters/clientdetect/detector.go
+++ b/install/integrationctl/agentplugins/adapters/clientdetect/detector.go
@@ -67,6 +67,10 @@ func (detector Detector) detectCodex() domain.DetectedClient {
 			detector.appSurface("codex_desktop", "Codex.app"),
 			detector.appSurface("chatgpt_desktop", "ChatGPT.app"),
 		)
+	} else if detector.GOOS == "windows" {
+		surfaces = append(surfaces,
+			detector.windowsAppSurface("chatgpt_desktop", filepath.Join("Microsoft", "WindowsApps", "ChatGPT.exe")),
+		)
 	}
 	return detected(domain.ClientCodex, "OpenAI Codex / ChatGPT", configRoot, detector.lookup("codex"), surfaces)
 }
@@ -79,6 +83,8 @@ func (detector Detector) detectCursor() domain.DetectedClient {
 	}
 	if detector.GOOS == "darwin" {
 		surfaces = append(surfaces, detector.appSurface("cursor_desktop", "Cursor.app"))
+	} else if detector.GOOS == "windows" {
+		surfaces = append(surfaces, detector.windowsAppSurface("cursor_desktop", filepath.Join("Programs", "cursor", "Cursor.exe")))
 	}
 	return detected(domain.ClientCursor, "Cursor", configRoot, detector.lookup("cursor"), surfaces)
 }
@@ -100,20 +106,27 @@ func (detector Detector) detectVSCode() domain.DetectedClient {
 	}
 	if detector.GOOS == "darwin" {
 		surfaces = append(surfaces, detector.appSurface("vscode_desktop", "Visual Studio Code.app"))
+	} else if detector.GOOS == "windows" {
+		surfaces = append(surfaces, detector.windowsAppSurface("vscode_desktop", filepath.Join("Programs", "Microsoft VS Code", "Code.exe")))
 	}
 	return detected(domain.ClientVSCode, "Visual Studio Code", configRoot, detector.lookup("code"), surfaces)
 }
 
 func (detector Detector) detectKiro() domain.DetectedClient {
 	configRoot := filepath.Join(detector.HomeDir, ".kiro")
+	kiroCLI := detector.lookup("kiro-cli")
+	legacyCLI := detector.lookup("kiro")
 	surfaces := []domain.ClientSurface{
-		detector.binarySurface("kiro_cli", "kiro"),
+		{ID: "kiro_cli", Detected: kiroCLI != "", Evidence: evidence(kiroCLI != "", "executable_on_path")},
+		{ID: "kiro_legacy_cli", Detected: legacyCLI != "", Evidence: evidence(legacyCLI != "", "legacy_executable_on_path")},
 		detector.directorySurface("kiro_config", configRoot),
 	}
 	if detector.GOOS == "darwin" {
 		surfaces = append(surfaces, detector.appSurface("kiro_desktop", "Kiro.app"))
+	} else if detector.GOOS == "windows" {
+		surfaces = append(surfaces, detector.windowsAppSurface("kiro_desktop", filepath.Join("Programs", "Kiro", "Kiro.exe")))
 	}
-	return detected(domain.ClientKiro, "Kiro", configRoot, detector.lookup("kiro"), surfaces)
+	return detected(domain.ClientKiro, "Kiro", configRoot, firstPath(kiroCLI, legacyCLI), surfaces)
 }
 
 func (detector Detector) vscodeConfigRoot() string {
@@ -156,6 +169,15 @@ func (detector Detector) appSurface(id, appName string) domain.ClientSurface {
 	return domain.ClientSurface{ID: id}
 }
 
+func (detector Detector) windowsAppSurface(id, relativePath string) domain.ClientSurface {
+	root := strings.TrimSpace(detector.Environment["LOCALAPPDATA"])
+	if root == "" {
+		return domain.ClientSurface{ID: id}
+	}
+	detected := detector.realFile(filepath.Join(root, relativePath))
+	return domain.ClientSurface{ID: id, Detected: detected, Evidence: evidence(detected, "application_installation")}
+}
+
 func (detector Detector) lookup(binary string) string {
 	path, err := detector.LookPath(binary)
 	if err != nil || strings.TrimSpace(path) == "" {
@@ -170,6 +192,23 @@ func (detector Detector) realDirectory(path string) bool {
 	}
 	info, err := detector.Lstat(path)
 	return err == nil && info.IsDir() && info.Mode()&os.ModeSymlink == 0
+}
+
+func (detector Detector) realFile(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	info, err := detector.Lstat(path)
+	return err == nil && info.Mode().IsRegular() && info.Mode()&os.ModeSymlink == 0
+}
+
+func firstPath(paths ...string) string {
+	for _, path := range paths {
+		if strings.TrimSpace(path) != "" {
+			return path
+		}
+	}
+	return ""
 }
 
 func detected(clientID domain.ClientID, displayName, configRoot, executablePath string, surfaces []domain.ClientSurface) domain.DetectedClient {

--- a/install/integrationctl/agentplugins/adapters/clientdetect/detector_test.go
+++ b/install/integrationctl/agentplugins/adapters/clientdetect/detector_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -32,7 +33,7 @@ func TestNewOSDoesNotProbeRelativeLocalApplicationsWithoutHome(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", "")
 	detector := NewOS("")
 	for _, directory := range detector.LinuxApplicationDirs {
-		if directory == filepath.Join(".local", "share", "applications") || !filepath.IsAbs(directory) {
+		if directory == path.Join(".local", "share", "applications") || !path.IsAbs(directory) {
 			t.Fatalf("NewOS configured unsafe relative application probe %q", directory)
 		}
 	}

--- a/install/integrationctl/agentplugins/adapters/clientdetect/detector_test.go
+++ b/install/integrationctl/agentplugins/adapters/clientdetect/detector_test.go
@@ -129,6 +129,52 @@ func TestDetectorFindsFixedWindowsDesktopInstallationWithoutPATH(t *testing.T) {
 	}
 }
 
+func TestDetectorFindsWindowsSystemInstallationWithoutUserInstall(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	programFiles := filepath.Join(home, "Program Files")
+	executable := filepath.Join(programFiles, "Microsoft VS Code", "Code.exe")
+	if err := os.MkdirAll(filepath.Dir(executable), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(executable, []byte("synthetic"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	detector := testDetector(home, nil)
+	detector.GOOS = "windows"
+	detector.WindowsProgramFiles = []string{programFiles}
+	clients, err := detector.Detect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	vscode := clientOf(clients, domain.ClientVSCode)
+	if vscode.Status != domain.DetectionDetected || !surfaceDetected(vscode.Surfaces, "vscode_desktop") {
+		t.Fatalf("VS Code system detection = %+v", vscode)
+	}
+}
+
+func TestDetectorFindsLinuxGUIOnlyFromExactDesktopEntry(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	applications := filepath.Join(home, "usr-share-applications")
+	if err := os.MkdirAll(applications, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(applications, "kiro.desktop"), []byte("[Desktop Entry]"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	detector := testDetector(home, nil)
+	detector.LinuxApplicationDirs = []string{applications}
+	clients, err := detector.Detect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	kiro := clientOf(clients, domain.ClientKiro)
+	if kiro.Status != domain.DetectionDetected || kiro.ExecutablePath != "" || !surfaceDetected(kiro.Surfaces, "kiro_desktop") {
+		t.Fatalf("Kiro Linux GUI-only detection = %+v", kiro)
+	}
+}
+
 func testDetector(home string, binaries map[string]string) Detector {
 	applications := filepath.Join(home, "system-applications")
 	return Detector{

--- a/install/integrationctl/agentplugins/adapters/clientdetect/detector_test.go
+++ b/install/integrationctl/agentplugins/adapters/clientdetect/detector_test.go
@@ -89,6 +89,46 @@ func TestDetectorUsesInjectedWindowsConfigRoot(t *testing.T) {
 	}
 }
 
+func TestDetectorRecognizesKiroCLIAndPreservesLegacyEvidence(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	modern := filepath.Join(home, "bin", "kiro-cli")
+	legacy := filepath.Join(home, "bin", "kiro")
+	detector := testDetector(home, map[string]string{"kiro-cli": modern, "kiro": legacy})
+	clients, err := detector.Detect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	kiro := clientOf(clients, domain.ClientKiro)
+	if kiro.ExecutablePath != modern || !surfaceDetected(kiro.Surfaces, "kiro_cli") || !surfaceDetected(kiro.Surfaces, "kiro_legacy_cli") {
+		t.Fatalf("Kiro detection = %+v", kiro)
+	}
+}
+
+func TestDetectorFindsFixedWindowsDesktopInstallationWithoutPATH(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	local := filepath.Join(home, "AppData", "Local")
+	executable := filepath.Join(local, "Programs", "cursor", "Cursor.exe")
+	if err := os.MkdirAll(filepath.Dir(executable), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(executable, []byte("synthetic"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	detector := testDetector(home, nil)
+	detector.GOOS = "windows"
+	detector.Environment = map[string]string{"LOCALAPPDATA": local}
+	clients, err := detector.Detect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cursor := clientOf(clients, domain.ClientCursor)
+	if cursor.Status != domain.DetectionDetected || !surfaceDetected(cursor.Surfaces, "cursor_desktop") {
+		t.Fatalf("Cursor Windows detection = %+v", cursor)
+	}
+}
+
 func testDetector(home string, binaries map[string]string) Detector {
 	applications := filepath.Join(home, "system-applications")
 	return Detector{
@@ -113,4 +153,22 @@ func statusOf(clients []domain.DetectedClient, id domain.ClientID) domain.Detect
 		}
 	}
 	return ""
+}
+
+func clientOf(clients []domain.DetectedClient, id domain.ClientID) domain.DetectedClient {
+	for _, client := range clients {
+		if client.ClientID == id {
+			return client
+		}
+	}
+	return domain.DetectedClient{}
+}
+
+func surfaceDetected(surfaces []domain.ClientSurface, id string) bool {
+	for _, surface := range surfaces {
+		if surface.ID == id {
+			return surface.Detected
+		}
+	}
+	return false
 }

--- a/install/integrationctl/agentplugins/adapters/clientdetect/detector_test.go
+++ b/install/integrationctl/agentplugins/adapters/clientdetect/detector_test.go
@@ -28,6 +28,16 @@ func TestDetectorReturnsAllSupportedClientsWithoutAmbientDiscovery(t *testing.T)
 	}
 }
 
+func TestNewOSDoesNotProbeRelativeLocalApplicationsWithoutHome(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", "")
+	detector := NewOS("")
+	for _, directory := range detector.LinuxApplicationDirs {
+		if directory == filepath.Join(".local", "share", "applications") || !filepath.IsAbs(directory) {
+			t.Fatalf("NewOS configured unsafe relative application probe %q", directory)
+		}
+	}
+}
+
 func TestDetectorFindsOneAndMultipleClientsFromInjectedHomeAndPath(t *testing.T) {
 	t.Parallel()
 	home := t.TempDir()

--- a/install/integrationctl/agentplugins/adapters/loader/loader.go
+++ b/install/integrationctl/agentplugins/adapters/loader/loader.go
@@ -64,6 +64,7 @@ func (loader Loader) Load(ctx context.Context, input domain.LoadInput) (domain.P
 		FormatID:        domain.FormatIDAgentPluginsV1,
 		SchemaURI:       manifest.SchemaURI,
 		SchemaVersion:   "1.0.0",
+		ManifestSchema:  domain.SchemaIdentity{URI: manifest.SchemaURI, Version: "1.0.0"},
 		Manifest:        manifest,
 		MCP:             mcp,
 		Skills:          skills,

--- a/install/integrationctl/agentplugins/adapters/statev2/store_test.go
+++ b/install/integrationctl/agentplugins/adapters/statev2/store_test.go
@@ -1,6 +1,9 @@
 package statev2
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,6 +11,27 @@ import (
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 )
+
+type oldPackageBindingV2 struct {
+	LoaderKind     string                    `json:"loader_kind"`
+	FormatID       string                    `json:"format_id"`
+	SchemaURI      string                    `json:"schema_uri"`
+	DeclaredName   string                    `json:"declared_name"`
+	Version        string                    `json:"version,omitempty"`
+	ManifestDigest string                    `json:"manifest_digest"`
+	Inventory      domain.ComponentInventory `json:"inventory"`
+}
+
+type oldInstallationV2 struct {
+	InstallationID string                          `json:"installation_id"`
+	DeclaredName   string                          `json:"declared_name"`
+	Source         domain.SourceBinding            `json:"source"`
+	Package        oldPackageBindingV2             `json:"package"`
+	Clients        map[string]domain.ClientBinding `json:"clients"`
+	NeedsRebind    bool                            `json:"needs_rebind,omitempty"`
+	CreatedAt      string                          `json:"created_at"`
+	UpdatedAt      string                          `json:"updated_at"`
+}
 
 func TestStoreRoundTripAndDuplicateDeclaredNames(t *testing.T) {
 	t.Parallel()
@@ -35,6 +59,38 @@ func TestStoreRoundTripAndDuplicateDeclaredNames(t *testing.T) {
 	}
 	if info.Mode().Perm() != 0o600 {
 		t.Fatalf("state mode = %o", info.Mode().Perm())
+	}
+}
+
+func TestNewlyWrittenStateDecodesWithStrictOldV2Shape(t *testing.T) {
+	t.Parallel()
+	store := Store{Path: filepath.Join(t.TempDir(), "state-v2.json")}
+	state := domain.StateFileV2{SchemaVersion: domain.StateSchemaVersion, Installations: []domain.Installation{
+		validInstallation("00000000-0000-4000-8000-000000000001", "src_one", "demo-000000000001"),
+	}}
+	if err := store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(store.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	var old struct {
+		SchemaVersion int                 `json:"schema_version"`
+		Installations []oldInstallationV2 `json:"installations"`
+	}
+	if err := decoder.Decode(&old); err != nil {
+		t.Fatalf("old 0.1.4 v2 decoder rejected new state: %v\n%s", err, body)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		t.Fatalf("trailing state data: %v", err)
+	}
+	for _, forbidden := range []string{`"manifest_schema"`, `"manifest_document"`, `"catalog_evidence"`, `"diagnostics"`} {
+		if bytes.Contains(body, []byte(forbidden)) {
+			t.Fatalf("new state contains incompatible key %s", forbidden)
+		}
 	}
 }
 

--- a/install/integrationctl/agentplugins/domain/catalog.go
+++ b/install/integrationctl/agentplugins/domain/catalog.go
@@ -3,10 +3,18 @@ package domain
 const CatalogSchemaV1 = "https://github.com/777genius/universal-agent-plugins/schemas/catalog-v1.schema.json"
 
 type CatalogCompatibility struct {
-	Package        string `json:"package"`
-	Verification   string `json:"verification"`
-	Authentication string `json:"authentication"`
+	Package        string                    `json:"package"`
+	Verification   string                    `json:"verification"`
+	Authentication AuthenticationRequirement `json:"authentication"`
 }
+
+type AuthenticationRequirement string
+
+const (
+	AuthenticationRequirementNotRequired AuthenticationRequirement = "not_required"
+	AuthenticationRequirementRequired    AuthenticationRequirement = "required"
+	AuthenticationRequirementUnknown     AuthenticationRequirement = "unknown"
+)
 
 type CatalogPlugin struct {
 	Name               string                          `json:"name"`
@@ -36,4 +44,20 @@ type CatalogResolution struct {
 	SourceReference string             `json:"source_reference"`
 	CatalogDigest   string             `json:"catalog_digest"`
 	Hints           CompatibilityHints `json:"hints,omitempty"`
+	Evidence        CatalogEvidence    `json:"evidence"`
+}
+
+// CatalogEvidence is an immutable, versioned snapshot of the catalog facts
+// used to resolve a package. It is kept separate from author-controlled
+// plugin.json metadata so neither source can overwrite the other as schemas
+// evolve.
+type CatalogEvidence struct {
+	SchemaVersion      int                             `json:"schema_version"`
+	CatalogVersion     string                          `json:"catalog_version"`
+	Repository         string                          `json:"repository"`
+	Revision           string                          `json:"revision"`
+	Digest             string                          `json:"digest"`
+	MinimumCLIVersion  string                          `json:"minimum_cli_version"`
+	AgentPluginsSchema string                          `json:"agent_plugins_schema"`
+	Compatibility      map[string]CatalogCompatibility `json:"compatibility,omitempty"`
 }

--- a/install/integrationctl/agentplugins/domain/clients.go
+++ b/install/integrationctl/agentplugins/domain/clients.go
@@ -144,7 +144,7 @@ type ActivationRequest struct {
 	BackendExecutable string         `json:"-"`
 	// VerifyOnly forbids client mutation and asks the provider to inspect the
 	// current client state. ActivationComplete is an explicit user attestation
-	// for a phase which the selected client cannot expose through an API.
+	// accepted only when verification is unavailable or returns unknown evidence.
 	VerifyOnly         bool `json:"verify_only,omitempty"`
 	ActivationComplete bool `json:"activation_complete,omitempty"`
 }

--- a/install/integrationctl/agentplugins/domain/clients.go
+++ b/install/integrationctl/agentplugins/domain/clients.go
@@ -94,8 +94,9 @@ type DeliveryPlan struct {
 	UserActions        []string            `json:"user_actions,omitempty"`
 	// LocalActions can contain operational paths and are rendered only in
 	// human-readable output. They must never be emitted by the public JSON API.
-	LocalActions []string `json:"-"`
-	Warnings     []string `json:"warnings,omitempty"`
+	LocalActions []string     `json:"-"`
+	Warnings     []string     `json:"warnings,omitempty"`
+	Diagnostics  []Diagnostic `json:"diagnostics,omitempty"`
 	// TargetRoot and ActivePath are intentionally excluded from public JSON.
 	TargetAnchor string `json:"-"`
 	TargetRoot   string `json:"-"`
@@ -117,7 +118,11 @@ type OpenAIMCPAuthHint struct {
 }
 
 type CompatibilityHints struct {
-	OpenAIMCPAuth map[string]OpenAIMCPAuthHint `json:"openai_mcp_auth,omitempty"`
+	// Compatibility preserves generic, per-client catalog requirements. The
+	// OpenAI map remains for legacy projection consumers and is not authoritative
+	// for whether authentication is required.
+	Compatibility map[string]CatalogCompatibility `json:"compatibility,omitempty"`
+	OpenAIMCPAuth map[string]OpenAIMCPAuthHint    `json:"openai_mcp_auth,omitempty"`
 }
 
 type StagedDelivery struct {

--- a/install/integrationctl/agentplugins/domain/clients.go
+++ b/install/integrationctl/agentplugins/domain/clients.go
@@ -142,15 +142,22 @@ type ActivationRequest struct {
 	Replacing         bool           `json:"replacing"`
 	Interactive       bool           `json:"interactive"`
 	BackendExecutable string         `json:"-"`
+	// VerifyOnly forbids client mutation and asks the provider to inspect the
+	// current client state. ActivationComplete is an explicit user attestation
+	// for a phase which the selected client cannot expose through an API.
+	VerifyOnly         bool `json:"verify_only,omitempty"`
+	ActivationComplete bool `json:"activation_complete,omitempty"`
 }
 
 type ActivationOutcome struct {
-	Activation     ActivationState     `json:"activation"`
-	Authentication AuthenticationState `json:"authentication"`
-	Policy         PolicyState         `json:"policy"`
-	Verification   VerificationState   `json:"verification"`
-	UserActions    []string            `json:"user_actions,omitempty"`
-	LocalActions   []string            `json:"-"`
+	Activation             ActivationState     `json:"activation"`
+	Authentication         AuthenticationState `json:"authentication"`
+	Policy                 PolicyState         `json:"policy"`
+	Verification           VerificationState   `json:"verification"`
+	UserActions            []string            `json:"user_actions,omitempty"`
+	LocalActions           []string            `json:"-"`
+	ActivationAttested     bool                `json:"activation_attested,omitempty"`
+	AuthenticationAttested bool                `json:"authentication_attested,omitempty"`
 }
 
 type DeactivationRequest struct {

--- a/install/integrationctl/agentplugins/domain/clients.go
+++ b/install/integrationctl/agentplugins/domain/clients.go
@@ -158,6 +158,9 @@ type ActivationOutcome struct {
 	LocalActions           []string            `json:"-"`
 	ActivationAttested     bool                `json:"activation_attested,omitempty"`
 	AuthenticationAttested bool                `json:"authentication_attested,omitempty"`
+	// AuthoritativeObservation marks recognized negative verifier evidence.
+	// It is transient control-plane metadata and is never persisted as state.
+	AuthoritativeObservation bool `json:"-"`
 }
 
 type DeactivationRequest struct {

--- a/install/integrationctl/agentplugins/domain/state.go
+++ b/install/integrationctl/agentplugins/domain/state.go
@@ -49,13 +49,18 @@ type SourceBinding struct {
 }
 
 type PackageBinding struct {
-	LoaderKind     string             `json:"loader_kind"`
-	FormatID       string             `json:"format_id"`
-	SchemaURI      string             `json:"schema_uri"`
-	DeclaredName   string             `json:"declared_name"`
-	Version        string             `json:"version,omitempty"`
-	ManifestDigest string             `json:"manifest_digest"`
-	Inventory      ComponentInventory `json:"inventory"`
+	LoaderKind       string             `json:"loader_kind"`
+	FormatID         string             `json:"format_id"`
+	SchemaURI        string             `json:"schema_uri"`
+	SchemaVersion    string             `json:"schema_version,omitempty"`
+	ManifestSchema   *SchemaIdentity    `json:"manifest_schema,omitempty"`
+	ManifestDocument *VersionedDocument `json:"manifest_document,omitempty"`
+	CatalogEvidence  *CatalogEvidence   `json:"catalog_evidence,omitempty"`
+	Diagnostics      []Diagnostic       `json:"diagnostics,omitempty"`
+	DeclaredName     string             `json:"declared_name"`
+	Version          string             `json:"version,omitempty"`
+	ManifestDigest   string             `json:"manifest_digest"`
+	Inventory        ComponentInventory `json:"inventory"`
 }
 
 type NativeObjectOwnership struct {

--- a/install/integrationctl/agentplugins/domain/state.go
+++ b/install/integrationctl/agentplugins/domain/state.go
@@ -49,18 +49,13 @@ type SourceBinding struct {
 }
 
 type PackageBinding struct {
-	LoaderKind       string             `json:"loader_kind"`
-	FormatID         string             `json:"format_id"`
-	SchemaURI        string             `json:"schema_uri"`
-	SchemaVersion    string             `json:"schema_version,omitempty"`
-	ManifestSchema   *SchemaIdentity    `json:"manifest_schema,omitempty"`
-	ManifestDocument *VersionedDocument `json:"manifest_document,omitempty"`
-	CatalogEvidence  *CatalogEvidence   `json:"catalog_evidence,omitempty"`
-	Diagnostics      []Diagnostic       `json:"diagnostics,omitempty"`
-	DeclaredName     string             `json:"declared_name"`
-	Version          string             `json:"version,omitempty"`
-	ManifestDigest   string             `json:"manifest_digest"`
-	Inventory        ComponentInventory `json:"inventory"`
+	LoaderKind     string             `json:"loader_kind"`
+	FormatID       string             `json:"format_id"`
+	SchemaURI      string             `json:"schema_uri"`
+	DeclaredName   string             `json:"declared_name"`
+	Version        string             `json:"version,omitempty"`
+	ManifestDigest string             `json:"manifest_digest"`
+	Inventory      ComponentInventory `json:"inventory"`
 }
 
 type NativeObjectOwnership struct {

--- a/install/integrationctl/agentplugins/domain/types.go
+++ b/install/integrationctl/agentplugins/domain/types.go
@@ -70,6 +70,21 @@ type PluginManifest struct {
 	Raw           json.RawMessage            `json:"-"`
 }
 
+// SchemaIdentity makes a document's schema URI and interpreted version
+// explicit without replacing its lossless Raw representation.
+type SchemaIdentity struct {
+	URI     string `json:"uri"`
+	Version string `json:"version"`
+}
+
+// VersionedDocument preserves author-controlled JSON independently of any
+// catalog or legacy metadata that describes the same package.
+type VersionedDocument struct {
+	Schema  SchemaIdentity             `json:"schema"`
+	Raw     json.RawMessage            `json:"raw"`
+	Unknown map[string]json.RawMessage `json:"unknown,omitempty"`
+}
+
 type MCPServer struct {
 	Name    string          `json:"name"`
 	Type    string          `json:"type"`
@@ -113,11 +128,13 @@ type PackageEnvelope struct {
 	FormatID        string             `json:"format_id"`
 	SchemaURI       string             `json:"schema_uri"`
 	SchemaVersion   string             `json:"schema_version"`
+	ManifestSchema  SchemaIdentity     `json:"manifest_schema"`
 	Manifest        PluginManifest     `json:"manifest"`
 	MCP             MCPComponent       `json:"mcp"`
 	Skills          map[string]Skill   `json:"skills,omitempty"`
 	Inventory       ComponentInventory `json:"inventory"`
 	Diagnostics     []Diagnostic       `json:"diagnostics,omitempty"`
+	CatalogEvidence *CatalogEvidence   `json:"catalog_evidence,omitempty"`
 	Source          SourceIdentity     `json:"source"`
 	TreeDigest      string             `json:"tree_digest"`
 	ManifestDigest  string             `json:"manifest_digest"`

--- a/install/integrationctl/agentplugins/planner/planner.go
+++ b/install/integrationctl/agentplugins/planner/planner.go
@@ -78,11 +78,6 @@ func (planner Planner) Plan(
 			}
 		}
 	}
-	if plan.Authentication == domain.AuthenticationPending {
-		plan.UserActions = append(plan.UserActions, "complete authentication for this plugin in the selected client")
-	} else if plan.Authentication == domain.AuthenticationNotChecked {
-		plan.UserActions = append(plan.UserActions, "verify the plugin's authentication requirements before using it")
-	}
 	if !hasComponents(plan.Components) && hasComponentErrors {
 		plan.Status = domain.PlanUnsupported
 		plan.Activation = domain.ActivationFailed
@@ -91,6 +86,14 @@ func (planner Planner) Plan(
 		plan.Status = domain.PlanUnsupported
 		plan.Activation = domain.ActivationFailed
 		plan.Warnings = append(plan.Warnings, "no_supported_components")
+	}
+	if plan.Status == domain.PlanUnsupported {
+		return plan, nil
+	}
+	if plan.Authentication == domain.AuthenticationPending {
+		plan.UserActions = append(plan.UserActions, "complete authentication for this plugin in the selected client")
+	} else if plan.Authentication == domain.AuthenticationNotChecked {
+		plan.UserActions = append(plan.UserActions, "verify the plugin's authentication requirements before using it")
 	}
 	if plan.Status != domain.PlanUnsupported && planner.hasNativeCopilotBackend(client) {
 		plan.Status = domain.PlanReady
@@ -155,7 +158,9 @@ func applyCatalogCompatibility(plan *domain.DeliveryPlan, evidence *domain.Catal
 	}
 	if compatibility.Verification == "schema_only" || compatibility.Verification == "not_tested" {
 		plan.Warnings = appendUnique(plan.Warnings, "catalog_"+compatibility.Verification)
-		plan.UserActions = append(plan.UserActions, "verify the plugin in the selected client before relying on it")
+		if plan.Status != domain.PlanUnsupported {
+			plan.UserActions = append(plan.UserActions, "verify the plugin in the selected client before relying on it")
+		}
 	}
 }
 

--- a/install/integrationctl/agentplugins/planner/planner.go
+++ b/install/integrationctl/agentplugins/planner/planner.go
@@ -127,7 +127,10 @@ func applyCatalogCompatibility(plan *domain.DeliveryPlan, evidence *domain.Catal
 	}
 	compatibility, ok := evidence.Compatibility[string(plan.ClientID)]
 	if !ok {
+		plan.Status = domain.PlanUnsupported
+		plan.Activation = domain.ActivationFailed
 		plan.Warnings = appendUnique(plan.Warnings, "client_compatibility_not_catalog_verified")
+		plan.UserActions = append(plan.UserActions, "choose a client present in the pinned catalog evidence")
 		return
 	}
 	switch compatibility.Authentication {

--- a/install/integrationctl/agentplugins/planner/planner.go
+++ b/install/integrationctl/agentplugins/planner/planner.go
@@ -34,12 +34,15 @@ func (planner Planner) Plan(
 		return domain.DeliveryPlan{}, fmt.Errorf("unsupported client %q", client.ClientID)
 	}
 	plan := domain.DeliveryPlan{
-		ClientID:           client.ClientID,
-		Scope:              scope,
-		Status:             statusFor(capabilities.ActivationMode),
-		PackageMode:        capabilities.PackageMode,
-		Activation:         activationFor(capabilities.ActivationMode),
-		Authentication:     domain.AuthenticationNotRequired,
+		ClientID:    client.ClientID,
+		Scope:       scope,
+		Status:      statusFor(capabilities.ActivationMode),
+		PackageMode: capabilities.PackageMode,
+		Activation:  activationFor(capabilities.ActivationMode),
+		// A package loaded without catalog evidence has unknown authentication
+		// requirements. Only affirmative per-client evidence may mark it as not
+		// required.
+		Authentication:     domain.AuthenticationNotChecked,
 		Policy:             domain.PolicyAllowed,
 		Verification:       domain.VerificationPackageValid,
 		PhysicalArtifactID: physicalArtifactID,
@@ -64,17 +67,21 @@ func (planner Planner) Plan(
 	plan.TargetAnchor = target.TargetAnchor
 	plan.ActivePath = target.ActivePath
 	plan.Components = componentDecisions(envelope, capabilities)
-	if envelope.MCP.Present {
-		plan.Authentication = domain.AuthenticationNotChecked
-	}
+	applyCatalogCompatibility(&plan, envelope.CatalogEvidence)
 	hasComponentErrors := false
 	for _, diagnostic := range envelope.Diagnostics {
+		plan.Diagnostics = append(plan.Diagnostics, diagnostic)
+		plan.Warnings = appendUnique(plan.Warnings, diagnostic.Code)
 		if diagnostic.Severity == domain.SeverityError {
-			plan.Warnings = append(plan.Warnings, diagnostic.Code)
 			if diagnostic.Boundary == domain.BoundaryMCP || diagnostic.Boundary == domain.BoundaryMCPServer || diagnostic.Boundary == domain.BoundarySkill || diagnostic.Boundary == domain.BoundaryExtension {
 				hasComponentErrors = true
 			}
 		}
+	}
+	if plan.Authentication == domain.AuthenticationPending {
+		plan.UserActions = append(plan.UserActions, "complete authentication for this plugin in the selected client")
+	} else if plan.Authentication == domain.AuthenticationNotChecked {
+		plan.UserActions = append(plan.UserActions, "verify the plugin's authentication requirements before using it")
 	}
 	if !hasComponents(plan.Components) && hasComponentErrors {
 		plan.Status = domain.PlanUnsupported
@@ -111,6 +118,64 @@ func (planner Planner) Plan(
 		}
 	}
 	return plan, nil
+}
+
+func applyCatalogCompatibility(plan *domain.DeliveryPlan, evidence *domain.CatalogEvidence) {
+	if evidence == nil {
+		plan.Warnings = appendUnique(plan.Warnings, "authentication_not_catalog_verified")
+		return
+	}
+	compatibility, ok := evidence.Compatibility[string(plan.ClientID)]
+	if !ok {
+		plan.Warnings = appendUnique(plan.Warnings, "client_compatibility_not_catalog_verified")
+		return
+	}
+	switch compatibility.Authentication {
+	case domain.AuthenticationRequirementNotRequired:
+		plan.Authentication = domain.AuthenticationNotRequired
+	case domain.AuthenticationRequirementRequired:
+		plan.Authentication = domain.AuthenticationPending
+	default:
+		plan.Authentication = domain.AuthenticationNotChecked
+		plan.Warnings = appendUnique(plan.Warnings, "authentication_requirement_unknown")
+	}
+	if compatibility.Package == "unsupported" {
+		plan.Status = domain.PlanUnsupported
+		plan.Activation = domain.ActivationFailed
+		plan.Warnings = appendUnique(plan.Warnings, "catalog_client_unsupported")
+		plan.UserActions = append(plan.UserActions, "choose a client marked compatible by the pinned catalog")
+	} else if !catalogPackageMatches(compatibility.Package, plan.PackageMode) {
+		plan.Status = domain.PlanUnsupported
+		plan.Activation = domain.ActivationFailed
+		plan.Warnings = appendUnique(plan.Warnings, "catalog_package_mode_mismatch")
+		plan.UserActions = append(plan.UserActions, "update agentplugins or choose a client whose catalog package mode is supported")
+	}
+	if compatibility.Verification == "schema_only" || compatibility.Verification == "not_tested" {
+		plan.Warnings = appendUnique(plan.Warnings, "catalog_"+compatibility.Verification)
+		plan.UserActions = append(plan.UserActions, "verify the plugin in the selected client before relying on it")
+	}
+}
+
+func catalogPackageMatches(value string, mode domain.PackageMode) bool {
+	switch value {
+	case "native":
+		return mode == domain.PackageNative
+	case "projected":
+		return mode == domain.PackageProjection
+	case "prepared":
+		return mode == domain.PackagePrepared
+	default:
+		return false
+	}
+}
+
+func appendUnique(values []string, value string) []string {
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
 }
 
 func (planner Planner) hasNativeCopilotBackend(client domain.DetectedClient) bool {

--- a/install/integrationctl/agentplugins/planner/planner_test.go
+++ b/install/integrationctl/agentplugins/planner/planner_test.go
@@ -62,6 +62,25 @@ func TestPlannerAuthenticationRequiresAffirmativePerClientCatalogEvidence(t *tes
 	}
 }
 
+func TestPlannerFailsClosedWhenPinnedCatalogEvidenceOmitsSelectedClient(t *testing.T) {
+	t.Parallel()
+	envelope := testEnvelope()
+	envelope.CatalogEvidence = &domain.CatalogEvidence{Compatibility: map[string]domain.CatalogCompatibility{
+		"codex": {Package: "projected", Verification: "tested", Authentication: domain.AuthenticationRequirementNotRequired},
+	}}
+	plan, err := (Planner{ManagedRoot: t.TempDir()}).Plan(
+		context.Background(), envelope,
+		detectedClient(domain.ClientCursor, filepath.Join(t.TempDir(), ".cursor")),
+		domain.ScopeUser, "demo-0123456789ab",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Status != domain.PlanUnsupported || plan.Activation != domain.ActivationFailed || !contains(plan.Warnings, "client_compatibility_not_catalog_verified") {
+		t.Fatalf("plan = %+v", plan)
+	}
+}
+
 func TestPlannerCarriesNonFatalLoaderDiagnosticsToPlan(t *testing.T) {
 	t.Parallel()
 	envelope := testEnvelope()

--- a/install/integrationctl/agentplugins/planner/planner_test.go
+++ b/install/integrationctl/agentplugins/planner/planner_test.go
@@ -33,6 +33,48 @@ func TestPlannerNegotiatesPartialSupportWithoutRejectingSupportedComponents(t *t
 	}
 }
 
+func TestPlannerAuthenticationRequiresAffirmativePerClientCatalogEvidence(t *testing.T) {
+	t.Parallel()
+	client := detectedClient(domain.ClientCursor, filepath.Join(t.TempDir(), ".cursor"))
+	for name, test := range map[string]struct {
+		evidence *domain.CatalogEvidence
+		want     domain.AuthenticationState
+	}{
+		"external_without_catalog": {want: domain.AuthenticationNotChecked},
+		"catalog_required": {evidence: &domain.CatalogEvidence{Compatibility: map[string]domain.CatalogCompatibility{
+			"cursor": {Package: "native", Verification: "tested", Authentication: domain.AuthenticationRequirementRequired},
+		}}, want: domain.AuthenticationPending},
+		"catalog_not_required": {evidence: &domain.CatalogEvidence{Compatibility: map[string]domain.CatalogCompatibility{
+			"cursor": {Package: "native", Verification: "tested", Authentication: domain.AuthenticationRequirementNotRequired},
+		}}, want: domain.AuthenticationNotRequired},
+	} {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			envelope := domain.PackageEnvelope{Manifest: domain.PluginManifest{Name: "metadata-only"}, CatalogEvidence: test.evidence}
+			plan, err := (Planner{ManagedRoot: t.TempDir()}).Plan(context.Background(), envelope, client, domain.ScopeUser, "demo-0123456789ab")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if plan.Authentication != test.want {
+				t.Fatalf("authentication = %s, want %s", plan.Authentication, test.want)
+			}
+		})
+	}
+}
+
+func TestPlannerCarriesNonFatalLoaderDiagnosticsToPlan(t *testing.T) {
+	t.Parallel()
+	envelope := testEnvelope()
+	envelope.Diagnostics = []domain.Diagnostic{{Severity: domain.SeverityWarning, Boundary: domain.BoundaryPlugin, Code: "plugin_unknown_field", Message: "future field preserved"}}
+	plan, err := (Planner{ManagedRoot: t.TempDir()}).Plan(context.Background(), envelope, detectedClient(domain.ClientCursor, filepath.Join(t.TempDir(), ".cursor")), domain.ScopeUser, "demo-0123456789ab")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Diagnostics) != 1 || plan.Diagnostics[0].Message != "future field preserved" || !contains(plan.Warnings, "plugin_unknown_field") {
+		t.Fatalf("plan diagnostics = %+v warnings=%v", plan.Diagnostics, plan.Warnings)
+	}
+}
+
 func TestPlannerUsesNativeCursorTargetAndDoesNotExposeItInJSON(t *testing.T) {
 	t.Parallel()
 	config := filepath.Join(t.TempDir(), ".cursor")

--- a/install/integrationctl/agentplugins/planner/planner_test.go
+++ b/install/integrationctl/agentplugins/planner/planner_test.go
@@ -212,6 +212,54 @@ func TestPlannerRejectsMetadataOnlyProjectionWhenAllDeclaredComponentsAreInvalid
 	}
 }
 
+func TestPlannerDoesNotAppendActivationOrAuthenticationGuidanceWhenUnsupported(t *testing.T) {
+	t.Parallel()
+	tests := map[string]domain.PackageEnvelope{
+		"catalog_omits_client": func() domain.PackageEnvelope {
+			envelope := testEnvelope()
+			envelope.CatalogEvidence = &domain.CatalogEvidence{Compatibility: map[string]domain.CatalogCompatibility{
+				"codex": {Package: "projected", Verification: "tested", Authentication: domain.AuthenticationRequirementNotRequired},
+			}}
+			return envelope
+		}(),
+		"catalog_package_mismatch": func() domain.PackageEnvelope {
+			envelope := testEnvelope()
+			envelope.CatalogEvidence = &domain.CatalogEvidence{Compatibility: map[string]domain.CatalogCompatibility{
+				"cursor": {Package: "projected", Verification: "schema_only", Authentication: domain.AuthenticationRequirementRequired},
+			}}
+			return envelope
+		}(),
+		"invalid_components": {
+			Manifest: domain.PluginManifest{Name: "broken"},
+			Diagnostics: []domain.Diagnostic{{
+				Severity: domain.SeverityError, Boundary: domain.BoundarySkill,
+				Code: "skill_invalid", Message: "all skills are invalid",
+			}},
+		},
+	}
+	for name, envelope := range tests {
+		name, envelope := name, envelope
+		t.Run(name, func(t *testing.T) {
+			plan, err := (Planner{ManagedRoot: t.TempDir()}).Plan(
+				context.Background(), envelope,
+				detectedClient(domain.ClientCursor, filepath.Join(t.TempDir(), ".cursor")),
+				domain.ScopeUser, "broken-0123456789ab",
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if plan.Status != domain.PlanUnsupported {
+				t.Fatalf("plan = %+v", plan)
+			}
+			for _, action := range plan.UserActions {
+				if strings.Contains(action, "authentication") || strings.Contains(action, "reload Cursor") || strings.Contains(action, "verify the plugin") {
+					t.Fatalf("unsupported plan appended lifecycle guidance %q: %+v", action, plan)
+				}
+			}
+		})
+	}
+}
+
 func testEnvelope() domain.PackageEnvelope {
 	return domain.PackageEnvelope{
 		Manifest: domain.PluginManifest{

--- a/install/integrationctl/agentplugins/ports/interfaces.go
+++ b/install/integrationctl/agentplugins/ports/interfaces.go
@@ -2,9 +2,35 @@ package ports
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 )
+
+type VerificationKind string
+
+const (
+	VerificationAbsent         VerificationKind = "absent"
+	VerificationDigestMismatch VerificationKind = "digest_mismatch"
+	VerificationIndeterminate  VerificationKind = "indeterminate"
+)
+
+// VerificationError classifies integrity failures without converting an
+// infrastructure error into evidence that a managed directory drifted.
+type VerificationError struct {
+	Kind         VerificationKind
+	ActualDigest string
+	Err          error
+}
+
+func (err *VerificationError) Error() string {
+	if err.Err != nil {
+		return err.Err.Error()
+	}
+	return fmt.Sprintf("package verification failed: %s", err.Kind)
+}
+
+func (err *VerificationError) Unwrap() error { return err.Err }
 
 type SchemaRegistry interface {
 	Supports(schemaURI string) bool

--- a/install/integrationctl/agentplugins/ports/interfaces.go
+++ b/install/integrationctl/agentplugins/ports/interfaces.go
@@ -13,6 +13,7 @@ const (
 	VerificationAbsent         VerificationKind = "absent"
 	VerificationDigestMismatch VerificationKind = "digest_mismatch"
 	VerificationIndeterminate  VerificationKind = "indeterminate"
+	VerificationExcludedMarker VerificationKind = "excluded_ownership_marker"
 )
 
 // VerificationError classifies integrity failures without converting an

--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -104,6 +104,9 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 		Policy:         domain.PolicyAllowed,
 		Verification:   domain.VerificationPackageValid,
 	}
+	if request.ActivationComplete && activationObservable(request, activator.Runner != nil) {
+		return outcome, fmt.Errorf("--activation-complete cannot be used when %s activation is observable; the available verifier must run", request.Client.ClientID)
+	}
 	if request.ActivationComplete {
 		outcome.Activation = domain.ActivationActive
 		outcome.Verification = domain.VerificationInstalled
@@ -194,6 +197,9 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 		}
 		if request.VerifyOnly {
 			if err := activator.verifyCopilot(ctx, request); err != nil {
+				if errors.Is(err, errCopilotListContractUnknown) {
+					return manualCopilotVerification(outcome, request), nil
+				}
 				return failedActivation(outcome, fmt.Sprintf("verify with `%s plugin list`", request.BackendExecutable), err)
 			}
 			outcome.Activation = domain.ActivationActive
@@ -201,6 +207,9 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 			return outcome, nil
 		}
 		if err := activator.activateCopilot(ctx, request); err != nil {
+			if errors.Is(err, errCopilotListContractUnknown) {
+				return manualCopilotVerification(outcome, request), nil
+			}
 			return failedActivation(outcome, fmt.Sprintf("rerun add for the prepared package at %s, then verify with `%s plugin list`", request.Delivery.ActivePath, request.BackendExecutable), err)
 		}
 		outcome.Activation = domain.ActivationActive
@@ -244,10 +253,14 @@ func (activator Activator) verifyCopilot(ctx context.Context, request domain.Act
 	if err != nil {
 		return fmt.Errorf("verify Copilot plugin listing: %w", err)
 	}
-	if !copilotHasInstalledPlugin(listed.Stdout, pluginSpec) {
+	switch copilotPluginStatus(listed.Stdout, pluginSpec) {
+	case copilotStatusInstalled:
+		return nil
+	case copilotStatusAbsent:
 		return fmt.Errorf("verify Copilot plugin listing: %s is not listed", pluginSpec)
+	default:
+		return fmt.Errorf("%w: verify Copilot plugin listing", errCopilotListContractUnknown)
 	}
-	return nil
 }
 
 func (activator Activator) activateCodex(ctx context.Context, request domain.ActivationRequest) error {
@@ -408,15 +421,28 @@ func codexHasInstalledPlugin(body []byte, name, marketplace string) bool {
 
 var copilotInstalledEntry = regexp.MustCompile(`^[ \t]+•[ \t]+([A-Za-z0-9][A-Za-z0-9._-]*@[A-Za-z0-9][A-Za-z0-9._-]*)[ \t]+\(v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?\)[ \t]*$`)
 
-func copilotHasInstalledPlugin(stdout []byte, expected string) bool {
+type copilotStatus int
+
+const (
+	copilotStatusUnknown copilotStatus = iota
+	copilotStatusInstalled
+	copilotStatusAbsent
+)
+
+var errCopilotListContractUnknown = errors.New("Copilot plugin list output is not recognized")
+
+func copilotPluginStatus(stdout []byte, expected string) copilotStatus {
 	inInstalledSection := false
+	recognizedSection := false
+	recognizedEntry := false
 	matches := 0
 	for _, rawLine := range strings.Split(strings.ReplaceAll(string(stdout), "\r\n", "\n"), "\n") {
 		if strings.TrimSpace(rawLine) == "Installed plugins:" {
 			if inInstalledSection {
-				return false
+				return copilotStatusUnknown
 			}
 			inInstalledSection = true
+			recognizedSection = true
 			continue
 		}
 		if !inInstalledSection {
@@ -427,11 +453,55 @@ func copilotHasInstalledPlugin(stdout []byte, expected string) bool {
 			continue
 		}
 		entry := copilotInstalledEntry.FindStringSubmatch(rawLine)
-		if len(entry) == 2 && entry[1] == expected {
-			matches++
+		if len(entry) == 2 {
+			recognizedEntry = true
+			if entry[1] == expected {
+				matches++
+			}
+			continue
+		}
+		trimmed := strings.TrimSpace(rawLine)
+		if trimmed == "" {
+			continue
+		}
+		if trimmed == "No plugins installed." || trimmed == "No plugins installed" {
+			recognizedEntry = true
+			continue
+		}
+		lower := strings.ToLower(trimmed)
+		if strings.Contains(trimmed, expected) {
+			for _, state := range []string{"pending", "disconnected", "disabled", "auth-required", "auth required", "authentication required", "error", "failed", "failure"} {
+				if strings.Contains(lower, state) {
+					return copilotStatusAbsent
+				}
+			}
+			return copilotStatusUnknown
 		}
 	}
-	return matches == 1
+	if matches == 1 {
+		return copilotStatusInstalled
+	}
+	if matches > 1 {
+		return copilotStatusUnknown
+	}
+	if recognizedSection && recognizedEntry {
+		return copilotStatusAbsent
+	}
+	return copilotStatusUnknown
+}
+
+func activationObservable(request domain.ActivationRequest, runnerAvailable bool) bool {
+	if !runnerAvailable || strings.TrimSpace(request.BackendExecutable) == "" {
+		return false
+	}
+	switch request.Client.ClientID {
+	case domain.ClientCodex, domain.ClientCopilot, domain.ClientVSCode:
+		return true
+	case domain.ClientKiro:
+		return mcpOnly(request.Plan.Components) && isKiroCLI(request.BackendExecutable)
+	default:
+		return false
+	}
 }
 
 type kiroStatus int
@@ -471,6 +541,13 @@ func manualKiroVerification(outcome domain.ActivationOutcome, request domain.Act
 	outcome.Activation = domain.ActivationManual
 	outcome.UserActions = []string{"confirm each imported MCP server is connected in Kiro"}
 	outcome.LocalActions = []string{fmt.Sprintf("Kiro's documented `%s mcp status --name <server>` output contract was not recognized; inspect each server manually", request.BackendExecutable)}
+	return outcome
+}
+
+func manualCopilotVerification(outcome domain.ActivationOutcome, request domain.ActivationRequest) domain.ActivationOutcome {
+	outcome.Activation = domain.ActivationManual
+	outcome.UserActions = []string{"confirm the managed plugin is installed and enabled in GitHub Copilot"}
+	outcome.LocalActions = []string{fmt.Sprintf("the `%s plugin list` output contract was not recognized; inspect %s manually", request.BackendExecutable, request.DeclaredName)}
 	return outcome
 }
 

--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -102,8 +102,23 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 		Policy:         domain.PolicyAllowed,
 		Verification:   domain.VerificationPackageValid,
 	}
+	if request.ActivationComplete {
+		if activationCanBeObserved(activator, request) {
+			return domain.ActivationOutcome{}, fmt.Errorf("--activation-complete is not accepted when client verification is available")
+		}
+		outcome.Activation = domain.ActivationActive
+		outcome.Verification = domain.VerificationInstalled
+		outcome.ActivationAttested = true
+		return outcome, nil
+	}
 	switch request.Client.ClientID {
 	case domain.ClientCursor:
+		if request.VerifyOnly {
+			outcome.Activation = domain.ActivationManual
+			outcome.UserActions = []string{"confirm that the plugin is visible and enabled in Cursor"}
+			outcome.LocalActions = []string{fmt.Sprintf("open Cursor and verify the plugin from %s is visible and enabled", request.Delivery.ActivePath)}
+			return outcome, nil
+		}
 		outcome.Activation = domain.ActivationManual
 		outcome.UserActions = append(outcome.UserActions, "register the prepared package in Cursor and verify it is visible before using its components")
 		outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf("open Cursor and register %s, then reload Cursor and verify %s is visible", request.Delivery.ActivePath, request.DeclaredName))
@@ -115,18 +130,33 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 			outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf("in the ChatGPT/Codex app, install %s from %s, then verify it appears in Plugins > Personal", request.DeclaredName, request.Delivery.ActivePath))
 			return outcome, nil
 		}
+		if request.VerifyOnly {
+			if err := activator.verifyCodex(ctx, request); err != nil {
+				return failedActivation(outcome, fmt.Sprintf("verify with `%s plugin list --json`", request.BackendExecutable), err)
+			}
+			outcome.Activation = domain.ActivationActive
+			outcome.Verification = domain.VerificationInstalled
+			return outcome, nil
+		}
 		if err := activator.activateCodex(ctx, request); err != nil {
 			return failedActivation(outcome, fmt.Sprintf("run Codex activation again for the prepared package at %s, then verify with `%s plugin list --json`", request.Delivery.ActivePath, request.BackendExecutable), err)
 		}
 		outcome.Activation = domain.ActivationActive
 		outcome.Verification = domain.VerificationInstalled
-		completeUncheckedAuthentication(&outcome)
 		return outcome, nil
 	case domain.ClientKiro:
 		if !mcpOnly(request.Plan.Components) {
 			outcome.Activation = domain.ActivationManual
 			outcome.UserActions = append(outcome.UserActions, "import the prepared package as a custom Power in Kiro, then verify it is active")
 			outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf("Kiro: Powers > Add Custom Power > Import power from a folder > select %s > Install, then verify %s is active", request.Delivery.ActivePath, request.DeclaredName))
+			return outcome, nil
+		}
+		if request.VerifyOnly {
+			if err := activator.verifyKiroMCP(ctx, request); err != nil {
+				return failedActivation(outcome, fmt.Sprintf("verify with `%s mcp list global`", request.BackendExecutable), err)
+			}
+			outcome.Activation = domain.ActivationActive
+			outcome.Verification = domain.VerificationInstalled
 			return outcome, nil
 		}
 		if !isKiroCLI(request.BackendExecutable) || activator.Runner == nil {
@@ -140,7 +170,6 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 		}
 		outcome.Activation = domain.ActivationActive
 		outcome.Verification = domain.VerificationInstalled
-		completeUncheckedAuthentication(&outcome)
 		return outcome, nil
 	case domain.ClientCopilot, domain.ClientVSCode:
 		if strings.TrimSpace(request.BackendExecutable) == "" || activator.Runner == nil {
@@ -158,15 +187,36 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 			}
 			return outcome, nil
 		}
+		if request.VerifyOnly {
+			if err := activator.verifyCopilot(ctx, request); err != nil {
+				return failedActivation(outcome, fmt.Sprintf("verify with `%s plugin list`", request.BackendExecutable), err)
+			}
+			outcome.Activation = domain.ActivationActive
+			outcome.Verification = domain.VerificationInstalled
+			return outcome, nil
+		}
 		if err := activator.activateCopilot(ctx, request); err != nil {
 			return failedActivation(outcome, fmt.Sprintf("rerun add for the prepared package at %s, then verify with `%s plugin list`", request.Delivery.ActivePath, request.BackendExecutable), err)
 		}
 		outcome.Activation = domain.ActivationActive
 		outcome.Verification = domain.VerificationInstalled
-		completeUncheckedAuthentication(&outcome)
 		return outcome, nil
 	default:
 		return domain.ActivationOutcome{}, fmt.Errorf("unsupported activation client %q", request.Client.ClientID)
+	}
+}
+
+func activationCanBeObserved(activator Activator, request domain.ActivationRequest) bool {
+	if activator.Runner == nil || strings.TrimSpace(request.BackendExecutable) == "" {
+		return false
+	}
+	switch request.Client.ClientID {
+	case domain.ClientCodex, domain.ClientCopilot, domain.ClientVSCode:
+		return true
+	case domain.ClientKiro:
+		return mcpOnly(request.Plan.Components) && isKiroCLI(request.BackendExecutable)
+	default:
+		return false
 	}
 }
 
@@ -194,11 +244,16 @@ func (activator Activator) activateCopilot(ctx context.Context, request domain.A
 			return err
 		}
 	}
+	return activator.verifyCopilot(ctx, request)
+}
+
+func (activator Activator) verifyCopilot(ctx context.Context, request domain.ActivationRequest) error {
+	pluginSpec := request.DeclaredName + "@" + managedMarketplaceName(request.Plan.PhysicalArtifactID)
 	listed, err := activator.runCopilotResult(ctx, request.BackendExecutable, "plugin", "list")
 	if err != nil {
 		return fmt.Errorf("verify Copilot plugin listing: %w", err)
 	}
-	if !outputHasToken(listed, pluginSpec) && !outputHasToken(listed, request.DeclaredName) {
+	if !stdoutHasHealthyIdentity(listed.Stdout, pluginSpec) {
 		return fmt.Errorf("verify Copilot plugin listing: %s is not listed", pluginSpec)
 	}
 	return nil
@@ -222,11 +277,17 @@ func (activator Activator) activateCodex(ctx context.Context, request domain.Act
 		}
 		return fmt.Errorf("activate Codex plugin: %w", err)
 	}
+	return activator.verifyCodex(ctx, request)
+}
+
+func (activator Activator) verifyCodex(ctx context.Context, request domain.ActivationRequest) error {
+	marketplace := managedMarketplaceName(request.Plan.PhysicalArtifactID)
+	pluginSpec := request.DeclaredName + "@" + marketplace
 	listed, err := activator.runClientResult(ctx, "Codex CLI", request.BackendExecutable, "plugin", "list", "--json")
 	if err != nil {
 		return fmt.Errorf("verify Codex plugin listing: %w", err)
 	}
-	if !jsonHasActiveIdentity(listed.Stdout, pluginSpec) && !jsonHasActiveIdentity(listed.Stdout, request.DeclaredName) {
+	if !codexHasInstalledPlugin(listed.Stdout, request.DeclaredName, marketplace) {
 		return fmt.Errorf("verify Codex plugin listing: %s is not listed", pluginSpec)
 	}
 	return nil
@@ -237,12 +298,16 @@ func (activator Activator) activateKiroMCP(ctx context.Context, request domain.A
 	if _, err := activator.runClientResult(ctx, "Kiro CLI", request.BackendExecutable, "mcp", "import", "--file", config, "global", "--force"); err != nil {
 		return fmt.Errorf("import Kiro MCP configuration: %w", err)
 	}
+	return activator.verifyKiroMCP(ctx, request)
+}
+
+func (activator Activator) verifyKiroMCP(ctx context.Context, request domain.ActivationRequest) error {
 	listed, err := activator.runClientResult(ctx, "Kiro CLI", request.BackendExecutable, "mcp", "list", "global")
 	if err != nil {
 		return fmt.Errorf("verify Kiro MCP listing: %w", err)
 	}
 	for _, component := range request.Plan.Components {
-		if component.Kind == domain.ComponentMCPServer && !outputHasToken(listed, component.Name) {
+		if component.Kind == domain.ComponentMCPServer && !stdoutHasHealthyIdentity(listed.Stdout, component.Name) {
 			return fmt.Errorf("verify Kiro MCP listing: %s is not listed", component.Name)
 		}
 	}
@@ -296,12 +361,6 @@ func failedActivation(outcome domain.ActivationOutcome, next string, err error) 
 	return outcome, err
 }
 
-func completeUncheckedAuthentication(outcome *domain.ActivationOutcome) {
-	if outcome.Authentication == domain.AuthenticationNotChecked {
-		outcome.Authentication = domain.AuthenticationNotRequired
-	}
-}
-
 func mcpOnly(components []domain.ComponentDecision) bool {
 	found := false
 	for _, component := range components {
@@ -318,48 +377,39 @@ func isKiroCLI(executable string) bool {
 	return base == "kiro-cli" || base == "kiro-cli.exe" || base == "kiro" || base == "kiro.exe"
 }
 
-func jsonHasActiveIdentity(body []byte, expected string) bool {
-	var value any
+func codexHasInstalledPlugin(body []byte, name, marketplace string) bool {
+	var value struct {
+		Installed []struct {
+			PluginID        string `json:"pluginId"`
+			Name            string `json:"name"`
+			MarketplaceName string `json:"marketplaceName"`
+			Installed       bool   `json:"installed"`
+			Enabled         bool   `json:"enabled"`
+		} `json:"installed"`
+	}
 	if len(body) == 0 || json.Unmarshal(body, &value) != nil {
 		return false
 	}
-	var visit func(any, bool) bool
-	visit = func(current any, listedValue bool) bool {
-		switch typed := current.(type) {
-		case string:
-			return listedValue && typed == expected
-		case []any:
-			for _, item := range typed {
-				if visit(item, true) {
-					return true
-				}
-			}
-		case map[string]any:
-			if enabled, ok := typed["enabled"].(bool); ok && !enabled {
-				return false
-			}
-			if active, ok := typed["active"].(bool); ok && !active {
-				return false
-			}
-			for key, item := range typed {
-				identity := key == "name" || key == "id" || key == "plugin" || key == "spec" || key == "plugin_spec"
-				if visit(item, identity) {
-					return true
-				}
-			}
+	for _, plugin := range value.Installed {
+		if plugin.Name == name && plugin.MarketplaceName == marketplace && plugin.Installed && plugin.Enabled {
+			return true
 		}
-		return false
 	}
-	return visit(value, false)
+	return false
 }
 
-func outputHasToken(result legacyports.CommandResult, expected string) bool {
-	output := string(result.Stdout) + "\n" + string(result.Stderr)
-	for _, token := range strings.FieldsFunc(output, func(r rune) bool {
-		return !(r == '-' || r == '_' || r == '@' || r == '.' || r >= '0' && r <= '9' || r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z')
-	}) {
-		if token == expected {
-			return true
+func stdoutHasHealthyIdentity(stdout []byte, expected string) bool {
+	for _, line := range strings.Split(string(stdout), "\n") {
+		lower := strings.ToLower(line)
+		if strings.Contains(lower, "disabled") || strings.Contains(lower, "error") || strings.Contains(lower, "failed") {
+			continue
+		}
+		for _, token := range strings.FieldsFunc(line, func(r rune) bool {
+			return !(r == '-' || r == '_' || r == '@' || r == '.' || r >= '0' && r <= '9' || r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z')
+		}) {
+			if token == expected {
+				return true
+			}
 		}
 	}
 	return false

--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -2,9 +2,10 @@ package providers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
-	"runtime"
+	"path/filepath"
 	"strings"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/pathpolicy"
@@ -104,24 +105,42 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 	switch request.Client.ClientID {
 	case domain.ClientCursor:
 		outcome.Activation = domain.ActivationManual
-		outcome.UserActions = append(outcome.UserActions, "reload Cursor, then verify the plugin appears before using its components")
+		outcome.UserActions = append(outcome.UserActions, "register the prepared package in Cursor and verify it is visible before using its components")
+		outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf("open Cursor and register %s, then reload Cursor and verify %s is visible", request.Delivery.ActivePath, request.DeclaredName))
 		return outcome, nil
 	case domain.ClientCodex:
-		outcome.Activation = domain.ActivationManual
-		outcome.UserActions = append(outcome.UserActions, "finish installation in Codex or ChatGPT Plugins, then start a new session")
-		marketplace := managedMarketplaceName(request.Plan.PhysicalArtifactID)
-		outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf(
-			"Codex CLI: run `codex plugin marketplace add %s --json`, then `codex plugin add %s --json`; ChatGPT/Codex app: open Plugins > Personal and install %s",
-			shellQuoteForHint(request.Delivery.ActivePath), request.DeclaredName+"@"+marketplace, request.DeclaredName,
-		))
+		if strings.TrimSpace(request.BackendExecutable) == "" || activator.Runner == nil {
+			outcome.Activation = domain.ActivationManual
+			outcome.UserActions = append(outcome.UserActions, "install the prepared plugin in the ChatGPT/Codex app, then verify it appears in Plugins > Personal")
+			outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf("in the ChatGPT/Codex app, install %s from %s, then verify it appears in Plugins > Personal", request.DeclaredName, request.Delivery.ActivePath))
+			return outcome, nil
+		}
+		if err := activator.activateCodex(ctx, request); err != nil {
+			return failedActivation(outcome, fmt.Sprintf("run Codex activation again for the prepared package at %s, then verify with `%s plugin list --json`", request.Delivery.ActivePath, request.BackendExecutable), err)
+		}
+		outcome.Activation = domain.ActivationActive
+		outcome.Verification = domain.VerificationInstalled
+		completeUncheckedAuthentication(&outcome)
 		return outcome, nil
 	case domain.ClientKiro:
-		outcome.Activation = domain.ActivationManual
-		outcome.UserActions = append(outcome.UserActions, "finish the prepared Power installation in Kiro")
-		outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf(
-			"Kiro: Powers > Add Custom Power > Import power from a folder > select %s > Install",
-			request.Delivery.ActivePath,
-		))
+		if !mcpOnly(request.Plan.Components) {
+			outcome.Activation = domain.ActivationManual
+			outcome.UserActions = append(outcome.UserActions, "import the prepared package as a custom Power in Kiro, then verify it is active")
+			outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf("Kiro: Powers > Add Custom Power > Import power from a folder > select %s > Install, then verify %s is active", request.Delivery.ActivePath, request.DeclaredName))
+			return outcome, nil
+		}
+		if !isKiroCLI(request.BackendExecutable) || activator.Runner == nil {
+			outcome.Activation = domain.ActivationManual
+			outcome.UserActions = append(outcome.UserActions, "install kiro-cli and rerun add to import and verify the prepared MCP configuration")
+			outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf("install kiro-cli, rerun add for %s, then verify its MCP servers with `kiro-cli mcp list global`", request.Delivery.ActivePath))
+			return outcome, nil
+		}
+		if err := activator.activateKiroMCP(ctx, request); err != nil {
+			return failedActivation(outcome, fmt.Sprintf("rerun the MCP import from %s, then verify with `%s mcp list global`", filepath.Join(request.Delivery.ActivePath, "mcp.json"), request.BackendExecutable), err)
+		}
+		outcome.Activation = domain.ActivationActive
+		outcome.Verification = domain.VerificationInstalled
+		completeUncheckedAuthentication(&outcome)
 		return outcome, nil
 	case domain.ClientCopilot, domain.ClientVSCode:
 		if strings.TrimSpace(request.BackendExecutable) == "" || activator.Runner == nil {
@@ -129,19 +148,22 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 			if request.Client.ClientID == domain.ClientVSCode {
 				outcome.UserActions = append(outcome.UserActions, "register the prepared local plugin in VS Code")
 				outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf(
-					"VS Code: add %q to the `chat.pluginLocations` setting with value `true`, then reload VS Code",
+					"VS Code: add %q to the `chat.pluginLocations` setting with value `true`, then reload VS Code and verify %s appears in the Plugins view",
 					request.Delivery.ActivePath,
+					request.DeclaredName,
 				))
 			} else {
 				outcome.UserActions = append(outcome.UserActions, "install GitHub Copilot CLI, then rerun `agentplugins update` for this plugin")
+				outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf("install GitHub Copilot CLI, rerun add for the prepared package at %s, then verify with `copilot plugin list`", request.Delivery.ActivePath))
 			}
 			return outcome, nil
 		}
 		if err := activator.activateCopilot(ctx, request); err != nil {
-			return outcome, err
+			return failedActivation(outcome, fmt.Sprintf("rerun add for the prepared package at %s, then verify with `%s plugin list`", request.Delivery.ActivePath, request.BackendExecutable), err)
 		}
 		outcome.Activation = domain.ActivationActive
 		outcome.Verification = domain.VerificationInstalled
+		completeUncheckedAuthentication(&outcome)
 		return outcome, nil
 	default:
 		return domain.ActivationOutcome{}, fmt.Errorf("unsupported activation client %q", request.Client.ClientID)
@@ -150,26 +172,79 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 
 func (activator Activator) activateCopilot(ctx context.Context, request domain.ActivationRequest) error {
 	marketplace := managedMarketplaceName(request.Plan.PhysicalArtifactID)
+	updated := false
 	if request.Replacing {
 		if err := activator.runCopilot(ctx, request.BackendExecutable, "plugin", "marketplace", "update", marketplace); err != nil {
 			if fallbackErr := activator.runCopilot(ctx, request.BackendExecutable, "plugin", "marketplace", "add", request.Delivery.ActivePath); fallbackErr != nil {
 				return fmt.Errorf("refresh managed Copilot marketplace: %v; fallback registration: %w", err, fallbackErr)
 			}
 		}
-		if err := activator.runCopilot(ctx, request.BackendExecutable, "plugin", "update", request.DeclaredName+"@"+marketplace); err == nil {
-			return nil
-		}
+		updated = activator.runCopilot(ctx, request.BackendExecutable, "plugin", "update", request.DeclaredName+"@"+marketplace) == nil
 	} else if err := activator.runCopilot(ctx, request.BackendExecutable, "plugin", "marketplace", "add", request.Delivery.ActivePath); err != nil {
 		if fallbackErr := activator.runCopilot(ctx, request.BackendExecutable, "plugin", "marketplace", "update", marketplace); fallbackErr != nil {
 			return fmt.Errorf("register managed Copilot marketplace: %v; fallback refresh: %w", err, fallbackErr)
 		}
 	}
 	pluginSpec := request.DeclaredName + "@" + marketplace
-	if err := activator.runCopilot(ctx, request.BackendExecutable, "plugin", "install", pluginSpec); err != nil {
-		if !request.Replacing {
-			_ = activator.runCopilot(ctx, request.BackendExecutable, "plugin", "marketplace", "remove", marketplace)
+	if !updated {
+		if err := activator.runCopilot(ctx, request.BackendExecutable, "plugin", "install", pluginSpec); err != nil {
+			if !request.Replacing {
+				_ = activator.runCopilot(ctx, request.BackendExecutable, "plugin", "marketplace", "remove", marketplace)
+			}
+			return err
 		}
-		return err
+	}
+	listed, err := activator.runCopilotResult(ctx, request.BackendExecutable, "plugin", "list")
+	if err != nil {
+		return fmt.Errorf("verify Copilot plugin listing: %w", err)
+	}
+	if !outputHasToken(listed, pluginSpec) && !outputHasToken(listed, request.DeclaredName) {
+		return fmt.Errorf("verify Copilot plugin listing: %s is not listed", pluginSpec)
+	}
+	return nil
+}
+
+func (activator Activator) activateCodex(ctx context.Context, request domain.ActivationRequest) error {
+	marketplace := managedMarketplaceName(request.Plan.PhysicalArtifactID)
+	if request.Replacing {
+		if _, err := activator.runClientResult(ctx, "Codex CLI", request.BackendExecutable, "plugin", "marketplace", "update", marketplace, "--json"); err != nil {
+			if _, fallbackErr := activator.runClientResult(ctx, "Codex CLI", request.BackendExecutable, "plugin", "marketplace", "add", request.Delivery.ActivePath, "--json"); fallbackErr != nil {
+				return fmt.Errorf("refresh Codex marketplace: %v; fallback registration: %w", err, fallbackErr)
+			}
+		}
+	} else if _, err := activator.runClientResult(ctx, "Codex CLI", request.BackendExecutable, "plugin", "marketplace", "add", request.Delivery.ActivePath, "--json"); err != nil {
+		return fmt.Errorf("register Codex marketplace: %w", err)
+	}
+	pluginSpec := request.DeclaredName + "@" + marketplace
+	if _, err := activator.runClientResult(ctx, "Codex CLI", request.BackendExecutable, "plugin", "add", pluginSpec, "--json"); err != nil {
+		if !request.Replacing {
+			_, _ = activator.runClientResult(ctx, "Codex CLI", request.BackendExecutable, "plugin", "marketplace", "remove", marketplace, "--json")
+		}
+		return fmt.Errorf("activate Codex plugin: %w", err)
+	}
+	listed, err := activator.runClientResult(ctx, "Codex CLI", request.BackendExecutable, "plugin", "list", "--json")
+	if err != nil {
+		return fmt.Errorf("verify Codex plugin listing: %w", err)
+	}
+	if !jsonHasActiveIdentity(listed.Stdout, pluginSpec) && !jsonHasActiveIdentity(listed.Stdout, request.DeclaredName) {
+		return fmt.Errorf("verify Codex plugin listing: %s is not listed", pluginSpec)
+	}
+	return nil
+}
+
+func (activator Activator) activateKiroMCP(ctx context.Context, request domain.ActivationRequest) error {
+	config := filepath.Join(request.Delivery.ActivePath, "mcp.json")
+	if _, err := activator.runClientResult(ctx, "Kiro CLI", request.BackendExecutable, "mcp", "import", "--file", config, "global", "--force"); err != nil {
+		return fmt.Errorf("import Kiro MCP configuration: %w", err)
+	}
+	listed, err := activator.runClientResult(ctx, "Kiro CLI", request.BackendExecutable, "mcp", "list", "global")
+	if err != nil {
+		return fmt.Errorf("verify Kiro MCP listing: %w", err)
+	}
+	for _, component := range request.Plan.Components {
+		if component.Kind == domain.ComponentMCPServer && !outputHasToken(listed, component.Name) {
+			return fmt.Errorf("verify Kiro MCP listing: %s is not listed", component.Name)
+		}
 	}
 	return nil
 }
@@ -196,27 +271,101 @@ func (activator Activator) runCopilot(ctx context.Context, executable string, ar
 }
 
 func (activator Activator) runCopilotResult(ctx context.Context, executable string, args ...string) (legacyports.CommandResult, error) {
+	return activator.runClientResult(ctx, "GitHub Copilot CLI", executable, args...)
+}
+
+func (activator Activator) runClientResult(ctx context.Context, client, executable string, args ...string) (legacyports.CommandResult, error) {
 	if activator.Runner == nil {
-		return legacyports.CommandResult{}, fmt.Errorf("GitHub Copilot CLI runner is unavailable")
+		return legacyports.CommandResult{}, fmt.Errorf("%s runner is unavailable", client)
 	}
 	result, err := activator.Runner.Run(ctx, legacyports.Command{Argv: append([]string{executable}, args...)})
 	if err != nil {
-		return result, fmt.Errorf("start GitHub Copilot CLI: %w", err)
+		return result, fmt.Errorf("start %s: %w", client, err)
 	}
 	if result.ExitCode != 0 {
-		return result, fmt.Errorf("GitHub Copilot CLI command failed with exit code %d", result.ExitCode)
+		return result, fmt.Errorf("%s command failed with exit code %d", client, result.ExitCode)
 	}
 	return result, nil
+}
+
+func failedActivation(outcome domain.ActivationOutcome, next string, err error) (domain.ActivationOutcome, error) {
+	outcome.Activation = domain.ActivationFailed
+	outcome.Verification = domain.VerificationFailed
+	outcome.UserActions = []string{"retry client activation and verify client visibility"}
+	outcome.LocalActions = []string{next}
+	return outcome, err
+}
+
+func completeUncheckedAuthentication(outcome *domain.ActivationOutcome) {
+	if outcome.Authentication == domain.AuthenticationNotChecked {
+		outcome.Authentication = domain.AuthenticationNotRequired
+	}
+}
+
+func mcpOnly(components []domain.ComponentDecision) bool {
+	found := false
+	for _, component := range components {
+		if component.Support == domain.SupportUnsupported || component.Kind != domain.ComponentMCPServer {
+			return false
+		}
+		found = true
+	}
+	return found
+}
+
+func isKiroCLI(executable string) bool {
+	base := strings.ToLower(filepath.Base(strings.TrimSpace(executable)))
+	return base == "kiro-cli" || base == "kiro-cli.exe" || base == "kiro" || base == "kiro.exe"
+}
+
+func jsonHasActiveIdentity(body []byte, expected string) bool {
+	var value any
+	if len(body) == 0 || json.Unmarshal(body, &value) != nil {
+		return false
+	}
+	var visit func(any, bool) bool
+	visit = func(current any, listedValue bool) bool {
+		switch typed := current.(type) {
+		case string:
+			return listedValue && typed == expected
+		case []any:
+			for _, item := range typed {
+				if visit(item, true) {
+					return true
+				}
+			}
+		case map[string]any:
+			if enabled, ok := typed["enabled"].(bool); ok && !enabled {
+				return false
+			}
+			if active, ok := typed["active"].(bool); ok && !active {
+				return false
+			}
+			for key, item := range typed {
+				identity := key == "name" || key == "id" || key == "plugin" || key == "spec" || key == "plugin_spec"
+				if visit(item, identity) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	return visit(value, false)
+}
+
+func outputHasToken(result legacyports.CommandResult, expected string) bool {
+	output := string(result.Stdout) + "\n" + string(result.Stderr)
+	for _, token := range strings.FieldsFunc(output, func(r rune) bool {
+		return !(r == '-' || r == '_' || r == '@' || r == '.' || r >= '0' && r <= '9' || r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z')
+	}) {
+		if token == expected {
+			return true
+		}
+	}
+	return false
 }
 
 func commandOutputContains(result legacyports.CommandResult, fragment string) bool {
 	output := string(result.Stdout) + "\n" + string(result.Stderr)
 	return strings.Contains(strings.ToLower(output), strings.ToLower(fragment))
-}
-
-func shellQuoteForHint(value string) string {
-	if runtime.GOOS == "windows" {
-		return "'" + strings.ReplaceAll(value, "'", "''") + "'"
-	}
-	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }

--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -104,10 +104,7 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 		Policy:         domain.PolicyAllowed,
 		Verification:   domain.VerificationPackageValid,
 	}
-	if request.ActivationComplete && activationObservable(request, activator.Runner != nil) {
-		return outcome, fmt.Errorf("--activation-complete cannot be used when %s activation is observable; the available verifier must run", request.Client.ClientID)
-	}
-	if request.ActivationComplete {
+	if request.ActivationComplete && !activationObservable(request, activator.Runner != nil) {
 		outcome.Activation = domain.ActivationActive
 		outcome.Verification = domain.VerificationInstalled
 		outcome.ActivationAttested = true
@@ -257,7 +254,7 @@ func (activator Activator) verifyCopilot(ctx context.Context, request domain.Act
 	case copilotStatusInstalled:
 		return nil
 	case copilotStatusAbsent:
-		return fmt.Errorf("verify Copilot plugin listing: %s is not listed", pluginSpec)
+		return fmt.Errorf("%w: verify Copilot plugin listing: %s is not listed", errRecognizedNegativeEvidence, pluginSpec)
 	default:
 		return fmt.Errorf("%w: verify Copilot plugin listing", errCopilotListContractUnknown)
 	}
@@ -292,6 +289,9 @@ func (activator Activator) verifyCodex(ctx context.Context, request domain.Activ
 		return fmt.Errorf("verify Codex plugin listing: %w", err)
 	}
 	if !codexHasInstalledPlugin(listed.Stdout, request.DeclaredName, marketplace) {
+		if codexListingContractRecognized(listed.Stdout) {
+			return fmt.Errorf("%w: verify Codex plugin listing: %s is not listed", errRecognizedNegativeEvidence, pluginSpec)
+		}
 		return fmt.Errorf("verify Codex plugin listing: %s is not listed", pluginSpec)
 	}
 	return nil
@@ -318,7 +318,7 @@ func (activator Activator) verifyKiroMCP(ctx context.Context, request domain.Act
 		case kiroStatusHealthy:
 			continue
 		case kiroStatusUnhealthy:
-			return fmt.Errorf("verify Kiro MCP server %s: server is not connected", component.Name)
+			return fmt.Errorf("%w: verify Kiro MCP server %s: server is not connected", errRecognizedNegativeEvidence, component.Name)
 		default:
 			return fmt.Errorf("%w for server %s", errKiroStatusContractUnknown, component.Name)
 		}
@@ -368,6 +368,7 @@ func (activator Activator) runClientResult(ctx context.Context, client, executab
 func failedActivation(outcome domain.ActivationOutcome, next string, err error) (domain.ActivationOutcome, error) {
 	outcome.Activation = domain.ActivationFailed
 	outcome.Verification = domain.VerificationFailed
+	outcome.AuthoritativeObservation = errors.Is(err, errRecognizedNegativeEvidence)
 	outcome.UserActions = []string{"retry client activation and verify client visibility"}
 	outcome.LocalActions = []string{next}
 	return outcome, err
@@ -419,6 +420,19 @@ func codexHasInstalledPlugin(body []byte, name, marketplace string) bool {
 	return matches == 1
 }
 
+func codexListingContractRecognized(body []byte) bool {
+	var value map[string]json.RawMessage
+	if len(body) == 0 || json.Unmarshal(body, &value) != nil {
+		return false
+	}
+	installed, ok := value["installed"]
+	if !ok {
+		return false
+	}
+	var entries []json.RawMessage
+	return json.Unmarshal(installed, &entries) == nil
+}
+
 var copilotInstalledEntry = regexp.MustCompile(`^[ \t]+•[ \t]+([A-Za-z0-9][A-Za-z0-9._-]*@[A-Za-z0-9][A-Za-z0-9._-]*)[ \t]+\(v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?\)[ \t]*$`)
 
 type copilotStatus int
@@ -430,6 +444,7 @@ const (
 )
 
 var errCopilotListContractUnknown = errors.New("Copilot plugin list output is not recognized")
+var errRecognizedNegativeEvidence = errors.New("recognized negative client evidence")
 
 func copilotPluginStatus(stdout []byte, expected string) copilotStatus {
 	inInstalledSection := false

--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -131,6 +131,9 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 		}
 		if request.VerifyOnly {
 			if err := activator.verifyCodex(ctx, request); err != nil {
+				if errors.Is(err, errCodexListContractUnknown) {
+					return manualCodexVerification(outcome, request), nil
+				}
 				return failedActivation(outcome, fmt.Sprintf("verify with `%s plugin list --json`", request.BackendExecutable), err)
 			}
 			outcome.Activation = domain.ActivationActive
@@ -138,6 +141,9 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 			return outcome, nil
 		}
 		if err := activator.activateCodex(ctx, request); err != nil {
+			if errors.Is(err, errCodexListContractUnknown) {
+				return manualCodexVerification(outcome, request), nil
+			}
 			return failedActivation(outcome, fmt.Sprintf("run Codex activation again for the prepared package at %s, then verify with `%s plugin list --json`", request.Delivery.ActivePath, request.BackendExecutable), err)
 		}
 		outcome.Activation = domain.ActivationActive
@@ -288,13 +294,14 @@ func (activator Activator) verifyCodex(ctx context.Context, request domain.Activ
 	if err != nil {
 		return fmt.Errorf("verify Codex plugin listing: %w", err)
 	}
-	if !codexHasInstalledPlugin(listed.Stdout, request.DeclaredName, marketplace) {
-		if codexListingContractRecognized(listed.Stdout) {
-			return fmt.Errorf("%w: verify Codex plugin listing: %s is not listed", errRecognizedNegativeEvidence, pluginSpec)
-		}
-		return fmt.Errorf("verify Codex plugin listing: %s is not listed", pluginSpec)
+	switch codexPluginStatus(listed.Stdout, request.DeclaredName, marketplace) {
+	case codexStatusInstalled:
+		return nil
+	case codexStatusAbsent:
+		return fmt.Errorf("%w: verify Codex plugin listing: %s is not installed and enabled", errRecognizedNegativeEvidence, pluginSpec)
+	default:
+		return fmt.Errorf("%w: verify Codex plugin listing", errCodexListContractUnknown)
 	}
-	return nil
 }
 
 func (activator Activator) activateKiroMCP(ctx context.Context, request domain.ActivationRequest) error {
@@ -390,47 +397,59 @@ func isKiroCLI(executable string) bool {
 	return base == "kiro-cli" || base == "kiro-cli.exe" || base == "kiro" || base == "kiro.exe"
 }
 
-func codexHasInstalledPlugin(body []byte, name, marketplace string) bool {
-	var value struct {
-		Installed []struct {
-			PluginID        *string `json:"pluginId"`
-			Name            *string `json:"name"`
-			MarketplaceName *string `json:"marketplaceName"`
-			Installed       *bool   `json:"installed"`
-			Enabled         *bool   `json:"enabled"`
-		} `json:"installed"`
+type codexStatus int
+
+const (
+	codexStatusUnknown codexStatus = iota
+	codexStatusInstalled
+	codexStatusAbsent
+)
+
+var errCodexListContractUnknown = errors.New("Codex plugin list output is not recognized")
+
+func codexPluginStatus(body []byte, name, marketplace string) codexStatus {
+	var document map[string]json.RawMessage
+	if len(body) == 0 || json.Unmarshal(body, &document) != nil {
+		return codexStatusUnknown
 	}
-	if len(body) == 0 || json.Unmarshal(body, &value) != nil {
-		return false
+	rawInstalled, ok := document["installed"]
+	if !ok || string(rawInstalled) == "null" {
+		return codexStatusUnknown
+	}
+	type installedEntry struct {
+		PluginID        *string `json:"pluginId"`
+		Name            *string `json:"name"`
+		MarketplaceName *string `json:"marketplaceName"`
+		Installed       *bool   `json:"installed"`
+		Enabled         *bool   `json:"enabled"`
+	}
+	var entries []installedEntry
+	if json.Unmarshal(rawInstalled, &entries) != nil {
+		return codexStatusUnknown
 	}
 	expectedID := name + "@" + marketplace
-	matches := 0
-	for _, plugin := range value.Installed {
-		idMatches := plugin.PluginID != nil && *plugin.PluginID == expectedID
-		pairMatches := plugin.Name != nil && plugin.MarketplaceName != nil && *plugin.Name == name && *plugin.MarketplaceName == marketplace
-		if !idMatches && !pairMatches {
-			continue
+	identities := make(map[string]struct{}, len(entries))
+	foundExpected := false
+	expectedActive := false
+	for _, entry := range entries {
+		if entry.PluginID == nil || entry.Name == nil || entry.MarketplaceName == nil || entry.Installed == nil || entry.Enabled == nil ||
+			*entry.PluginID == "" || *entry.Name == "" || *entry.MarketplaceName == "" ||
+			*entry.PluginID != *entry.Name+"@"+*entry.MarketplaceName {
+			return codexStatusUnknown
 		}
-		matches++
-		if plugin.PluginID == nil || plugin.Name == nil || plugin.MarketplaceName == nil || plugin.Installed == nil || plugin.Enabled == nil ||
-			*plugin.PluginID != expectedID || *plugin.Name != name || *plugin.MarketplaceName != marketplace || !*plugin.Installed || !*plugin.Enabled {
-			return false
+		if _, duplicate := identities[*entry.PluginID]; duplicate {
+			return codexStatusUnknown
+		}
+		identities[*entry.PluginID] = struct{}{}
+		if *entry.PluginID == expectedID {
+			foundExpected = true
+			expectedActive = *entry.Installed && *entry.Enabled
 		}
 	}
-	return matches == 1
-}
-
-func codexListingContractRecognized(body []byte) bool {
-	var value map[string]json.RawMessage
-	if len(body) == 0 || json.Unmarshal(body, &value) != nil {
-		return false
+	if foundExpected && expectedActive {
+		return codexStatusInstalled
 	}
-	installed, ok := value["installed"]
-	if !ok {
-		return false
-	}
-	var entries []json.RawMessage
-	return json.Unmarshal(installed, &entries) == nil
+	return codexStatusAbsent
 }
 
 var copilotInstalledEntry = regexp.MustCompile(`^[ \t]+•[ \t]+([A-Za-z0-9][A-Za-z0-9._-]*@[A-Za-z0-9][A-Za-z0-9._-]*)[ \t]+\(v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?\)[ \t]*$`)
@@ -530,29 +549,53 @@ const (
 var errKiroStatusContractUnknown = errors.New("Kiro MCP status output is not recognized")
 
 func kiroMCPStatus(stdout []byte, expected string) kiroStatus {
-	lines := strings.Split(strings.ReplaceAll(string(stdout), "\r\n", "\n"), "\n")
-	nonEmpty := make([]string, 0, len(lines))
-	for _, line := range lines {
-		if trimmed := strings.TrimSpace(line); trimmed != "" {
-			nonEmpty = append(nonEmpty, trimmed)
+	contract := strings.ReplaceAll(string(stdout), "\r\n", "\n")
+	contract = strings.TrimSuffix(contract, "\n")
+	status := ""
+	if prefix := expected + ": "; strings.HasPrefix(contract, prefix) && !strings.Contains(contract, "\n") {
+		status = strings.TrimPrefix(contract, prefix)
+	} else {
+		lines := strings.Split(contract, "\n")
+		if len(lines) != 2 || lines[0] != "Name: "+expected || !strings.HasPrefix(lines[1], "Status: ") {
+			return kiroStatusUnknown
 		}
+		status = strings.TrimPrefix(lines[1], "Status: ")
 	}
-	if len(nonEmpty) == 1 && (nonEmpty[0] == expected+": connected" || nonEmpty[0] == expected+" connected") {
+	if status == "connected" {
 		return kiroStatusHealthy
 	}
-	if len(nonEmpty) == 2 && nonEmpty[0] == "Name: "+expected && nonEmpty[1] == "Status: connected" {
-		return kiroStatusHealthy
-	}
-	lower := strings.ToLower(strings.Join(nonEmpty, "\n"))
-	for _, state := range []string{"pending", "disconnected", "disabled", "auth-required", "auth required", "authentication required", "error", "failed", "failure"} {
-		if strings.Contains(lower, state) {
+	for _, negative := range []string{"pending", "disconnected", "disabled", "auth-required", "auth required", "authentication required", "error", "failed", "failure"} {
+		if status == negative {
 			return kiroStatusUnhealthy
 		}
 	}
 	return kiroStatusUnknown
 }
 
+func attestedUnknownVerification(outcome domain.ActivationOutcome, request domain.ActivationRequest) (domain.ActivationOutcome, bool) {
+	if !request.ActivationComplete {
+		return outcome, false
+	}
+	outcome.Activation = domain.ActivationActive
+	outcome.Verification = domain.VerificationInstalled
+	outcome.ActivationAttested = true
+	return outcome, true
+}
+
+func manualCodexVerification(outcome domain.ActivationOutcome, request domain.ActivationRequest) domain.ActivationOutcome {
+	if attested, ok := attestedUnknownVerification(outcome, request); ok {
+		return attested
+	}
+	outcome.Activation = domain.ActivationManual
+	outcome.UserActions = []string{"confirm the managed plugin is installed and enabled in Codex"}
+	outcome.LocalActions = []string{fmt.Sprintf("the `%s plugin list --json` output contract was not recognized; inspect %s manually", request.BackendExecutable, request.DeclaredName)}
+	return outcome
+}
+
 func manualKiroVerification(outcome domain.ActivationOutcome, request domain.ActivationRequest) domain.ActivationOutcome {
+	if attested, ok := attestedUnknownVerification(outcome, request); ok {
+		return attested
+	}
 	outcome.Activation = domain.ActivationManual
 	outcome.UserActions = []string{"confirm each imported MCP server is connected in Kiro"}
 	outcome.LocalActions = []string{fmt.Sprintf("Kiro's documented `%s mcp status --name <server>` output contract was not recognized; inspect each server manually", request.BackendExecutable)}
@@ -560,6 +603,9 @@ func manualKiroVerification(outcome domain.ActivationOutcome, request domain.Act
 }
 
 func manualCopilotVerification(outcome domain.ActivationOutcome, request domain.ActivationRequest) domain.ActivationOutcome {
+	if attested, ok := attestedUnknownVerification(outcome, request); ok {
+		return attested
+	}
 	outcome.Activation = domain.ActivationManual
 	outcome.UserActions = []string{"confirm the managed plugin is installed and enabled in GitHub Copilot"}
 	outcome.LocalActions = []string{fmt.Sprintf("the `%s plugin list` output contract was not recognized; inspect %s manually", request.BackendExecutable, request.DeclaredName)}

--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -3,9 +3,11 @@ package providers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/pathpolicy"
@@ -150,7 +152,10 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 		}
 		if request.VerifyOnly {
 			if err := activator.verifyKiroMCP(ctx, request); err != nil {
-				return failedActivation(outcome, fmt.Sprintf("verify with `%s mcp list global`", request.BackendExecutable), err)
+				if errors.Is(err, errKiroStatusContractUnknown) {
+					return manualKiroVerification(outcome, request), nil
+				}
+				return failedActivation(outcome, fmt.Sprintf("verify each server with `%s mcp status --name <server>`", request.BackendExecutable), err)
 			}
 			outcome.Activation = domain.ActivationActive
 			outcome.Verification = domain.VerificationInstalled
@@ -159,11 +164,14 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 		if !isKiroCLI(request.BackendExecutable) || activator.Runner == nil {
 			outcome.Activation = domain.ActivationManual
 			outcome.UserActions = append(outcome.UserActions, "install kiro-cli and rerun add to import and verify the prepared MCP configuration")
-			outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf("install kiro-cli, rerun add for %s, then verify its MCP servers with `kiro-cli mcp list global`", request.Delivery.ActivePath))
+			outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf("install kiro-cli, rerun add for %s, then verify each MCP server with `kiro-cli mcp status --name <server>`", request.Delivery.ActivePath))
 			return outcome, nil
 		}
 		if err := activator.activateKiroMCP(ctx, request); err != nil {
-			return failedActivation(outcome, fmt.Sprintf("rerun the MCP import from %s, then verify with `%s mcp list global`", filepath.Join(request.Delivery.ActivePath, "mcp.json"), request.BackendExecutable), err)
+			if errors.Is(err, errKiroStatusContractUnknown) {
+				return manualKiroVerification(outcome, request), nil
+			}
+			return failedActivation(outcome, fmt.Sprintf("rerun the MCP import from %s, then verify each server with `%s mcp status --name <server>`", filepath.Join(request.Delivery.ActivePath, "mcp.json"), request.BackendExecutable), err)
 		}
 		outcome.Activation = domain.ActivationActive
 		outcome.Verification = domain.VerificationInstalled
@@ -236,7 +244,7 @@ func (activator Activator) verifyCopilot(ctx context.Context, request domain.Act
 	if err != nil {
 		return fmt.Errorf("verify Copilot plugin listing: %w", err)
 	}
-	if !stdoutHasHealthyIdentity(listed.Stdout, pluginSpec) {
+	if !copilotHasInstalledPlugin(listed.Stdout, pluginSpec) {
 		return fmt.Errorf("verify Copilot plugin listing: %s is not listed", pluginSpec)
 	}
 	return nil
@@ -285,13 +293,21 @@ func (activator Activator) activateKiroMCP(ctx context.Context, request domain.A
 }
 
 func (activator Activator) verifyKiroMCP(ctx context.Context, request domain.ActivationRequest) error {
-	listed, err := activator.runClientResult(ctx, "Kiro CLI", request.BackendExecutable, "mcp", "list", "global")
-	if err != nil {
-		return fmt.Errorf("verify Kiro MCP listing: %w", err)
-	}
 	for _, component := range request.Plan.Components {
-		if component.Kind == domain.ComponentMCPServer && !stdoutHasHealthyIdentity(listed.Stdout, component.Name) {
-			return fmt.Errorf("verify Kiro MCP listing: %s is not listed", component.Name)
+		if component.Kind != domain.ComponentMCPServer {
+			continue
+		}
+		status, err := activator.runClientResult(ctx, "Kiro CLI", request.BackendExecutable, "mcp", "status", "--name", component.Name)
+		if err != nil {
+			return fmt.Errorf("verify Kiro MCP server %s: %w", component.Name, err)
+		}
+		switch kiroMCPStatus(status.Stdout, component.Name) {
+		case kiroStatusHealthy:
+			continue
+		case kiroStatusUnhealthy:
+			return fmt.Errorf("verify Kiro MCP server %s: server is not connected", component.Name)
+		default:
+			return fmt.Errorf("%w for server %s", errKiroStatusContractUnknown, component.Name)
 		}
 	}
 	return nil
@@ -363,39 +379,99 @@ func isKiroCLI(executable string) bool {
 func codexHasInstalledPlugin(body []byte, name, marketplace string) bool {
 	var value struct {
 		Installed []struct {
-			PluginID        string `json:"pluginId"`
-			Name            string `json:"name"`
-			MarketplaceName string `json:"marketplaceName"`
-			Installed       bool   `json:"installed"`
-			Enabled         bool   `json:"enabled"`
+			PluginID        *string `json:"pluginId"`
+			Name            *string `json:"name"`
+			MarketplaceName *string `json:"marketplaceName"`
+			Installed       *bool   `json:"installed"`
+			Enabled         *bool   `json:"enabled"`
 		} `json:"installed"`
 	}
 	if len(body) == 0 || json.Unmarshal(body, &value) != nil {
 		return false
 	}
+	expectedID := name + "@" + marketplace
+	matches := 0
 	for _, plugin := range value.Installed {
-		if plugin.Name == name && plugin.MarketplaceName == marketplace && plugin.Installed && plugin.Enabled {
-			return true
-		}
-	}
-	return false
-}
-
-func stdoutHasHealthyIdentity(stdout []byte, expected string) bool {
-	for _, line := range strings.Split(string(stdout), "\n") {
-		lower := strings.ToLower(line)
-		if strings.Contains(lower, "disabled") || strings.Contains(lower, "error") || strings.Contains(lower, "failed") {
+		idMatches := plugin.PluginID != nil && *plugin.PluginID == expectedID
+		pairMatches := plugin.Name != nil && plugin.MarketplaceName != nil && *plugin.Name == name && *plugin.MarketplaceName == marketplace
+		if !idMatches && !pairMatches {
 			continue
 		}
-		for _, token := range strings.FieldsFunc(line, func(r rune) bool {
-			return !(r == '-' || r == '_' || r == '@' || r == '.' || r >= '0' && r <= '9' || r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z')
-		}) {
-			if token == expected {
-				return true
-			}
+		matches++
+		if plugin.PluginID == nil || plugin.Name == nil || plugin.MarketplaceName == nil || plugin.Installed == nil || plugin.Enabled == nil ||
+			*plugin.PluginID != expectedID || *plugin.Name != name || *plugin.MarketplaceName != marketplace || !*plugin.Installed || !*plugin.Enabled {
+			return false
 		}
 	}
-	return false
+	return matches == 1
+}
+
+var copilotInstalledEntry = regexp.MustCompile(`^[ \t]+•[ \t]+([A-Za-z0-9][A-Za-z0-9._-]*@[A-Za-z0-9][A-Za-z0-9._-]*)[ \t]+\(v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?\)[ \t]*$`)
+
+func copilotHasInstalledPlugin(stdout []byte, expected string) bool {
+	inInstalledSection := false
+	matches := 0
+	for _, rawLine := range strings.Split(strings.ReplaceAll(string(stdout), "\r\n", "\n"), "\n") {
+		if strings.TrimSpace(rawLine) == "Installed plugins:" {
+			if inInstalledSection {
+				return false
+			}
+			inInstalledSection = true
+			continue
+		}
+		if !inInstalledSection {
+			continue
+		}
+		if rawLine != "" && rawLine[0] != ' ' && rawLine[0] != '\t' {
+			inInstalledSection = false
+			continue
+		}
+		entry := copilotInstalledEntry.FindStringSubmatch(rawLine)
+		if len(entry) == 2 && entry[1] == expected {
+			matches++
+		}
+	}
+	return matches == 1
+}
+
+type kiroStatus int
+
+const (
+	kiroStatusUnknown kiroStatus = iota
+	kiroStatusHealthy
+	kiroStatusUnhealthy
+)
+
+var errKiroStatusContractUnknown = errors.New("Kiro MCP status output is not recognized")
+
+func kiroMCPStatus(stdout []byte, expected string) kiroStatus {
+	lines := strings.Split(strings.ReplaceAll(string(stdout), "\r\n", "\n"), "\n")
+	nonEmpty := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			nonEmpty = append(nonEmpty, trimmed)
+		}
+	}
+	if len(nonEmpty) == 1 && (nonEmpty[0] == expected+": connected" || nonEmpty[0] == expected+" connected") {
+		return kiroStatusHealthy
+	}
+	if len(nonEmpty) == 2 && nonEmpty[0] == "Name: "+expected && nonEmpty[1] == "Status: connected" {
+		return kiroStatusHealthy
+	}
+	lower := strings.ToLower(strings.Join(nonEmpty, "\n"))
+	for _, state := range []string{"pending", "disconnected", "disabled", "auth-required", "auth required", "authentication required", "error", "failed", "failure"} {
+		if strings.Contains(lower, state) {
+			return kiroStatusUnhealthy
+		}
+	}
+	return kiroStatusUnknown
+}
+
+func manualKiroVerification(outcome domain.ActivationOutcome, request domain.ActivationRequest) domain.ActivationOutcome {
+	outcome.Activation = domain.ActivationManual
+	outcome.UserActions = []string{"confirm each imported MCP server is connected in Kiro"}
+	outcome.LocalActions = []string{fmt.Sprintf("Kiro's documented `%s mcp status --name <server>` output contract was not recognized; inspect each server manually", request.BackendExecutable)}
+	return outcome
 }
 
 func commandOutputContains(result legacyports.CommandResult, fragment string) bool {

--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -313,22 +314,41 @@ func (activator Activator) activateKiroMCP(ctx context.Context, request domain.A
 }
 
 func (activator Activator) verifyKiroMCP(ctx context.Context, request domain.ActivationRequest) error {
+	var firstCommandErr error
+	var firstUnknown string
+	var firstUnhealthy string
 	for _, component := range request.Plan.Components {
 		if component.Kind != domain.ComponentMCPServer {
 			continue
 		}
 		status, err := activator.runClientResult(ctx, "Kiro CLI", request.BackendExecutable, "mcp", "status", "--name", component.Name)
 		if err != nil {
-			return fmt.Errorf("verify Kiro MCP server %s: %w", component.Name, err)
+			if firstCommandErr == nil {
+				firstCommandErr = fmt.Errorf("verify Kiro MCP server %s: %w", component.Name, err)
+			}
+			continue
 		}
 		switch kiroMCPStatus(status.Stdout, component.Name) {
 		case kiroStatusHealthy:
 			continue
 		case kiroStatusUnhealthy:
-			return fmt.Errorf("%w: verify Kiro MCP server %s: server is not connected", errRecognizedNegativeEvidence, component.Name)
+			if firstUnhealthy == "" {
+				firstUnhealthy = component.Name
+			}
 		default:
-			return fmt.Errorf("%w for server %s", errKiroStatusContractUnknown, component.Name)
+			if firstUnknown == "" {
+				firstUnknown = component.Name
+			}
 		}
+	}
+	if firstUnhealthy != "" {
+		return fmt.Errorf("%w: verify Kiro MCP server %s: server is not connected", errRecognizedNegativeEvidence, firstUnhealthy)
+	}
+	if firstCommandErr != nil {
+		return firstCommandErr
+	}
+	if firstUnknown != "" {
+		return fmt.Errorf("%w for server %s", errKiroStatusContractUnknown, firstUnknown)
 	}
 	return nil
 }
@@ -408,48 +428,126 @@ const (
 var errCodexListContractUnknown = errors.New("Codex plugin list output is not recognized")
 
 func codexPluginStatus(body []byte, name, marketplace string) codexStatus {
-	var document map[string]json.RawMessage
-	if len(body) == 0 || json.Unmarshal(body, &document) != nil {
+	if len(body) == 0 {
 		return codexStatusUnknown
 	}
-	rawInstalled, ok := document["installed"]
-	if !ok || string(rawInstalled) == "null" {
+	decoder := json.NewDecoder(strings.NewReader(string(body)))
+	decoder.UseNumber()
+	parsed, err := decodeUniqueJSONValue(decoder)
+	if err != nil {
 		return codexStatusUnknown
 	}
-	type installedEntry struct {
-		PluginID        *string `json:"pluginId"`
-		Name            *string `json:"name"`
-		MarketplaceName *string `json:"marketplaceName"`
-		Installed       *bool   `json:"installed"`
-		Enabled         *bool   `json:"enabled"`
+	if _, tokenErr := decoder.Token(); tokenErr == nil || !errors.Is(tokenErr, io.EOF) {
+		return codexStatusUnknown
 	}
-	var entries []installedEntry
-	if json.Unmarshal(rawInstalled, &entries) != nil {
+	document, ok := parsed.(map[string]any)
+	if !ok {
+		return codexStatusUnknown
+	}
+	installedValue, ok := document["installed"]
+	if !ok {
+		return codexStatusUnknown
+	}
+	entries, ok := installedValue.([]any)
+	if !ok {
 		return codexStatusUnknown
 	}
 	expectedID := name + "@" + marketplace
 	identities := make(map[string]struct{}, len(entries))
 	foundExpected := false
 	expectedActive := false
-	for _, entry := range entries {
-		if entry.PluginID == nil || entry.Name == nil || entry.MarketplaceName == nil || entry.Installed == nil || entry.Enabled == nil ||
-			*entry.PluginID == "" || *entry.Name == "" || *entry.MarketplaceName == "" ||
-			*entry.PluginID != *entry.Name+"@"+*entry.MarketplaceName {
+	required := []string{"pluginId", "name", "marketplaceName", "installed", "enabled"}
+	for _, value := range entries {
+		entry, ok := value.(map[string]any)
+		if !ok || len(entry) != len(required) {
 			return codexStatusUnknown
 		}
-		if _, duplicate := identities[*entry.PluginID]; duplicate {
+		for _, field := range required {
+			if _, present := entry[field]; !present {
+				return codexStatusUnknown
+			}
+		}
+		pluginID, pluginIDOK := entry["pluginId"].(string)
+		entryName, nameOK := entry["name"].(string)
+		marketplaceName, marketplaceOK := entry["marketplaceName"].(string)
+		installed, installedOK := entry["installed"].(bool)
+		enabled, enabledOK := entry["enabled"].(bool)
+		if !pluginIDOK || !nameOK || !marketplaceOK || !installedOK || !enabledOK ||
+			pluginID == "" || entryName == "" || marketplaceName == "" ||
+			pluginID != entryName+"@"+marketplaceName {
 			return codexStatusUnknown
 		}
-		identities[*entry.PluginID] = struct{}{}
-		if *entry.PluginID == expectedID {
+		if _, duplicate := identities[pluginID]; duplicate {
+			return codexStatusUnknown
+		}
+		identities[pluginID] = struct{}{}
+		if pluginID == expectedID {
 			foundExpected = true
-			expectedActive = *entry.Installed && *entry.Enabled
+			expectedActive = installed && enabled
 		}
 	}
 	if foundExpected && expectedActive {
 		return codexStatusInstalled
 	}
 	return codexStatusAbsent
+}
+
+func decodeUniqueJSONValue(decoder *json.Decoder) (any, error) {
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, err
+	}
+	delimiter, isDelimiter := token.(json.Delim)
+	if !isDelimiter {
+		return token, nil
+	}
+	switch delimiter {
+	case '{':
+		object := make(map[string]any)
+		var keys []string
+		for decoder.More() {
+			keyToken, keyErr := decoder.Token()
+			if keyErr != nil {
+				return nil, keyErr
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return nil, fmt.Errorf("JSON object key is not a string")
+			}
+			for _, prior := range keys {
+				if strings.EqualFold(prior, key) {
+					return nil, fmt.Errorf("duplicate or case-ambiguous JSON object key %q", key)
+				}
+			}
+			keys = append(keys, key)
+			value, valueErr := decodeUniqueJSONValue(decoder)
+			if valueErr != nil {
+				return nil, valueErr
+			}
+			object[key] = value
+		}
+		closing, closingErr := decoder.Token()
+		if closingErr != nil || closing != json.Delim('}') {
+			return nil, fmt.Errorf("invalid JSON object")
+		}
+		return object, nil
+	case '[':
+		var array []any
+		for decoder.More() {
+			value, valueErr := decodeUniqueJSONValue(decoder)
+			if valueErr != nil {
+				return nil, valueErr
+			}
+			array = append(array, value)
+		}
+		closing, closingErr := decoder.Token()
+		if closingErr != nil || closing != json.Delim(']') {
+			return nil, fmt.Errorf("invalid JSON array")
+		}
+		return array, nil
+	default:
+		return nil, fmt.Errorf("unexpected JSON delimiter %q", delimiter)
+	}
 }
 
 var copilotInstalledEntry = regexp.MustCompile(`^[ \t]+•[ \t]+([A-Za-z0-9][A-Za-z0-9._-]*@[A-Za-z0-9][A-Za-z0-9._-]*)[ \t]+\(v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?\)[ \t]*$`)

--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -103,9 +103,6 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 		Verification:   domain.VerificationPackageValid,
 	}
 	if request.ActivationComplete {
-		if activationCanBeObserved(activator, request) {
-			return domain.ActivationOutcome{}, fmt.Errorf("--activation-complete is not accepted when client verification is available")
-		}
 		outcome.Activation = domain.ActivationActive
 		outcome.Verification = domain.VerificationInstalled
 		outcome.ActivationAttested = true
@@ -203,20 +200,6 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 		return outcome, nil
 	default:
 		return domain.ActivationOutcome{}, fmt.Errorf("unsupported activation client %q", request.Client.ClientID)
-	}
-}
-
-func activationCanBeObserved(activator Activator, request domain.ActivationRequest) bool {
-	if activator.Runner == nil || strings.TrimSpace(request.BackendExecutable) == "" {
-		return false
-	}
-	switch request.Client.ClientID {
-	case domain.ClientCodex, domain.ClientCopilot, domain.ClientVSCode:
-		return true
-	case domain.ClientKiro:
-		return mcpOnly(request.Plan.Components) && isKiroCLI(request.BackendExecutable)
-	default:
-		return false
 	}
 }
 

--- a/install/integrationctl/agentplugins/providers/activator_test.go
+++ b/install/integrationctl/agentplugins/providers/activator_test.go
@@ -215,9 +215,13 @@ func TestCopilotUnknownOutputContractRemainsManual(t *testing.T) {
 		"duplicate":       {Stdout: []byte("Installed plugins:\n  • " + spec + " (v1.0.0)\n  • " + spec + " (v1.0.0)")},
 	} {
 		t.Run(name, func(t *testing.T) {
-			outcome, err := (Activator{Runner: &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult { return listed }}}).Activate(context.Background(), request)
+			runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult { return listed }}
+			outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
 			if err != nil || outcome.Activation != domain.ActivationManual || outcome.Verification != domain.VerificationPackageValid {
 				t.Fatalf("outcome=%+v err=%v", outcome, err)
+			}
+			if outcome.ActivationAttested || len(runner.commands) != 1 || len(outcome.LocalActions) == 0 {
+				t.Fatalf("unknown output path is not actionable: outcome=%+v commands=%+v", outcome, runner.commands)
 			}
 		})
 	}
@@ -242,9 +246,19 @@ func TestActivationAttestationCannotBypassObservableVerifier(t *testing.T) {
 	t.Parallel()
 	for _, client := range []domain.ClientID{domain.ClientCodex, domain.ClientCopilot, domain.ClientVSCode, domain.ClientKiro} {
 		t.Run(string(client), func(t *testing.T) {
-			runner := &recordingRunner{}
+			runner := &recordingRunner{run: func(command legacyports.Command) legacyports.CommandResult {
+				switch client {
+				case domain.ClientCopilot, domain.ClientVSCode:
+					return legacyports.CommandResult{Stdout: []byte("Installed plugins:\n  No plugins installed.")}
+				case domain.ClientKiro:
+					return legacyports.CommandResult{Stdout: []byte("demo: disconnected")}
+				default:
+					return legacyports.CommandResult{Stdout: []byte(`{"installed":[]}`)}
+				}
+			}}
 			request := activationRequest(t, client)
 			request.ActivationComplete = true
+			request.VerifyOnly = true
 			request.BackendExecutable = "/test/bin/" + string(client)
 			if client == domain.ClientVSCode {
 				request.BackendExecutable = "/test/bin/copilot"
@@ -253,11 +267,15 @@ func TestActivationAttestationCannotBypassObservableVerifier(t *testing.T) {
 				request.BackendExecutable = "/test/bin/kiro-cli"
 				request.Plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "demo", Support: domain.SupportNative}}
 			}
-			if _, err := (Activator{Runner: runner}).Activate(context.Background(), request); err == nil || !strings.Contains(err.Error(), "available verifier must run") {
-				t.Fatalf("attestation error = %v", err)
+			outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
+			if err == nil || outcome.Activation != domain.ActivationFailed || outcome.Verification != domain.VerificationFailed || !outcome.AuthoritativeObservation {
+				t.Fatalf("recognized negative evidence did not fail closed: outcome=%+v err=%v", outcome, err)
 			}
-			if len(runner.commands) != 0 {
-				t.Fatalf("attestation unexpectedly ran commands: %+v", runner.commands)
+			if outcome.ActivationAttested {
+				t.Fatalf("observable activation was marked attested: %+v", outcome)
+			}
+			if len(runner.commands) == 0 {
+				t.Fatal("observable activation completion did not run the verifier")
 			}
 		})
 	}
@@ -299,9 +317,13 @@ func TestKiroUnknownStatusContractRemainsManual(t *testing.T) {
 		"unknown":     {Stdout: []byte("demo-server: enabled")},
 	} {
 		t.Run(name, func(t *testing.T) {
-			outcome, err := (Activator{Runner: &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult { return listed }}}).Activate(context.Background(), request)
+			runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult { return listed }}
+			outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
 			if err != nil || outcome.Activation != domain.ActivationManual || outcome.Verification != domain.VerificationPackageValid {
 				t.Fatalf("outcome=%+v err=%v", outcome, err)
+			}
+			if outcome.ActivationAttested || len(runner.commands) != 1 || len(outcome.LocalActions) == 0 {
+				t.Fatalf("unknown output path is not actionable: outcome=%+v commands=%+v", outcome, runner.commands)
 			}
 		})
 	}

--- a/install/integrationctl/agentplugins/providers/activator_test.go
+++ b/install/integrationctl/agentplugins/providers/activator_test.go
@@ -150,19 +150,31 @@ func TestCodexVerificationRequiresExactEnabledManagedEntry(t *testing.T) {
 		body string
 		want codexStatus
 	}{
-		"installed":              {`{"installed":[` + valid("demo@managed", "demo", marketplace, true, true) + `]}`, codexStatusInstalled},
-		"empty":                  {`{"installed":[]}`, codexStatusAbsent},
-		"valid unrelated":        {`{"installed":[` + valid("other@managed", "other", marketplace, true, true) + `]}`, codexStatusAbsent},
-		"expected disabled":      {`{"installed":[` + valid("demo@managed", "demo", marketplace, true, false) + `]}`, codexStatusAbsent},
-		"expected not installed": {`{"installed":[` + valid("demo@managed", "demo", marketplace, false, true) + `]}`, codexStatusAbsent},
-		"malformed":              {`{`, codexStatusUnknown},
-		"old shape":              {`{"plugins":[{"name":"demo"}]}`, codexStatusUnknown},
-		"null array":             {`{"installed":null}`, codexStatusUnknown},
-		"arbitrary entry":        {`{"installed":[{"message":"not authenticated"}]}`, codexStatusUnknown},
-		"wrong field type":       {`{"installed":[{"pluginId":7,"name":"demo","marketplaceName":"managed","installed":true,"enabled":true}]}`, codexStatusUnknown},
-		"missing plugin id":      {`{"installed":[{"name":"demo","marketplaceName":"managed","installed":true,"enabled":true}]}`, codexStatusUnknown},
-		"inconsistent identity":  {`{"installed":[` + valid("demo@other", "demo", marketplace, true, true) + `]}`, codexStatusUnknown},
-		"duplicate identity":     {`{"installed":[` + valid("demo@managed", "demo", marketplace, true, true) + `,` + valid("demo@managed", "demo", marketplace, false, false) + `]}`, codexStatusUnknown},
+		"installed":               {`{"metadata":{"version":1},"installed":[` + valid("demo@managed", "demo", marketplace, true, true) + `]}`, codexStatusInstalled},
+		"empty":                   {`{"installed":[]}`, codexStatusAbsent},
+		"valid unrelated":         {`{"installed":[` + valid("other@managed", "other", marketplace, true, true) + `]}`, codexStatusAbsent},
+		"expected disabled":       {`{"installed":[` + valid("demo@managed", "demo", marketplace, true, false) + `]}`, codexStatusAbsent},
+		"expected not installed":  {`{"installed":[` + valid("demo@managed", "demo", marketplace, false, true) + `]}`, codexStatusAbsent},
+		"malformed":               {`{`, codexStatusUnknown},
+		"old shape":               {`{"plugins":[{"name":"demo"}]}`, codexStatusUnknown},
+		"null array":              {`{"installed":null}`, codexStatusUnknown},
+		"arbitrary entry":         {`{"installed":[{"message":"not authenticated"}]}`, codexStatusUnknown},
+		"wrong field type":        {`{"installed":[{"pluginId":7,"name":"demo","marketplaceName":"managed","installed":true,"enabled":true}]}`, codexStatusUnknown},
+		"wrong name type":         {`{"installed":[{"pluginId":"demo@managed","name":7,"marketplaceName":"managed","installed":true,"enabled":true}]}`, codexStatusUnknown},
+		"wrong marketplace type":  {`{"installed":[{"pluginId":"demo@managed","name":"demo","marketplaceName":7,"installed":true,"enabled":true}]}`, codexStatusUnknown},
+		"wrong installed type":    {`{"installed":[{"pluginId":"demo@managed","name":"demo","marketplaceName":"managed","installed":"true","enabled":true}]}`, codexStatusUnknown},
+		"wrong enabled type":      {`{"installed":[{"pluginId":"demo@managed","name":"demo","marketplaceName":"managed","installed":true,"enabled":1}]}`, codexStatusUnknown},
+		"missing plugin id":       {`{"installed":[{"name":"demo","marketplaceName":"managed","installed":true,"enabled":true}]}`, codexStatusUnknown},
+		"missing enabled":         {`{"installed":[{"pluginId":"demo@managed","name":"demo","marketplaceName":"managed","installed":true}]}`, codexStatusUnknown},
+		"unknown entry field":     {`{"installed":[{"pluginId":"demo@managed","name":"demo","marketplaceName":"managed","installed":true,"enabled":true,"status":"active"}]}`, codexStatusUnknown},
+		"enabled case variant":    {`{"installed":[{"pluginId":"demo@managed","name":"demo","marketplaceName":"managed","installed":true,"Enabled":true}]}`, codexStatusUnknown},
+		"duplicate enabled":       {`{"installed":[{"pluginId":"demo@managed","name":"demo","marketplaceName":"managed","installed":true,"enabled":true,"enabled":false}]}`, codexStatusUnknown},
+		"duplicate installed":     {`{"installed":[{"pluginId":"demo@managed","name":"demo","marketplaceName":"managed","installed":true,"installed":false,"enabled":true}]}`, codexStatusUnknown},
+		"inconsistent identity":   {`{"installed":[` + valid("demo@other", "demo", marketplace, true, true) + `]}`, codexStatusUnknown},
+		"duplicate identity":      {`{"installed":[` + valid("demo@managed", "demo", marketplace, true, true) + `,` + valid("demo@managed", "demo", marketplace, false, false) + `]}`, codexStatusUnknown},
+		"duplicate top installed": {`{"installed":[],"installed":[` + valid("demo@managed", "demo", marketplace, true, true) + `]}`, codexStatusUnknown},
+		"top installed variant":   {`{"Installed":[` + valid("demo@managed", "demo", marketplace, true, true) + `]}`, codexStatusUnknown},
+		"ambiguous top installed": {`{"installed":[],"Installed":[]}`, codexStatusUnknown},
 	}
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -170,6 +182,64 @@ func TestCodexVerificationRequiresExactEnabledManagedEntry(t *testing.T) {
 				t.Fatalf("status = %v, want %v", got, test.want)
 			}
 		})
+	}
+}
+
+func TestKiroVerificationScansUnknownBeforeRecognizedNegative(t *testing.T) {
+	t.Parallel()
+	for _, activationComplete := range []bool{false, true} {
+		t.Run(fmt.Sprintf("activation_complete_%t", activationComplete), func(t *testing.T) {
+			request := activationRequest(t, domain.ClientKiro)
+			request.BackendExecutable = "/test/bin/kiro-cli"
+			request.VerifyOnly = true
+			request.ActivationComplete = activationComplete
+			request.Plan.Components = []domain.ComponentDecision{
+				{Kind: domain.ComponentMCPServer, Name: "unknown-first", Support: domain.SupportNative},
+				{Kind: domain.ComponentMCPServer, Name: "negative-later", Support: domain.SupportNative},
+			}
+			runner := &recordingRunner{run: func(command legacyports.Command) legacyports.CommandResult {
+				name := command.Argv[len(command.Argv)-1]
+				if name == "negative-later" {
+					return legacyports.CommandResult{Stdout: []byte(name + ": disconnected")}
+				}
+				return legacyports.CommandResult{Stdout: []byte(name + ": enabled")}
+			}}
+			outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
+			if err == nil || outcome.Activation != domain.ActivationFailed || !outcome.AuthoritativeObservation {
+				t.Fatalf("outcome=%+v err=%v", outcome, err)
+			}
+			if outcome.ActivationAttested {
+				t.Fatalf("recognized negative evidence was bypassed by attestation: %+v", outcome)
+			}
+			if len(runner.commands) != 2 {
+				t.Fatalf("verifier calls = %d, want every MCP server", len(runner.commands))
+			}
+		})
+	}
+}
+
+func TestKiroVerificationReturnsUnknownOnlyAfterScanningEveryServer(t *testing.T) {
+	t.Parallel()
+	request := activationRequest(t, domain.ClientKiro)
+	request.BackendExecutable = "/test/bin/kiro-cli"
+	request.VerifyOnly = true
+	request.Plan.Components = []domain.ComponentDecision{
+		{Kind: domain.ComponentMCPServer, Name: "unknown-first", Support: domain.SupportNative},
+		{Kind: domain.ComponentMCPServer, Name: "healthy-later", Support: domain.SupportNative},
+	}
+	runner := &recordingRunner{run: func(command legacyports.Command) legacyports.CommandResult {
+		name := command.Argv[len(command.Argv)-1]
+		if name == "healthy-later" {
+			return legacyports.CommandResult{Stdout: []byte(name + ": connected")}
+		}
+		return legacyports.CommandResult{Stdout: []byte(name + ": enabled")}
+	}}
+	outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
+	if err != nil || outcome.Activation != domain.ActivationManual || outcome.AuthoritativeObservation {
+		t.Fatalf("outcome=%+v err=%v", outcome, err)
+	}
+	if len(runner.commands) != 2 {
+		t.Fatalf("verifier calls = %d, want every MCP server", len(runner.commands))
 	}
 }
 

--- a/install/integrationctl/agentplugins/providers/activator_test.go
+++ b/install/integrationctl/agentplugins/providers/activator_test.go
@@ -98,16 +98,16 @@ func TestActivatorUpdateRecoversMissingMarketplaceAndPlugin(t *testing.T) {
 	}
 }
 
-func TestActivatorDoesNotTrustCopilotInstallExitZeroWithoutListingEvidence(t *testing.T) {
+func TestActivatorFallsBackToManualForUnknownCopilotListing(t *testing.T) {
 	t.Parallel()
 	runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult { return legacyports.CommandResult{} }}
 	request := activationRequest(t, domain.ClientCopilot)
 	request.BackendExecutable = "/test/bin/copilot"
 	outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
-	if err == nil || !strings.Contains(err.Error(), "not listed") {
+	if err != nil {
 		t.Fatalf("verification error = %v", err)
 	}
-	if outcome.Activation != domain.ActivationFailed || outcome.Verification != domain.VerificationFailed || len(outcome.LocalActions) != 1 {
+	if outcome.Activation != domain.ActivationManual || outcome.Verification != domain.VerificationPackageValid || len(outcome.LocalActions) != 1 {
 		t.Fatalf("outcome = %+v", outcome)
 	}
 }
@@ -175,30 +175,89 @@ func TestCodexVerificationRequiresExactEnabledManagedEntry(t *testing.T) {
 	}
 }
 
-func TestCopilotVerificationUsesOnlyExactHealthyStdoutToken(t *testing.T) {
+func TestCopilotVerificationRejectsRecognizedNegativeEvidence(t *testing.T) {
 	t.Parallel()
 	request := activationRequest(t, domain.ClientCopilot)
 	request.BackendExecutable = "/test/bin/copilot"
 	request.VerifyOnly = true
 	spec := "demo@" + managedMarketplaceName(request.Plan.PhysicalArtifactID)
 	cases := map[string]legacyports.CommandResult{
-		"bare name":       {Stdout: []byte("Installed plugins:\n  • demo (v1.0.0)")},
-		"stderr only":     {Stderr: []byte("Installed plugins:\n  • " + spec + " (v1.0.0)")},
-		"outside section": {Stdout: []byte("• " + spec + " (v1.0.0)")},
-		"pending":         {Stdout: []byte("Installed plugins:\n  • " + spec + " pending")},
-		"disconnected":    {Stdout: []byte("Installed plugins:\n  • " + spec + " disconnected")},
-		"disabled":        {Stdout: []byte("Installed plugins:\n  • " + spec + " disabled")},
-		"auth required":   {Stdout: []byte("Installed plugins:\n  • " + spec + " auth-required")},
-		"error":           {Stdout: []byte("Installed plugins:\n  error: " + spec)},
-		"unrelated":       {Stdout: []byte("Installed plugins:\n  • demo-extra@" + managedMarketplaceName(request.Plan.PhysicalArtifactID) + " (v1.0.0)")},
-		"bad version":     {Stdout: []byte("Installed plugins:\n  • " + spec + " (latest)")},
-		"duplicate":       {Stdout: []byte("Installed plugins:\n  • " + spec + " (v1.0.0)\n  • " + spec + " (v1.0.0)")},
+		"pending":          {Stdout: []byte("Installed plugins:\n  • " + spec + " pending")},
+		"disconnected":     {Stdout: []byte("Installed plugins:\n  • " + spec + " disconnected")},
+		"disabled":         {Stdout: []byte("Installed plugins:\n  • " + spec + " disabled")},
+		"auth required":    {Stdout: []byte("Installed plugins:\n  • " + spec + " auth-required")},
+		"error":            {Stdout: []byte("Installed plugins:\n  error: " + spec)},
+		"unrelated":        {Stdout: []byte("Installed plugins:\n  • demo-extra@" + managedMarketplaceName(request.Plan.PhysicalArtifactID) + " (v1.0.0)")},
+		"explicitly empty": {Stdout: []byte("Installed plugins:\n  No plugins installed.")},
 	}
 	for name, listed := range cases {
 		t.Run(name, func(t *testing.T) {
 			runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult { return listed }}
 			if _, err := (Activator{Runner: runner}).Activate(context.Background(), request); err == nil {
 				t.Fatalf("untrusted Copilot listing was accepted: %+v", listed)
+			}
+		})
+	}
+}
+
+func TestCopilotUnknownOutputContractRemainsManual(t *testing.T) {
+	t.Parallel()
+	request := activationRequest(t, domain.ClientCopilot)
+	request.BackendExecutable = "/test/bin/copilot"
+	request.VerifyOnly = true
+	spec := "demo@" + managedMarketplaceName(request.Plan.PhysicalArtifactID)
+	for name, listed := range map[string]legacyports.CommandResult{
+		"empty":           {},
+		"bare name":       {Stdout: []byte("Installed plugins:\n  • demo (v1.0.0)")},
+		"stderr only":     {Stderr: []byte("Installed plugins:\n  • " + spec + " (v1.0.0)")},
+		"outside section": {Stdout: []byte("• " + spec + " (v1.0.0)")},
+		"bad version":     {Stdout: []byte("Installed plugins:\n  • " + spec + " (latest)")},
+		"duplicate":       {Stdout: []byte("Installed plugins:\n  • " + spec + " (v1.0.0)\n  • " + spec + " (v1.0.0)")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			outcome, err := (Activator{Runner: &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult { return listed }}}).Activate(context.Background(), request)
+			if err != nil || outcome.Activation != domain.ActivationManual || outcome.Verification != domain.VerificationPackageValid {
+				t.Fatalf("outcome=%+v err=%v", outcome, err)
+			}
+		})
+	}
+}
+
+func TestCopilotExactVersion1078OutputRemainsSupported(t *testing.T) {
+	t.Parallel()
+	request := activationRequest(t, domain.ClientCopilot)
+	request.BackendExecutable = "/test/bin/copilot"
+	request.VerifyOnly = true
+	spec := "demo@" + managedMarketplaceName(request.Plan.PhysicalArtifactID)
+	runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult {
+		return legacyports.CommandResult{Stdout: []byte("Installed plugins:\n  • " + spec + " (v1.0.78)")}
+	}}
+	outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
+	if err != nil || outcome.Activation != domain.ActivationActive {
+		t.Fatalf("outcome=%+v err=%v", outcome, err)
+	}
+}
+
+func TestActivationAttestationCannotBypassObservableVerifier(t *testing.T) {
+	t.Parallel()
+	for _, client := range []domain.ClientID{domain.ClientCodex, domain.ClientCopilot, domain.ClientVSCode, domain.ClientKiro} {
+		t.Run(string(client), func(t *testing.T) {
+			runner := &recordingRunner{}
+			request := activationRequest(t, client)
+			request.ActivationComplete = true
+			request.BackendExecutable = "/test/bin/" + string(client)
+			if client == domain.ClientVSCode {
+				request.BackendExecutable = "/test/bin/copilot"
+			}
+			if client == domain.ClientKiro {
+				request.BackendExecutable = "/test/bin/kiro-cli"
+				request.Plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "demo", Support: domain.SupportNative}}
+			}
+			if _, err := (Activator{Runner: runner}).Activate(context.Background(), request); err == nil || !strings.Contains(err.Error(), "available verifier must run") {
+				t.Fatalf("attestation error = %v", err)
+			}
+			if len(runner.commands) != 0 {
+				t.Fatalf("attestation unexpectedly ran commands: %+v", runner.commands)
 			}
 		})
 	}

--- a/install/integrationctl/agentplugins/providers/activator_test.go
+++ b/install/integrationctl/agentplugins/providers/activator_test.go
@@ -142,34 +142,59 @@ func TestActivatorUsesCodexCLIAndVerifiesJSONState(t *testing.T) {
 
 func TestCodexVerificationRequiresExactEnabledManagedEntry(t *testing.T) {
 	t.Parallel()
+	marketplace := "managed"
+	valid := func(pluginID, name, market string, installed, enabled bool) string {
+		return fmt.Sprintf(`{"pluginId":%q,"name":%q,"marketplaceName":%q,"installed":%t,"enabled":%t}`, pluginID, name, market, installed, enabled)
+	}
+	cases := map[string]struct {
+		body string
+		want codexStatus
+	}{
+		"installed":              {`{"installed":[` + valid("demo@managed", "demo", marketplace, true, true) + `]}`, codexStatusInstalled},
+		"empty":                  {`{"installed":[]}`, codexStatusAbsent},
+		"valid unrelated":        {`{"installed":[` + valid("other@managed", "other", marketplace, true, true) + `]}`, codexStatusAbsent},
+		"expected disabled":      {`{"installed":[` + valid("demo@managed", "demo", marketplace, true, false) + `]}`, codexStatusAbsent},
+		"expected not installed": {`{"installed":[` + valid("demo@managed", "demo", marketplace, false, true) + `]}`, codexStatusAbsent},
+		"malformed":              {`{`, codexStatusUnknown},
+		"old shape":              {`{"plugins":[{"name":"demo"}]}`, codexStatusUnknown},
+		"null array":             {`{"installed":null}`, codexStatusUnknown},
+		"arbitrary entry":        {`{"installed":[{"message":"not authenticated"}]}`, codexStatusUnknown},
+		"wrong field type":       {`{"installed":[{"pluginId":7,"name":"demo","marketplaceName":"managed","installed":true,"enabled":true}]}`, codexStatusUnknown},
+		"missing plugin id":      {`{"installed":[{"name":"demo","marketplaceName":"managed","installed":true,"enabled":true}]}`, codexStatusUnknown},
+		"inconsistent identity":  {`{"installed":[` + valid("demo@other", "demo", marketplace, true, true) + `]}`, codexStatusUnknown},
+		"duplicate identity":     {`{"installed":[` + valid("demo@managed", "demo", marketplace, true, true) + `,` + valid("demo@managed", "demo", marketplace, false, false) + `]}`, codexStatusUnknown},
+	}
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := codexPluginStatus([]byte(test.body), "demo", marketplace); got != test.want {
+				t.Fatalf("status = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestCodexProviderDistinguishesNegativeAndUnknownListings(t *testing.T) {
+	t.Parallel()
 	request := activationRequest(t, domain.ClientCodex)
 	request.BackendExecutable = "/test/bin/codex"
 	request.VerifyOnly = true
-	marketplace := managedMarketplaceName(request.Plan.PhysicalArtifactID)
-	cases := map[string]string{
-		"malformed":             `{`,
-		"old shape":             `{"plugins":[{"name":"demo"}]}`,
-		"error only":            `{"error":"not authenticated"}`,
-		"missing plugin id":     fmt.Sprintf(`{"installed":[{"name":"demo","marketplaceName":%q,"installed":true,"enabled":true}]}`, marketplace),
-		"wrong plugin id":       fmt.Sprintf(`{"installed":[{"pluginId":"demo@other","name":"demo","marketplaceName":%q,"installed":true,"enabled":true}]}`, marketplace),
-		"missing name":          fmt.Sprintf(`{"installed":[{"pluginId":"demo@%s","marketplaceName":%q,"installed":true,"enabled":true}]}`, marketplace, marketplace),
-		"missing marketplace":   fmt.Sprintf(`{"installed":[{"pluginId":"demo@%s","name":"demo","installed":true,"enabled":true}]}`, marketplace),
-		"missing installed":     fmt.Sprintf(`{"installed":[{"pluginId":"demo@%s","name":"demo","marketplaceName":%q,"enabled":true}]}`, marketplace, marketplace),
-		"missing enabled":       fmt.Sprintf(`{"installed":[{"pluginId":"demo@%s","name":"demo","marketplaceName":%q,"installed":true}]}`, marketplace, marketplace),
-		"not installed":         fmt.Sprintf(`{"installed":[{"pluginId":"demo@%s","name":"demo","marketplaceName":%q,"installed":false,"enabled":true}]}`, marketplace, marketplace),
-		"disabled":              fmt.Sprintf(`{"installed":[{"pluginId":"demo@%s","name":"demo","marketplaceName":%q,"installed":true,"enabled":false}]}`, marketplace, marketplace),
-		"wrong marketplace":     `{"installed":[{"pluginId":"demo@other","name":"demo","marketplaceName":"other","installed":true,"enabled":true}]}`,
-		"unrelated":             fmt.Sprintf(`{"installed":[{"pluginId":"demo-extra@%s","name":"demo-extra","marketplaceName":%q,"installed":true,"enabled":true}]}`, marketplace, marketplace),
-		"duplicate exact":       fmt.Sprintf(`{"installed":[{"pluginId":"demo@%s","name":"demo","marketplaceName":%q,"installed":true,"enabled":true},{"pluginId":"demo@%s","name":"demo","marketplaceName":%q,"installed":true,"enabled":true}]}`, marketplace, marketplace, marketplace, marketplace),
-		"duplicate conflicting": fmt.Sprintf(`{"installed":[{"pluginId":"demo@%s","name":"demo","marketplaceName":%q,"installed":true,"enabled":true},{"pluginId":"demo@%s","name":"wrong","marketplaceName":%q,"installed":true,"enabled":true}]}`, marketplace, marketplace, marketplace, marketplace),
-	}
-	for name, body := range cases {
+	for name, body := range map[string]string{
+		"negative": `{"installed":[]}`,
+		"unknown":  `{"installed":[{"name":"demo"}]}`,
+	} {
 		t.Run(name, func(t *testing.T) {
 			runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult {
 				return legacyports.CommandResult{Stdout: []byte(body)}
 			}}
-			if _, err := (Activator{Runner: runner}).Activate(context.Background(), request); err == nil {
-				t.Fatal("untrusted Codex listing was accepted")
+			outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
+			if name == "negative" {
+				if err == nil || outcome.Activation != domain.ActivationFailed || !outcome.AuthoritativeObservation {
+					t.Fatalf("outcome=%+v err=%v", outcome, err)
+				}
+				return
+			}
+			if err != nil || outcome.Activation != domain.ActivationManual || outcome.AuthoritativeObservation {
+				t.Fatalf("outcome=%+v err=%v", outcome, err)
 			}
 		})
 	}
@@ -312,9 +337,12 @@ func TestKiroUnknownStatusContractRemainsManual(t *testing.T) {
 	request.VerifyOnly = true
 	request.Plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "demo-server", Support: domain.SupportNative}}
 	for name, listed := range map[string]legacyports.CommandResult{
-		"stderr only": {Stderr: []byte("demo-server: connected")},
-		"unrelated":   {Stdout: []byte("demo-server-other: connected")},
-		"unknown":     {Stdout: []byte("demo-server: enabled")},
+		"stderr only":              {Stderr: []byte("demo-server: connected")},
+		"unrelated positive":       {Stdout: []byte("demo-server-other: connected")},
+		"unrelated negative":       {Stdout: []byte("demo-server-other: disconnected")},
+		"warning plus negative":    {Stdout: []byte("warning: stale cache\ndemo-server: disconnected")},
+		"negative plus extra text": {Stdout: []byte("demo-server: disconnected\nretrying")},
+		"unknown":                  {Stdout: []byte("demo-server: enabled")},
 	} {
 		t.Run(name, func(t *testing.T) {
 			runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult { return listed }}
@@ -324,6 +352,55 @@ func TestKiroUnknownStatusContractRemainsManual(t *testing.T) {
 			}
 			if outcome.ActivationAttested || len(runner.commands) != 1 || len(outcome.LocalActions) == 0 {
 				t.Fatalf("unknown output path is not actionable: outcome=%+v commands=%+v", outcome, runner.commands)
+			}
+		})
+	}
+}
+
+func TestKiroStatusParserAcceptsOnlyExactRequestedIdentityShapes(t *testing.T) {
+	t.Parallel()
+	for name, test := range map[string]struct {
+		body string
+		want kiroStatus
+	}{
+		"one line healthy":  {"demo: connected\n", kiroStatusHealthy},
+		"two line healthy":  {"Name: demo\nStatus: connected\n", kiroStatusHealthy},
+		"one line negative": {"demo: disabled\n", kiroStatusUnhealthy},
+		"two line negative": {"Name: demo\nStatus: auth required\n", kiroStatusUnhealthy},
+		"other negative":    {"other: disconnected\n", kiroStatusUnknown},
+		"extra warning":     {"warning\ndemo: disconnected\n", kiroStatusUnknown},
+		"extra suffix":      {"demo: disconnected now\n", kiroStatusUnknown},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := kiroMCPStatus([]byte(test.body), "demo"); got != test.want {
+				t.Fatalf("status = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestUnknownObservableVerificationRequiresAndRecordsExplicitAttestation(t *testing.T) {
+	t.Parallel()
+	for _, client := range []domain.ClientID{domain.ClientCodex, domain.ClientCopilot, domain.ClientVSCode, domain.ClientKiro} {
+		t.Run(string(client), func(t *testing.T) {
+			request := activationRequest(t, client)
+			request.VerifyOnly = true
+			request.ActivationComplete = true
+			request.BackendExecutable = "/test/bin/" + string(client)
+			if client == domain.ClientVSCode {
+				request.BackendExecutable = "/test/bin/copilot"
+			}
+			if client == domain.ClientKiro {
+				request.BackendExecutable = "/test/bin/kiro-cli"
+				request.Plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "demo", Support: domain.SupportNative}}
+			}
+			runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult { return legacyports.CommandResult{} }}
+			outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
+			if err != nil || outcome.Activation != domain.ActivationActive || outcome.Verification != domain.VerificationInstalled || !outcome.ActivationAttested {
+				t.Fatalf("outcome=%+v err=%v", outcome, err)
+			}
+			if len(runner.commands) != 1 {
+				t.Fatalf("verifier calls = %d", len(runner.commands))
 			}
 		})
 	}

--- a/install/integrationctl/agentplugins/providers/activator_test.go
+++ b/install/integrationctl/agentplugins/providers/activator_test.go
@@ -23,6 +23,9 @@ func (runner *recordingRunner) Run(_ context.Context, command legacyports.Comman
 	if runner.run != nil {
 		return runner.run(command), nil
 	}
+	if strings.HasSuffix(strings.Join(command.Argv, " "), "plugin list") {
+		return legacyports.CommandResult{Stdout: []byte("demo")}, nil
+	}
 	return legacyports.CommandResult{}, nil
 }
 
@@ -45,6 +48,7 @@ func TestActivatorInstallsCopilotAndVSCodeThroughManagedMarketplace(t *testing.T
 			want := [][]string{
 				{"/test/bin/copilot", "plugin", "marketplace", "add", request.Delivery.ActivePath},
 				{"/test/bin/copilot", "plugin", "install", "demo@" + marketplace},
+				{"/test/bin/copilot", "plugin", "list"},
 			}
 			if got := commandArgv(runner.commands); !reflect.DeepEqual(got, want) {
 				t.Fatalf("commands = %#v, want %#v", got, want)
@@ -59,6 +63,9 @@ func TestActivatorUpdateRecoversMissingMarketplaceAndPlugin(t *testing.T) {
 		joined := strings.Join(command.Argv, " ")
 		if strings.Contains(joined, "marketplace update") || strings.Contains(joined, "plugin update") {
 			return legacyports.CommandResult{ExitCode: 1, Stderr: []byte("missing")}
+		}
+		if strings.HasSuffix(joined, "plugin list") {
+			return legacyports.CommandResult{Stdout: []byte("demo")}
 		}
 		return legacyports.CommandResult{}
 	}}
@@ -78,9 +85,93 @@ func TestActivatorUpdateRecoversMissingMarketplaceAndPlugin(t *testing.T) {
 		{"/test/bin/copilot", "plugin", "marketplace", "add", request.Delivery.ActivePath},
 		{"/test/bin/copilot", "plugin", "update", "demo@" + marketplace},
 		{"/test/bin/copilot", "plugin", "install", "demo@" + marketplace},
+		{"/test/bin/copilot", "plugin", "list"},
 	}
 	if got := commandArgv(runner.commands); !reflect.DeepEqual(got, want) {
 		t.Fatalf("commands = %#v, want %#v", got, want)
+	}
+}
+
+func TestActivatorDoesNotTrustCopilotInstallExitZeroWithoutListingEvidence(t *testing.T) {
+	t.Parallel()
+	runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult { return legacyports.CommandResult{} }}
+	request := activationRequest(t, domain.ClientCopilot)
+	request.BackendExecutable = "/test/bin/copilot"
+	outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
+	if err == nil || !strings.Contains(err.Error(), "not listed") {
+		t.Fatalf("verification error = %v", err)
+	}
+	if outcome.Activation != domain.ActivationFailed || outcome.Verification != domain.VerificationFailed || len(outcome.LocalActions) != 1 {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+}
+
+func TestActivatorUsesCodexCLIAndVerifiesJSONState(t *testing.T) {
+	t.Parallel()
+	runner := &recordingRunner{run: func(command legacyports.Command) legacyports.CommandResult {
+		if strings.Contains(strings.Join(command.Argv, " "), "plugin list --json") {
+			return legacyports.CommandResult{Stdout: []byte(`{"plugins":[{"name":"demo"}]}`)}
+		}
+		return legacyports.CommandResult{}
+	}}
+	request := activationRequest(t, domain.ClientCodex)
+	request.BackendExecutable = "/test/bin/codex"
+	outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.Activation != domain.ActivationActive || outcome.Verification != domain.VerificationInstalled {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+	marketplace := managedMarketplaceName(request.Plan.PhysicalArtifactID)
+	want := [][]string{
+		{"/test/bin/codex", "plugin", "marketplace", "add", request.Delivery.ActivePath, "--json"},
+		{"/test/bin/codex", "plugin", "add", "demo@" + marketplace, "--json"},
+		{"/test/bin/codex", "plugin", "list", "--json"},
+	}
+	if got := commandArgv(runner.commands); !reflect.DeepEqual(got, want) {
+		t.Fatalf("commands = %#v, want %#v", got, want)
+	}
+}
+
+func TestActivatorImportsMCPOnlyPackageThroughKiroCLIAndVerifiesListing(t *testing.T) {
+	t.Parallel()
+	runner := &recordingRunner{run: func(command legacyports.Command) legacyports.CommandResult {
+		if strings.Contains(strings.Join(command.Argv, " "), "mcp list global") {
+			return legacyports.CommandResult{Stdout: []byte("demo-server enabled")}
+		}
+		return legacyports.CommandResult{}
+	}}
+	request := activationRequest(t, domain.ClientKiro)
+	request.BackendExecutable = "/test/bin/kiro-cli"
+	request.Plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "demo-server", Support: domain.SupportNative}}
+	outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.Activation != domain.ActivationActive || outcome.Verification != domain.VerificationInstalled {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+	want := [][]string{
+		{"/test/bin/kiro-cli", "mcp", "import", "--file", filepath.Join(request.Delivery.ActivePath, "mcp.json"), "global", "--force"},
+		{"/test/bin/kiro-cli", "mcp", "list", "global"},
+	}
+	if got := commandArgv(runner.commands); !reflect.DeepEqual(got, want) {
+		t.Fatalf("commands = %#v, want %#v", got, want)
+	}
+}
+
+func TestActivatorKeepsKiroUIComponentsToOneActionableManualStep(t *testing.T) {
+	t.Parallel()
+	request := activationRequest(t, domain.ClientKiro)
+	request.BackendExecutable = "/test/bin/kiro-cli"
+	request.Plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentSkill, Name: "guide", Support: domain.SupportNative}}
+	outcome, err := (Activator{Runner: &recordingRunner{}}).Activate(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.Activation != domain.ActivationManual || len(outcome.LocalActions) != 1 || !strings.Contains(outcome.LocalActions[0], request.Delivery.ActivePath) || !strings.Contains(outcome.LocalActions[0], "verify") {
+		t.Fatalf("outcome = %+v", outcome)
 	}
 }
 

--- a/install/integrationctl/agentplugins/providers/activator_test.go
+++ b/install/integrationctl/agentplugins/providers/activator_test.go
@@ -28,7 +28,7 @@ func (runner *recordingRunner) Run(_ context.Context, command legacyports.Comman
 		for index := len(runner.commands) - 2; index >= 0; index-- {
 			argv := runner.commands[index].Argv
 			if len(argv) >= 4 && argv[1] == "plugin" && argv[2] == "install" {
-				return legacyports.CommandResult{Stdout: []byte("• " + argv[3] + " (v1.0.0)")}, nil
+				return legacyports.CommandResult{Stdout: []byte("Installed plugins:\n  • " + argv[3] + " (v1.0.0)")}, nil
 			}
 		}
 	}
@@ -71,7 +71,7 @@ func TestActivatorUpdateRecoversMissingMarketplaceAndPlugin(t *testing.T) {
 			return legacyports.CommandResult{ExitCode: 1, Stderr: []byte("missing")}
 		}
 		if strings.HasSuffix(joined, "plugin list") {
-			return legacyports.CommandResult{Stdout: []byte("• demo@agentplugins-8f97b00da374 (v1.0.0)")}
+			return legacyports.CommandResult{Stdout: []byte("Installed plugins:\n  • demo@agentplugins-8f97b00da374 (v1.0.0)")}
 		}
 		return legacyports.CommandResult{}
 	}}
@@ -147,10 +147,21 @@ func TestCodexVerificationRequiresExactEnabledManagedEntry(t *testing.T) {
 	request.VerifyOnly = true
 	marketplace := managedMarketplaceName(request.Plan.PhysicalArtifactID)
 	cases := map[string]string{
-		"old shape":         `{"plugins":[{"name":"demo"}]}`,
-		"disabled":          fmt.Sprintf(`{"installed":[{"name":"demo","marketplaceName":%q,"installed":true,"enabled":false}]}`, marketplace),
-		"wrong marketplace": `{"installed":[{"name":"demo","marketplaceName":"other","installed":true,"enabled":true}]}`,
-		"unrelated":         fmt.Sprintf(`{"installed":[{"name":"demo-extra","marketplaceName":%q,"installed":true,"enabled":true}]}`, marketplace),
+		"malformed":             `{`,
+		"old shape":             `{"plugins":[{"name":"demo"}]}`,
+		"error only":            `{"error":"not authenticated"}`,
+		"missing plugin id":     fmt.Sprintf(`{"installed":[{"name":"demo","marketplaceName":%q,"installed":true,"enabled":true}]}`, marketplace),
+		"wrong plugin id":       fmt.Sprintf(`{"installed":[{"pluginId":"demo@other","name":"demo","marketplaceName":%q,"installed":true,"enabled":true}]}`, marketplace),
+		"missing name":          fmt.Sprintf(`{"installed":[{"pluginId":"demo@%s","marketplaceName":%q,"installed":true,"enabled":true}]}`, marketplace, marketplace),
+		"missing marketplace":   fmt.Sprintf(`{"installed":[{"pluginId":"demo@%s","name":"demo","installed":true,"enabled":true}]}`, marketplace),
+		"missing installed":     fmt.Sprintf(`{"installed":[{"pluginId":"demo@%s","name":"demo","marketplaceName":%q,"enabled":true}]}`, marketplace, marketplace),
+		"missing enabled":       fmt.Sprintf(`{"installed":[{"pluginId":"demo@%s","name":"demo","marketplaceName":%q,"installed":true}]}`, marketplace, marketplace),
+		"not installed":         fmt.Sprintf(`{"installed":[{"pluginId":"demo@%s","name":"demo","marketplaceName":%q,"installed":false,"enabled":true}]}`, marketplace, marketplace),
+		"disabled":              fmt.Sprintf(`{"installed":[{"pluginId":"demo@%s","name":"demo","marketplaceName":%q,"installed":true,"enabled":false}]}`, marketplace, marketplace),
+		"wrong marketplace":     `{"installed":[{"pluginId":"demo@other","name":"demo","marketplaceName":"other","installed":true,"enabled":true}]}`,
+		"unrelated":             fmt.Sprintf(`{"installed":[{"pluginId":"demo-extra@%s","name":"demo-extra","marketplaceName":%q,"installed":true,"enabled":true}]}`, marketplace, marketplace),
+		"duplicate exact":       fmt.Sprintf(`{"installed":[{"pluginId":"demo@%s","name":"demo","marketplaceName":%q,"installed":true,"enabled":true},{"pluginId":"demo@%s","name":"demo","marketplaceName":%q,"installed":true,"enabled":true}]}`, marketplace, marketplace, marketplace, marketplace),
+		"duplicate conflicting": fmt.Sprintf(`{"installed":[{"pluginId":"demo@%s","name":"demo","marketplaceName":%q,"installed":true,"enabled":true},{"pluginId":"demo@%s","name":"wrong","marketplaceName":%q,"installed":true,"enabled":true}]}`, marketplace, marketplace, marketplace, marketplace),
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -170,18 +181,26 @@ func TestCopilotVerificationUsesOnlyExactHealthyStdoutToken(t *testing.T) {
 	request.BackendExecutable = "/test/bin/copilot"
 	request.VerifyOnly = true
 	spec := "demo@" + managedMarketplaceName(request.Plan.PhysicalArtifactID)
-	cases := []legacyports.CommandResult{
-		{Stdout: []byte("• demo (v1)")},
-		{Stderr: []byte("• " + spec + " (v1)")},
-		{Stdout: []byte("• " + spec + " disabled")},
-		{Stdout: []byte("error: " + spec)},
-		{Stdout: []byte("• demo-extra@" + managedMarketplaceName(request.Plan.PhysicalArtifactID) + " (v1)")},
+	cases := map[string]legacyports.CommandResult{
+		"bare name":       {Stdout: []byte("Installed plugins:\n  • demo (v1.0.0)")},
+		"stderr only":     {Stderr: []byte("Installed plugins:\n  • " + spec + " (v1.0.0)")},
+		"outside section": {Stdout: []byte("• " + spec + " (v1.0.0)")},
+		"pending":         {Stdout: []byte("Installed plugins:\n  • " + spec + " pending")},
+		"disconnected":    {Stdout: []byte("Installed plugins:\n  • " + spec + " disconnected")},
+		"disabled":        {Stdout: []byte("Installed plugins:\n  • " + spec + " disabled")},
+		"auth required":   {Stdout: []byte("Installed plugins:\n  • " + spec + " auth-required")},
+		"error":           {Stdout: []byte("Installed plugins:\n  error: " + spec)},
+		"unrelated":       {Stdout: []byte("Installed plugins:\n  • demo-extra@" + managedMarketplaceName(request.Plan.PhysicalArtifactID) + " (v1.0.0)")},
+		"bad version":     {Stdout: []byte("Installed plugins:\n  • " + spec + " (latest)")},
+		"duplicate":       {Stdout: []byte("Installed plugins:\n  • " + spec + " (v1.0.0)\n  • " + spec + " (v1.0.0)")},
 	}
-	for _, listed := range cases {
-		runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult { return listed }}
-		if _, err := (Activator{Runner: runner}).Activate(context.Background(), request); err == nil {
-			t.Fatalf("untrusted Copilot listing was accepted: %+v", listed)
-		}
+	for name, listed := range cases {
+		t.Run(name, func(t *testing.T) {
+			runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult { return listed }}
+			if _, err := (Activator{Runner: runner}).Activate(context.Background(), request); err == nil {
+				t.Fatalf("untrusted Copilot listing was accepted: %+v", listed)
+			}
+		})
 	}
 }
 
@@ -191,14 +210,92 @@ func TestKiroVerificationUsesExactHealthyStdoutIdentity(t *testing.T) {
 	request.BackendExecutable = "/test/bin/kiro-cli"
 	request.VerifyOnly = true
 	request.Plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "demo-server", Support: domain.SupportNative}}
-	for _, listed := range []legacyports.CommandResult{
-		{Stderr: []byte("demo-server enabled")}, {Stdout: []byte("demo-server disabled")},
-		{Stdout: []byte("demo-server error")}, {Stdout: []byte("demo-server-other enabled")},
+	for name, listed := range map[string]legacyports.CommandResult{
+		"pending":       {Stdout: []byte("demo-server: pending")},
+		"disconnected":  {Stdout: []byte("demo-server: disconnected")},
+		"disabled":      {Stdout: []byte("demo-server: disabled")},
+		"auth required": {Stdout: []byte("demo-server: auth-required")},
+		"error":         {Stdout: []byte("demo-server: error")},
+		"failed":        {Stdout: []byte("demo-server: failed")},
 	} {
-		runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult { return listed }}
-		if _, err := (Activator{Runner: runner}).Activate(context.Background(), request); err == nil {
-			t.Fatalf("untrusted Kiro listing was accepted: %+v", listed)
-		}
+		t.Run(name, func(t *testing.T) {
+			runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult { return listed }}
+			outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
+			if err == nil || outcome.Activation != domain.ActivationFailed {
+				t.Fatalf("untrusted Kiro status was accepted: outcome=%+v err=%v", outcome, err)
+			}
+		})
+	}
+}
+
+func TestKiroUnknownStatusContractRemainsManual(t *testing.T) {
+	t.Parallel()
+	request := activationRequest(t, domain.ClientKiro)
+	request.BackendExecutable = "/test/bin/kiro-cli"
+	request.VerifyOnly = true
+	request.Plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "demo-server", Support: domain.SupportNative}}
+	for name, listed := range map[string]legacyports.CommandResult{
+		"stderr only": {Stderr: []byte("demo-server: connected")},
+		"unrelated":   {Stdout: []byte("demo-server-other: connected")},
+		"unknown":     {Stdout: []byte("demo-server: enabled")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			outcome, err := (Activator{Runner: &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult { return listed }}}).Activate(context.Background(), request)
+			if err != nil || outcome.Activation != domain.ActivationManual || outcome.Verification != domain.VerificationPackageValid {
+				t.Fatalf("outcome=%+v err=%v", outcome, err)
+			}
+		})
+	}
+}
+
+func TestVerifyOnlyRunsOnlyReadOnlyClientCommands(t *testing.T) {
+	t.Parallel()
+	for _, client := range []domain.ClientID{domain.ClientCodex, domain.ClientCopilot, domain.ClientKiro} {
+		client := client
+		t.Run(string(client), func(t *testing.T) {
+			request := activationRequest(t, client)
+			request.VerifyOnly = true
+			runner := &recordingRunner{}
+			var want [][]string
+			switch client {
+			case domain.ClientCodex:
+				request.BackendExecutable = "/test/bin/codex"
+				marketplace := managedMarketplaceName(request.Plan.PhysicalArtifactID)
+				runner.run = func(legacyports.Command) legacyports.CommandResult {
+					return legacyports.CommandResult{Stdout: []byte(fmt.Sprintf(`{"installed":[{"pluginId":"demo@%s","name":"demo","marketplaceName":%q,"installed":true,"enabled":true}]}`, marketplace, marketplace))}
+				}
+				want = [][]string{{"/test/bin/codex", "plugin", "list", "--json"}}
+			case domain.ClientCopilot:
+				request.BackendExecutable = "/test/bin/copilot"
+				spec := "demo@" + managedMarketplaceName(request.Plan.PhysicalArtifactID)
+				runner.run = func(legacyports.Command) legacyports.CommandResult {
+					return legacyports.CommandResult{Stdout: []byte("Installed plugins:\n  • " + spec + " (v1.0.0)")}
+				}
+				want = [][]string{{"/test/bin/copilot", "plugin", "list"}}
+			case domain.ClientKiro:
+				request.BackendExecutable = "/test/bin/kiro-cli"
+				request.Plan.Components = []domain.ComponentDecision{
+					{Kind: domain.ComponentMCPServer, Name: "alpha", Support: domain.SupportNative},
+					{Kind: domain.ComponentMCPServer, Name: "beta", Support: domain.SupportNative},
+				}
+				runner.run = func(command legacyports.Command) legacyports.CommandResult {
+					name := command.Argv[len(command.Argv)-1]
+					return legacyports.CommandResult{Stdout: []byte(name + ": connected")}
+				}
+				want = [][]string{
+					{"/test/bin/kiro-cli", "mcp", "status", "--name", "alpha"},
+					{"/test/bin/kiro-cli", "mcp", "status", "--name", "beta"},
+				}
+			}
+
+			outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
+			if err != nil || outcome.Activation != domain.ActivationActive {
+				t.Fatalf("outcome=%+v err=%v", outcome, err)
+			}
+			if got := commandArgv(runner.commands); !reflect.DeepEqual(got, want) {
+				t.Fatalf("commands = %#v, want %#v", got, want)
+			}
+		})
 	}
 }
 
@@ -215,11 +312,11 @@ func TestClientListingDoesNotConvertUnknownAuthentication(t *testing.T) {
 	}
 }
 
-func TestActivatorImportsMCPOnlyPackageThroughKiroCLIAndVerifiesListing(t *testing.T) {
+func TestActivatorImportsMCPOnlyPackageThroughKiroCLIAndVerifiesEachStatus(t *testing.T) {
 	t.Parallel()
 	runner := &recordingRunner{run: func(command legacyports.Command) legacyports.CommandResult {
-		if strings.Contains(strings.Join(command.Argv, " "), "mcp list global") {
-			return legacyports.CommandResult{Stdout: []byte("demo-server enabled")}
+		if strings.Contains(strings.Join(command.Argv, " "), "mcp status --name demo-server") {
+			return legacyports.CommandResult{Stdout: []byte("Name: demo-server\nStatus: connected")}
 		}
 		return legacyports.CommandResult{}
 	}}
@@ -235,7 +332,7 @@ func TestActivatorImportsMCPOnlyPackageThroughKiroCLIAndVerifiesListing(t *testi
 	}
 	want := [][]string{
 		{"/test/bin/kiro-cli", "mcp", "import", "--file", filepath.Join(request.Delivery.ActivePath, "mcp.json"), "global", "--force"},
-		{"/test/bin/kiro-cli", "mcp", "list", "global"},
+		{"/test/bin/kiro-cli", "mcp", "status", "--name", "demo-server"},
 	}
 	if got := commandArgv(runner.commands); !reflect.DeepEqual(got, want) {
 		t.Fatalf("commands = %#v, want %#v", got, want)

--- a/install/integrationctl/agentplugins/providers/activator_test.go
+++ b/install/integrationctl/agentplugins/providers/activator_test.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -24,7 +25,12 @@ func (runner *recordingRunner) Run(_ context.Context, command legacyports.Comman
 		return runner.run(command), nil
 	}
 	if strings.HasSuffix(strings.Join(command.Argv, " "), "plugin list") {
-		return legacyports.CommandResult{Stdout: []byte("demo")}, nil
+		for index := len(runner.commands) - 2; index >= 0; index-- {
+			argv := runner.commands[index].Argv
+			if len(argv) >= 4 && argv[1] == "plugin" && argv[2] == "install" {
+				return legacyports.CommandResult{Stdout: []byte("• " + argv[3] + " (v1.0.0)")}, nil
+			}
+		}
 	}
 	return legacyports.CommandResult{}, nil
 }
@@ -65,7 +71,7 @@ func TestActivatorUpdateRecoversMissingMarketplaceAndPlugin(t *testing.T) {
 			return legacyports.CommandResult{ExitCode: 1, Stderr: []byte("missing")}
 		}
 		if strings.HasSuffix(joined, "plugin list") {
-			return legacyports.CommandResult{Stdout: []byte("demo")}
+			return legacyports.CommandResult{Stdout: []byte("• demo@agentplugins-8f97b00da374 (v1.0.0)")}
 		}
 		return legacyports.CommandResult{}
 	}}
@@ -110,7 +116,7 @@ func TestActivatorUsesCodexCLIAndVerifiesJSONState(t *testing.T) {
 	t.Parallel()
 	runner := &recordingRunner{run: func(command legacyports.Command) legacyports.CommandResult {
 		if strings.Contains(strings.Join(command.Argv, " "), "plugin list --json") {
-			return legacyports.CommandResult{Stdout: []byte(`{"plugins":[{"name":"demo"}]}`)}
+			return legacyports.CommandResult{Stdout: []byte(`{"installed":[{"pluginId":"demo@agentplugins-8f97b00da374","name":"demo","marketplaceName":"agentplugins-8f97b00da374","installed":true,"enabled":true}],"available":[]}`)}
 		}
 		return legacyports.CommandResult{}
 	}}
@@ -131,6 +137,81 @@ func TestActivatorUsesCodexCLIAndVerifiesJSONState(t *testing.T) {
 	}
 	if got := commandArgv(runner.commands); !reflect.DeepEqual(got, want) {
 		t.Fatalf("commands = %#v, want %#v", got, want)
+	}
+}
+
+func TestCodexVerificationRequiresExactEnabledManagedEntry(t *testing.T) {
+	t.Parallel()
+	request := activationRequest(t, domain.ClientCodex)
+	request.BackendExecutable = "/test/bin/codex"
+	request.VerifyOnly = true
+	marketplace := managedMarketplaceName(request.Plan.PhysicalArtifactID)
+	cases := map[string]string{
+		"old shape":         `{"plugins":[{"name":"demo"}]}`,
+		"disabled":          fmt.Sprintf(`{"installed":[{"name":"demo","marketplaceName":%q,"installed":true,"enabled":false}]}`, marketplace),
+		"wrong marketplace": `{"installed":[{"name":"demo","marketplaceName":"other","installed":true,"enabled":true}]}`,
+		"unrelated":         fmt.Sprintf(`{"installed":[{"name":"demo-extra","marketplaceName":%q,"installed":true,"enabled":true}]}`, marketplace),
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult {
+				return legacyports.CommandResult{Stdout: []byte(body)}
+			}}
+			if _, err := (Activator{Runner: runner}).Activate(context.Background(), request); err == nil {
+				t.Fatal("untrusted Codex listing was accepted")
+			}
+		})
+	}
+}
+
+func TestCopilotVerificationUsesOnlyExactHealthyStdoutToken(t *testing.T) {
+	t.Parallel()
+	request := activationRequest(t, domain.ClientCopilot)
+	request.BackendExecutable = "/test/bin/copilot"
+	request.VerifyOnly = true
+	spec := "demo@" + managedMarketplaceName(request.Plan.PhysicalArtifactID)
+	cases := []legacyports.CommandResult{
+		{Stdout: []byte("• demo (v1)")},
+		{Stderr: []byte("• " + spec + " (v1)")},
+		{Stdout: []byte("• " + spec + " disabled")},
+		{Stdout: []byte("error: " + spec)},
+		{Stdout: []byte("• demo-extra@" + managedMarketplaceName(request.Plan.PhysicalArtifactID) + " (v1)")},
+	}
+	for _, listed := range cases {
+		runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult { return listed }}
+		if _, err := (Activator{Runner: runner}).Activate(context.Background(), request); err == nil {
+			t.Fatalf("untrusted Copilot listing was accepted: %+v", listed)
+		}
+	}
+}
+
+func TestKiroVerificationUsesExactHealthyStdoutIdentity(t *testing.T) {
+	t.Parallel()
+	request := activationRequest(t, domain.ClientKiro)
+	request.BackendExecutable = "/test/bin/kiro-cli"
+	request.VerifyOnly = true
+	request.Plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "demo-server", Support: domain.SupportNative}}
+	for _, listed := range []legacyports.CommandResult{
+		{Stderr: []byte("demo-server enabled")}, {Stdout: []byte("demo-server disabled")},
+		{Stdout: []byte("demo-server error")}, {Stdout: []byte("demo-server-other enabled")},
+	} {
+		runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult { return listed }}
+		if _, err := (Activator{Runner: runner}).Activate(context.Background(), request); err == nil {
+			t.Fatalf("untrusted Kiro listing was accepted: %+v", listed)
+		}
+	}
+}
+
+func TestClientListingDoesNotConvertUnknownAuthentication(t *testing.T) {
+	t.Parallel()
+	request := activationRequest(t, domain.ClientCopilot)
+	request.BackendExecutable = "/test/bin/copilot"
+	outcome, err := (Activator{Runner: &recordingRunner{}}).Activate(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.Authentication != domain.AuthenticationNotChecked {
+		t.Fatalf("authentication = %s", outcome.Authentication)
 	}
 }
 

--- a/install/integrationctl/agentplugins/providers/stager.go
+++ b/install/integrationctl/agentplugins/providers/stager.go
@@ -41,7 +41,10 @@ func (stager Stager) Verify(ctx context.Context, root, expectedDigest string) er
 	}
 	if err := rejectExcludedOwnershipMarkers(root); err != nil {
 		kind := ports.VerificationIndeterminate
-		if errors.Is(err, os.ErrNotExist) {
+		var marker *excludedOwnershipMarkerError
+		if errors.As(err, &marker) {
+			kind = ports.VerificationExcludedMarker
+		} else if errors.Is(err, os.ErrNotExist) {
 			kind = ports.VerificationAbsent
 		}
 		return &ports.VerificationError{Kind: kind, Err: err}
@@ -64,6 +67,12 @@ func (stager Stager) Verify(ctx context.Context, root, expectedDigest string) er
 	return nil
 }
 
+type excludedOwnershipMarkerError struct{ name string }
+
+func (err *excludedOwnershipMarkerError) Error() string {
+	return fmt.Sprintf("managed artifact contains excluded ownership marker %q", err.name)
+}
+
 func rejectExcludedOwnershipMarkers(root string) error {
 	return filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -73,7 +82,7 @@ func rejectExcludedOwnershipMarkers(root string) error {
 			return nil
 		}
 		if entry.Name() == ".git" || entry.Name() == ".plugin-kit-ai.lock" {
-			return fmt.Errorf("managed artifact contains excluded ownership marker %q", entry.Name())
+			return &excludedOwnershipMarkerError{name: entry.Name()}
 		}
 		return nil
 	})

--- a/install/integrationctl/agentplugins/providers/stager.go
+++ b/install/integrationctl/agentplugins/providers/stager.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,6 +16,7 @@ import (
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/filetree"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/pathpolicy"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/ports"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/packagesnapshot"
 )
 
@@ -38,18 +40,26 @@ func (stager Stager) Verify(ctx context.Context, root, expectedDigest string) er
 		return fmt.Errorf("expected artifact digest is required")
 	}
 	if err := rejectExcludedOwnershipMarkers(root); err != nil {
-		return err
+		kind := ports.VerificationIndeterminate
+		if errors.Is(err, os.ErrNotExist) {
+			kind = ports.VerificationAbsent
+		}
+		return &ports.VerificationError{Kind: kind, Err: err}
 	}
 	artifact, err := stager.SnapshotBuilder.Build(ctx, root)
 	if err != nil {
-		return err
+		kind := ports.VerificationIndeterminate
+		if errors.Is(err, os.ErrNotExist) {
+			kind = ports.VerificationAbsent
+		}
+		return &ports.VerificationError{Kind: kind, Err: err}
 	}
 	digest := artifact.Digest
 	if closeErr := artifact.Close(); closeErr != nil {
-		return closeErr
+		return &ports.VerificationError{Kind: ports.VerificationIndeterminate, Err: closeErr}
 	}
 	if digest != expectedDigest {
-		return fmt.Errorf("artifact digest mismatch")
+		return &ports.VerificationError{Kind: ports.VerificationDigestMismatch, ActualDigest: digest, Err: fmt.Errorf("artifact digest mismatch")}
 	}
 	return nil
 }

--- a/install/integrationctl/agentplugins/usecase/binding.go
+++ b/install/integrationctl/agentplugins/usecase/binding.go
@@ -142,11 +142,8 @@ func (service Service) changeBinding(ctx context.Context, input BindingChangeInp
 	}
 	installation.Package = domain.PackageBinding{
 		LoaderKind: input.Envelope.LoaderKind, FormatID: input.Envelope.FormatID,
-		SchemaURI: input.Envelope.SchemaURI, SchemaVersion: input.Envelope.SchemaVersion,
-		ManifestSchema: schemaIdentity(input.Envelope), ManifestDocument: manifestDocument(input.Envelope),
-		CatalogEvidence: input.Envelope.CatalogEvidence, Diagnostics: append([]domain.Diagnostic(nil), input.Envelope.Diagnostics...),
-		DeclaredName: input.Envelope.Manifest.Name,
-		Version:      input.Envelope.Manifest.Version, ManifestDigest: input.Envelope.ManifestDigest,
+		SchemaURI: input.Envelope.SchemaURI, DeclaredName: input.Envelope.Manifest.Name,
+		Version: input.Envelope.Manifest.Version, ManifestDigest: input.Envelope.ManifestDigest,
 		Inventory: input.Envelope.Inventory,
 	}
 	installation.NeedsRebind = false

--- a/install/integrationctl/agentplugins/usecase/binding.go
+++ b/install/integrationctl/agentplugins/usecase/binding.go
@@ -142,8 +142,11 @@ func (service Service) changeBinding(ctx context.Context, input BindingChangeInp
 	}
 	installation.Package = domain.PackageBinding{
 		LoaderKind: input.Envelope.LoaderKind, FormatID: input.Envelope.FormatID,
-		SchemaURI: input.Envelope.SchemaURI, DeclaredName: input.Envelope.Manifest.Name,
-		Version: input.Envelope.Manifest.Version, ManifestDigest: input.Envelope.ManifestDigest,
+		SchemaURI: input.Envelope.SchemaURI, SchemaVersion: input.Envelope.SchemaVersion,
+		ManifestSchema: schemaIdentity(input.Envelope), ManifestDocument: manifestDocument(input.Envelope),
+		CatalogEvidence: input.Envelope.CatalogEvidence, Diagnostics: append([]domain.Diagnostic(nil), input.Envelope.Diagnostics...),
+		DeclaredName: input.Envelope.Manifest.Name,
+		Version:      input.Envelope.Manifest.Version, ManifestDigest: input.Envelope.ManifestDigest,
 		Inventory: input.Envelope.Inventory,
 	}
 	installation.NeedsRebind = false

--- a/install/integrationctl/agentplugins/usecase/repair.go
+++ b/install/integrationctl/agentplugins/usecase/repair.go
@@ -44,12 +44,19 @@ func (service Service) Repair(ctx context.Context, input AddInput) (AddResult, e
 	result := AddResult{InstallationID: installation.InstallationID, Plan: plan}
 	clientKey := domain.ComputeClientBindingID(installation.InstallationID, string(input.Client.ClientID), string(input.Scope), plan.ActivePath)
 	client, ok := installation.Clients[clientKey]
-	if !ok || client.Materialization != domain.MaterializationMaterialized {
+	if !ok || (client.Materialization != domain.MaterializationMaterialized && client.Materialization != domain.MaterializationDegraded) {
 		return result, fmt.Errorf("plugin is not materialized for %s", input.Client.ClientID)
+	}
+	if client.ClientBindingID != clientKey || client.ClientID != string(input.Client.ClientID) ||
+		client.Scope != string(input.Scope) || client.PhysicalArtifact != physicalID {
+		return result, fmt.Errorf("managed repair target identity does not match the selected binding")
 	}
 	result.Activation = lifecycleOutcome(client)
 	if !packageRevisionMatches(client.PackageRevision, input.Envelope) {
 		return result, fmt.Errorf("resolved repair package differs from the installed revision; use update")
+	}
+	if client.PackageRevision == nil || strings.TrimSpace(client.PackageRevision.ResolvedRevision) != strings.TrimSpace(input.Envelope.Source.ResolvedRevision) {
+		return result, fmt.Errorf("resolved repair package does not match the exact installed revision")
 	}
 	target, err := service.Targets.ResolveTarget(ctx, input.Client, input.Scope, client.PhysicalArtifact)
 	if err != nil {
@@ -67,10 +74,43 @@ func (service Service) Repair(ctx context.Context, input AddInput) (AddResult, e
 		if verifyErr != nil {
 			return result, verifyErr
 		}
-		if verified.Activation == domain.ActivationActive && verified.Verification == domain.VerificationInstalled {
-			result.Activation = verified
+		corrected := client
+		corrected.Materialization = domain.MaterializationMaterialized
+		if corrected.Verification == domain.VerificationFailed {
+			corrected.Verification = domain.VerificationPackageValid
 		}
-		result.NoChange = true
+		if verified.Activation != "" {
+			corrected.Activation = verified.Activation
+		}
+		if verified.Authentication != "" {
+			corrected.Authentication = verified.Authentication
+		}
+		if verified.Policy != "" {
+			corrected.Policy = verified.Policy
+		}
+		if verified.Verification != "" {
+			corrected.Verification = verified.Verification
+		}
+		result.Activation = lifecycleOutcome(corrected)
+		if corrected.Materialization == client.Materialization && sameLifecycleOutcome(lifecycleOutcome(corrected), lifecycleOutcome(client)) {
+			result.NoChange = true
+			return result, nil
+		}
+		if input.DryRun {
+			return result, nil
+		}
+		if !input.Confirmed {
+			result.RequiresConfirmation = true
+			return result, nil
+		}
+		corrected.UpdatedAt = service.now().Format("2006-01-02T15:04:05.999999999Z07:00")
+		installation.Clients[clientKey] = corrected
+		installation.UpdatedAt = corrected.UpdatedAt
+		state.Installations[index] = installation
+		if err := service.StateStore.Save(state); err != nil {
+			return result, fmt.Errorf("persist corrected repair verification state: %w", err)
+		}
+		result.Mutated = true
 		return result, nil
 	}
 	if input.DryRun {
@@ -100,12 +140,21 @@ func (service Service) Repair(ctx context.Context, input AddInput) (AddResult, e
 	}
 	kernel := service.Kernel
 	kernel.StateStore = service.StateStore
+	verifiedState := lifecycleOutcome(client)
+	verifiedState.Verification = domain.VerificationPackageValid
+	desiredClient := client
+	desiredClient.Materialization = domain.MaterializationMaterialized
+	desiredClient.Verification = domain.VerificationPackageValid
+	desiredClient.UpdatedAt = service.now().Format("2006-01-02T15:04:05.999999999Z07:00")
+	installation.Clients[clientKey] = desiredClient
+	installation.UpdatedAt = desiredClient.UpdatedAt
+	state.Installations[index] = installation
 	receipt, err := kernel.ApplyDirectory(ctx, transaction.DirectoryMutation{
 		OperationID: operationID, InstallationID: installation.InstallationID, ClientBindingID: clientKey,
 		Sequence: nextSequence(client), OwnedBase: delivery.OwnedBase, ActivePath: target.ActivePath,
-		StagingPath: delivery.StagingPath, BeforeDigest: "", AfterDigest: delivery.ArtifactDigest,
-		NativeObjects: delivery.NativeObjects, Activation: client.Activation, Authentication: client.Authentication,
-		Policy: client.Policy, Verification: client.Verification, DesiredState: state,
+		StagingPath: delivery.StagingPath, BeforeDigest: expectedDigest, AfterDigest: delivery.ArtifactDigest,
+		NativeObjects: delivery.NativeObjects, Activation: verifiedState.Activation, Authentication: verifiedState.Authentication,
+		Policy: verifiedState.Policy, Verification: verifiedState.Verification, DesiredState: state,
 		Verify: func(verifyContext context.Context, activePath string) error {
 			return service.Stager.Verify(verifyContext, activePath, delivery.ArtifactDigest)
 		},
@@ -115,5 +164,11 @@ func (service Service) Repair(ctx context.Context, input AddInput) (AddResult, e
 		return result, err
 	}
 	result.Mutated = true
+	result.Activation = verifiedState
 	return result, nil
+}
+
+func sameLifecycleOutcome(left, right domain.ActivationOutcome) bool {
+	return left.Activation == right.Activation && left.Authentication == right.Authentication &&
+		left.Policy == right.Policy && left.Verification == right.Verification
 }

--- a/install/integrationctl/agentplugins/usecase/repair.go
+++ b/install/integrationctl/agentplugins/usecase/repair.go
@@ -2,11 +2,13 @@ package usecase
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/pathpolicy"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/ports"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/transaction"
 )
 
@@ -69,7 +71,8 @@ func (service Service) Repair(ctx context.Context, input AddInput) (AddResult, e
 	if expectedDigest == "" {
 		return result, fmt.Errorf("managed package digest is missing; refusing repair")
 	}
-	if verifyErr := service.Stager.Verify(ctx, target.ActivePath, expectedDigest); verifyErr == nil {
+	verifyErr := service.Stager.Verify(ctx, target.ActivePath, expectedDigest)
+	if verifyErr == nil {
 		verified, verifyErr := service.verifyClientReadOnly(ctx, input, result, client)
 		if verifyErr != nil {
 			return result, verifyErr
@@ -113,6 +116,17 @@ func (service Service) Repair(ctx context.Context, input AddInput) (AddResult, e
 		result.Mutated = true
 		return result, nil
 	}
+	var verification *ports.VerificationError
+	if !errors.As(verifyErr, &verification) || (verification.Kind != ports.VerificationAbsent && verification.Kind != ports.VerificationDigestMismatch) {
+		return result, fmt.Errorf("managed package integrity could not be determined; refusing repair: %w", verifyErr)
+	}
+	beforeDigest := ""
+	if verification.Kind == ports.VerificationDigestMismatch {
+		if strings.TrimSpace(verification.ActualDigest) == "" {
+			return result, fmt.Errorf("managed package verifier reported a digest mismatch without the actual digest; refusing repair")
+		}
+		beforeDigest = verification.ActualDigest
+	}
 	if input.DryRun {
 		return result, nil
 	}
@@ -152,7 +166,7 @@ func (service Service) Repair(ctx context.Context, input AddInput) (AddResult, e
 	receipt, err := kernel.ApplyDirectory(ctx, transaction.DirectoryMutation{
 		OperationID: operationID, InstallationID: installation.InstallationID, ClientBindingID: clientKey,
 		Sequence: nextSequence(client), OwnedBase: delivery.OwnedBase, ActivePath: target.ActivePath,
-		StagingPath: delivery.StagingPath, BeforeDigest: expectedDigest, AfterDigest: delivery.ArtifactDigest,
+		StagingPath: delivery.StagingPath, BeforeDigest: beforeDigest, AfterDigest: delivery.ArtifactDigest,
 		NativeObjects: delivery.NativeObjects, Activation: verifiedState.Activation, Authentication: verifiedState.Authentication,
 		Policy: verifiedState.Policy, Verification: verifiedState.Verification, DesiredState: state,
 		Verify: func(verifyContext context.Context, activePath string) error {

--- a/install/integrationctl/agentplugins/usecase/repair.go
+++ b/install/integrationctl/agentplugins/usecase/repair.go
@@ -1,0 +1,119 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/pathpolicy"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/transaction"
+)
+
+// Repair replaces a missing or modified managed directory from a freshly
+// resolved package. It never uses a persisted target until that target has
+// been matched to the target resolver's current safe result.
+func (service Service) Repair(ctx context.Context, input AddInput) (AddResult, error) {
+	if service.StateStore == nil || service.Planner == nil || service.Targets == nil || service.Stager == nil {
+		return AddResult{}, fmt.Errorf("agentplugins repair dependencies are incomplete")
+	}
+	release, err := service.beginMutation(ctx, input.DryRun, input.Confirmed)
+	if err != nil {
+		return AddResult{}, err
+	}
+	if release != nil {
+		defer func() { _ = release() }()
+	}
+	state, err := service.StateStore.Load()
+	if err != nil {
+		return AddResult{}, err
+	}
+	index, existing := findSourceInstallation(state, domain.ComputeSourceBindingID(input.Envelope.Source))
+	if !existing {
+		return AddResult{}, fmt.Errorf("resolved source is not bound to an installation")
+	}
+	installation := state.Installations[index]
+	if installation.InstallationID != input.InstallationID || installation.DeclaredName != input.Envelope.Manifest.Name {
+		return AddResult{}, fmt.Errorf("resolved repair source identity does not match the selected installation")
+	}
+	physicalID := domain.ComputePhysicalArtifactID(installation.DeclaredName, installation.InstallationID)
+	plan, err := service.Planner.Plan(ctx, input.Envelope, input.Client, input.Scope, physicalID)
+	if err != nil {
+		return AddResult{}, err
+	}
+	result := AddResult{InstallationID: installation.InstallationID, Plan: plan}
+	clientKey := domain.ComputeClientBindingID(installation.InstallationID, string(input.Client.ClientID), string(input.Scope), plan.ActivePath)
+	client, ok := installation.Clients[clientKey]
+	if !ok || client.Materialization != domain.MaterializationMaterialized {
+		return result, fmt.Errorf("plugin is not materialized for %s", input.Client.ClientID)
+	}
+	result.Activation = lifecycleOutcome(client)
+	if !packageRevisionMatches(client.PackageRevision, input.Envelope) {
+		return result, fmt.Errorf("resolved repair package differs from the installed revision; use update")
+	}
+	target, err := service.Targets.ResolveTarget(ctx, input.Client, input.Scope, client.PhysicalArtifact)
+	if err != nil {
+		return result, fmt.Errorf("resolve managed repair target: %w", err)
+	}
+	if err := pathpolicy.RequireExactPath(target.ActivePath, client.TargetLocator); err != nil {
+		return result, fmt.Errorf("refuse repair of untrusted persisted target: %w", err)
+	}
+	expectedDigest := managedDigest(client)
+	if expectedDigest == "" {
+		return result, fmt.Errorf("managed package digest is missing; refusing repair")
+	}
+	if verifyErr := service.Stager.Verify(ctx, target.ActivePath, expectedDigest); verifyErr == nil {
+		verified, verifyErr := service.verifyClientReadOnly(ctx, input, result, client)
+		if verifyErr != nil {
+			return result, verifyErr
+		}
+		if verified.Activation == domain.ActivationActive && verified.Verification == domain.VerificationInstalled {
+			result.Activation = verified
+		}
+		result.NoChange = true
+		return result, nil
+	}
+	if input.DryRun {
+		return result, nil
+	}
+	if !input.Confirmed {
+		result.RequiresConfirmation = true
+		return result, nil
+	}
+	operationID := strings.TrimSpace(input.OperationID)
+	if operationID == "" {
+		operationID, err = newOperationID()
+		if err != nil {
+			return result, err
+		}
+	}
+	delivery, err := service.Stager.Stage(ctx, input.Envelope, plan, operationID, input.Hints)
+	if err != nil {
+		return result, err
+	}
+	defer func() { _ = service.Stager.Discard(context.Background(), delivery) }()
+	if delivery.ActivePath != target.ActivePath {
+		return result, fmt.Errorf("stager returned an unexpected repair target")
+	}
+	if delivery.ArtifactDigest != expectedDigest {
+		return result, fmt.Errorf("resolved repair projection digest differs from the originally managed package")
+	}
+	kernel := service.Kernel
+	kernel.StateStore = service.StateStore
+	receipt, err := kernel.ApplyDirectory(ctx, transaction.DirectoryMutation{
+		OperationID: operationID, InstallationID: installation.InstallationID, ClientBindingID: clientKey,
+		Sequence: nextSequence(client), OwnedBase: delivery.OwnedBase, ActivePath: target.ActivePath,
+		StagingPath: delivery.StagingPath, BeforeDigest: "", AfterDigest: delivery.ArtifactDigest,
+		NativeObjects: delivery.NativeObjects, Activation: client.Activation, Authentication: client.Authentication,
+		Policy: client.Policy, Verification: client.Verification, DesiredState: state,
+		Verify: func(verifyContext context.Context, activePath string) error {
+			return service.Stager.Verify(verifyContext, activePath, delivery.ArtifactDigest)
+		},
+	})
+	result.Receipt = receipt
+	if err != nil {
+		return result, err
+	}
+	result.Mutated = true
+	return result, nil
+}

--- a/install/integrationctl/agentplugins/usecase/service.go
+++ b/install/integrationctl/agentplugins/usecase/service.go
@@ -132,6 +132,9 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 		}
 	}
 	isMaterialized := existing && materializedClient(state.Installations[installationIndex], clientBindingID)
+	if !isMaterialized && (input.ActivationComplete || input.AuthComplete) {
+		return result, fmt.Errorf("lifecycle completion flags require an already materialized package; run add first, then rerun add with the completion flags")
+	}
 	if isMaterialized && !replace {
 		current := state.Installations[installationIndex].Clients[clientBindingID]
 		result.Activation = lifecycleOutcome(current)
@@ -305,7 +308,7 @@ func (service Service) resume(
 		outcome.Activation = client.Activation
 		outcome.Verification = client.Verification
 	}
-	if client.Authentication == domain.AuthenticationPending && input.AuthComplete {
+	if (client.Authentication == domain.AuthenticationPending || client.Authentication == domain.AuthenticationNotChecked) && input.AuthComplete {
 		outcome.Authentication = domain.AuthenticationComplete
 		outcome.AuthenticationAttested = true
 	} else if client.Authentication != "" {

--- a/install/integrationctl/agentplugins/usecase/service.go
+++ b/install/integrationctl/agentplugins/usecase/service.go
@@ -31,16 +31,18 @@ type Service struct {
 }
 
 type AddInput struct {
-	Envelope          domain.PackageEnvelope
-	Client            domain.DetectedClient
-	Scope             domain.InstallScope
-	DryRun            bool
-	Confirmed         bool
-	Interactive       bool
-	Hints             domain.CompatibilityHints
-	InstallationID    string
-	OperationID       string
-	BackendExecutable string
+	Envelope           domain.PackageEnvelope
+	Client             domain.DetectedClient
+	Scope              domain.InstallScope
+	DryRun             bool
+	Confirmed          bool
+	Interactive        bool
+	Hints              domain.CompatibilityHints
+	InstallationID     string
+	OperationID        string
+	BackendExecutable  string
+	ActivationComplete bool
+	AuthComplete       bool
 }
 
 type AddResult struct {
@@ -109,7 +111,7 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 	if err != nil {
 		return AddResult{}, err
 	}
-	if hasOAuthRequirement(input.Envelope, input.Hints) {
+	if openAIOAuthApplies(input.Client.ClientID, input.Envelope, input.Hints) {
 		plan.Authentication = domain.AuthenticationPending
 	}
 	result := AddResult{InstallationID: installationID, Plan: plan}
@@ -133,10 +135,21 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 	isMaterialized := existing && materializedClient(state.Installations[installationIndex], clientBindingID)
 	if isMaterialized && !replace {
 		current := state.Installations[installationIndex].Clients[clientBindingID]
+		result.Activation = lifecycleOutcome(current)
 		if !packageRevisionMatches(current.PackageRevision, input.Envelope) {
 			return result, fmt.Errorf("plugin is already materialized for %s at a different revision; use update", input.Client.ClientID)
 		}
 		if lifecycleConverged(current) {
+			if err := service.verifyManagedTarget(ctx, input.Client, input.Scope, current, "no-change check"); err != nil {
+				return result, err
+			}
+			verified, verifyErr := service.verifyClientReadOnly(ctx, input, result, current)
+			if verifyErr != nil {
+				return result, verifyErr
+			}
+			if verified.Activation == domain.ActivationActive && verified.Verification == domain.VerificationInstalled {
+				result.Activation = verified
+			}
 			result.NoChange = true
 			return result, nil
 		}
@@ -148,12 +161,23 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 	if replace {
 		current := state.Installations[installationIndex]
 		previousClient := current.Clients[clientBindingID]
+		result.Activation = lifecycleOutcome(previousClient)
 		if err := service.verifyManagedTarget(ctx, input.Client, input.Scope, previousClient, "update"); err != nil {
 			return result, err
 		}
-		if packageRevisionMatches(previousClient.PackageRevision, input.Envelope) && lifecycleConverged(previousClient) {
-			result.NoChange = true
-			return result, nil
+		if packageRevisionMatches(previousClient.PackageRevision, input.Envelope) {
+			if lifecycleConverged(previousClient) {
+				verified, verifyErr := service.verifyClientReadOnly(ctx, input, result, previousClient)
+				if verifyErr != nil {
+					return result, verifyErr
+				}
+				if verified.Activation == domain.ActivationActive && verified.Verification == domain.VerificationInstalled {
+					result.Activation = verified
+				}
+				result.NoChange = true
+				return result, nil
+			}
+			return service.resume(ctx, input, result, installationID, clientBindingID, previousClient)
 		}
 	}
 	if input.DryRun {
@@ -224,7 +248,7 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 		}
 		result.Activation = outcome
 	}
-	if updateErr := service.updateLifecycle(installationID, clientBindingID, outcome); updateErr != nil {
+	if _, updateErr := service.updateLifecycle(installationID, clientBindingID, outcome); updateErr != nil {
 		if activationErr != nil {
 			return result, fmt.Errorf("activate client: %v; persist activation state: %w", activationErr, updateErr)
 		}
@@ -257,12 +281,13 @@ func (service Service) resume(
 	if input.DryRun {
 		return result, nil
 	}
+	if err := service.verifyManagedTarget(ctx, input.Client, input.Scope, client, "resume"); err != nil {
+		return result, err
+	}
+	result.Activation = lifecycleOutcome(client)
 	if !input.Confirmed {
 		result.RequiresConfirmation = true
 		return result, nil
-	}
-	if err := service.verifyManagedTarget(ctx, input.Client, input.Scope, client, "resume"); err != nil {
-		return result, err
 	}
 	delivery := domain.StagedDelivery{
 		ClientID: input.Client.ClientID, OwnedBase: result.Plan.TargetRoot,
@@ -273,9 +298,21 @@ func (service Service) resume(
 		Client: input.Client, Plan: result.Plan, Delivery: delivery,
 		DeclaredName: input.Envelope.Manifest.Name, Replacing: true,
 		Interactive: input.Interactive, BackendExecutable: input.BackendExecutable,
+		VerifyOnly: true, ActivationComplete: input.ActivationComplete,
 	})
+	// Authentication completion is a separate phase. Client installation/list
+	// evidence must never silently complete it.
+	if client.Activation == domain.ActivationActive && client.Verification == domain.VerificationInstalled {
+		outcome.Activation = client.Activation
+		outcome.Verification = client.Verification
+	}
+	if client.Authentication == domain.AuthenticationPending && input.AuthComplete {
+		outcome.Authentication = domain.AuthenticationComplete
+		outcome.AuthenticationAttested = true
+	} else if client.Authentication != "" {
+		outcome.Authentication = client.Authentication
+	}
 	result.Activation = outcome
-	result.Mutated = true
 	if activationErr != nil && outcome.Activation == "" {
 		outcome = domain.ActivationOutcome{
 			Activation: domain.ActivationFailed, Authentication: result.Plan.Authentication,
@@ -283,7 +320,9 @@ func (service Service) resume(
 		}
 		result.Activation = outcome
 	}
-	if updateErr := service.updateLifecycle(installationID, clientBindingID, outcome); updateErr != nil {
+	changed, updateErr := service.updateLifecycle(installationID, clientBindingID, outcome)
+	result.Mutated = changed
+	if updateErr != nil {
 		if activationErr != nil {
 			return result, fmt.Errorf("resume client activation: %v; persist activation state: %w", activationErr, updateErr)
 		}
@@ -295,7 +334,18 @@ func (service Service) resume(
 	return result, nil
 }
 
-func hasOAuthRequirement(envelope domain.PackageEnvelope, hints domain.CompatibilityHints) bool {
+func openAIOAuthApplies(clientID domain.ClientID, envelope domain.PackageEnvelope, hints domain.CompatibilityHints) bool {
+	if clientID != domain.ClientCodex {
+		return false
+	}
+	if envelope.CatalogEvidence != nil {
+		if _, present := envelope.CatalogEvidence.Compatibility[string(clientID)]; present {
+			return false
+		}
+	}
+	if _, present := hints.Compatibility[string(clientID)]; present {
+		return false
+	}
 	for serverName := range envelope.MCP.Servers {
 		if strings.TrimSpace(hints.OpenAIMCPAuth[serverName].OAuthResource) != "" {
 			return true
@@ -324,10 +374,10 @@ func (service Service) beginMutation(ctx context.Context, dryRun, confirmed bool
 	return release, nil
 }
 
-func (service Service) updateLifecycle(installationID, clientBindingID string, outcome domain.ActivationOutcome) error {
+func (service Service) updateLifecycle(installationID, clientBindingID string, outcome domain.ActivationOutcome) (bool, error) {
 	state, err := service.StateStore.Load()
 	if err != nil {
-		return err
+		return false, err
 	}
 	for installationIndex, installation := range state.Installations {
 		if installation.InstallationID != installationID {
@@ -335,7 +385,11 @@ func (service Service) updateLifecycle(installationID, clientBindingID string, o
 		}
 		client, ok := installation.Clients[clientBindingID]
 		if !ok {
-			return fmt.Errorf("client binding disappeared during activation")
+			return false, fmt.Errorf("client binding disappeared during activation")
+		}
+		if client.Activation == outcome.Activation && client.Authentication == outcome.Authentication &&
+			client.Policy == outcome.Policy && client.Verification == outcome.Verification {
+			return false, nil
 		}
 		client.Activation = outcome.Activation
 		client.Authentication = outcome.Authentication
@@ -345,9 +399,37 @@ func (service Service) updateLifecycle(installationID, clientBindingID string, o
 		installation.Clients[clientBindingID] = client
 		installation.UpdatedAt = client.UpdatedAt
 		state.Installations[installationIndex] = installation
-		return service.StateStore.Save(state)
+		if err := service.StateStore.Save(state); err != nil {
+			return false, err
+		}
+		return true, nil
 	}
-	return fmt.Errorf("installation disappeared during activation")
+	return false, fmt.Errorf("installation disappeared during activation")
+}
+
+func lifecycleOutcome(client domain.ClientBinding) domain.ActivationOutcome {
+	return domain.ActivationOutcome{Activation: client.Activation, Authentication: client.Authentication, Policy: client.Policy, Verification: client.Verification}
+}
+
+func (service Service) verifyClientReadOnly(ctx context.Context, input AddInput, result AddResult, client domain.ClientBinding) (domain.ActivationOutcome, error) {
+	if strings.TrimSpace(input.BackendExecutable) == "" {
+		return domain.ActivationOutcome{}, nil
+	}
+	switch input.Client.ClientID {
+	case domain.ClientCodex, domain.ClientCopilot, domain.ClientVSCode:
+	case domain.ClientKiro:
+		if !strings.Contains(strings.ToLower(input.BackendExecutable), "kiro") {
+			return domain.ActivationOutcome{}, nil
+		}
+	default:
+		return domain.ActivationOutcome{}, nil
+	}
+	delivery := domain.StagedDelivery{ClientID: input.Client.ClientID, OwnedBase: result.Plan.TargetRoot, ActivePath: client.TargetLocator, ArtifactDigest: managedDigest(client), NativeObjects: client.NativeObjects}
+	outcome, err := service.Activator.Activate(ctx, domain.ActivationRequest{Client: input.Client, Plan: result.Plan, Delivery: delivery, DeclaredName: input.Envelope.Manifest.Name, Replacing: true, BackendExecutable: input.BackendExecutable, VerifyOnly: true})
+	if outcome.Authentication == "" || outcome.Authentication == domain.AuthenticationNotChecked {
+		outcome.Authentication = client.Authentication
+	}
+	return outcome, err
 }
 
 func (service Service) now() time.Time {

--- a/install/integrationctl/agentplugins/usecase/service.go
+++ b/install/integrationctl/agentplugins/usecase/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -380,8 +381,11 @@ func upsertPreparedInstallation(
 		},
 		Package: domain.PackageBinding{
 			LoaderKind: input.Envelope.LoaderKind, FormatID: input.Envelope.FormatID,
-			SchemaURI: input.Envelope.SchemaURI, DeclaredName: input.Envelope.Manifest.Name,
-			Version: input.Envelope.Manifest.Version, ManifestDigest: input.Envelope.ManifestDigest,
+			SchemaURI: input.Envelope.SchemaURI, SchemaVersion: input.Envelope.SchemaVersion,
+			ManifestSchema: schemaIdentity(input.Envelope), ManifestDocument: manifestDocument(input.Envelope),
+			CatalogEvidence: input.Envelope.CatalogEvidence, Diagnostics: append([]domain.Diagnostic(nil), input.Envelope.Diagnostics...),
+			DeclaredName: input.Envelope.Manifest.Name,
+			Version:      input.Envelope.Manifest.Version, ManifestDigest: input.Envelope.ManifestDigest,
 			Inventory: input.Envelope.Inventory,
 		},
 		Clients:   map[string]domain.ClientBinding{},
@@ -395,8 +399,11 @@ func upsertPreparedInstallation(
 		installation.Source.TreeDigest = input.Envelope.TreeDigest
 		installation.Package = domain.PackageBinding{
 			LoaderKind: input.Envelope.LoaderKind, FormatID: input.Envelope.FormatID,
-			SchemaURI: input.Envelope.SchemaURI, DeclaredName: input.Envelope.Manifest.Name,
-			Version: input.Envelope.Manifest.Version, ManifestDigest: input.Envelope.ManifestDigest,
+			SchemaURI: input.Envelope.SchemaURI, SchemaVersion: input.Envelope.SchemaVersion,
+			ManifestSchema: schemaIdentity(input.Envelope), ManifestDocument: manifestDocument(input.Envelope),
+			CatalogEvidence: input.Envelope.CatalogEvidence, Diagnostics: append([]domain.Diagnostic(nil), input.Envelope.Diagnostics...),
+			DeclaredName: input.Envelope.Manifest.Name,
+			Version:      input.Envelope.Manifest.Version, ManifestDigest: input.Envelope.ManifestDigest,
 			Inventory: input.Envelope.Inventory,
 		}
 		installation.UpdatedAt = timestamp
@@ -421,6 +428,27 @@ func upsertPreparedInstallation(
 	}
 	state.Installations = append(state.Installations, installation)
 	return state, len(state.Installations) - 1
+}
+
+func schemaIdentity(envelope domain.PackageEnvelope) *domain.SchemaIdentity {
+	identity := envelope.ManifestSchema
+	if identity.URI == "" {
+		identity = domain.SchemaIdentity{URI: envelope.SchemaURI, Version: envelope.SchemaVersion}
+	}
+	return &identity
+}
+
+func manifestDocument(envelope domain.PackageEnvelope) *domain.VersionedDocument {
+	if len(envelope.Manifest.Raw) == 0 {
+		return nil
+	}
+	unknown := make(map[string]json.RawMessage, len(envelope.Manifest.Unknown))
+	for key, value := range envelope.Manifest.Unknown {
+		unknown[key] = append(json.RawMessage(nil), value...)
+	}
+	return &domain.VersionedDocument{
+		Schema: *schemaIdentity(envelope), Raw: append(json.RawMessage(nil), envelope.Manifest.Raw...), Unknown: unknown,
+	}
 }
 
 func validatePackageTransition(installation domain.Installation, envelope domain.PackageEnvelope) error {

--- a/install/integrationctl/agentplugins/usecase/service.go
+++ b/install/integrationctl/agentplugins/usecase/service.go
@@ -42,6 +42,10 @@ type AddInput struct {
 	BackendExecutable  string
 	ActivationComplete bool
 	AuthComplete       bool
+	// PersistAuthoritativeObservations allows a read-only client verifier to
+	// record negative evidence even during a plan-first CLI pass. It does not
+	// authorize package, client, or user-requested lifecycle mutations.
+	PersistAuthoritativeObservations bool
 }
 
 type AddResult struct {
@@ -147,9 +151,9 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 			}
 			verified, verifyErr := service.verifyClientReadOnly(ctx, input, result, current)
 			if verifyErr != nil {
-				if verified.Activation != "" && input.Confirmed && !input.DryRun {
+				if verified.Activation != "" && !input.DryRun && (input.Confirmed || input.PersistAuthoritativeObservations && verified.AuthoritativeObservation) {
 					result.Activation = verified
-					changed, updateErr := service.updateLifecycle(installationID, clientBindingID, verified)
+					changed, updateErr := service.persistAuthoritativeObservation(ctx, input, installationID, clientBindingID, verified)
 					result.Mutated = changed
 					if updateErr != nil {
 						return result, fmt.Errorf("client verification failed: %v; persist negative verification evidence: %w", verifyErr, updateErr)
@@ -179,9 +183,9 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 			if lifecycleConverged(previousClient) {
 				verified, verifyErr := service.verifyClientReadOnly(ctx, input, result, previousClient)
 				if verifyErr != nil {
-					if verified.Activation != "" && input.Confirmed && !input.DryRun {
+					if verified.Activation != "" && !input.DryRun && (input.Confirmed || input.PersistAuthoritativeObservations && verified.AuthoritativeObservation) {
 						result.Activation = verified
-						changed, updateErr := service.updateLifecycle(installationID, clientBindingID, verified)
+						changed, updateErr := service.persistAuthoritativeObservation(ctx, input, installationID, clientBindingID, verified)
 						result.Mutated = changed
 						if updateErr != nil {
 							return result, fmt.Errorf("client verification failed: %v; persist negative verification evidence: %w", verifyErr, updateErr)
@@ -386,6 +390,18 @@ func (service Service) persistObservedLifecycle(input AddInput, result AddResult
 	changed, err := service.updateLifecycle(installationID, clientBindingID, outcome)
 	result.Mutated = changed
 	return result, err
+}
+
+func (service Service) persistAuthoritativeObservation(ctx context.Context, input AddInput, installationID, clientBindingID string, outcome domain.ActivationOutcome) (bool, error) {
+	if input.Confirmed {
+		return service.updateLifecycle(installationID, clientBindingID, outcome)
+	}
+	release, err := service.beginMutation(ctx, false, true)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = release() }()
+	return service.updateLifecycle(installationID, clientBindingID, outcome)
 }
 
 func openAIOAuthApplies(clientID domain.ClientID, envelope domain.PackageEnvelope, hints domain.CompatibilityHints) bool {

--- a/install/integrationctl/agentplugins/usecase/service.go
+++ b/install/integrationctl/agentplugins/usecase/service.go
@@ -131,7 +131,15 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 	}
 	isMaterialized := existing && materializedClient(state.Installations[installationIndex], clientBindingID)
 	if isMaterialized && !replace {
-		return result, fmt.Errorf("plugin is already materialized for %s; use update", input.Client.ClientID)
+		current := state.Installations[installationIndex].Clients[clientBindingID]
+		if !packageRevisionMatches(current.PackageRevision, input.Envelope) {
+			return result, fmt.Errorf("plugin is already materialized for %s at a different revision; use update", input.Client.ClientID)
+		}
+		if lifecycleConverged(current) {
+			result.NoChange = true
+			return result, nil
+		}
+		return service.resume(ctx, input, result, installationID, clientBindingID, current)
 	}
 	if replace && !isMaterialized {
 		return result, fmt.Errorf("plugin is not materialized for %s; use add", input.Client.ClientID)
@@ -228,10 +236,62 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 }
 
 func lifecycleConverged(client domain.ClientBinding) bool {
-	if client.ClientID != string(domain.ClientCopilot) && client.ClientID != string(domain.ClientVSCode) {
-		return true
+	authComplete := client.Authentication == domain.AuthenticationNotRequired || client.Authentication == domain.AuthenticationComplete
+	return client.Materialization == domain.MaterializationMaterialized &&
+		client.Activation == domain.ActivationActive &&
+		client.Verification == domain.VerificationInstalled && authComplete
+}
+
+// resume retries only the external client lifecycle against an existing,
+// digest-verified managed package. It deliberately creates no directory
+// transaction or receipt, so repeating add cannot replace or duplicate the
+// materialized artifact.
+func (service Service) resume(
+	ctx context.Context,
+	input AddInput,
+	result AddResult,
+	installationID, clientBindingID string,
+	client domain.ClientBinding,
+) (AddResult, error) {
+	if input.DryRun {
+		return result, nil
 	}
-	return client.Activation == domain.ActivationActive && client.Verification == domain.VerificationInstalled
+	if !input.Confirmed {
+		result.RequiresConfirmation = true
+		return result, nil
+	}
+	if err := service.verifyManagedTarget(ctx, input.Client, input.Scope, client, "resume"); err != nil {
+		return result, err
+	}
+	delivery := domain.StagedDelivery{
+		ClientID: input.Client.ClientID, OwnedBase: result.Plan.TargetRoot,
+		ActivePath: client.TargetLocator, ArtifactDigest: managedDigest(client),
+		NativeObjects: append([]domain.NativeObjectOwnership(nil), client.NativeObjects...),
+	}
+	outcome, activationErr := service.Activator.Activate(ctx, domain.ActivationRequest{
+		Client: input.Client, Plan: result.Plan, Delivery: delivery,
+		DeclaredName: input.Envelope.Manifest.Name, Replacing: true,
+		Interactive: input.Interactive, BackendExecutable: input.BackendExecutable,
+	})
+	result.Activation = outcome
+	result.Mutated = true
+	if activationErr != nil && outcome.Activation == "" {
+		outcome = domain.ActivationOutcome{
+			Activation: domain.ActivationFailed, Authentication: result.Plan.Authentication,
+			Policy: domain.PolicyAllowed, Verification: domain.VerificationFailed,
+		}
+		result.Activation = outcome
+	}
+	if updateErr := service.updateLifecycle(installationID, clientBindingID, outcome); updateErr != nil {
+		if activationErr != nil {
+			return result, fmt.Errorf("resume client activation: %v; persist activation state: %w", activationErr, updateErr)
+		}
+		return result, updateErr
+	}
+	if activationErr != nil {
+		return result, activationErr
+	}
+	return result, nil
 }
 
 func hasOAuthRequirement(envelope domain.PackageEnvelope, hints domain.CompatibilityHints) bool {

--- a/install/integrationctl/agentplugins/usecase/service.go
+++ b/install/integrationctl/agentplugins/usecase/service.go
@@ -147,10 +147,18 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 			}
 			verified, verifyErr := service.verifyClientReadOnly(ctx, input, result, current)
 			if verifyErr != nil {
+				if verified.Activation != "" && input.Confirmed && !input.DryRun {
+					result.Activation = verified
+					changed, updateErr := service.updateLifecycle(installationID, clientBindingID, verified)
+					result.Mutated = changed
+					if updateErr != nil {
+						return result, fmt.Errorf("client verification failed: %v; persist negative verification evidence: %w", verifyErr, updateErr)
+					}
+				}
 				return result, verifyErr
 			}
-			if verified.Activation == domain.ActivationActive && verified.Verification == domain.VerificationInstalled {
-				result.Activation = verified
+			if verified.Activation != "" && !sameLifecycleOutcome(verified, lifecycleOutcome(current)) {
+				return service.persistObservedLifecycle(input, result, installationID, clientBindingID, verified)
 			}
 			result.NoChange = true
 			return result, nil
@@ -171,10 +179,18 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 			if lifecycleConverged(previousClient) {
 				verified, verifyErr := service.verifyClientReadOnly(ctx, input, result, previousClient)
 				if verifyErr != nil {
+					if verified.Activation != "" && input.Confirmed && !input.DryRun {
+						result.Activation = verified
+						changed, updateErr := service.updateLifecycle(installationID, clientBindingID, verified)
+						result.Mutated = changed
+						if updateErr != nil {
+							return result, fmt.Errorf("client verification failed: %v; persist negative verification evidence: %w", verifyErr, updateErr)
+						}
+					}
 					return result, verifyErr
 				}
-				if verified.Activation == domain.ActivationActive && verified.Verification == domain.VerificationInstalled {
-					result.Activation = verified
+				if verified.Activation != "" && !sameLifecycleOutcome(verified, lifecycleOutcome(previousClient)) {
+					return service.persistObservedLifecycle(input, result, installationID, clientBindingID, verified)
 				}
 				result.NoChange = true
 				return result, nil
@@ -304,7 +320,7 @@ func (service Service) resume(
 	})
 	// Authentication completion is a separate phase. Client installation/list
 	// evidence must never silently complete it.
-	if client.Activation == domain.ActivationActive && client.Verification == domain.VerificationInstalled {
+	if activationErr == nil && !clientVerifierAvailable(input, result.Plan) && client.Activation == domain.ActivationActive && client.Verification == domain.VerificationInstalled {
 		outcome.Activation = client.Activation
 		outcome.Verification = client.Verification
 	}
@@ -334,6 +350,42 @@ func (service Service) resume(
 		return result, activationErr
 	}
 	return result, nil
+}
+
+func clientVerifierAvailable(input AddInput, plan domain.DeliveryPlan) bool {
+	if strings.TrimSpace(input.BackendExecutable) == "" {
+		return false
+	}
+	switch input.Client.ClientID {
+	case domain.ClientCodex, domain.ClientCopilot, domain.ClientVSCode:
+		return true
+	case domain.ClientKiro:
+		if !strings.Contains(strings.ToLower(input.BackendExecutable), "kiro") || len(plan.Components) == 0 {
+			return false
+		}
+		for _, component := range plan.Components {
+			if component.Support == domain.SupportUnsupported || component.Kind != domain.ComponentMCPServer {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func (service Service) persistObservedLifecycle(input AddInput, result AddResult, installationID, clientBindingID string, outcome domain.ActivationOutcome) (AddResult, error) {
+	result.Activation = outcome
+	if input.DryRun {
+		return result, nil
+	}
+	if !input.Confirmed {
+		result.RequiresConfirmation = true
+		return result, nil
+	}
+	changed, err := service.updateLifecycle(installationID, clientBindingID, outcome)
+	result.Mutated = changed
+	return result, err
 }
 
 func openAIOAuthApplies(clientID domain.ClientID, envelope domain.PackageEnvelope, hints domain.CompatibilityHints) bool {

--- a/install/integrationctl/agentplugins/usecase/service.go
+++ b/install/integrationctl/agentplugins/usecase/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -463,11 +462,8 @@ func upsertPreparedInstallation(
 		},
 		Package: domain.PackageBinding{
 			LoaderKind: input.Envelope.LoaderKind, FormatID: input.Envelope.FormatID,
-			SchemaURI: input.Envelope.SchemaURI, SchemaVersion: input.Envelope.SchemaVersion,
-			ManifestSchema: schemaIdentity(input.Envelope), ManifestDocument: manifestDocument(input.Envelope),
-			CatalogEvidence: input.Envelope.CatalogEvidence, Diagnostics: append([]domain.Diagnostic(nil), input.Envelope.Diagnostics...),
-			DeclaredName: input.Envelope.Manifest.Name,
-			Version:      input.Envelope.Manifest.Version, ManifestDigest: input.Envelope.ManifestDigest,
+			SchemaURI: input.Envelope.SchemaURI, DeclaredName: input.Envelope.Manifest.Name,
+			Version: input.Envelope.Manifest.Version, ManifestDigest: input.Envelope.ManifestDigest,
 			Inventory: input.Envelope.Inventory,
 		},
 		Clients:   map[string]domain.ClientBinding{},
@@ -481,11 +477,8 @@ func upsertPreparedInstallation(
 		installation.Source.TreeDigest = input.Envelope.TreeDigest
 		installation.Package = domain.PackageBinding{
 			LoaderKind: input.Envelope.LoaderKind, FormatID: input.Envelope.FormatID,
-			SchemaURI: input.Envelope.SchemaURI, SchemaVersion: input.Envelope.SchemaVersion,
-			ManifestSchema: schemaIdentity(input.Envelope), ManifestDocument: manifestDocument(input.Envelope),
-			CatalogEvidence: input.Envelope.CatalogEvidence, Diagnostics: append([]domain.Diagnostic(nil), input.Envelope.Diagnostics...),
-			DeclaredName: input.Envelope.Manifest.Name,
-			Version:      input.Envelope.Manifest.Version, ManifestDigest: input.Envelope.ManifestDigest,
+			SchemaURI: input.Envelope.SchemaURI, DeclaredName: input.Envelope.Manifest.Name,
+			Version: input.Envelope.Manifest.Version, ManifestDigest: input.Envelope.ManifestDigest,
 			Inventory: input.Envelope.Inventory,
 		}
 		installation.UpdatedAt = timestamp
@@ -510,27 +503,6 @@ func upsertPreparedInstallation(
 	}
 	state.Installations = append(state.Installations, installation)
 	return state, len(state.Installations) - 1
-}
-
-func schemaIdentity(envelope domain.PackageEnvelope) *domain.SchemaIdentity {
-	identity := envelope.ManifestSchema
-	if identity.URI == "" {
-		identity = domain.SchemaIdentity{URI: envelope.SchemaURI, Version: envelope.SchemaVersion}
-	}
-	return &identity
-}
-
-func manifestDocument(envelope domain.PackageEnvelope) *domain.VersionedDocument {
-	if len(envelope.Manifest.Raw) == 0 {
-		return nil
-	}
-	unknown := make(map[string]json.RawMessage, len(envelope.Manifest.Unknown))
-	for key, value := range envelope.Manifest.Unknown {
-		unknown[key] = append(json.RawMessage(nil), value...)
-	}
-	return &domain.VersionedDocument{
-		Schema: *schemaIdentity(envelope), Raw: append(json.RawMessage(nil), envelope.Manifest.Raw...), Unknown: unknown,
-	}
 }
 
 func validatePackageTransition(installation domain.Installation, envelope domain.PackageEnvelope) error {

--- a/install/integrationctl/agentplugins/usecase/service.go
+++ b/install/integrationctl/agentplugins/usecase/service.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -153,7 +154,7 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 			if verifyErr != nil {
 				if verified.Activation != "" && !input.DryRun && (input.Confirmed || input.PersistAuthoritativeObservations && verified.AuthoritativeObservation) {
 					result.Activation = verified
-					changed, updateErr := service.persistAuthoritativeObservation(ctx, input, installationID, clientBindingID, verified)
+					changed, updateErr := service.persistAuthoritativeObservation(ctx, input, installationID, clientBindingID, current, verified)
 					result.Mutated = changed
 					if updateErr != nil {
 						return result, fmt.Errorf("client verification failed: %v; persist negative verification evidence: %w", verifyErr, updateErr)
@@ -185,7 +186,7 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 				if verifyErr != nil {
 					if verified.Activation != "" && !input.DryRun && (input.Confirmed || input.PersistAuthoritativeObservations && verified.AuthoritativeObservation) {
 						result.Activation = verified
-						changed, updateErr := service.persistAuthoritativeObservation(ctx, input, installationID, clientBindingID, verified)
+						changed, updateErr := service.persistAuthoritativeObservation(ctx, input, installationID, clientBindingID, previousClient, verified)
 						result.Mutated = changed
 						if updateErr != nil {
 							return result, fmt.Errorf("client verification failed: %v; persist negative verification evidence: %w", verifyErr, updateErr)
@@ -392,7 +393,7 @@ func (service Service) persistObservedLifecycle(input AddInput, result AddResult
 	return result, err
 }
 
-func (service Service) persistAuthoritativeObservation(ctx context.Context, input AddInput, installationID, clientBindingID string, outcome domain.ActivationOutcome) (bool, error) {
+func (service Service) persistAuthoritativeObservation(ctx context.Context, input AddInput, installationID, clientBindingID string, observed domain.ClientBinding, outcome domain.ActivationOutcome) (bool, error) {
 	if input.Confirmed {
 		return service.updateLifecycle(installationID, clientBindingID, outcome)
 	}
@@ -401,7 +402,21 @@ func (service Service) persistAuthoritativeObservation(ctx context.Context, inpu
 		return false, err
 	}
 	defer func() { _ = release() }()
-	return service.updateLifecycle(installationID, clientBindingID, outcome)
+	state, err := service.StateStore.Load()
+	if err != nil {
+		return false, err
+	}
+	for _, installation := range state.Installations {
+		if installation.InstallationID != installationID {
+			continue
+		}
+		latest, ok := installation.Clients[clientBindingID]
+		if !ok || !reflect.DeepEqual(latest, observed) {
+			return false, fmt.Errorf("stale client binding observation; state changed before negative evidence could be persisted, retry the command")
+		}
+		return service.updateLifecycle(installationID, clientBindingID, outcome)
+	}
+	return false, fmt.Errorf("stale client binding observation; installation changed before negative evidence could be persisted, retry the command")
 }
 
 func openAIOAuthApplies(clientID domain.ClientID, envelope domain.PackageEnvelope, hints domain.CompatibilityHints) bool {

--- a/install/integrationctl/agentplugins/usecase/service_test.go
+++ b/install/integrationctl/agentplugins/usecase/service_test.go
@@ -214,6 +214,95 @@ func TestResumeCompletesManualActivationAndPendingAuthOnlyByAttestation(t *testi
 	}
 }
 
+func TestFreshCompletionFlagsFailBeforeMaterialization(t *testing.T) {
+	t.Parallel()
+	for _, flags := range []struct {
+		name       string
+		activation bool
+		auth       bool
+	}{
+		{name: "activation", activation: true},
+		{name: "authentication", auth: true},
+		{name: "both", activation: true, auth: true},
+	} {
+		flags := flags
+		t.Run(flags.name, func(t *testing.T) {
+			service, store, client := serviceFixture(t)
+			input := addInput(t, client, "https://example.com/fresh-"+flags.name)
+			input.Confirmed = true
+			input.ActivationComplete = flags.activation
+			input.AuthComplete = flags.auth
+			if _, err := service.Add(context.Background(), input); err == nil || !strings.Contains(err.Error(), "already materialized") {
+				t.Fatalf("completion error = %v", err)
+			}
+			state, err := store.Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(state.Installations) != 0 {
+				t.Fatalf("fresh completion flags mutated state: %+v", state)
+			}
+		})
+	}
+}
+
+func TestActivationAttestationDoesNotCompleteAuthentication(t *testing.T) {
+	t.Parallel()
+	service, store, client := serviceFixture(t)
+	input := addInput(t, client, "https://example.com/independent-attestations")
+	input.Envelope.CatalogEvidence = &domain.CatalogEvidence{Compatibility: map[string]domain.CatalogCompatibility{"cursor": {Package: "native", Authentication: domain.AuthenticationRequirementRequired}}}
+	input.Confirmed = true
+	if _, err := service.Add(context.Background(), input); err != nil {
+		t.Fatal(err)
+	}
+	input.ActivationComplete = true
+	result, err := service.Add(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Activation.ActivationAttested || result.Activation.AuthenticationAttested || result.Activation.Authentication != domain.AuthenticationPending {
+		t.Fatalf("activation-only result = %+v", result)
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding := onlyBinding(state.Installations[0])
+	if binding.Activation != domain.ActivationActive || binding.Authentication != domain.AuthenticationPending {
+		t.Fatalf("activation-only binding = %+v", binding)
+	}
+}
+
+func TestDirectSourceConvergesOnlyAfterAuthReviewAttestation(t *testing.T) {
+	t.Parallel()
+	service, _, client := serviceFixture(t)
+	input := addInput(t, client, "https://example.com/direct-source")
+	input.Confirmed = true
+	installed, err := service.Add(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if installed.Activation.Authentication != domain.AuthenticationNotChecked {
+		t.Fatalf("direct source auth = %+v", installed.Activation)
+	}
+	input.ActivationComplete = true
+	input.AuthComplete = true
+	completed, err := service.Add(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !completed.Mutated || !completed.Activation.ActivationAttested || !completed.Activation.AuthenticationAttested || !fullyConvergedOutcome(completed.Activation) {
+		t.Fatalf("direct completion = %+v", completed)
+	}
+	repeated, err := service.Add(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !repeated.NoChange || repeated.Mutated {
+		t.Fatalf("converged repeat = %+v", repeated)
+	}
+}
+
 func TestResumeCompletesOnlyPendingAuthentication(t *testing.T) {
 	t.Parallel()
 	service, store, client := serviceFixture(t)

--- a/install/integrationctl/agentplugins/usecase/service_test.go
+++ b/install/integrationctl/agentplugins/usecase/service_test.go
@@ -426,6 +426,48 @@ func TestConvergedManualVerifierOutcomeUsesConfirmationAndReplacesStaleState(t *
 	}
 }
 
+func TestUnconfirmedInfrastructureFailureIsNotPersistedAsAuthoritativeEvidence(t *testing.T) {
+	t.Parallel()
+	service, store, _ := serviceFixture(t)
+	client := domain.DetectedClient{ClientID: domain.ClientCopilot, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".copilot")}
+	input := addInput(t, client, "https://example.com/non-authoritative-failure")
+	input.Confirmed = true
+	if _, err := service.Add(context.Background(), input); err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, binding := range state.Installations[0].Clients {
+		binding.Activation = domain.ActivationActive
+		binding.Authentication = domain.AuthenticationNotRequired
+		binding.Verification = domain.VerificationInstalled
+		state.Installations[0].Clients[key] = binding
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+	service.Activator = &observedActivator{outcome: domain.ActivationOutcome{
+		Activation: domain.ActivationFailed, Authentication: domain.AuthenticationNotRequired,
+		Policy: domain.PolicyAllowed, Verification: domain.VerificationFailed,
+	}, err: fmt.Errorf("temporary verifier transport failure")}
+	input.Confirmed = false
+	input.PersistAuthoritativeObservations = true
+	input.BackendExecutable = "/test/bin/copilot"
+	if _, err := service.Add(context.Background(), input); err == nil {
+		t.Fatal("temporary verifier failure unexpectedly succeeded")
+	}
+	state, err = store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding := onlyBinding(state.Installations[0])
+	if binding.Activation != domain.ActivationActive || binding.Verification != domain.VerificationInstalled {
+		t.Fatalf("non-authoritative failure mutated converged state: %+v", binding)
+	}
+}
+
 func TestNoChangeChecksManagedDigestBeforeReturning(t *testing.T) {
 	t.Parallel()
 	service, store, client := serviceFixture(t)

--- a/install/integrationctl/agentplugins/usecase/service_test.go
+++ b/install/integrationctl/agentplugins/usecase/service_test.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -51,6 +52,13 @@ func TestAddCommitsCursorPackageReceiptAndLeavesDiscoveryManual(t *testing.T) {
 	t.Parallel()
 	service, store, client := serviceFixture(t)
 	input := addInput(t, client, "https://example.com/one")
+	input.Envelope.ManifestSchema = domain.SchemaIdentity{URI: domain.PluginSchemaV1, Version: "1.0.0"}
+	input.Envelope.Manifest.Raw = json.RawMessage(`{"$schema":"https://agent-plugins.org/schemas/1.0.0/plugin.schema.json","name":"demo","future":{"kept":true}}`)
+	input.Envelope.Manifest.Unknown = map[string]json.RawMessage{"future": json.RawMessage(`{"kept":true}`)}
+	input.Envelope.CatalogEvidence = &domain.CatalogEvidence{SchemaVersion: 1, CatalogVersion: "0.1.0", Compatibility: map[string]domain.CatalogCompatibility{
+		"cursor": {Package: "native", Verification: "tested", Authentication: domain.AuthenticationRequirementNotRequired},
+	}}
+	input.Envelope.Diagnostics = []domain.Diagnostic{{Severity: domain.SeverityWarning, Code: "plugin_unknown_field", Message: "future field preserved"}}
 	input.Confirmed = true
 	result, err := service.Add(context.Background(), input)
 	if err != nil {
@@ -68,6 +76,12 @@ func TestAddCommitsCursorPackageReceiptAndLeavesDiscoveryManual(t *testing.T) {
 	}
 	if len(state.Installations) != 1 {
 		t.Fatalf("installations = %+v", state.Installations)
+	}
+	packageState := state.Installations[0].Package
+	if packageState.ManifestDocument == nil || !strings.Contains(string(packageState.ManifestDocument.Raw), `"future"`) ||
+		packageState.CatalogEvidence == nil || packageState.CatalogEvidence.Compatibility["cursor"].Authentication != domain.AuthenticationRequirementNotRequired ||
+		len(packageState.Diagnostics) != 1 {
+		t.Fatalf("package evidence was not preserved: %+v", packageState)
 	}
 	clientState := onlyBinding(state.Installations[0])
 	if clientState.Materialization != domain.MaterializationMaterialized || clientState.Activation != domain.ActivationManual || clientState.Verification != domain.VerificationPackageValid {

--- a/install/integrationctl/agentplugins/usecase/service_test.go
+++ b/install/integrationctl/agentplugins/usecase/service_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/ports"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/transaction"
+	legacyports "github.com/777genius/plugin-kit-ai/install/integrationctl/ports"
 )
 
 func TestAddDryRunAndUnconfirmedPlanDoNotMutateStateOrClient(t *testing.T) {
@@ -426,11 +428,59 @@ func TestConvergedManualVerifierOutcomeUsesConfirmationAndReplacesStaleState(t *
 	}
 }
 
-func TestUnconfirmedInfrastructureFailureIsNotPersistedAsAuthoritativeEvidence(t *testing.T) {
+func TestUnconfirmedInfrastructureFailureIsNotPersistedAsAuthoritativeEvidenceForAddOrUpdate(t *testing.T) {
 	t.Parallel()
+	for _, operation := range []string{"add", "update"} {
+		t.Run(operation, func(t *testing.T) {
+			service, store, _ := serviceFixture(t)
+			client := domain.DetectedClient{ClientID: domain.ClientCopilot, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".copilot")}
+			input := addInput(t, client, "https://example.com/non-authoritative-failure-"+operation)
+			input.Confirmed = true
+			if _, err := service.Add(context.Background(), input); err != nil {
+				t.Fatal(err)
+			}
+			state, err := store.Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			for key, binding := range state.Installations[0].Clients {
+				binding.Activation = domain.ActivationActive
+				binding.Authentication = domain.AuthenticationNotRequired
+				binding.Verification = domain.VerificationInstalled
+				state.Installations[0].Clients[key] = binding
+			}
+			if err := store.Save(state); err != nil {
+				t.Fatal(err)
+			}
+			service.Activator = providers.Activator{Runner: fixedUsecaseRunner{err: fmt.Errorf("temporary verifier transport failure")}}
+			input.Confirmed = false
+			input.PersistAuthoritativeObservations = true
+			input.BackendExecutable = "/test/bin/copilot"
+			var result AddResult
+			if operation == "add" {
+				result, err = service.Add(context.Background(), input)
+			} else {
+				result, err = service.Update(context.Background(), input)
+			}
+			if err == nil || result.Mutated {
+				t.Fatalf("temporary verifier result=%+v err=%v", result, err)
+			}
+			state, err = store.Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			binding := onlyBinding(state.Installations[0])
+			if binding.Activation != domain.ActivationActive || binding.Verification != domain.VerificationInstalled {
+				t.Fatalf("non-authoritative failure mutated converged state: %+v", binding)
+			}
+		})
+	}
+}
+
+func TestPlanFirstAuthoritativePersistenceIsSurroundedByMutationLock(t *testing.T) {
 	service, store, _ := serviceFixture(t)
-	client := domain.DetectedClient{ClientID: domain.ClientCopilot, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".copilot")}
-	input := addInput(t, client, "https://example.com/non-authoritative-failure")
+	client := domain.DetectedClient{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".codex")}
+	input := addInput(t, client, "https://example.com/authoritative-lock")
 	input.Confirmed = true
 	if _, err := service.Add(context.Background(), input); err != nil {
 		t.Fatal(err)
@@ -448,23 +498,29 @@ func TestUnconfirmedInfrastructureFailureIsNotPersistedAsAuthoritativeEvidence(t
 	if err := store.Save(state); err != nil {
 		t.Fatal(err)
 	}
-	service.Activator = &observedActivator{outcome: domain.ActivationOutcome{
-		Activation: domain.ActivationFailed, Authentication: domain.AuthenticationNotRequired,
-		Policy: domain.PolicyAllowed, Verification: domain.VerificationFailed,
-	}, err: fmt.Errorf("temporary verifier transport failure")}
+
+	var held atomic.Bool
+	lock := &trackingMutationLock{held: &held}
+	guarded := lockAssertingStore{StateStore: store, held: &held}
+	service.StateStore = guarded
+	service.Lock = lock
+	service.Activator = providers.Activator{Runner: fixedUsecaseRunner{result: legacyports.CommandResult{Stdout: []byte(`{"installed":[]}`)}}}
 	input.Confirmed = false
 	input.PersistAuthoritativeObservations = true
-	input.BackendExecutable = "/test/bin/copilot"
-	if _, err := service.Add(context.Background(), input); err == nil {
-		t.Fatal("temporary verifier failure unexpectedly succeeded")
+	input.BackendExecutable = "/test/bin/codex"
+	result, err := service.Add(context.Background(), input)
+	if err == nil || !result.Mutated {
+		t.Fatalf("authoritative result=%+v err=%v", result, err)
 	}
-	state, err = store.Load()
+	if lock.acquisitions != 1 || held.Load() {
+		t.Fatalf("lock acquisitions=%d held-after-return=%t", lock.acquisitions, held.Load())
+	}
+	persisted, err := store.Load()
 	if err != nil {
 		t.Fatal(err)
 	}
-	binding := onlyBinding(state.Installations[0])
-	if binding.Activation != domain.ActivationActive || binding.Verification != domain.VerificationInstalled {
-		t.Fatalf("non-authoritative failure mutated converged state: %+v", binding)
+	if binding := onlyBinding(persisted.Installations[0]); binding.Activation != domain.ActivationFailed || binding.Verification != domain.VerificationFailed {
+		t.Fatalf("authoritative observation was not persisted: %+v", binding)
 	}
 }
 
@@ -1322,6 +1378,45 @@ type observedActivator struct {
 	outcome domain.ActivationOutcome
 	err     error
 	calls   int
+}
+
+type fixedUsecaseRunner struct {
+	result legacyports.CommandResult
+	err    error
+}
+
+func (runner fixedUsecaseRunner) Run(context.Context, legacyports.Command) (legacyports.CommandResult, error) {
+	return runner.result, runner.err
+}
+
+type trackingMutationLock struct {
+	held         *atomic.Bool
+	acquisitions int
+}
+
+func (lock *trackingMutationLock) Acquire(context.Context) (ports.UnlockFunc, error) {
+	lock.acquisitions++
+	if !lock.held.CompareAndSwap(false, true) {
+		return nil, fmt.Errorf("mutation lock acquired twice")
+	}
+	return func() error {
+		if !lock.held.CompareAndSwap(true, false) {
+			return fmt.Errorf("mutation lock released while not held")
+		}
+		return nil
+	}, nil
+}
+
+type lockAssertingStore struct {
+	transaction.StateStore
+	held *atomic.Bool
+}
+
+func (store lockAssertingStore) Save(state domain.StateFileV2) error {
+	if !store.held.Load() {
+		return fmt.Errorf("state save occurred outside mutation lock")
+	}
+	return store.StateStore.Save(state)
 }
 
 func (activator *observedActivator) Activate(context.Context, domain.ActivationRequest) (domain.ActivationOutcome, error) {

--- a/install/integrationctl/agentplugins/usecase/service_test.go
+++ b/install/integrationctl/agentplugins/usecase/service_test.go
@@ -421,6 +421,73 @@ func TestRepairRejectsStaleTargetAndRollsBackFailure(t *testing.T) {
 	}
 }
 
+func TestRepairCorrectsDegradedStateAndPreservesUnverifiedExternalLifecycle(t *testing.T) {
+	t.Parallel()
+	service, store, client := serviceFixture(t)
+	input := addInput(t, client, "https://example.com/repair-state")
+	input.Confirmed = true
+	installed, err := service.Add(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, binding := range state.Installations[0].Clients {
+		binding.Materialization = domain.MaterializationDegraded
+		binding.Activation = domain.ActivationFailed
+		binding.Authentication = domain.AuthenticationFailed
+		binding.Verification = domain.VerificationFailed
+		state.Installations[0].Clients[key] = binding
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := service.Repair(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Mutated || result.NoChange || result.Receipt.OperationID != "" {
+		t.Fatalf("state-only repair result = %+v", result)
+	}
+	state, _ = store.Load()
+	binding := onlyBinding(state.Installations[0])
+	if binding.Materialization != domain.MaterializationMaterialized || binding.Verification != domain.VerificationPackageValid ||
+		binding.Activation != domain.ActivationFailed || binding.Authentication != domain.AuthenticationFailed {
+		t.Fatalf("corrected state = %+v", binding)
+	}
+
+	if err := os.WriteFile(filepath.Join(installed.Plan.ActivePath, "plugin.json"), []byte("tampered"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	state, _ = store.Load()
+	beforeReceipts := len(onlyBinding(state.Installations[0]).Receipts)
+	for key, current := range state.Installations[0].Clients {
+		current.Materialization = domain.MaterializationDegraded
+		current.Verification = domain.VerificationFailed
+		state.Installations[0].Clients[key] = current
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+	input.OperationID = "repair-degraded-replacement"
+	result, err = service.Repair(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, _ = store.Load()
+	binding = onlyBinding(state.Installations[0])
+	if !result.Mutated || result.Receipt.OperationID != input.OperationID || len(binding.Receipts) != beforeReceipts+1 {
+		t.Fatalf("replacement result/state = %+v / %+v", result, binding)
+	}
+	if binding.Materialization != domain.MaterializationMaterialized || binding.Verification != domain.VerificationPackageValid ||
+		binding.Activation != domain.ActivationFailed || binding.Authentication != domain.AuthenticationFailed {
+		t.Fatalf("replacement lifecycle overclaimed = %+v", binding)
+	}
+}
+
 func fullyConvergedOutcome(outcome domain.ActivationOutcome) bool {
 	return outcome.Activation == domain.ActivationActive && outcome.Authentication == domain.AuthenticationComplete && outcome.Verification == domain.VerificationInstalled
 }

--- a/install/integrationctl/agentplugins/usecase/service_test.go
+++ b/install/integrationctl/agentplugins/usecase/service_test.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -97,7 +98,7 @@ func TestAddCommitsCursorPackageReceiptAndLeavesDiscoveryManual(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resume add: %v", err)
 	}
-	if !resumed.Mutated || resumed.Activation.Activation != domain.ActivationManual {
+	if resumed.Mutated || resumed.Activation.Activation != domain.ActivationManual {
 		t.Fatalf("resume result = %+v", resumed)
 	}
 	state, err = store.Load()
@@ -140,7 +141,8 @@ func TestAddKeepsCodexProjectionInManualActivationState(t *testing.T) {
 
 func TestAddKeepsOAuthPackageInAuthPendingState(t *testing.T) {
 	t.Parallel()
-	service, store, client := serviceFixture(t)
+	service, store, _ := serviceFixture(t)
+	client := domain.DetectedClient{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".codex")}
 	input := addInput(t, client, "https://example.com/oauth")
 	input.Envelope.MCP = domain.MCPComponent{
 		Present: true, Enabled: true,
@@ -164,6 +166,175 @@ func TestAddKeepsOAuthPackageInAuthPendingState(t *testing.T) {
 	if onlyBinding(state.Installations[0]).Authentication != domain.AuthenticationPending {
 		t.Fatalf("client = %+v", onlyBinding(state.Installations[0]))
 	}
+}
+
+func TestOpenAIOAuthHintsDoNotOverrideGenericAuthentication(t *testing.T) {
+	t.Parallel()
+	for _, clientID := range []domain.ClientID{domain.ClientCursor, domain.ClientCodex} {
+		service, _, _ := serviceFixture(t)
+		client := domain.DetectedClient{ClientID: clientID, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".client")}
+		input := addInput(t, client, "https://example.com/generic-auth-"+string(clientID))
+		input.Envelope.MCP = domain.MCPComponent{Present: true, Enabled: true, Servers: map[string]domain.MCPServer{"server": {Name: "server", Type: "stdio"}}}
+		input.Envelope.CatalogEvidence = &domain.CatalogEvidence{Compatibility: map[string]domain.CatalogCompatibility{string(clientID): {Package: map[bool]string{true: "projected", false: "native"}[clientID == domain.ClientCodex], Authentication: domain.AuthenticationRequirementNotRequired}}}
+		input.Hints.OpenAIMCPAuth = map[string]domain.OpenAIMCPAuthHint{"server": {OAuthResource: "https://example.com/oauth"}}
+		result, err := service.Add(context.Background(), input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Plan.Authentication != domain.AuthenticationNotRequired {
+			t.Fatalf("client %s authentication = %s", clientID, result.Plan.Authentication)
+		}
+	}
+}
+
+func TestResumeCompletesManualActivationAndPendingAuthOnlyByAttestation(t *testing.T) {
+	t.Parallel()
+	service, store, client := serviceFixture(t)
+	input := addInput(t, client, "https://example.com/pending-completion")
+	input.Envelope.CatalogEvidence = &domain.CatalogEvidence{Compatibility: map[string]domain.CatalogCompatibility{"cursor": {Package: "native", Authentication: domain.AuthenticationRequirementRequired}}}
+	input.Confirmed = true
+	if _, err := service.Add(context.Background(), input); err != nil {
+		t.Fatal(err)
+	}
+	input.ActivationComplete = true
+	input.AuthComplete = true
+	result, err := service.Add(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Mutated || !result.Activation.ActivationAttested || !result.Activation.AuthenticationAttested || !fullyConvergedOutcome(result.Activation) {
+		t.Fatalf("completion result = %+v", result)
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding := onlyBinding(state.Installations[0])
+	if binding.Activation != domain.ActivationActive || binding.Authentication != domain.AuthenticationComplete {
+		t.Fatalf("binding = %+v", binding)
+	}
+}
+
+func TestResumeCompletesOnlyPendingAuthentication(t *testing.T) {
+	t.Parallel()
+	service, store, client := serviceFixture(t)
+	input := addInput(t, client, "https://example.com/auth-only-completion")
+	input.Envelope.CatalogEvidence = &domain.CatalogEvidence{Compatibility: map[string]domain.CatalogCompatibility{"cursor": {Package: "native", Authentication: domain.AuthenticationRequirementRequired}}}
+	input.Confirmed = true
+	if _, err := service.Add(context.Background(), input); err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, binding := range state.Installations[0].Clients {
+		binding.Activation = domain.ActivationActive
+		binding.Verification = domain.VerificationInstalled
+		state.Installations[0].Clients[key] = binding
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+	input.AuthComplete = true
+	result, err := service.Add(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Mutated || result.Activation.ActivationAttested || !result.Activation.AuthenticationAttested || result.Activation.Authentication != domain.AuthenticationComplete {
+		t.Fatalf("auth-only result = %+v", result)
+	}
+}
+
+func TestNoChangeChecksManagedDigestBeforeReturning(t *testing.T) {
+	t.Parallel()
+	service, store, client := serviceFixture(t)
+	input := addInput(t, client, "https://example.com/no-change-digest")
+	input.Envelope.CatalogEvidence = &domain.CatalogEvidence{Compatibility: map[string]domain.CatalogCompatibility{"cursor": {Package: "native", Authentication: domain.AuthenticationRequirementNotRequired}}}
+	input.Confirmed = true
+	installed, err := service.Add(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, binding := range state.Installations[0].Clients {
+		binding.Activation = domain.ActivationActive
+		binding.Verification = domain.VerificationInstalled
+		state.Installations[0].Clients[key] = binding
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(installed.Plan.ActivePath, "plugin.json"), []byte("tampered"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.Add(context.Background(), input); err == nil || !strings.Contains(err.Error(), "changed or is missing") {
+		t.Fatalf("no-change error = %v", err)
+	}
+}
+
+func TestRepairRejectsStaleTargetAndRollsBackFailure(t *testing.T) {
+	t.Parallel()
+	service, store, client := serviceFixture(t)
+	input := addInput(t, client, "https://example.com/repair")
+	input.Confirmed = true
+	installed, err := service.Add(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(installed.Plan.ActivePath, "plugin.json")
+	if err := os.WriteFile(manifestPath, []byte("tampered"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, binding := range state.Installations[0].Clients {
+		binding.TargetLocator = filepath.Join(t.TempDir(), "outside")
+		state.Installations[0].Clients[key] = binding
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+	input.OperationID = "repair-stale"
+	if _, err := service.Repair(context.Background(), input); err == nil || !strings.Contains(err.Error(), "untrusted persisted target") {
+		t.Fatalf("stale repair error = %v", err)
+	}
+
+	state, _ = store.Load()
+	for key, binding := range state.Installations[0].Clients {
+		binding.TargetLocator = installed.Plan.ActivePath
+		state.Installations[0].Clients[key] = binding
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+	service.Kernel.Directory.Fault = func(phase string) error {
+		if phase == dirswap.FaultActivationApplied {
+			return fmt.Errorf("injected repair failure")
+		}
+		return nil
+	}
+	input.OperationID = "repair-rollback"
+	if _, err := service.Repair(context.Background(), input); err == nil {
+		t.Fatal("repair unexpectedly succeeded")
+	}
+	body, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "tampered" {
+		t.Fatalf("rollback did not restore prior directory: %q", body)
+	}
+}
+
+func fullyConvergedOutcome(outcome domain.ActivationOutcome) bool {
+	return outcome.Activation == domain.ActivationActive && outcome.Authentication == domain.AuthenticationComplete && outcome.Verification == domain.VerificationInstalled
 }
 
 func TestAddRejectsSameNativePluginNameFromDifferentSources(t *testing.T) {

--- a/install/integrationctl/agentplugins/usecase/service_test.go
+++ b/install/integrationctl/agentplugins/usecase/service_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -521,6 +522,65 @@ func TestPlanFirstAuthoritativePersistenceIsSurroundedByMutationLock(t *testing.
 	}
 	if binding := onlyBinding(persisted.Installations[0]); binding.Activation != domain.ActivationFailed || binding.Verification != domain.VerificationFailed {
 		t.Fatalf("authoritative observation was not persisted: %+v", binding)
+	}
+}
+
+func TestPlanFirstAuthoritativePersistenceRejectsStaleObservedBinding(t *testing.T) {
+	service, store, _ := serviceFixture(t)
+	client := domain.DetectedClient{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".codex")}
+	input := addInput(t, client, "https://example.com/stale-authoritative-observation")
+	input.Confirmed = true
+	if _, err := service.Add(context.Background(), input); err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, binding := range state.Installations[0].Clients {
+		binding.Activation = domain.ActivationActive
+		binding.Authentication = domain.AuthenticationNotRequired
+		binding.Verification = domain.VerificationInstalled
+		state.Installations[0].Clients[key] = binding
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+
+	var held atomic.Bool
+	var newer domain.ClientBinding
+	lock := &trackingMutationLock{held: &held, onAcquire: func() error {
+		latest, loadErr := store.Load()
+		if loadErr != nil {
+			return loadErr
+		}
+		for key, binding := range latest.Installations[0].Clients {
+			binding.PackageRevision.ResolvedRevision = "newer-revision"
+			binding.UpdatedAt = "2026-08-09T12:00:00Z"
+			latest.Installations[0].Clients[key] = binding
+			newer = binding
+		}
+		return store.Save(latest)
+	}}
+	service.StateStore = lockAssertingStore{StateStore: store, held: &held}
+	service.Lock = lock
+	service.Activator = providers.Activator{Runner: fixedUsecaseRunner{result: legacyports.CommandResult{Stdout: []byte(`{"installed":[]}`)}}}
+	input.Confirmed = false
+	input.PersistAuthoritativeObservations = true
+	input.BackendExecutable = "/test/bin/codex"
+	result, err := service.Add(context.Background(), input)
+	if err == nil || !strings.Contains(err.Error(), "stale client binding observation") || !strings.Contains(err.Error(), "retry") {
+		t.Fatalf("result=%+v err=%v", result, err)
+	}
+	if result.Mutated {
+		t.Fatalf("stale observation reported a mutation: %+v", result)
+	}
+	persisted, loadErr := store.Load()
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if got := onlyBinding(persisted.Installations[0]); !reflect.DeepEqual(got, newer) {
+		t.Fatalf("newer binding was overwritten\n got: %+v\nwant: %+v", got, newer)
 	}
 }
 
@@ -1392,12 +1452,19 @@ func (runner fixedUsecaseRunner) Run(context.Context, legacyports.Command) (lega
 type trackingMutationLock struct {
 	held         *atomic.Bool
 	acquisitions int
+	onAcquire    func() error
 }
 
 func (lock *trackingMutationLock) Acquire(context.Context) (ports.UnlockFunc, error) {
 	lock.acquisitions++
 	if !lock.held.CompareAndSwap(false, true) {
 		return nil, fmt.Errorf("mutation lock acquired twice")
+	}
+	if lock.onAcquire != nil {
+		if err := lock.onAcquire(); err != nil {
+			lock.held.Store(false)
+			return nil, err
+		}
 	}
 	return func() error {
 		if !lock.held.CompareAndSwap(true, false) {

--- a/install/integrationctl/agentplugins/usecase/service_test.go
+++ b/install/integrationctl/agentplugins/usecase/service_test.go
@@ -79,8 +79,19 @@ func TestAddCommitsCursorPackageReceiptAndLeavesDiscoveryManual(t *testing.T) {
 	if clientState.PackageRevision == nil || clientState.PackageRevision.TreeDigest != input.Envelope.TreeDigest {
 		t.Fatalf("package revision = %+v", clientState.PackageRevision)
 	}
-	if _, err := service.Add(context.Background(), input); err == nil || !strings.Contains(err.Error(), "use update") {
-		t.Fatalf("duplicate add error = %v", err)
+	resumed, err := service.Add(context.Background(), input)
+	if err != nil {
+		t.Fatalf("resume add: %v", err)
+	}
+	if !resumed.Mutated || resumed.Activation.Activation != domain.ActivationManual {
+		t.Fatalf("resume result = %+v", resumed)
+	}
+	state, err = store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipts := onlyBinding(state.Installations[0]).Receipts; len(receipts) != 1 {
+		t.Fatalf("resume created a second directory transaction: %+v", receipts)
 	}
 }
 
@@ -348,6 +359,19 @@ func TestUpdateReturnsNoChangeWithoutMutation(t *testing.T) {
 	if _, err := service.Add(context.Background(), first); err != nil {
 		t.Fatal(err)
 	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, binding := range state.Installations[0].Clients {
+		binding.Activation = domain.ActivationActive
+		binding.Authentication = domain.AuthenticationNotRequired
+		binding.Verification = domain.VerificationInstalled
+		state.Installations[0].Clients[key] = binding
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatal(err)
+	}
 	result, err := service.Update(context.Background(), addInput(t, client, "https://example.com/one"))
 	if err != nil {
 		t.Fatal(err)
@@ -355,7 +379,7 @@ func TestUpdateReturnsNoChangeWithoutMutation(t *testing.T) {
 	if !result.NoChange || result.Mutated || result.RequiresConfirmation {
 		t.Fatalf("update result = %+v", result)
 	}
-	state, err := store.Load()
+	state, err = store.Load()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -364,25 +388,24 @@ func TestUpdateReturnsNoChangeWithoutMutation(t *testing.T) {
 	}
 }
 
-func TestLifecycleConvergenceRetriesOnlyNativeCopilotBackends(t *testing.T) {
+func TestLifecycleConvergenceRequiresActivationAuthenticationAndVerificationForEveryClient(t *testing.T) {
 	t.Parallel()
-	manual := domain.ClientBinding{Activation: domain.ActivationManual, Verification: domain.VerificationPackageValid}
-	for _, client := range []domain.ClientID{domain.ClientCursor, domain.ClientCodex, domain.ClientKiro} {
-		manual.ClientID = string(client)
-		if !lifecycleConverged(manual) {
-			t.Fatalf("manual lifecycle for %s should preserve normal no-change behavior", client)
-		}
-	}
-	for _, client := range []domain.ClientID{domain.ClientCopilot, domain.ClientVSCode} {
+	manual := domain.ClientBinding{Materialization: domain.MaterializationMaterialized, Activation: domain.ActivationManual, Authentication: domain.AuthenticationNotRequired, Verification: domain.VerificationPackageValid}
+	for _, client := range []domain.ClientID{domain.ClientCursor, domain.ClientCodex, domain.ClientKiro, domain.ClientCopilot, domain.ClientVSCode} {
 		manual.ClientID = string(client)
 		if lifecycleConverged(manual) {
-			t.Fatalf("manual lifecycle for %s should retry native activation", client)
+			t.Fatalf("manual lifecycle for %s was reported converged", client)
 		}
 		manual.Activation = domain.ActivationActive
 		manual.Verification = domain.VerificationInstalled
 		if !lifecycleConverged(manual) {
 			t.Fatalf("installed lifecycle for %s should be converged", client)
 		}
+		manual.Authentication = domain.AuthenticationPending
+		if lifecycleConverged(manual) {
+			t.Fatalf("auth-pending lifecycle for %s was reported converged", client)
+		}
+		manual.Authentication = domain.AuthenticationNotRequired
 		manual.Activation = domain.ActivationManual
 		manual.Verification = domain.VerificationPackageValid
 	}

--- a/install/integrationctl/agentplugins/usecase/service_test.go
+++ b/install/integrationctl/agentplugins/usecase/service_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/statev2"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 	clientplanner "github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/planner"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/ports"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/transaction"
 )
@@ -329,8 +330,99 @@ func TestResumeCompletesOnlyPendingAuthentication(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !result.Mutated || result.Activation.ActivationAttested || !result.Activation.AuthenticationAttested || result.Activation.Authentication != domain.AuthenticationComplete {
+	if !result.Mutated || result.Activation.ActivationAttested || !result.Activation.AuthenticationAttested || result.Activation.Authentication != domain.AuthenticationComplete || result.Activation.Activation != domain.ActivationActive || result.Activation.Verification != domain.VerificationInstalled {
 		t.Fatalf("auth-only result = %+v", result)
+	}
+}
+
+func TestAuthOnlyResumeRunsVerifierAndPersistsNegativeEvidence(t *testing.T) {
+	t.Parallel()
+	service, store, _ := serviceFixture(t)
+	client := domain.DetectedClient{ClientID: domain.ClientCopilot, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".copilot")}
+	input := addInput(t, client, "https://example.com/auth-negative")
+	input.Envelope.CatalogEvidence = &domain.CatalogEvidence{Compatibility: map[string]domain.CatalogCompatibility{"copilot": {Package: "native", Authentication: domain.AuthenticationRequirementRequired}}}
+	input.Confirmed = true
+	if _, err := service.Add(context.Background(), input); err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, binding := range state.Installations[0].Clients {
+		binding.Activation = domain.ActivationActive
+		binding.Verification = domain.VerificationInstalled
+		binding.Authentication = domain.AuthenticationPending
+		state.Installations[0].Clients[key] = binding
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+	observer := &observedActivator{outcome: domain.ActivationOutcome{
+		Activation: domain.ActivationFailed, Authentication: domain.AuthenticationNotChecked,
+		Policy: domain.PolicyAllowed, Verification: domain.VerificationFailed,
+	}, err: fmt.Errorf("negative Copilot listing evidence")}
+	service.Activator = observer
+	input.AuthComplete = true
+	input.BackendExecutable = "/test/bin/copilot"
+	result, err := service.Add(context.Background(), input)
+	if err == nil || observer.calls != 1 {
+		t.Fatalf("resume result=%+v err=%v verifier calls=%d", result, err, observer.calls)
+	}
+	state, err = store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding := onlyBinding(state.Installations[0])
+	if binding.Activation != domain.ActivationFailed || binding.Verification != domain.VerificationFailed {
+		t.Fatalf("negative verifier evidence was discarded: %+v", binding)
+	}
+}
+
+func TestConvergedManualVerifierOutcomeUsesConfirmationAndReplacesStaleState(t *testing.T) {
+	t.Parallel()
+	service, store, _ := serviceFixture(t)
+	client := domain.DetectedClient{ClientID: domain.ClientCopilot, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".copilot")}
+	input := addInput(t, client, "https://example.com/converged-manual")
+	input.Confirmed = true
+	if _, err := service.Add(context.Background(), input); err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, binding := range state.Installations[0].Clients {
+		binding.Activation = domain.ActivationActive
+		binding.Verification = domain.VerificationInstalled
+		binding.Authentication = domain.AuthenticationNotRequired
+		state.Installations[0].Clients[key] = binding
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+	observer := &observedActivator{outcome: domain.ActivationOutcome{
+		Activation: domain.ActivationManual, Authentication: domain.AuthenticationNotChecked,
+		Policy: domain.PolicyAllowed, Verification: domain.VerificationPackageValid,
+	}}
+	service.Activator = observer
+	input.BackendExecutable = "/test/bin/copilot"
+	input.Confirmed = false
+	preview, err := service.Add(context.Background(), input)
+	if err != nil || !preview.RequiresConfirmation || preview.NoChange || preview.Activation.Activation != domain.ActivationManual {
+		t.Fatalf("manual preview = %+v, err=%v", preview, err)
+	}
+	input.Confirmed = true
+	result, err := service.Add(context.Background(), input)
+	if err != nil || !result.Mutated || result.NoChange {
+		t.Fatalf("manual correction = %+v, err=%v", result, err)
+	}
+	state, err = store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binding := onlyBinding(state.Installations[0]); binding.Activation != domain.ActivationManual || binding.Verification != domain.VerificationPackageValid {
+		t.Fatalf("manual correction was not persisted: %+v", binding)
 	}
 }
 
@@ -418,6 +510,64 @@ func TestRepairRejectsStaleTargetAndRollsBackFailure(t *testing.T) {
 	}
 	if string(body) != "tampered" {
 		t.Fatalf("rollback did not restore prior directory: %q", body)
+	}
+}
+
+func TestRepairPropagatesIndeterminateVerificationFailure(t *testing.T) {
+	t.Parallel()
+	service, store, client := serviceFixture(t)
+	input := addInput(t, client, "https://example.com/repair-indeterminate")
+	input.Confirmed = true
+	if _, err := service.Add(context.Background(), input); err != nil {
+		t.Fatal(err)
+	}
+	stateBefore, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	service.Stager = verificationFailureStager{PackageStager: service.Stager, err: fmt.Errorf("permission denied")}
+	if _, err := service.Repair(context.Background(), input); err == nil || !strings.Contains(err.Error(), "could not be determined") {
+		t.Fatalf("indeterminate repair error = %v", err)
+	}
+	stateAfter, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(onlyBinding(stateAfter.Installations[0]).Receipts) != len(onlyBinding(stateBefore.Installations[0]).Receipts) {
+		t.Fatalf("indeterminate verification wrote a receipt: %+v", onlyBinding(stateAfter.Installations[0]).Receipts)
+	}
+}
+
+func TestRepairReceiptRecordsObservedDigestOrAbsence(t *testing.T) {
+	t.Parallel()
+	for _, mode := range []string{"mismatch", "absent"} {
+		t.Run(mode, func(t *testing.T) {
+			service, _, client := serviceFixture(t)
+			input := addInput(t, client, "https://example.com/repair-before-"+mode)
+			input.Confirmed = true
+			installed, err := service.Add(context.Background(), input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if mode == "mismatch" {
+				if err := os.WriteFile(filepath.Join(installed.Plan.ActivePath, "plugin.json"), []byte("tampered"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := os.RemoveAll(installed.Plan.ActivePath); err != nil {
+				t.Fatal(err)
+			}
+			input.OperationID = "repair-before-" + mode
+			result, err := service.Repair(context.Background(), input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if mode == "absent" && result.Receipt.BeforeDigest != "" {
+				t.Fatalf("absent BeforeDigest = %q", result.Receipt.BeforeDigest)
+			}
+			if mode == "mismatch" && (result.Receipt.BeforeDigest == "" || result.Receipt.BeforeDigest == result.Receipt.AfterDigest) {
+				t.Fatalf("mismatch receipt = %+v", result.Receipt)
+			}
+		})
 	}
 }
 
@@ -1119,6 +1269,30 @@ func serviceFixture(t *testing.T) (Service, statev2.Store, domain.DetectedClient
 		},
 		Now: func() time.Time { return time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC) },
 	}, store, client
+}
+
+type verificationFailureStager struct {
+	ports.PackageStager
+	err error
+}
+
+type observedActivator struct {
+	outcome domain.ActivationOutcome
+	err     error
+	calls   int
+}
+
+func (activator *observedActivator) Activate(context.Context, domain.ActivationRequest) (domain.ActivationOutcome, error) {
+	activator.calls++
+	return activator.outcome, activator.err
+}
+
+func (*observedActivator) Deactivate(context.Context, domain.DeactivationRequest) (domain.DeactivationOutcome, error) {
+	return domain.DeactivationOutcome{}, nil
+}
+
+func (stager verificationFailureStager) Verify(context.Context, string, string) error {
+	return stager.err
 }
 
 func addInput(t *testing.T, client domain.DetectedClient, canonicalSource string) AddInput {

--- a/install/integrationctl/agentplugins/usecase/service_test.go
+++ b/install/integrationctl/agentplugins/usecase/service_test.go
@@ -79,10 +79,9 @@ func TestAddCommitsCursorPackageReceiptAndLeavesDiscoveryManual(t *testing.T) {
 		t.Fatalf("installations = %+v", state.Installations)
 	}
 	packageState := state.Installations[0].Package
-	if packageState.ManifestDocument == nil || !strings.Contains(string(packageState.ManifestDocument.Raw), `"future"`) ||
-		packageState.CatalogEvidence == nil || packageState.CatalogEvidence.Compatibility["cursor"].Authentication != domain.AuthenticationRequirementNotRequired ||
-		len(packageState.Diagnostics) != 1 {
-		t.Fatalf("package evidence was not preserved: %+v", packageState)
+	if packageState.SchemaURI != domain.PluginSchemaV1 || packageState.ManifestDigest != input.Envelope.ManifestDigest ||
+		!strings.Contains(string(input.Envelope.Manifest.Raw), `"future"`) || input.Envelope.CatalogEvidence == nil || len(input.Envelope.Diagnostics) != 1 {
+		t.Fatalf("in-memory evidence or compatible package binding was lost: envelope=%+v package=%+v", input.Envelope, packageState)
 	}
 	clientState := onlyBinding(state.Installations[0])
 	if clientState.Materialization != domain.MaterializationMaterialized || clientState.Activation != domain.ActivationManual || clientState.Verification != domain.VerificationPackageValid {

--- a/npm/agentplugins/bin/agentplugins.js
+++ b/npm/agentplugins/bin/agentplugins.js
@@ -15,7 +15,10 @@ async function main() {
     process.exitCode = 1;
     return;
   }
-  const child = spawn(resolved.binaryPath, process.argv.slice(2), { stdio: "inherit" });
+  const childEnvironment = { ...process.env };
+  delete childEnvironment.AGENTPLUGINS_INTERNAL_PROOF_MODE;
+  delete childEnvironment.AGENTPLUGINS_INTERNAL_PROOF_BINARY;
+  const child = spawn(resolved.binaryPath, process.argv.slice(2), { stdio: "inherit", env: childEnvironment });
   child.once("error", (error) => {
     process.stderr.write(`agentplugins npm launcher: ${error.message}\n`);
     process.exitCode = 1;

--- a/npm/agentplugins/lib/bootstrap.js
+++ b/npm/agentplugins/lib/bootstrap.js
@@ -14,6 +14,7 @@ const DIGEST = /^[0-9a-f]{64}$/;
 const MAX_REDIRECTS = 5;
 const DOWNLOAD_TIMEOUT_MS = 30_000;
 const LOCK_TIMEOUT_MS = 30_000;
+const PROOF_MODE = "local-frozen-release-asset-v1";
 
 function loadRelease(packageRoot, platformInfo) {
   const pkg = JSON.parse(fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"));
@@ -65,6 +66,24 @@ async function validCachedBinary(file, expectedHash) {
       return false;
     }
     throw error;
+  }
+}
+
+function localProofAsset(environment = {}) {
+  const mode = String(environment.AGENTPLUGINS_INTERNAL_PROOF_MODE || "").trim();
+  const file = String(environment.AGENTPLUGINS_INTERNAL_PROOF_BINARY || "").trim();
+  if (!mode && !file) return "";
+  if (mode !== PROOF_MODE || !file || !path.isAbsolute(file)) {
+    throw new Error("internal proof bootstrap requires an absolute frozen release asset and exact proof mode");
+  }
+  return file;
+}
+
+async function verifyLocalProofAsset(file, expected) {
+  const stat = await fsp.lstat(file);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.size !== expected.size ||
+      await sha256File(file) !== expected.sha256) {
+    throw new Error("internal proof release asset does not match embedded size and SHA-256 metadata");
   }
 }
 
@@ -300,6 +319,21 @@ async function ensureBinary(options = {}) {
   if (await validCachedBinary(binaryPath, release.asset.sha256)) {
     return { binaryPath, version: release.version, cacheHit: true };
   }
+  const proofAsset = localProofAsset(options.environment || process.env);
+  if (proofAsset) {
+    try {
+      if (path.basename(proofAsset) !== release.asset.file) {
+        throw new Error("internal proof release asset filename does not match embedded metadata");
+      }
+      await verifyLocalProofAsset(proofAsset, release.asset);
+      await installVerifiedBinary(proofAsset, binaryPath, release, platformInfo);
+      return { binaryPath, version: release.version, cacheHit: false, source: "local_frozen_asset" };
+    } catch (error) {
+      const cold = !(await validCachedBinary(binaryPath, release.asset.sha256));
+      const suffix = cold ? " No client or plugin files were changed." : "";
+      throw new Error(`unable to obtain agentplugins ${release.version}: ${error.message}.${suffix}`);
+    }
+  }
   const releaseBase = `https://github.com/${release.manifest.repository}/releases/download/${release.manifest.tag}`;
   const url = `${String(releaseBase).replace(/\/$/, "")}/${encodeURIComponent(release.asset.file)}`;
   const temporary = path.join(os.tmpdir(), `agentplugins-download-${process.pid}-${crypto.randomBytes(8).toString("hex")}`);
@@ -324,11 +358,13 @@ function formatBootstrapError(error, version = "this exact version") {
 }
 
 module.exports = {
+  PROOF_MODE,
   acquireLock,
   downloadFile,
   ensureBinary,
   formatBootstrapError,
   loadRelease,
+  localProofAsset,
   sha256File,
   validCachedBinary
 };

--- a/npm/agentplugins/package.json
+++ b/npm/agentplugins/package.json
@@ -25,6 +25,15 @@
   "engines": {
     "node": ">=22"
   },
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ],
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/npm/agentplugins/scripts/platform-proof.js
+++ b/npm/agentplugins/scripts/platform-proof.js
@@ -6,6 +6,10 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const { spawnSync } = require("node:child_process");
+const { PROOF_MODE } = require("../lib/bootstrap");
+
+const COMMIT = /^[0-9a-f]{40}$/;
+const BOOTSTRAP_MODES = new Set(["local_frozen_asset", "public_release_download"]);
 
 function fail(message) {
   throw new Error(message);
@@ -49,6 +53,31 @@ function parseLifecycle(value) {
   return value === "true";
 }
 
+function parseBootstrapMode(value) {
+  if (!BOOTSTRAP_MODES.has(value)) {
+    fail("bootstrap mode must be exactly local_frozen_asset or public_release_download");
+  }
+  return value;
+}
+
+function frozenReleaseAsset(releaseAssetsRoot, expectedCommit, version, expectedTarget, pinned) {
+  if (!COMMIT.test(expectedCommit)) fail("expected commit must be an exact lowercase 40-character commit");
+  const root = path.resolve(releaseAssetsRoot);
+  const manifest = JSON.parse(fs.readFileSync(path.join(root, "release-manifest.json"), "utf8"));
+  const asset = manifest.assets?.[expectedTarget];
+  if (manifest.schema_version !== 2 || manifest.version !== version ||
+      manifest.tag !== `agentplugins-v${version}` || manifest.commit !== expectedCommit ||
+      !asset || asset.file !== pinned.file || asset.size !== pinned.size || asset.sha256 !== pinned.sha256) {
+    fail("frozen release manifest does not match the npm package pin and exact release identity");
+  }
+  const file = path.join(root, asset.file);
+  const stat = fs.lstatSync(file);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.size !== pinned.size || sha256(file) !== pinned.sha256) {
+    fail("frozen release binary does not match the npm package size and SHA-256 pin");
+  }
+  return file;
+}
+
 function lifecycleCommands(synthetic) {
   return [
     ["add", synthetic, "--target", "cursor"],
@@ -59,11 +88,13 @@ function lifecycleCommands(synthetic) {
 }
 
 function main() {
-  const [tarballArg, version, expectedTarget, lifecycleArg, resultArg] = process.argv.slice(2);
-  if (!tarballArg || !version || !expectedTarget || !lifecycleArg || !resultArg) {
-    fail("usage: platform-proof.js <npm-tarball> <version> <os-arch> <true|false> <result-json>");
+  const [tarballArg, version, expectedTarget, lifecycleArg, resultArg, expectedCommit, bootstrapModeArg, releaseAssetsArg] = process.argv.slice(2);
+  if (!tarballArg || !version || !expectedTarget || !lifecycleArg || !resultArg || !expectedCommit || !bootstrapModeArg || !releaseAssetsArg) {
+    fail("usage: platform-proof.js <npm-tarball> <version> <os-arch> <true|false> <result-json> <expected-commit> <local_frozen_asset|public_release_download> <release-assets-dir|->");
   }
   const lifecycle = parseLifecycle(lifecycleArg);
+  const bootstrapMode = parseBootstrapMode(bootstrapModeArg);
+  if (!COMMIT.test(expectedCommit)) fail("expected commit must be an exact lowercase 40-character commit");
   const osNames = { darwin: "darwin", linux: "linux", win32: "windows" };
   const archNames = { x64: "amd64", arm64: "arm64" };
   const actualTarget = `${osNames[process.platform] || process.platform}-${archNames[process.arch] || process.arch}`;
@@ -112,7 +143,7 @@ function main() {
     TEMP: temporary,
     TMP: temporary
   });
-  for (const name of ["CODEX_HOME", "CLAUDE_CONFIG_DIR", "CURSOR_CONFIG_DIR", "NPM_TOKEN", "NODE_AUTH_TOKEN"]) {
+  for (const name of ["CODEX_HOME", "CLAUDE_CONFIG_DIR", "CURSOR_CONFIG_DIR", "NPM_TOKEN", "NODE_AUTH_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"]) {
     delete env[name];
   }
   fs.writeFileSync(env.NPM_CONFIG_USERCONFIG, "registry=https://registry.npmjs.org/\n");
@@ -136,6 +167,16 @@ function main() {
   if (!pinned || manifest.version !== version) fail(`tarball has no exact pin for ${expectedTarget}`);
   if (fs.existsSync(cache)) fail("binary cache was not cold before the launcher ran");
 
+  if (bootstrapMode === "local_frozen_asset") {
+    if (releaseAssetsArg === "-") fail("local frozen asset bootstrap requires the same-run release assets directory");
+    env.AGENTPLUGINS_INTERNAL_PROOF_MODE = PROOF_MODE;
+    env.AGENTPLUGINS_INTERNAL_PROOF_BINARY = frozenReleaseAsset(
+      releaseAssetsArg, expectedCommit, version, expectedTarget, pinned
+    );
+  } else if (releaseAssetsArg !== "-") {
+    fail("public release bootstrap must not receive a local proof asset directory");
+  }
+
   const shim = path.join(project, "node_modules", ".bin", process.platform === "win32" ? "agentplugins.cmd" : "agentplugins");
   if (!fs.existsSync(shim)) fail("npm did not create the agentplugins executable shim");
   const launcher = path.join(packageRoot, "bin", "agentplugins.js");
@@ -145,6 +186,8 @@ function main() {
 
   const versionOutput = invoke(["version"]).trim();
   if (versionOutput !== `agentplugins ${version}`) fail(`unexpected version output: ${versionOutput}`);
+  delete env.AGENTPLUGINS_INTERNAL_PROOF_MODE;
+  delete env.AGENTPLUGINS_INTERNAL_PROOF_BINARY;
   const binaryName = process.platform === "win32" ? "agentplugins.exe" : "agentplugins";
   const binaryPath = path.join(cache, version, expectedTarget, binaryName);
   const stat = fs.lstatSync(binaryPath);
@@ -192,9 +235,12 @@ function main() {
     execution: "native-runtime-e2e",
     release_version: version,
     npm_tarball: path.basename(tarball),
+    bootstrap_source: bootstrapMode,
     proofs: {
       npm_install_ignore_scripts: true,
       launcher_cold_bootstrap: true,
+      local_frozen_asset_bootstrap: bootstrapMode === "local_frozen_asset",
+      anonymous_public_release_download: bootstrapMode === "public_release_download",
       embedded_sha256_and_size: true,
       released_binary_executed: true,
       version: true,
@@ -202,6 +248,7 @@ function main() {
       doctor_read_only: true,
       synthetic_add_dry_run: true,
       warm_cache: true,
+      warm_cache_without_proof_source: true,
       isolated_add_update_remove: lifecycle
     }
   };
@@ -220,4 +267,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { lifecycleCommands, npmInvocation, parseLifecycle };
+module.exports = { frozenReleaseAsset, lifecycleCommands, npmInvocation, parseBootstrapMode, parseLifecycle };

--- a/npm/agentplugins/scripts/platform-proof.js
+++ b/npm/agentplugins/scripts/platform-proof.js
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function run(command, args, options) {
+  const result = spawnSync(command, args, { ...options, encoding: "utf8" });
+  if (result.status !== 0) {
+    fail(`${command} ${args.join(" ")} failed (${result.status}):\n${result.stdout || ""}${result.stderr || ""}`);
+  }
+  return result.stdout;
+}
+
+function jsonCommand(command, args, options) {
+  const body = run(command, args, options);
+  try {
+    return JSON.parse(body);
+  } catch (error) {
+    fail(`command did not return JSON: ${body}\n${error.message}`);
+  }
+}
+
+function sha256(file) {
+  return crypto.createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+}
+
+function mkdir(directory) {
+  fs.mkdirSync(directory, { recursive: true });
+}
+
+function main() {
+  const [tarballArg, version, expectedTarget, lifecycleArg, resultArg] = process.argv.slice(2);
+  if (!tarballArg || !version || !expectedTarget || !lifecycleArg || !resultArg) {
+    fail("usage: platform-proof.js <npm-tarball> <version> <os-arch> <true|false> <result-json>");
+  }
+  const osNames = { darwin: "darwin", linux: "linux", win32: "windows" };
+  const archNames = { x64: "amd64", arm64: "arm64" };
+  const actualTarget = `${osNames[process.platform] || process.platform}-${archNames[process.arch] || process.arch}`;
+  if (actualTarget !== expectedTarget) {
+    fail(`runner architecture mismatch: expected ${expectedTarget}, got ${actualTarget}`);
+  }
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "agentplugins-platform-proof-"));
+  const project = path.join(root, "project");
+  const home = path.join(root, "home");
+  const cursor = path.join(home, ".cursor");
+  const state = path.join(root, "state");
+  const cache = path.join(root, "binary-cache");
+  const synthetic = path.join(root, "synthetic-plugin");
+  const temporary = path.join(root, "tmp");
+  for (const directory of [project, cursor, synthetic, temporary]) mkdir(directory);
+  fs.writeFileSync(path.join(cursor, "platform-proof-marker"), "synthetic isolated client root\n");
+  fs.writeFileSync(path.join(synthetic, "plugin.json"), JSON.stringify({
+    $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+    name: "platform-proof-synthetic",
+    version: "1.0.0",
+    description: "Synthetic package used only by isolated release CI"
+  }, null, 2) + "\n");
+  fs.writeFileSync(path.join(project, "package.json"), JSON.stringify({
+    name: "agentplugins-platform-proof-project",
+    version: "1.0.0",
+    private: true
+  }, null, 2) + "\n");
+
+  const env = { ...process.env };
+  Object.assign(env, {
+    HOME: home,
+    USERPROFILE: home,
+    APPDATA: path.join(root, "appdata"),
+    LOCALAPPDATA: path.join(root, "localappdata"),
+    XDG_CONFIG_HOME: path.join(root, "config"),
+    XDG_CACHE_HOME: path.join(root, "xdg-cache"),
+    AGENTPLUGINS_HOME: state,
+    AGENTPLUGINS_CACHE_DIR: cache,
+    NPM_CONFIG_CACHE: path.join(root, "npm-cache"),
+    NPM_CONFIG_USERCONFIG: path.join(home, ".npmrc"),
+    GIT_CONFIG_GLOBAL: path.join(home, ".gitconfig"),
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_TERMINAL_PROMPT: "0",
+    TMPDIR: temporary,
+    TEMP: temporary,
+    TMP: temporary
+  });
+  for (const name of ["CODEX_HOME", "CLAUDE_CONFIG_DIR", "CURSOR_CONFIG_DIR", "NPM_TOKEN", "NODE_AUTH_TOKEN"]) {
+    delete env[name];
+  }
+  fs.writeFileSync(env.NPM_CONFIG_USERCONFIG, "registry=https://registry.npmjs.org/\n");
+
+  const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+  const tarball = path.resolve(tarballArg);
+  run(npm, ["install", "--ignore-scripts", "--no-audit", "--no-fund", "--save-exact", tarball], {
+    cwd: project,
+    env,
+    shell: process.platform === "win32"
+  });
+  const packageRoot = path.join(project, "node_modules", "universal-agent-plugins");
+  const pkg = JSON.parse(fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"));
+  if (pkg.version !== version || pkg.scripts?.preinstall || pkg.scripts?.install || pkg.scripts?.postinstall) {
+    fail("installed tarball version or no-install-script invariant is invalid");
+  }
+  const manifest = JSON.parse(fs.readFileSync(path.join(packageRoot, "assets.json"), "utf8"));
+  const pinned = manifest.assets?.[expectedTarget];
+  if (!pinned || manifest.version !== version) fail(`tarball has no exact pin for ${expectedTarget}`);
+  if (fs.existsSync(cache)) fail("binary cache was not cold before the launcher ran");
+
+  const shim = path.join(project, "node_modules", ".bin", process.platform === "win32" ? "agentplugins.cmd" : "agentplugins");
+  if (!fs.existsSync(shim)) fail("npm did not create the agentplugins executable shim");
+  const launcher = path.join(packageRoot, "bin", "agentplugins.js");
+  const commandOptions = { cwd: project, env };
+  const invoke = (args) => run(process.execPath, [launcher, ...args], commandOptions);
+  const invokeJSON = (args) => jsonCommand(process.execPath, [launcher, ...args, "--format", "json"], commandOptions);
+
+  const versionOutput = invoke(["version"]).trim();
+  if (versionOutput !== `agentplugins ${version}`) fail(`unexpected version output: ${versionOutput}`);
+  const binaryName = process.platform === "win32" ? "agentplugins.exe" : "agentplugins";
+  const binaryPath = path.join(cache, version, expectedTarget, binaryName);
+  const stat = fs.lstatSync(binaryPath);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.size !== pinned.size || sha256(binaryPath) !== pinned.sha256) {
+    fail("bootstrapped binary does not match the tarball's exact size and SHA-256 pin");
+  }
+  const firstMtime = stat.mtimeMs;
+  const list = invokeJSON(["list"]);
+  const doctor = invokeJSON(["doctor"]);
+  if (list.schema_version !== 1 || list.command !== "list" || list.data.installations.length !== 0) {
+    fail("clean list contract failed");
+  }
+  if (doctor.schema_version !== 1 || doctor.command !== "doctor" || doctor.data.read_only !== true) {
+    fail("read-only doctor contract failed");
+  }
+  const dryRun = invokeJSON(["add", synthetic, "--target", "cursor", "--dry-run"]);
+  if (dryRun.schema_version !== 1 || dryRun.command !== "add" || dryRun.data.dry_run !== true) {
+    fail("synthetic add dry-run contract failed");
+  }
+  if (fs.existsSync(path.join(state, "state-v2.json"))) fail("dry-run wrote lifecycle state");
+  if (fs.readdirSync(cursor).join(",") !== "platform-proof-marker") fail("dry-run changed the synthetic client root");
+  if (fs.lstatSync(binaryPath).mtimeMs !== firstMtime) fail("warm launcher invocation replaced the verified cache entry");
+
+  const lifecycle = lifecycleArg === "true";
+  if (lifecycle) {
+    const add = invokeJSON(["add", synthetic, "--target", "cursor", "--yes"]);
+    const update = invokeJSON(["update", "platform-proof-synthetic", "--target", "cursor", "--yes"]);
+    const remove = invokeJSON(["remove", "platform-proof-synthetic", "--target", "cursor", "--yes"]);
+    if (add.data.result.mutated !== true || update.data.result.no_change !== true ||
+        update.data.result.mutated !== false || remove.data.result.mutated !== true) {
+      fail("isolated synthetic add/update/remove lifecycle contract failed");
+    }
+    const after = invokeJSON(["list"]);
+    if (after.data.installations.length !== 0) fail("removed synthetic package remained in the active list");
+  }
+
+  const result = {
+    schema_version: 1,
+    target: expectedTarget,
+    runner_platform: process.platform,
+    runner_arch: process.arch,
+    execution: "native-runtime-e2e",
+    release_version: version,
+    npm_tarball: path.basename(tarball),
+    proofs: {
+      npm_install_ignore_scripts: true,
+      launcher_cold_bootstrap: true,
+      embedded_sha256_and_size: true,
+      released_binary_executed: true,
+      version: true,
+      list: true,
+      doctor_read_only: true,
+      synthetic_add_dry_run: true,
+      warm_cache: true,
+      isolated_add_update_remove: lifecycle
+    }
+  };
+  mkdir(path.dirname(path.resolve(resultArg)));
+  fs.writeFileSync(path.resolve(resultArg), JSON.stringify(result, null, 2) + "\n");
+  fs.rmSync(root, { recursive: true, force: true });
+  process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`agentplugins platform proof: ${error.message}\n`);
+  process.exitCode = 1;
+}

--- a/npm/agentplugins/scripts/platform-proof.js
+++ b/npm/agentplugins/scripts/platform-proof.js
@@ -146,9 +146,12 @@ function main() {
   const lifecycle = lifecycleArg === "true";
   if (lifecycle) {
     const add = invokeJSON(["add", synthetic, "--target", "cursor", "--yes"]);
+    const complete = invokeJSON(["add", synthetic, "--target", "cursor", "--yes", "--activation-complete", "--auth-complete"]);
     const update = invokeJSON(["update", "platform-proof-synthetic", "--target", "cursor", "--yes"]);
     const remove = invokeJSON(["remove", "platform-proof-synthetic", "--target", "cursor", "--yes"]);
-    if (add.data.result.mutated !== true || update.data.result.no_change !== true ||
+    if (add.data.result.mutated !== true || add.data.result.activation.authentication !== "not_checked" ||
+        complete.data.result.mutated !== true || complete.data.result.activation.activation_attested !== true ||
+        complete.data.result.activation.authentication_attested !== true || update.data.result.no_change !== true ||
         update.data.result.mutated !== false || remove.data.result.mutated !== true) {
       fail("isolated synthetic add/update/remove lifecycle contract failed");
     }

--- a/npm/agentplugins/scripts/platform-proof.js
+++ b/npm/agentplugins/scripts/platform-proof.js
@@ -36,11 +36,34 @@ function mkdir(directory) {
   fs.mkdirSync(directory, { recursive: true });
 }
 
+function npmInvocation(args, platform = process.platform, execPath = process.execPath) {
+  if (platform !== "win32") return { command: "npm", args };
+  const npmCLI = path.win32.join(path.win32.dirname(execPath), "node_modules", "npm", "bin", "npm-cli.js");
+  return { command: execPath, args: [npmCLI, ...args] };
+}
+
+function parseLifecycle(value) {
+  if (value !== "true" && value !== "false") {
+    fail("lifecycle must be exactly true or false");
+  }
+  return value === "true";
+}
+
+function lifecycleCommands(synthetic) {
+  return [
+    ["add", synthetic, "--target", "cursor"],
+    ["add", synthetic, "--target", "cursor", "--activation-complete", "--auth-complete"],
+    ["update", "platform-proof-synthetic", "--target", "cursor"],
+    ["remove", "platform-proof-synthetic", "--target", "cursor"]
+  ];
+}
+
 function main() {
   const [tarballArg, version, expectedTarget, lifecycleArg, resultArg] = process.argv.slice(2);
   if (!tarballArg || !version || !expectedTarget || !lifecycleArg || !resultArg) {
     fail("usage: platform-proof.js <npm-tarball> <version> <os-arch> <true|false> <result-json>");
   }
+  const lifecycle = parseLifecycle(lifecycleArg);
   const osNames = { darwin: "darwin", linux: "linux", win32: "windows" };
   const archNames = { x64: "amd64", arm64: "arm64" };
   const actualTarget = `${osNames[process.platform] || process.platform}-${archNames[process.arch] || process.arch}`;
@@ -94,12 +117,14 @@ function main() {
   }
   fs.writeFileSync(env.NPM_CONFIG_USERCONFIG, "registry=https://registry.npmjs.org/\n");
 
-  const npm = process.platform === "win32" ? "npm.cmd" : "npm";
   const tarball = path.resolve(tarballArg);
-  run(npm, ["install", "--ignore-scripts", "--no-audit", "--no-fund", "--save-exact", tarball], {
+  const npmInstall = npmInvocation(["install", "--ignore-scripts", "--no-audit", "--no-fund", "--save-exact", tarball]);
+  if (process.platform === "win32" && !fs.existsSync(npmInstall.args[0])) {
+    fail(`npm CLI was not found next to Node.js: ${npmInstall.args[0]}`);
+  }
+  run(npmInstall.command, npmInstall.args, {
     cwd: project,
-    env,
-    shell: process.platform === "win32"
+    env
   });
   const packageRoot = path.join(project, "node_modules", "universal-agent-plugins");
   const pkg = JSON.parse(fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"));
@@ -143,12 +168,12 @@ function main() {
   if (fs.readdirSync(cursor).join(",") !== "platform-proof-marker") fail("dry-run changed the synthetic client root");
   if (fs.lstatSync(binaryPath).mtimeMs !== firstMtime) fail("warm launcher invocation replaced the verified cache entry");
 
-  const lifecycle = lifecycleArg === "true";
   if (lifecycle) {
-    const add = invokeJSON(["add", synthetic, "--target", "cursor", "--yes"]);
-    const complete = invokeJSON(["add", synthetic, "--target", "cursor", "--yes", "--activation-complete", "--auth-complete"]);
-    const update = invokeJSON(["update", "platform-proof-synthetic", "--target", "cursor", "--yes"]);
-    const remove = invokeJSON(["remove", "platform-proof-synthetic", "--target", "cursor", "--yes"]);
+    const [addCommand, completeCommand, updateCommand, removeCommand] = lifecycleCommands(synthetic);
+    const add = invokeJSON(addCommand);
+    const complete = invokeJSON(completeCommand);
+    const update = invokeJSON(updateCommand);
+    const remove = invokeJSON(removeCommand);
     if (add.data.result.mutated !== true || add.data.result.activation.authentication !== "not_checked" ||
         complete.data.result.mutated !== true || complete.data.result.activation.activation_attested !== true ||
         complete.data.result.activation.authentication_attested !== true || update.data.result.no_change !== true ||
@@ -186,9 +211,13 @@ function main() {
   process.stdout.write(JSON.stringify(result, null, 2) + "\n");
 }
 
-try {
-  main();
-} catch (error) {
-  process.stderr.write(`agentplugins platform proof: ${error.message}\n`);
-  process.exitCode = 1;
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`agentplugins platform proof: ${error.message}\n`);
+    process.exitCode = 1;
+  }
 }
+
+module.exports = { lifecycleCommands, npmInvocation, parseLifecycle };

--- a/npm/agentplugins/scripts/release-assets.js
+++ b/npm/agentplugins/scripts/release-assets.js
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const COMMIT = /^[0-9a-f]{40}$/;
+const DIGEST = /^[0-9a-f]{64}$/;
+const TARGETS = [
+  ["darwin-amd64", "darwin", "amd64", ""],
+  ["darwin-arm64", "darwin", "arm64", ""],
+  ["linux-amd64", "linux", "amd64", ""],
+  ["linux-arm64", "linux", "arm64", ""],
+  ["windows-amd64", "windows", "amd64", ".exe"],
+  ["windows-arm64", "windows", "arm64", ".exe"]
+];
+
+function sha256(file) {
+  return crypto.createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+}
+
+function releaseIdentity(tag, commit) {
+  if (!/^agentplugins-v\d+\.\d+\.\d+$/.test(tag)) {
+    throw new Error(`invalid stable release tag: ${tag}`);
+  }
+  const version = tag.slice("agentplugins-v".length);
+  if (!VERSION.test(version) || !COMMIT.test(commit)) {
+    throw new Error("release version or commit is invalid");
+  }
+  return { tag, version, commit };
+}
+
+function expectedAssets(version) {
+  return Object.fromEntries(TARGETS.map(([key, osName, archName, suffix]) => [
+    key,
+    `agentplugins_${version}_${osName}_${archName}${suffix}`
+  ]));
+}
+
+function assetMetadata(assetRoot, version) {
+  const assets = {};
+  for (const [key, file] of Object.entries(expectedAssets(version))) {
+    const filePath = path.join(assetRoot, file);
+    const stat = fs.lstatSync(filePath);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size <= 0) {
+      throw new Error(`release asset is not a regular non-empty file: ${file}`);
+    }
+    assets[key] = { file, sha256: sha256(filePath), size: stat.size };
+  }
+  return assets;
+}
+
+function writeChecksums(assetRoot, assets) {
+  const names = [...Object.values(assets).map((asset) => asset.file), "release-manifest.json"];
+  const body = names.map((file) => `${sha256(path.join(assetRoot, file))}  ${file}`).join("\n") + "\n";
+  fs.writeFileSync(path.join(assetRoot, "checksums.txt"), body);
+}
+
+function prepareRelease(assetRoot, tag, commit) {
+  const identity = releaseIdentity(tag, commit);
+  const manifest = {
+    schema_version: 2,
+    ...identity,
+    assets: assetMetadata(assetRoot, identity.version)
+  };
+  fs.writeFileSync(path.join(assetRoot, "release-manifest.json"), JSON.stringify(manifest, null, 2) + "\n");
+  writeChecksums(assetRoot, manifest.assets);
+  return manifest;
+}
+
+function parseChecksums(assetRoot) {
+  const body = fs.readFileSync(path.join(assetRoot, "checksums.txt"), "utf8");
+  const entries = new Map();
+  for (const line of body.split(/\r?\n/)) {
+    if (!line) continue;
+    const match = line.match(/^([0-9a-f]{64})  ([A-Za-z0-9_.-]+)$/);
+    if (!match || entries.has(match[2])) {
+      throw new Error("checksums.txt contains an invalid or duplicate entry");
+    }
+    entries.set(match[2], match[1]);
+  }
+  return entries;
+}
+
+function verifyChecksums(assetRoot, expectedNames) {
+  const entries = parseChecksums(assetRoot);
+  if (entries.size !== expectedNames.length || expectedNames.some((name) => !entries.has(name))) {
+    throw new Error("checksums.txt does not name exactly the six binaries and release manifest");
+  }
+  for (const name of expectedNames) {
+    if (entries.get(name) !== sha256(path.join(assetRoot, name))) {
+      throw new Error(`checksum mismatch: ${name}`);
+    }
+  }
+}
+
+function verifyRelease(assetRoot, tag, commit, options = {}) {
+  const identity = releaseIdentity(tag, commit);
+  const manifestPath = path.join(assetRoot, "release-manifest.json");
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  if (manifest.tag !== identity.tag || manifest.commit !== identity.commit) {
+    throw new Error("release manifest identity does not match the exact tag and commit");
+  }
+  const computed = assetMetadata(assetRoot, identity.version);
+  const names = [...Object.values(computed).map((asset) => asset.file), "release-manifest.json"];
+  verifyChecksums(assetRoot, names);
+
+  if (manifest.schema_version === 1 && options.allowLegacyManifest === true) {
+    if (Object.keys(manifest).sort().join(",") !== "commit,schema_version,tag") {
+      throw new Error("legacy release manifest has unexpected fields");
+    }
+    return { ...identity, assets: computed, manifest_schema: 1, gate_eligible: false };
+  }
+  if (manifest.schema_version !== 2 || manifest.version !== identity.version) {
+    throw new Error("release manifest schema or version does not match");
+  }
+  if (Object.keys(manifest).sort().join(",") !== "assets,commit,schema_version,tag,version") {
+    throw new Error("release manifest has unexpected or missing fields");
+  }
+  const expectedKeys = Object.keys(computed).sort();
+  if (!manifest.assets || Object.keys(manifest.assets).sort().join(",") !== expectedKeys.join(",")) {
+    throw new Error("release manifest must contain exactly six target assets");
+  }
+  for (const key of expectedKeys) {
+    const actual = manifest.assets[key];
+    const expected = computed[key];
+    if (!actual || Object.keys(actual).sort().join(",") !== "file,sha256,size" ||
+        actual.file !== expected.file || actual.sha256 !== expected.sha256 || actual.size !== expected.size ||
+        !DIGEST.test(String(actual.sha256)) || !Number.isSafeInteger(actual.size) || actual.size <= 0) {
+      throw new Error(`release manifest asset metadata mismatch: ${key}`);
+    }
+  }
+  return { ...identity, assets: computed, manifest_schema: 2, gate_eligible: true };
+}
+
+function main() {
+  const [command, rootArg, tag, commit, policy] = process.argv.slice(2);
+  if (!command || !rootArg || !tag || !commit) {
+    throw new Error("usage: release-assets.js <prepare|verify> <asset-root> <tag> <commit> [allow-legacy-v1]");
+  }
+  const assetRoot = path.resolve(rootArg);
+  const result = command === "prepare"
+    ? prepareRelease(assetRoot, tag, commit)
+    : command === "verify"
+      ? verifyRelease(assetRoot, tag, commit, { allowLegacyManifest: policy === "allow-legacy-v1" })
+      : (() => { throw new Error(`unknown command: ${command}`); })();
+  process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`agentplugins release assets: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = { expectedAssets, prepareRelease, verifyRelease };

--- a/npm/agentplugins/scripts/release-assets.js
+++ b/npm/agentplugins/scripts/release-assets.js
@@ -106,6 +106,11 @@ function verifyRelease(assetRoot, tag, commit, options = {}) {
   const computed = assetMetadata(assetRoot, identity.version);
   const names = [...Object.values(computed).map((asset) => asset.file), "release-manifest.json"];
   verifyChecksums(assetRoot, names);
+  const expectedFiles = [...names, "checksums.txt"].sort();
+  const actualFiles = fs.readdirSync(assetRoot).sort();
+  if (actualFiles.join("\n") !== expectedFiles.join("\n")) {
+    throw new Error("release directory must contain exactly the six binaries, checksums, and manifest");
+  }
 
   if (manifest.schema_version === 1 && options.allowLegacyManifest === true) {
     if (Object.keys(manifest).sort().join(",") !== "commit,schema_version,tag") {

--- a/npm/agentplugins/scripts/stage-release.js
+++ b/npm/agentplugins/scripts/stage-release.js
@@ -6,6 +6,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const { detectPlatform, expectedAssetName } = require("../lib/platform");
+const { verifyRelease } = require("./release-assets");
 
 const VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 const NPM_PACKAGE_NAME = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/;
@@ -34,10 +35,11 @@ function validatePackageMetadata(pkg) {
   return packageName;
 }
 
-function stage(packageRoot, assetRoot, version) {
+function stage(packageRoot, assetRoot, version, commit, options = {}) {
   if (!VERSION.test(version)) {
     throw new Error(`invalid release version: ${version}`);
   }
+  verifyRelease(assetRoot, `agentplugins-v${version}`, commit, options);
   const pkgPath = path.join(packageRoot, "package.json");
   const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
   const packageName = validatePackageMetadata(pkg);
@@ -67,11 +69,13 @@ function stage(packageRoot, assetRoot, version) {
 }
 
 function main() {
-  const [packageRoot, assetRoot, version] = process.argv.slice(2);
-  if (!packageRoot || !assetRoot || !version) {
-    throw new Error("usage: stage-release.js <package-root> <asset-root> <version>");
+  const [packageRoot, assetRoot, version, commit, policy] = process.argv.slice(2);
+  if (!packageRoot || !assetRoot || !version || !commit) {
+    throw new Error("usage: stage-release.js <package-root> <asset-root> <version> <commit> [allow-legacy-v1]");
   }
-  const manifest = stage(path.resolve(packageRoot), path.resolve(assetRoot), version);
+  const manifest = stage(path.resolve(packageRoot), path.resolve(assetRoot), version, commit, {
+    allowLegacyManifest: policy === "allow-legacy-v1"
+  });
   process.stdout.write(`Staged agentplugins ${manifest.version} with ${Object.keys(manifest.assets).length} pinned assets\n`);
 }
 

--- a/npm/agentplugins/test/bootstrap.test.js
+++ b/npm/agentplugins/test/bootstrap.test.js
@@ -145,7 +145,12 @@ test("package has no install scripts", async () => {
   const packageRoot = path.resolve(__dirname, "..");
   const pkg = JSON.parse(await fsp.readFile(path.join(packageRoot, "package.json"), "utf8"));
   assert.equal(pkg.engines.node, ">=22");
+  assert.deepEqual(pkg.os, ["darwin", "linux", "win32"]);
+  assert.deepEqual(pkg.cpu, ["x64", "arm64"]);
   assert.deepEqual(pkg.scripts, { test: "node --test" });
+  assert.equal(pkg.scripts.preinstall, undefined);
+  assert.equal(pkg.scripts.install, undefined);
+  assert.equal(pkg.scripts.postinstall, undefined);
 });
 
 test("development metadata cannot download a release binary", async (t) => {

--- a/npm/agentplugins/test/bootstrap.test.js
+++ b/npm/agentplugins/test/bootstrap.test.js
@@ -7,9 +7,10 @@ const fsp = require("node:fs/promises");
 const http = require("node:http");
 const os = require("node:os");
 const path = require("node:path");
+const { spawnSync } = require("node:child_process");
 const test = require("node:test");
 
-const { acquireLock, downloadFile, ensureBinary, loadRelease } = require("../lib/bootstrap");
+const { PROOF_MODE, acquireLock, downloadFile, ensureBinary, loadRelease } = require("../lib/bootstrap");
 const { cacheRoot, detectPlatform, expectedAssetName } = require("../lib/platform");
 
 const VERSION = "0.1.0";
@@ -79,6 +80,102 @@ test("cold, warm, corrupted, and concurrent cache paths stay verified", async (t
   const repaired = await ensureBinary(options);
   assert.equal(await fsp.readFile(repaired.binaryPath, "utf8"), fixture.binary.toString());
   assert.ok(requests > beforeWarm);
+});
+
+test("internal draft proof bootstraps a cold cache from one exact frozen local asset", async (t) => {
+  const fixture = await fixturePackage(t);
+  const releaseRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "agentplugins-proof-release-"));
+  const releaseAsset = path.join(releaseRoot, fixture.file);
+  const cache = path.join(releaseRoot, "cache");
+  await fsp.writeFile(releaseAsset, fixture.binary, { mode: 0o755 });
+  t.after(() => fsp.rm(releaseRoot, { recursive: true, force: true }));
+  let requested = false;
+  const options = {
+    packageRoot: fixture.root,
+    cacheRoot: cache,
+    environment: {
+      AGENTPLUGINS_INTERNAL_PROOF_MODE: PROOF_MODE,
+      AGENTPLUGINS_INTERNAL_PROOF_BINARY: releaseAsset
+    },
+    request: () => {
+      requested = true;
+      throw new Error("draft proof must not request a public release");
+    },
+    platform: "linux",
+    arch: "x64"
+  };
+  const cold = await ensureBinary(options);
+  assert.equal(cold.cacheHit, false);
+  assert.equal(cold.source, "local_frozen_asset");
+  assert.equal(requested, false);
+  assert.equal(await fsp.readFile(cold.binaryPath, "utf8"), fixture.binary.toString());
+  const warm = await ensureBinary({ ...options, environment: {} });
+  assert.equal(warm.cacheHit, true);
+  assert.equal(requested, false);
+});
+
+test("internal draft proof rejects wrong mode, filename, bytes, and symlinks", async (t) => {
+  const fixture = await fixturePackage(t);
+  const releaseRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "agentplugins-bad-proof-release-"));
+  const cache = path.join(releaseRoot, "cache");
+  t.after(() => fsp.rm(releaseRoot, { recursive: true, force: true }));
+  const run = (file, mode = PROOF_MODE) => ensureBinary({
+    packageRoot: fixture.root,
+    cacheRoot: cache,
+    environment: {
+      AGENTPLUGINS_INTERNAL_PROOF_MODE: mode,
+      AGENTPLUGINS_INTERNAL_PROOF_BINARY: file
+    },
+    platform: "linux",
+    arch: "x64"
+  });
+  const wrongName = path.join(releaseRoot, "wrong-name");
+  await fsp.writeFile(wrongName, fixture.binary);
+  await assert.rejects(run(wrongName), /filename does not match/);
+  const exactName = path.join(releaseRoot, fixture.file);
+  await fsp.writeFile(exactName, "wrong bytes");
+  await assert.rejects(run(exactName), /does not match embedded size and SHA-256/);
+  await assert.rejects(run(exactName, "wrong-mode"), /exact proof mode/);
+  await fsp.rm(exactName);
+  try {
+    await fsp.symlink(wrongName, exactName);
+    await assert.rejects(run(exactName), /does not match embedded size and SHA-256/);
+  } catch (error) {
+    if (!error || !["EPERM", "ENOTSUP"].includes(error.code)) throw error;
+  }
+  assert.equal(fs.existsSync(cache), false);
+});
+
+test("real npm launcher consumes local proof bootstrap variables without forwarding them", async (t) => {
+  if (process.platform !== "linux" || process.arch !== "x64") {
+    t.skip("launcher fixture is pinned to linux-amd64");
+    return;
+  }
+  const launcherBinary = Buffer.from(
+    "#!/usr/bin/env node\n" +
+    "process.stdout.write(JSON.stringify({args: process.argv.slice(2), mode: process.env.AGENTPLUGINS_INTERNAL_PROOF_MODE || '', binary: process.env.AGENTPLUGINS_INTERNAL_PROOF_BINARY || ''}));\n"
+  );
+  const fixture = await fixturePackage(t, launcherBinary);
+  const packageSource = path.resolve(__dirname, "..");
+  await fsp.cp(path.join(packageSource, "bin"), path.join(fixture.root, "bin"), { recursive: true });
+  await fsp.cp(path.join(packageSource, "lib"), path.join(fixture.root, "lib"), { recursive: true });
+  const releaseRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "agentplugins-launcher-proof-"));
+  const releaseAsset = path.join(releaseRoot, fixture.file);
+  const cache = path.join(releaseRoot, "cache");
+  await fsp.writeFile(releaseAsset, fixture.binary, { mode: 0o755 });
+  t.after(() => fsp.rm(releaseRoot, { recursive: true, force: true }));
+  const result = spawnSync(process.execPath, [path.join(fixture.root, "bin", "agentplugins.js"), "version"], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      AGENTPLUGINS_CACHE_DIR: cache,
+      AGENTPLUGINS_INTERNAL_PROOF_MODE: PROOF_MODE,
+      AGENTPLUGINS_INTERNAL_PROOF_BINARY: releaseAsset
+    }
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), { args: ["version"], mode: "", binary: "" });
+  assert.equal(await fsp.readFile(path.join(cache, VERSION, "linux-amd64", "agentplugins"), "utf8"), launcherBinary.toString());
 });
 
 test("offline cold cache fails without creating the cache", async (t) => {

--- a/npm/agentplugins/test/platform-proof.test.js
+++ b/npm/agentplugins/test/platform-proof.test.js
@@ -1,0 +1,41 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const script = path.resolve(__dirname, "..", "scripts", "platform-proof.js");
+const { lifecycleCommands, npmInvocation, parseLifecycle } = require(script);
+
+test("platform proof rejects lifecycle values other than exact true or false", () => {
+  for (const value of ["TRUE", "False", "1", "yes"]) {
+    assert.throws(() => parseLifecycle(value), /lifecycle must be exactly true or false/);
+  }
+  assert.equal(parseLifecycle("true"), true);
+  assert.equal(parseLifecycle("false"), false);
+});
+
+test("Windows npm invocation executes npm-cli.js without a shell", () => {
+  const execPath = "C:\\Program Files\\nodejs\\node.exe";
+  const tarball = "C:\\proof workspace\\universal-agent-plugins.tgz";
+  const invocation = npmInvocation(["install", "--save-exact", tarball], "win32", execPath);
+
+  assert.equal(invocation.command, execPath);
+  assert.deepEqual(invocation.args, [
+    "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js",
+    "install",
+    "--save-exact",
+    tarball
+  ]);
+  assert.equal(Object.hasOwn(invocation, "shell"), false);
+});
+
+test("platform proof lifecycle commands use the default no-confirmation flow", () => {
+  const commands = lifecycleCommands("C:\\proof workspace\\synthetic plugin");
+
+  assert.equal(commands.length, 4);
+  assert.deepEqual(commands.map((command) => command[0]), ["add", "add", "update", "remove"]);
+  for (const command of commands) {
+    assert.equal(command.includes("--yes"), false, `unexpected --yes in ${command.join(" ")}`);
+  }
+});

--- a/npm/agentplugins/test/platform-proof.test.js
+++ b/npm/agentplugins/test/platform-proof.test.js
@@ -1,11 +1,14 @@
 "use strict";
 
 const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
 
 const script = path.resolve(__dirname, "..", "scripts", "platform-proof.js");
-const { lifecycleCommands, npmInvocation, parseLifecycle } = require(script);
+const { frozenReleaseAsset, lifecycleCommands, npmInvocation, parseBootstrapMode, parseLifecycle } = require(script);
 
 test("platform proof rejects lifecycle values other than exact true or false", () => {
   for (const value of ["TRUE", "False", "1", "yes"]) {
@@ -38,4 +41,42 @@ test("platform proof lifecycle commands use the default no-confirmation flow", (
   for (const command of commands) {
     assert.equal(command.includes("--yes"), false, `unexpected --yes in ${command.join(" ")}`);
   }
+});
+
+test("platform proof accepts only explicit bootstrap evidence modes", () => {
+  assert.equal(parseBootstrapMode("local_frozen_asset"), "local_frozen_asset");
+  assert.equal(parseBootstrapMode("public_release_download"), "public_release_download");
+  assert.throws(() => parseBootstrapMode("download"), /bootstrap mode must be exactly/);
+});
+
+test("platform proof binds the local binary to the frozen release manifest and npm pin", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "agentplugins-platform-manifest-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const version = "0.1.0";
+  const commit = "a".repeat(40);
+  const target = "linux-amd64";
+  const file = `agentplugins_${version}_linux_amd64`;
+  const binary = Buffer.from("exact frozen binary");
+  const pinned = {
+    file,
+    size: binary.length,
+    sha256: crypto.createHash("sha256").update(binary).digest("hex")
+  };
+  fs.writeFileSync(path.join(root, file), binary);
+  fs.writeFileSync(path.join(root, "release-manifest.json"), JSON.stringify({
+    schema_version: 2,
+    tag: `agentplugins-v${version}`,
+    version,
+    commit,
+    assets: { [target]: pinned }
+  }));
+  assert.equal(frozenReleaseAsset(root, commit, version, target, pinned), path.join(root, file));
+  assert.throws(
+    () => frozenReleaseAsset(root, "b".repeat(40), version, target, pinned),
+    /manifest does not match/
+  );
+  assert.throws(
+    () => frozenReleaseAsset(root, commit, version, target, { ...pinned, sha256: "0".repeat(64) }),
+    /manifest does not match/
+  );
 });

--- a/npm/agentplugins/test/stage-release.test.js
+++ b/npm/agentplugins/test/stage-release.test.js
@@ -55,6 +55,10 @@ test("release verification fails closed on checksum, size, and manifest mismatch
   prepareRelease(root, `agentplugins-v${version}`, COMMIT);
   assert.equal(verifyRelease(root, `agentplugins-v${version}`, COMMIT).gate_eligible, true);
 
+  await fsp.writeFile(path.join(root, "ambiguous-extra-asset"), "unexpected");
+  assert.throws(() => verifyRelease(root, `agentplugins-v${version}`, COMMIT), /must contain exactly/);
+  await fsp.rm(path.join(root, "ambiguous-extra-asset"));
+
   const manifestPath = path.join(root, "release-manifest.json");
   const manifest = JSON.parse(await fsp.readFile(manifestPath, "utf8"));
   manifest.assets["linux-amd64"].size += 1;

--- a/npm/agentplugins/test/stage-release.test.js
+++ b/npm/agentplugins/test/stage-release.test.js
@@ -1,13 +1,18 @@
 "use strict";
 
 const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
 const fsp = require("node:fs/promises");
 const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
 
 const { detectPlatform, expectedAssetName } = require("../lib/platform");
+const { prepareRelease, verifyRelease } = require("../scripts/release-assets");
 const { stage, validatePackageMetadata } = require("../scripts/stage-release");
+
+const COMMIT = "a".repeat(40);
 
 test("release staging embeds every exact platform asset hash", async (t) => {
   const root = await fsp.mkdtemp(path.join(os.tmpdir(), "agentplugins-stage-"));
@@ -26,7 +31,8 @@ test("release staging embeds every exact platform asset hash", async (t) => {
     const info = detectPlatform(platform, arch);
     await fsp.writeFile(path.join(assetsRoot, expectedAssetName(version, info)), `${info.key}\n`);
   }
-  const manifest = stage(packageRoot, assetsRoot, version);
+  prepareRelease(assetsRoot, `agentplugins-v${version}`, COMMIT);
+  const manifest = stage(packageRoot, assetsRoot, version, COMMIT);
   assert.equal(manifest.version, version);
   assert.equal(manifest.npm_package, "universal-agent-plugins");
   assert.equal(Object.keys(manifest.assets).length, 6);
@@ -36,6 +42,67 @@ test("release staging embeds every exact platform asset hash", async (t) => {
   }
   const pkg = JSON.parse(await fsp.readFile(path.join(packageRoot, "package.json"), "utf8"));
   assert.equal(pkg.version, version);
+});
+
+test("release verification fails closed on checksum, size, and manifest mismatch", async (t) => {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "agentplugins-release-assets-"));
+  t.after(() => fsp.rm(root, { recursive: true, force: true }));
+  const version = "0.1.4";
+  for (const [platform, arch] of [["darwin", "x64"], ["darwin", "arm64"], ["linux", "x64"], ["linux", "arm64"], ["win32", "x64"], ["win32", "arm64"]]) {
+    const info = detectPlatform(platform, arch);
+    await fsp.writeFile(path.join(root, expectedAssetName(version, info)), `${info.key}\n`);
+  }
+  prepareRelease(root, `agentplugins-v${version}`, COMMIT);
+  assert.equal(verifyRelease(root, `agentplugins-v${version}`, COMMIT).gate_eligible, true);
+
+  const manifestPath = path.join(root, "release-manifest.json");
+  const manifest = JSON.parse(await fsp.readFile(manifestPath, "utf8"));
+  manifest.assets["linux-amd64"].size += 1;
+  await fsp.writeFile(manifestPath, JSON.stringify(manifest));
+  const checksumsPath = path.join(root, "checksums.txt");
+  const manifestDigest = crypto.createHash("sha256").update(await fsp.readFile(manifestPath)).digest("hex");
+  const checksums = (await fsp.readFile(checksumsPath, "utf8")).replace(
+    /^[0-9a-f]{64}  release-manifest\.json$/m,
+    `${manifestDigest}  release-manifest.json`
+  );
+  await fsp.writeFile(checksumsPath, checksums);
+  assert.throws(() => verifyRelease(root, `agentplugins-v${version}`, COMMIT), /asset metadata mismatch/);
+
+  prepareRelease(root, `agentplugins-v${version}`, COMMIT);
+  await fsp.appendFile(path.join(root, `agentplugins_${version}_linux_amd64`), "changed");
+  assert.throws(() => verifyRelease(root, `agentplugins-v${version}`, COMMIT), /checksum mismatch/);
+
+  prepareRelease(root, `agentplugins-v${version}`, COMMIT);
+  const wrongIdentity = JSON.parse(await fsp.readFile(manifestPath, "utf8"));
+  wrongIdentity.commit = "b".repeat(40);
+  await fsp.writeFile(manifestPath, JSON.stringify(wrongIdentity));
+  assert.throws(() => verifyRelease(root, `agentplugins-v${version}`, COMMIT), /identity does not match/);
+});
+
+test("legacy manifests are audit-only and never gate eligible", async (t) => {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "agentplugins-legacy-assets-"));
+  t.after(() => fsp.rm(root, { recursive: true, force: true }));
+  const version = "0.1.4";
+  for (const [platform, arch] of [["darwin", "x64"], ["darwin", "arm64"], ["linux", "x64"], ["linux", "arm64"], ["win32", "x64"], ["win32", "arm64"]]) {
+    const info = detectPlatform(platform, arch);
+    await fsp.writeFile(path.join(root, expectedAssetName(version, info)), `${info.key}\n`);
+  }
+  const { assets } = prepareRelease(root, `agentplugins-v${version}`, COMMIT);
+  await fsp.writeFile(path.join(root, "release-manifest.json"), JSON.stringify({
+    schema_version: 1,
+    tag: `agentplugins-v${version}`,
+    commit: COMMIT
+  }) + "\n");
+  const names = [...Object.values(assets).map((asset) => asset.file), "release-manifest.json"];
+  const checksums = names.map((name) => {
+    const body = fs.readFileSync(path.join(root, name));
+    return `${crypto.createHash("sha256").update(body).digest("hex")}  ${name}`;
+  }).join("\n") + "\n";
+  await fsp.writeFile(path.join(root, "checksums.txt"), checksums);
+  assert.throws(() => verifyRelease(root, `agentplugins-v${version}`, COMMIT), /schema or version/);
+  const audited = verifyRelease(root, `agentplugins-v${version}`, COMMIT, { allowLegacyManifest: true });
+  assert.equal(audited.manifest_schema, 1);
+  assert.equal(audited.gate_eligible, false);
 });
 
 test("npm distribution name is independent from the agentplugins binary name", () => {

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -45,11 +45,14 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	mustContain(t, releaseDraftJob, "existing draft asset differs from the frozen build")
 	mustContain(t, releaseDraftJob, "gh api graphql")
 	mustContain(t, releaseDraftJob, ".data.repository.release")
+	mustContain(t, releaseDraftJob, "Share frozen draft assets with the read-only proof workflow")
+	mustContain(t, releaseDraftJob, "assets_artifact=agentplugins-draft-assets-${FROZEN_COMMIT}")
 	mustNotContain(t, releaseDraftJob, "target_commitish")
 	mustContain(t, releaseProofJob, "needs: [validate, stage-draft]")
-	mustContain(t, releaseProofJob, "contents: write")
+	mustContain(t, releaseProofJob, "contents: read")
 	mustContain(t, releaseProofJob, "require_draft: true")
 	mustContain(t, releaseProofJob, "expected_asset_set_digest: ${{ needs.stage-draft.outputs.asset_set_digest }}")
+	mustContain(t, releaseProofJob, "release_assets_artifact: ${{ needs.stage-draft.outputs.assets_artifact }}")
 	mustContain(t, releasePromoteJob, "needs: [validate, stage-draft, platform-proof]")
 	mustContain(t, releasePromoteJob, "EXPECTED_ASSET_SET_DIGEST: ${{ needs.stage-draft.outputs.asset_set_digest }}")
 	mustContain(t, releasePromoteJob, "gh release edit \"${TAG}\"")
@@ -118,8 +121,8 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		`npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`,
 		"npm audit signatures --json --include-attestations",
 		`.attestations.provenance.predicateType == "https://slsa.dev/provenance/v1"`,
-		`run_agentplugins add "${synthetic}" --target cursor --yes --format json > add.json`,
-		`run_agentplugins add "${synthetic}" --target cursor --yes --activation-complete --auth-complete --format json > complete.json`,
+		`run_agentplugins add "${synthetic}" --target cursor --format json > add.json`,
+		`run_agentplugins add "${synthetic}" --target cursor --activation-complete --auth-complete --format json > complete.json`,
 		`.data.result.activation.authentication == "not_checked"`,
 		`.data.result.activation.activation_attested == true`,
 		`.data.result.activation.authentication_attested == true`,
@@ -144,14 +147,15 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	mustNotContain(t, npmVerifyJob, "environment: npm-agentplugins")
 	mustNotContain(t, npmVerifyJob, "id-token: write")
 	mustNotContain(t, npmVerifyJob, "platform-proof")
+	mustNotContain(t, npmVerifyJob, "--target cursor --yes")
 	mustAppearBefore(t, npmVerifyJob, "Resolve immutable verification target", `npm view --prefer-online "${NPM_PACKAGE}@${version}" version`)
 	mustAppearBefore(t, npmVerifyJob, `npm view --prefer-online "${NPM_PACKAGE}@${version}" version`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
 	mustAppearBefore(t, npmVerifyJob, `npm view --prefer-online "${NPM_PACKAGE}@latest" version`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
 	mustAppearBefore(t, npmVerifyJob, `test "${available}" = true`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
 	mustAppearBefore(t, npmVerifyJob, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`, "npm audit signatures --json --include-attestations")
 	mustAppearBefore(t, npmVerifyJob, "npm audit signatures --json --include-attestations", "run_agentplugins version")
-	mustAppearBefore(t, npmVerifyJob, `run_agentplugins add "${synthetic}" --target cursor --yes --format json > add.json`, `run_agentplugins add "${synthetic}" --target cursor --yes --activation-complete --auth-complete --format json > complete.json`)
-	mustAppearBefore(t, npmVerifyJob, `run_agentplugins add "${synthetic}" --target cursor --yes --activation-complete --auth-complete --format json > complete.json`, `run_agentplugins update registry-proof-synthetic --target cursor --yes --format json > update.json`)
+	mustAppearBefore(t, npmVerifyJob, `run_agentplugins add "${synthetic}" --target cursor --format json > add.json`, `run_agentplugins add "${synthetic}" --target cursor --activation-complete --auth-complete --format json > complete.json`)
+	mustAppearBefore(t, npmVerifyJob, `run_agentplugins add "${synthetic}" --target cursor --activation-complete --auth-complete --format json > complete.json`, `run_agentplugins update registry-proof-synthetic --target cursor --format json > update.json`)
 
 	for _, want := range []string{
 		"workflow_call:",
@@ -170,7 +174,8 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		"platform-proof.js",
 		"verified-release.json",
 		"Aggregate all six native platform proofs",
-		"platform proof requires the exact release to remain a non-public draft",
+		"draft proof requires caller-staged release assets",
+		"Download caller-staged draft assets",
 		".isDraft == false and .isPrerelease == false and .tagName == $tag",
 		`git -C release-source fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"`,
 		`git -C release-source rev-list -n 1 "refs/tags/${TAG}"`,
@@ -178,8 +183,9 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		mustContain(t, platformWorkflow, want)
 	}
 	for _, want := range []string{
-		"contents: write",
+		"contents: read",
 		"attestations: read",
+		"caller-staged assets are only valid for draft proof",
 		`[[ ! "${EXPECTED_COMMIT}" =~ ^[0-9a-f]{40}$ ]]`,
 		`if [[ "${commit}" != "${EXPECTED_COMMIT}" ]]`,
 		"release tag commit does not match the caller's frozen commit",

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -11,6 +11,9 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	releaseWorkflow := readRepoFile(t, root, ".github", "workflows", "agentplugins-release.yml")
 	npmWorkflow := readRepoFile(t, root, ".github", "workflows", "agentplugins-npm-publish.yml")
 	platformWorkflow := readRepoFile(t, root, ".github", "workflows", "agentplugins-platform-proof.yml")
+	releaseDraftJob := yamlJob(t, releaseWorkflow, "stage-draft")
+	releaseProofJob := yamlJob(t, releaseWorkflow, "platform-proof")
+	releasePromoteJob := yamlJob(t, releaseWorkflow, "promote-release")
 	npmReleaseIdentityJob := yamlJob(t, npmWorkflow, "release-identity")
 	npmPlatformProofJob := yamlJob(t, npmWorkflow, "platform-proof")
 	npmPublishJob := yamlJob(t, npmWorkflow, "publish")
@@ -35,7 +38,18 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	mustAppearBefore(t, releaseWorkflow, "actions/attest@", "gh release create")
 	mustContain(t, releaseWorkflow, "^agentplugins-v[0-9]+\\.[0-9]+\\.[0-9]+$")
 	mustNotContain(t, releaseWorkflow, "--prerelease")
-	mustContain(t, releaseWorkflow, "release ${TAG} already exists; refusing to overwrite immutable assets")
+	mustContain(t, releaseDraftJob, "exact resumable draft; refusing to overwrite immutable assets")
+	mustContain(t, releaseDraftJob, "--draft")
+	mustContain(t, releaseDraftJob, "existing draft asset differs from the frozen build")
+	mustContain(t, releaseProofJob, "needs: [validate, stage-draft]")
+	mustContain(t, releaseProofJob, "require_draft: true")
+	mustContain(t, releaseProofJob, "expected_asset_set_digest: ${{ needs.stage-draft.outputs.asset_set_digest }}")
+	mustContain(t, releasePromoteJob, "needs: [validate, stage-draft, platform-proof]")
+	mustContain(t, releasePromoteJob, "EXPECTED_ASSET_SET_DIGEST: ${{ needs.stage-draft.outputs.asset_set_digest }}")
+	mustContain(t, releasePromoteJob, "gh release edit \"${TAG}\"")
+	mustContain(t, releasePromoteJob, "--draft=false")
+	mustAppearBefore(t, releaseWorkflow, "gh release create", "gh release edit")
+	mustAppearBefore(t, releaseWorkflow, "uses: ./.github/workflows/agentplugins-platform-proof.yml", "gh release edit")
 	mustContain(t, releaseWorkflow, "uses: ./.github/workflows/agentplugins-platform-proof.yml")
 	mustContain(t, releaseWorkflow, "expected_commit: ${{ needs.validate.outputs.commit }}")
 	mustContain(t, releaseWorkflow, "commits/${COMMIT}/pulls")
@@ -143,6 +157,8 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		"windows-11-arm",
 		"platform-proof.js",
 		"verified-release.json",
+		"Aggregate all six native platform proofs",
+		"platform proof requires the exact release to remain a non-public draft",
 	} {
 		mustContain(t, platformWorkflow, want)
 	}
@@ -157,7 +173,8 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 
 	for _, want := range []string{
 		"attests all six binaries, `checksums.txt`, and",
-		"`release-manifest.json` before creating the public release",
+		"`release-manifest.json` before creating the non-public draft",
+		"promotes that exact draft only after all six native platform proofs succeed",
 		"requires a merged pull request into",
 		"Repository settings are not treated as the release proof",
 		"short-lived bootstrap",

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -11,6 +11,8 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	releaseWorkflow := readRepoFile(t, root, ".github", "workflows", "agentplugins-release.yml")
 	npmWorkflow := readRepoFile(t, root, ".github", "workflows", "agentplugins-npm-publish.yml")
 	platformWorkflow := readRepoFile(t, root, ".github", "workflows", "agentplugins-platform-proof.yml")
+	platformPrepareJob := yamlJob(t, platformWorkflow, "prepare")
+	platformCompleteJob := yamlJob(t, platformWorkflow, "proof-complete")
 	releaseDraftJob := yamlJob(t, releaseWorkflow, "stage-draft")
 	releaseProofJob := yamlJob(t, releaseWorkflow, "platform-proof")
 	releasePromoteJob := yamlJob(t, releaseWorkflow, "promote-release")
@@ -45,6 +47,7 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	mustContain(t, releaseDraftJob, ".data.repository.release")
 	mustNotContain(t, releaseDraftJob, "target_commitish")
 	mustContain(t, releaseProofJob, "needs: [validate, stage-draft]")
+	mustContain(t, releaseProofJob, "contents: write")
 	mustContain(t, releaseProofJob, "require_draft: true")
 	mustContain(t, releaseProofJob, "expected_asset_set_digest: ${{ needs.stage-draft.outputs.asset_set_digest }}")
 	mustContain(t, releasePromoteJob, "needs: [validate, stage-draft, platform-proof]")
@@ -86,6 +89,7 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	mustContain(t, npmPlatformProofJob, "needs: release-identity")
 	mustContain(t, npmPlatformProofJob, "if: ${{ !inputs.verify_only }}")
 	mustContain(t, npmPlatformProofJob, "allow_legacy_manifest: false")
+	mustContain(t, npmPlatformProofJob, "contents: read")
 	for _, want := range []string{
 		"needs: [release-identity, platform-proof]",
 		"if: ${{ !inputs.verify_only }}",
@@ -172,6 +176,25 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		`git -C release-source rev-list -n 1 "refs/tags/${TAG}"`,
 	} {
 		mustContain(t, platformWorkflow, want)
+	}
+	for _, want := range []string{
+		"contents: write",
+		"attestations: read",
+		`[[ ! "${EXPECTED_COMMIT}" =~ ^[0-9a-f]{40}$ ]]`,
+		`if [[ "${commit}" != "${EXPECTED_COMMIT}" ]]`,
+		"release tag commit does not match the caller's frozen commit",
+	} {
+		mustContain(t, platformPrepareJob, want)
+	}
+	for _, want := range []string{
+		"Download all native platform proofs",
+		"expected exactly six machine-readable platform proofs",
+		"expected exactly one machine-readable proof for ${target}",
+		".schema_version == 1",
+		".release_version == $version",
+		".proofs.isolated_add_update_remove == $lifecycle",
+	} {
+		mustContain(t, platformCompleteJob, want)
 	}
 	mustNotContain(t, platformWorkflow, "target_commitish")
 	mustNotContain(t, platformWorkflow, `releases/tags/${TAG}`)

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -10,6 +10,7 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	makefile := readRepoFile(t, root, "Makefile")
 	releaseWorkflow := readRepoFile(t, root, ".github", "workflows", "agentplugins-release.yml")
 	npmWorkflow := readRepoFile(t, root, ".github", "workflows", "agentplugins-npm-publish.yml")
+	platformWorkflow := readRepoFile(t, root, ".github", "workflows", "agentplugins-platform-proof.yml")
 	npmPublishJob := yamlJob(t, npmWorkflow, "publish")
 	npmVerifyJob := yamlJob(t, npmWorkflow, "verify")
 	removedBoundaryScript := readRepoFile(t, root, "scripts", "check-removed-contract-boundary.sh")
@@ -33,6 +34,8 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	mustContain(t, releaseWorkflow, "^agentplugins-v[0-9]+\\.[0-9]+\\.[0-9]+$")
 	mustNotContain(t, releaseWorkflow, "--prerelease")
 	mustContain(t, releaseWorkflow, "release ${TAG} already exists; refusing to overwrite immutable assets")
+	mustContain(t, releaseWorkflow, "uses: ./.github/workflows/agentplugins-platform-proof.yml")
+	mustContain(t, releaseWorkflow, "expected_commit: ${{ needs.validate.outputs.commit }}")
 	mustContain(t, releaseWorkflow, "commits/${COMMIT}/pulls")
 	mustContain(t, releaseWorkflow, "release commit must come from a merged pull request into main")
 	mustContain(t, releaseWorkflow, "check-runs?filter=latest&per_page=100")
@@ -54,6 +57,7 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	}
 
 	for _, want := range []string{
+		"needs: [release-identity, platform-proof]",
 		"if: ${{ !inputs.verify_only }}",
 		"environment: npm-agentplugins",
 		"id-token: write",
@@ -68,7 +72,7 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		mustContain(t, npmPublishJob, want)
 	}
 	for _, want := range []string{
-		"needs: publish",
+		"needs: [publish, platform-proof]",
 		"always() && !cancelled() && (inputs.verify_only || needs.publish.result == 'success')",
 		`ref: ${{ inputs.tag }}`,
 		"Resolve immutable verification target",
@@ -105,6 +109,30 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	mustAppearBefore(t, npmVerifyJob, `test "${available}" = true`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
 	mustAppearBefore(t, npmVerifyJob, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`, "npm audit signatures --json --include-attestations")
 	mustAppearBefore(t, npmVerifyJob, "npm audit signatures --json --include-attestations", "run_agentplugins version")
+
+	for _, want := range []string{
+		"workflow_call:",
+		"allow_legacy_manifest:",
+		"Audit a schema-v1 historical release; never eligible as an npm publish gate",
+		"native runtime E2E (${{ matrix.target }})",
+		"target: darwin-amd64",
+		"target: darwin-arm64",
+		"target: linux-amd64",
+		"target: linux-arm64",
+		"target: windows-amd64",
+		"target: windows-arm64",
+		"macos-15-intel",
+		"ubuntu-24.04-arm",
+		"windows-11-arm",
+		"platform-proof.js",
+		"verified-release.json",
+	} {
+		mustContain(t, platformWorkflow, want)
+	}
+	mustContain(t, npmWorkflow, "uses: ./.github/workflows/agentplugins-platform-proof.yml")
+	mustContain(t, npmWorkflow, "test \"${{ needs.platform-proof.outputs.gate_eligible }}\" = \"true\"")
+	mustContain(t, npmWorkflow, "npm publish --access public --tag latest --provenance \"${TARBALL}\"")
+	mustNotContain(t, npmWorkflow, "add context7")
 
 	mustContain(t, removedBoundaryScript, "if command -v rg")
 	mustContain(t, removedBoundaryScript, "git grep --untracked --exclude-standard")

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -41,6 +41,9 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	mustContain(t, releaseDraftJob, "exact resumable draft; refusing to overwrite immutable assets")
 	mustContain(t, releaseDraftJob, "--draft")
 	mustContain(t, releaseDraftJob, "existing draft asset differs from the frozen build")
+	mustContain(t, releaseDraftJob, "gh api graphql")
+	mustContain(t, releaseDraftJob, ".data.repository.release")
+	mustNotContain(t, releaseDraftJob, "target_commitish")
 	mustContain(t, releaseProofJob, "needs: [validate, stage-draft]")
 	mustContain(t, releaseProofJob, "require_draft: true")
 	mustContain(t, releaseProofJob, "expected_asset_set_digest: ${{ needs.stage-draft.outputs.asset_set_digest }}")
@@ -48,6 +51,10 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	mustContain(t, releasePromoteJob, "EXPECTED_ASSET_SET_DIGEST: ${{ needs.stage-draft.outputs.asset_set_digest }}")
 	mustContain(t, releasePromoteJob, "gh release edit \"${TAG}\"")
 	mustContain(t, releasePromoteJob, "--draft=false")
+	mustContain(t, releasePromoteJob, `git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"`)
+	mustContain(t, releasePromoteJob, `git rev-list -n 1 "refs/tags/${TAG}"`)
+	mustContain(t, releasePromoteJob, "gh api graphql")
+	mustNotContain(t, releasePromoteJob, "target_commitish")
 	mustAppearBefore(t, releaseWorkflow, "gh release create", "gh release edit")
 	mustAppearBefore(t, releaseWorkflow, "uses: ./.github/workflows/agentplugins-platform-proof.yml", "gh release edit")
 	mustContain(t, releaseWorkflow, "uses: ./.github/workflows/agentplugins-platform-proof.yml")
@@ -74,7 +81,8 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 
 	mustContain(t, npmReleaseIdentityJob, "if: ${{ !inputs.verify_only }}")
 	mustContain(t, npmReleaseIdentityJob, `test "${commit}" = "$(git rev-parse refs/remotes/origin/main)"`)
-	mustContain(t, npmReleaseIdentityJob, `test "${commit}" = "$(git rev-list -n 1 "${TAG}")"`)
+	mustContain(t, npmReleaseIdentityJob, `git fetch --force origin main:refs/remotes/origin/main "refs/tags/${TAG}:refs/tags/${TAG}"`)
+	mustContain(t, npmReleaseIdentityJob, `test "${commit}" = "$(git rev-list -n 1 "refs/tags/${TAG}")"`)
 	mustContain(t, npmPlatformProofJob, "needs: release-identity")
 	mustContain(t, npmPlatformProofJob, "if: ${{ !inputs.verify_only }}")
 	mustContain(t, npmPlatformProofJob, "allow_legacy_manifest: false")
@@ -159,9 +167,14 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		"verified-release.json",
 		"Aggregate all six native platform proofs",
 		"platform proof requires the exact release to remain a non-public draft",
+		".isDraft == false and .isPrerelease == false and .tagName == $tag",
+		`git -C release-source fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"`,
+		`git -C release-source rev-list -n 1 "refs/tags/${TAG}"`,
 	} {
 		mustContain(t, platformWorkflow, want)
 	}
+	mustNotContain(t, platformWorkflow, "target_commitish")
+	mustNotContain(t, platformWorkflow, `releases/tags/${TAG}`)
 	mustContain(t, npmWorkflow, "uses: ./.github/workflows/agentplugins-platform-proof.yml")
 	mustContain(t, npmWorkflow, "test \"${{ needs.platform-proof.outputs.gate_eligible }}\" = \"true\"")
 	mustContain(t, npmWorkflow, "npm publish --access public --tag latest --provenance \"${TARBALL}\"")

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -11,6 +11,8 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	releaseWorkflow := readRepoFile(t, root, ".github", "workflows", "agentplugins-release.yml")
 	npmWorkflow := readRepoFile(t, root, ".github", "workflows", "agentplugins-npm-publish.yml")
 	platformWorkflow := readRepoFile(t, root, ".github", "workflows", "agentplugins-platform-proof.yml")
+	npmReleaseIdentityJob := yamlJob(t, npmWorkflow, "release-identity")
+	npmPlatformProofJob := yamlJob(t, npmWorkflow, "platform-proof")
 	npmPublishJob := yamlJob(t, npmWorkflow, "publish")
 	npmVerifyJob := yamlJob(t, npmWorkflow, "verify")
 	removedBoundaryScript := readRepoFile(t, root, "scripts", "check-removed-contract-boundary.sh")
@@ -56,6 +58,12 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		mustContain(t, releaseWorkflow, name)
 	}
 
+	mustContain(t, npmReleaseIdentityJob, "if: ${{ !inputs.verify_only }}")
+	mustContain(t, npmReleaseIdentityJob, `test "${commit}" = "$(git rev-parse refs/remotes/origin/main)"`)
+	mustContain(t, npmReleaseIdentityJob, `test "${commit}" = "$(git rev-list -n 1 "${TAG}")"`)
+	mustContain(t, npmPlatformProofJob, "needs: release-identity")
+	mustContain(t, npmPlatformProofJob, "if: ${{ !inputs.verify_only }}")
+	mustContain(t, npmPlatformProofJob, "allow_legacy_manifest: false")
 	for _, want := range []string{
 		"needs: [release-identity, platform-proof]",
 		"if: ${{ !inputs.verify_only }}",
@@ -72,7 +80,7 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		mustContain(t, npmPublishJob, want)
 	}
 	for _, want := range []string{
-		"needs: [publish, platform-proof]",
+		"needs: publish",
 		"always() && !cancelled() && (inputs.verify_only || needs.publish.result == 'success')",
 		`ref: ${{ inputs.tag }}`,
 		"Resolve immutable verification target",
@@ -103,6 +111,7 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	mustNotContain(t, npmVerifyJob, "npm publish --access public --tag latest --provenance")
 	mustNotContain(t, npmVerifyJob, "environment: npm-agentplugins")
 	mustNotContain(t, npmVerifyJob, "id-token: write")
+	mustNotContain(t, npmVerifyJob, "platform-proof")
 	mustAppearBefore(t, npmVerifyJob, "Resolve immutable verification target", `npm view --prefer-online "${NPM_PACKAGE}@${version}" version`)
 	mustAppearBefore(t, npmVerifyJob, `npm view --prefer-online "${NPM_PACKAGE}@${version}" version`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
 	mustAppearBefore(t, npmVerifyJob, `npm view --prefer-online "${NPM_PACKAGE}@latest" version`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
@@ -151,6 +160,11 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		"`latest` dist-tag resolves to the exact published version",
 		"returned to `false` immediately after the publish",
 		"dispatched with `verify_only=true`",
+		"historical tag after publication",
+		"skips release identity",
+		"schema-v2 six-platform proof",
+		"not require the tag to point to current `main`",
+		"public registry, provenance, and isolated",
 	} {
 		mustContain(t, runbook, want)
 	}

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -92,6 +92,12 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		`npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`,
 		"npm audit signatures --json --include-attestations",
 		`.attestations.provenance.predicateType == "https://slsa.dev/provenance/v1"`,
+		`run_agentplugins add "${synthetic}" --target cursor --yes --format json > add.json`,
+		`run_agentplugins add "${synthetic}" --target cursor --yes --activation-complete --auth-complete --format json > complete.json`,
+		`.data.result.activation.authentication == "not_checked"`,
+		`.data.result.activation.activation_attested == true`,
+		`.data.result.activation.authentication_attested == true`,
+		`.data.result.no_change == true and .data.result.mutated == false`,
 	} {
 		mustContain(t, npmVerifyJob, want)
 	}
@@ -118,6 +124,8 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	mustAppearBefore(t, npmVerifyJob, `test "${available}" = true`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
 	mustAppearBefore(t, npmVerifyJob, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`, "npm audit signatures --json --include-attestations")
 	mustAppearBefore(t, npmVerifyJob, "npm audit signatures --json --include-attestations", "run_agentplugins version")
+	mustAppearBefore(t, npmVerifyJob, `run_agentplugins add "${synthetic}" --target cursor --yes --format json > add.json`, `run_agentplugins add "${synthetic}" --target cursor --yes --activation-complete --auth-complete --format json > complete.json`)
+	mustAppearBefore(t, npmVerifyJob, `run_agentplugins add "${synthetic}" --target cursor --yes --activation-complete --auth-complete --format json > complete.json`, `run_agentplugins update registry-proof-synthetic --target cursor --yes --format json > update.json`)
 
 	for _, want := range []string{
 		"workflow_call:",

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -12,6 +12,7 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	npmWorkflow := readRepoFile(t, root, ".github", "workflows", "agentplugins-npm-publish.yml")
 	platformWorkflow := readRepoFile(t, root, ".github", "workflows", "agentplugins-platform-proof.yml")
 	platformPrepareJob := yamlJob(t, platformWorkflow, "prepare")
+	platformNativeJob := yamlJob(t, platformWorkflow, "native-runtime")
 	platformCompleteJob := yamlJob(t, platformWorkflow, "proof-complete")
 	releaseDraftJob := yamlJob(t, releaseWorkflow, "stage-draft")
 	releaseProofJob := yamlJob(t, releaseWorkflow, "platform-proof")
@@ -65,6 +66,8 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	mustAppearBefore(t, releaseWorkflow, "uses: ./.github/workflows/agentplugins-platform-proof.yml", "gh release edit")
 	mustContain(t, releaseWorkflow, "uses: ./.github/workflows/agentplugins-platform-proof.yml")
 	mustContain(t, releaseWorkflow, "expected_commit: ${{ needs.validate.outputs.commit }}")
+	mustContain(t, releaseWorkflow, `test "${WORKFLOW_REF}" = "refs/heads/main"`)
+	mustContain(t, releaseWorkflow, "release workflow source does not match the exact tagged main commit")
 	mustContain(t, releaseWorkflow, "commits/${COMMIT}/pulls")
 	mustContain(t, releaseWorkflow, "release commit must come from a merged pull request into main")
 	mustContain(t, releaseWorkflow, "check-runs?filter=latest&per_page=100")
@@ -87,6 +90,8 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 
 	mustContain(t, npmReleaseIdentityJob, "if: ${{ !inputs.verify_only }}")
 	mustContain(t, npmReleaseIdentityJob, `test "${commit}" = "$(git rev-parse refs/remotes/origin/main)"`)
+	mustContain(t, npmReleaseIdentityJob, `test "${WORKFLOW_REF}" = "refs/heads/main"`)
+	mustContain(t, npmReleaseIdentityJob, "npm publish workflow source does not match the exact tagged main commit")
 	mustContain(t, npmReleaseIdentityJob, `git fetch --force origin main:refs/remotes/origin/main "refs/tags/${TAG}:refs/tags/${TAG}"`)
 	mustContain(t, npmReleaseIdentityJob, `test "${commit}" = "$(git rev-list -n 1 "refs/tags/${TAG}")"`)
 	mustContain(t, npmPlatformProofJob, "needs: release-identity")
@@ -176,6 +181,11 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		"Aggregate all six native platform proofs",
 		"draft proof requires caller-staged release assets",
 		"Download caller-staged draft assets",
+		"bootstrap_mode:",
+		"local_frozen_asset",
+		"public_release_download",
+		"platform proof workflow source does not match the frozen release commit",
+		"historical audit must be dispatched with --ref ${TAG}",
 		".isDraft == false and .isPrerelease == false and .tagName == $tag",
 		`git -C release-source fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"`,
 		`git -C release-source rev-list -n 1 "refs/tags/${TAG}"`,
@@ -189,8 +199,20 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		`[[ ! "${EXPECTED_COMMIT}" =~ ^[0-9a-f]{40}$ ]]`,
 		`if [[ "${commit}" != "${EXPECTED_COMMIT}" ]]`,
 		"release tag commit does not match the caller's frozen commit",
+		"ref: ${{ inputs.expected_commit }}",
+		"agentplugins-proof-bundle",
+		"release-assets",
 	} {
 		mustContain(t, platformPrepareJob, want)
+	}
+	for _, want := range []string{
+		"ref: ${{ inputs.expected_commit }}",
+		`test "$(git rev-parse HEAD)" = "${{ inputs.expected_commit }}"`,
+		"needs.prepare.outputs.bootstrap_mode",
+		"release_assets=\"-\"",
+		"npm/agentplugins/scripts/platform-proof.js",
+	} {
+		mustContain(t, platformNativeJob, want)
 	}
 	for _, want := range []string{
 		"Download all native platform proofs",
@@ -199,6 +221,10 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		".schema_version == 1",
 		".release_version == $version",
 		".proofs.isolated_add_update_remove == $lifecycle",
+		`.bootstrap_source == $bootstrap_mode`,
+		`.proofs.local_frozen_asset_bootstrap == ($bootstrap_mode == "local_frozen_asset")`,
+		`.proofs.anonymous_public_release_download == ($bootstrap_mode == "public_release_download")`,
+		".proofs.warm_cache_without_proof_source == true",
 	} {
 		mustContain(t, platformCompleteJob, want)
 	}
@@ -232,6 +258,8 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		"schema-v2 six-platform proof",
 		"not require the tag to point to current `main`",
 		"public registry, provenance, and isolated",
+		"same-run frozen",
+		"normal anonymous GitHub release download",
 	} {
 		mustContain(t, runbook, want)
 	}


### PR DESCRIPTION
## What

- make repeated add/update resume incomplete activation and OAuth flows instead of dead-ending
- preserve separate verified, attested, manual, and auth-pending lifecycle evidence
- add strict client verification for Codex, Copilot CLI, and Kiro without trusting ambiguous output
- make doctor and repair installation-scoped, transactional, and safe under concurrent state changes
- validate catalog compatibility/auth metadata instead of discarding it
- gate releases with native runtime checks for all six distributed OS/architecture binaries
- harden npm bootstrap, release manifests, checksums, tags, and draft/prerelease handling

## Why

The existing Agent Plugins 1.0 package flow could materialize packages, but several manual activation, OAuth, verification, and release paths were stronger in documentation than in runtime evidence. This closes those launch blockers while preserving plugin.json as the standard-first install contract.

## Safety

All agent/client behavior is covered through isolated fixtures and fake executables. No real user project, client configuration, OAuth session, or installed agent was mutated.

## Validation

- full Go workspace: go test ./...
- focused race tests for providers, lifecycle, and CLI
- Agent Plugins repository contract tests
- npm launcher/bootstrap suite: 18/18
- release workflow/schema parsing and diff checks
- independent final xhigh review: no P0-P2 findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repair command with verification, dry-run, confirmation, and safe restoration options.
  * Added lifecycle resumption, activation and authentication tracking, and clearer next-step guidance.
  * Improved client detection across macOS, Linux, and Windows, including Kiro and VS Code installations.
  * Added diagnostic reporting for installation integrity, compatibility, and recovery issues.

* **Release Improvements**
  * Releases now require verified six-platform validation before publication.
  * Strengthened asset, checksum, manifest, provenance, and lifecycle verification.
  * npm packages now support only macOS, Linux, and Windows on x64 or arm64 systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->