### PR TITLE
docs: clarify agentplugins quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ It reads the root `plugin.json` defined by Agent Plugins 1.0 and plans, prepares
 or installs one explicit target at a time across Codex/ChatGPT, Cursor, GitHub
 Copilot/VS Code, and Kiro. v0.1 supports user scope; client-native limits are
 reported before mutation. The first catalog contains [26 portable plugins](https://github.com/777genius/universal-agent-plugins).
-The portable source is only the root `plugin.json`; generated output for the
-official OpenAI host uses `.codex-plugin/plugin.json`.
+The portable manifest is the root `plugin.json`; optional portable components
+such as `mcp.json` and skills remain package inputs. For the Codex target, the
+CLI generates the official Codex package manifest at `.codex-plugin/plugin.json`.
 
 When GitHub Copilot CLI is detected, `agentplugins` installs, updates, and
 removes the plugin automatically through a managed local marketplace. VS Code

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ It reads the root `plugin.json` defined by Agent Plugins 1.0 and plans, prepares
 or installs one explicit target at a time across Codex/ChatGPT, Cursor, GitHub
 Copilot/VS Code, and Kiro. v0.1 supports user scope; client-native limits are
 reported before mutation. The first catalog contains [26 portable plugins](https://github.com/777genius/universal-agent-plugins).
+The portable source is only the root `plugin.json`; generated output for the
+official OpenAI host uses `.codex-plugin/plugin.json`.
 
 When GitHub Copilot CLI is detected, `agentplugins` installs, updates, and
 removes the plugin automatically through a managed local marketplace. VS Code
@@ -129,17 +131,18 @@ Guide:
 
 ## Quick Start
 
-If you do not know which path to choose yet, start here:
-
-Try a real plugin now without installing the CLI permanently:
+Want to try a real Agent Plugin without installing a CLI permanently?
 
 ```bash
-npx plugin-kit-ai@latest add notion
+npx universal-agent-plugins add context7
 ```
 
-This installs every supported output for that plugin.
+Building a plugin instead? Use `plugin-kit-ai` for authoring and generated
+output delivery. Its older `plugin-kit-ai add` lifecycle is not the default
+installer for portable Agent Plugins 1.0. Start with
+[Choose What You Are Building](#choose-what-you-are-building).
 
-Recommended daily-use install path:
+Recommended authoring CLI install path:
 
 ```bash
 brew install 777genius/homebrew-plugin-kit-ai/plugin-kit-ai

--- a/npm/agentplugins/README.md
+++ b/npm/agentplugins/README.md
@@ -3,6 +3,8 @@
 Install and manage portable Agent Plugins 1.0 packages across Codex/ChatGPT,
 Cursor, GitHub Copilot/VS Code, and Kiro.
 
+Prerequisite: Node.js 22 or newer.
+
 ```bash
 npx universal-agent-plugins add context7
 ```
@@ -18,6 +20,18 @@ The npm package has no `postinstall`. On first execution it downloads only the
 binary matching the exact npm version, verifies the SHA-256 embedded in the npm
 tarball, then caches it under XDG Cache or LocalAppData. It never falls back to
 `latest` and never sends `GITHUB_TOKEN` to public downloads.
+
+Release 0.1.5 passed exact native npm bootstrap proofs on all six supported
+platforms:
+
+| OS | x64 | arm64 |
+| --- | --- | --- |
+| macOS | Tested | Tested |
+| Linux | Tested | Tested |
+| Windows | Tested | Tested |
+
+Other operating systems and CPU architectures are unsupported and fail before
+the binary runs.
 
 ```bash
 npx universal-agent-plugins doctor


### PR DESCRIPTION
Makes the standard-first Agent Plugins CLI the default user quick start. Adds the Node.js 22 prerequisite and the exact supported platform matrix proven by the 0.1.5 release, while keeping legacy plugin-kit-ai authoring clearly separate.\n\nValidation: npm tests 26/26, README contracts, and diff check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified which plugin manifest is portable and which is generated for OpenAI hosts.
  * Updated the Quick Start guidance for trying and authoring Agent Plugins.
  * Documented the Node.js 22+ requirement.
  * Added native bootstrap validation coverage for supported macOS, Linux, and Windows platforms and architectures.
  * Noted that unsupported environments are rejected before the binary runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->