### PR TITLE
feat(agentplugins): support comma-separated targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this repository are documented here. **CLI releases** (`p
 
 Changes after `v1.2.4` land here.
 
+### Added
+
+- The `agentplugins` lifecycle commands now accept ordered, comma-separated
+  targets such as `--target codex,cursor`, with versioned batch JSON output and
+  explicit partial-failure reporting that preserves successful client changes.
+
 ### Fixed
 
 - NPM registry publish workflows now require an explicit `NPM_PUBLISH_READY=true` repository variable before auto-running from release asset publication, while keeping manual dispatch available for credential repair.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npx universal-agent-plugins add context7
 ```
 
 It reads the root `plugin.json` defined by Agent Plugins 1.0 and plans, prepares,
-or installs one explicit target at a time across Codex, ChatGPT, Cursor, GitHub
+or installs one or more explicit targets across Codex, ChatGPT, Cursor, GitHub
 Copilot/VS Code, and Kiro. v0.1 supports user scope; client-native limits are
 reported before mutation. The first catalog contains [26 portable plugins](https://github.com/777genius/universal-agent-plugins).
 Accepted source shapes are either a portable root `plugin.json` with optional
@@ -48,7 +48,12 @@ human-readable output.
 ```bash
 npx universal-agent-plugins add context7 --dry-run --target cursor
 npx universal-agent-plugins add context7 --target cursor
+npx universal-agent-plugins add context7 --target codex,cursor
 ```
+
+Comma-separated targets run through the same client-specific lifecycle one by
+one. Successful targets remain installed if another target fails, and the CLI
+returns a non-zero status with an exact per-target summary.
 
 Short names resolve through the pinned catalog, while a local directory or an
 exact GitHub source such as `owner/repo@ref//path/to/plugin` can install any

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -19,13 +19,15 @@ func newAddCommand(app App, opts *options) *cobra.Command {
 	var activationComplete, authComplete bool
 	command := &cobra.Command{
 		Use:   "add <name-or-source>",
-		Short: "Plan and install one Agent Plugins 1.0 package",
+		Short: "Plan and install one Agent Plugins 1.0 package for one or more clients",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateCommonOptions(opts); err != nil {
 				return err
 			}
-			return runAdd(cmd.Context(), cmd, app, opts, args[0], activationComplete, authComplete)
+			return runForTargets(cmd, opts, "add", func() error {
+				return runAdd(cmd.Context(), cmd, app, opts, args[0], activationComplete, authComplete)
+			})
 		},
 	}
 	command.Flags().BoolVar(&activationComplete, "activation-complete", false, "attest that manual client activation is complete")
@@ -224,7 +226,7 @@ func selectClient(
 		return detected[0], detectedMap, nil
 	}
 	if !app.Terminal || opts.yes || opts.format == "json" {
-		return domain.DetectedClient{}, detectedMap, fmt.Errorf("multiple clients detected; choose exactly one with --target")
+		return domain.DetectedClient{}, detectedMap, fmt.Errorf("multiple clients detected; choose one or more with --target codex,cursor")
 	}
 	sort.Slice(detected, func(i, j int) bool { return detected[i].DisplayName < detected[j].DisplayName })
 	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Detected clients:")

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -794,6 +794,42 @@ func TestInteractiveRepairUsesOneReaderForTargetAndConfirmation(t *testing.T) {
 	}
 }
 
+func TestInteractiveMultiTargetRepairSharesOneReaderAcrossConfirmations(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{
+		fixtureClient(t, domain.ClientCodex),
+		fixtureClient(t, domain.ClientCursor),
+	})
+	plugin := writeCLIPlugin(t)
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "codex,cursor", "--yes"); err != nil {
+		t.Fatal(err)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	targets := make(map[string]string, len(state.Installations[0].Clients))
+	for _, binding := range state.Installations[0].Clients {
+		targets[binding.ClientID] = binding.TargetLocator
+		if err := os.RemoveAll(binding.TargetLocator); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stdout, _, err := fixture.executeInput(true, "y\ny\n", "repair", "demo", "--target", "codex,cursor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "Completed: 2 succeeded, 0 failed.") {
+		t.Fatalf("repair output = %q", stdout)
+	}
+	for client, target := range targets {
+		if _, err := os.Stat(filepath.Join(target, "plugin.json")); err != nil {
+			t.Fatalf("%s target was not repaired: %v", client, err)
+		}
+	}
+}
+
 func TestJSONRepairAutoConfirmsWithoutYes(t *testing.T) {
 	t.Parallel()
 	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -101,6 +101,83 @@ func TestAutomatedAddRequiresExplicitTargetButNotYes(t *testing.T) {
 	}
 }
 
+func TestCommaSeparatedTargetsRunAddUpdateAndRemove(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{
+		fixtureClient(t, domain.ClientCodex), fixtureClient(t, domain.ClientCursor),
+	})
+	plugin := writeCLIPlugin(t)
+
+	stdout, _, err := fixture.execute(false, "add", plugin, "--target", "codex, cursor,codex", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertBatchJSON(t, stdout, "add", 2, 0)
+	assertClientBindings(t, fixture, domain.MaterializationMaterialized, 1)
+
+	manifest := filepath.Join(plugin, "plugin.json")
+	body, err := os.ReadFile(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(manifest, []byte(strings.Replace(string(body), `"version": "1.0.0"`, `"version": "2.0.0"`, 1)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, err = fixture.execute(false, "update", "demo", "--target", "codex,cursor", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertBatchJSON(t, stdout, "update", 2, 0)
+	assertClientBindings(t, fixture, domain.MaterializationMaterialized, 2)
+
+	stdout, _, err = fixture.execute(false, "remove", "demo", "--target", "codex,cursor", "--external-uninstalled", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertBatchJSON(t, stdout, "remove", 2, 0)
+	assertClientBindings(t, fixture, domain.MaterializationAbsent, 3)
+}
+
+func TestCommaSeparatedTargetsRejectUnsafeValues(t *testing.T) {
+	t.Parallel()
+	for name, value := range map[string]string{
+		"empty":        "codex,,cursor",
+		"all":          "all",
+		"ambiguous":    "openai,cursor",
+		"unsupported":  "claude,cursor",
+		"legacy_mixed": "legacy-all,cursor",
+	} {
+		name, value := name, value
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := parseTargetOption(value); err == nil {
+				t.Fatalf("parseTargetOption(%q) succeeded", value)
+			}
+		})
+	}
+}
+
+func TestCommaSeparatedTargetsKeepSuccessfulClientsOnPartialFailure(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	plugin := writeCLIPlugin(t)
+	stdout, _, err := fixture.execute(false, "add", plugin, "--target", "cursor,codex", "--format", "json")
+	if err == nil || !strings.Contains(err.Error(), "codex") {
+		t.Fatalf("partial failure = %v", err)
+	}
+	assertBatchJSON(t, stdout, "add", 1, 1)
+	state, loadErr := fixture.store.Load()
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if len(state.Installations) != 1 || len(state.Installations[0].Clients) != 1 || onlyCLIClient(state.Installations[0]).ClientID != string(domain.ClientCursor) {
+		t.Fatalf("partial state = %+v", state)
+	}
+	if strings.Contains(stdout, fixture.root) {
+		t.Fatalf("batch JSON leaked sandbox path: %s", stdout)
+	}
+}
+
 func TestTTYYesNeverBypassesExplicitStandardTargetGuards(t *testing.T) {
 	t.Parallel()
 	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
@@ -1802,6 +1879,42 @@ func assertVersionedJSON(t *testing.T, body, command string) {
 	}
 	if value["schema_version"] != float64(1) || value["command"] != command {
 		t.Fatalf("JSON envelope = %+v", value)
+	}
+}
+
+func assertBatchJSON(t *testing.T, body, command string, succeeded, failed int) {
+	t.Helper()
+	var value struct {
+		SchemaVersion int    `json:"schema_version"`
+		Command       string `json:"command"`
+		Data          struct {
+			Batch     bool                `json:"batch"`
+			Succeeded int                 `json:"succeeded"`
+			Failed    int                 `json:"failed"`
+			Targets   []batchTargetResult `json:"targets"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(body), &value); err != nil {
+		t.Fatalf("decode batch JSON output %q: %v", body, err)
+	}
+	if value.SchemaVersion != outputSchemaVersion || value.Command != command || !value.Data.Batch || value.Data.Succeeded != succeeded || value.Data.Failed != failed || len(value.Data.Targets) != succeeded+failed {
+		t.Fatalf("batch JSON envelope = %+v", value)
+	}
+}
+
+func assertClientBindings(t *testing.T, fixture cliFixture, materialization domain.MaterializationState, receipts int) {
+	t.Helper()
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Installations) != 1 || len(state.Installations[0].Clients) != 2 {
+		t.Fatalf("state = %+v", state)
+	}
+	for _, binding := range state.Installations[0].Clients {
+		if binding.Materialization != materialization || len(binding.Receipts) != receipts {
+			t.Fatalf("binding = %+v", binding)
+		}
 	}
 }
 

--- a/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
@@ -26,7 +26,9 @@ func newUpdateCommand(app App, opts *options) *cobra.Command {
 			if err := validateCommonOptions(opts); err != nil {
 				return err
 			}
-			return runUpdate(cmd.Context(), cmd, app, opts, args[0])
+			return runForTargets(cmd, opts, "update", func() error {
+				return runUpdate(cmd.Context(), cmd, app, opts, args[0])
+			})
 		},
 	}
 }
@@ -39,7 +41,9 @@ func newRepairCommand(app App, opts *options) *cobra.Command {
 			if err := validateCommonOptions(opts); err != nil {
 				return err
 			}
-			return runRepair(cmd.Context(), cmd, app, opts, args[0])
+			return runForTargets(cmd, opts, "repair", func() error {
+				return runRepair(cmd.Context(), cmd, app, opts, args[0])
+			})
 		},
 	}
 }
@@ -259,7 +263,9 @@ func newRemoveCommand(app App, opts *options) *cobra.Command {
 			if err := validateCommonOptions(opts); err != nil {
 				return err
 			}
-			return runRemove(cmd.Context(), cmd, app, opts, args[0])
+			return runForTargets(cmd, opts, "remove", func() error {
+				return runRemove(cmd.Context(), cmd, app, opts, args[0])
+			})
 		},
 	}
 	command.Flags().BoolVar(&opts.externalUninstalled, "external-uninstalled", false, "confirm the selected client plugin was uninstalled manually or was never activated/imported")
@@ -551,7 +557,7 @@ func selectBoundClient(
 		return client, detectedMap, err
 	}
 	if !app.Terminal || opts.yes || opts.format == "json" {
-		return domain.DetectedClient{}, detectedMap, fmt.Errorf("plugin has multiple installed targets; choose exactly one with --target")
+		return domain.DetectedClient{}, detectedMap, fmt.Errorf("plugin has multiple installed targets; choose one or more with --target codex,cursor")
 	}
 	if _, err := fmt.Fprintln(cmd.OutOrStdout(), "Installed targets:"); err != nil {
 		return domain.DetectedClient{}, detectedMap, err

--- a/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
@@ -41,15 +41,15 @@ func newRepairCommand(app App, opts *options) *cobra.Command {
 			if err := validateCommonOptions(opts); err != nil {
 				return err
 			}
+			stdin := bufio.NewReader(cmd.InOrStdin())
 			return runForTargets(cmd, opts, "repair", func() error {
-				return runRepair(cmd.Context(), cmd, app, opts, args[0])
+				return runRepair(cmd.Context(), cmd, app, opts, args[0], stdin)
 			})
 		},
 	}
 }
 
-func runRepair(ctx context.Context, cmd *cobra.Command, app App, opts *options, selector string) error {
-	stdin := bufio.NewReader(cmd.InOrStdin())
+func runRepair(ctx context.Context, cmd *cobra.Command, app App, opts *options, selector string, stdin *bufio.Reader) error {
 	state, err := app.StateStore.Load()
 	if err != nil {
 		return err

--- a/cli/plugin-kit-ai/internal/agentpluginscli/root.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/root.go
@@ -2,7 +2,6 @@ package agentpluginscli
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -19,7 +18,7 @@ func NewRoot(app App) *cobra.Command {
 	root.SetOut(app.output())
 	root.SetErr(app.errorOutput())
 	flags := root.PersistentFlags()
-	flags.StringVar(&opts.target, "target", "", "target client: codex, chatgpt, cursor, copilot, vscode, or kiro")
+	flags.StringVar(&opts.target, "target", "", "target client(s), comma-separated: codex, chatgpt, cursor, copilot, vscode, or kiro")
 	flags.StringVar(&opts.scope, "scope", "user", "installation scope: user or project")
 	flags.BoolVar(&opts.dryRun, "dry-run", false, "show the exact plan without changes")
 	flags.BoolVar(&opts.yes, "yes", false, "confirm this selected target without installing everywhere")
@@ -48,8 +47,8 @@ func validateCommonOptions(opts *options) error {
 	if opts.scope != "user" && opts.scope != "project" {
 		return fmt.Errorf("--scope must be user or project")
 	}
-	if strings.EqualFold(strings.TrimSpace(opts.target), "all") {
-		return fmt.Errorf("--target all is not supported; choose clients explicitly")
+	if _, err := parseTargetOption(opts.target); err != nil {
+		return err
 	}
 	return nil
 }

--- a/cli/plugin-kit-ai/internal/agentpluginscli/target_batch.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/target_batch.go
@@ -1,0 +1,153 @@
+package agentpluginscli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/spf13/cobra"
+)
+
+type batchTargetResult struct {
+	Target string `json:"target"`
+	Output any    `json:"output,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+type batchCommandResult struct {
+	Batch     bool                `json:"batch"`
+	Succeeded int                 `json:"succeeded"`
+	Failed    int                 `json:"failed"`
+	Targets   []batchTargetResult `json:"targets"`
+}
+
+func parseTargetOption(value string) ([]domain.ClientID, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(trimmed, ",")
+	targets := make([]domain.ClientID, 0, len(parts))
+	seen := make(map[domain.ClientID]struct{}, len(parts))
+	for _, part := range parts {
+		raw := strings.TrimSpace(part)
+		if raw == "" {
+			return nil, fmt.Errorf("--target contains an empty client; use a comma-separated list such as codex,cursor")
+		}
+		if strings.EqualFold(raw, "all") {
+			return nil, fmt.Errorf("--target all is not supported; choose clients explicitly")
+		}
+		if strings.EqualFold(raw, "openai") {
+			return nil, fmt.Errorf("target %q is ambiguous; use codex, chatgpt, or both", raw)
+		}
+
+		target := normalizeTarget(raw)
+		if target == "legacy-all" {
+			if len(parts) != 1 {
+				return nil, fmt.Errorf("--target legacy-all cannot be combined with Agent Plugins clients")
+			}
+			return []domain.ClientID{target}, nil
+		}
+		if !supportedTarget(target) {
+			return nil, fmt.Errorf("unsupported target %q; choose codex, chatgpt, cursor, copilot, vscode, or kiro", raw)
+		}
+		if _, duplicate := seen[target]; duplicate {
+			continue
+		}
+		seen[target] = struct{}{}
+		targets = append(targets, target)
+	}
+	return targets, nil
+}
+
+func supportedTarget(target domain.ClientID) bool {
+	switch target {
+	case domain.ClientCodex, domain.ClientChatGPT, domain.ClientCursor, domain.ClientCopilot, domain.ClientVSCode, domain.ClientKiro:
+		return true
+	default:
+		return false
+	}
+}
+
+func runForTargets(cmd *cobra.Command, opts *options, command string, run func() error) error {
+	targets, err := parseTargetOption(opts.target)
+	if err != nil {
+		return err
+	}
+	if len(targets) <= 1 {
+		if len(targets) == 1 {
+			original := opts.target
+			opts.target = string(targets[0])
+			defer func() { opts.target = original }()
+		}
+		return run()
+	}
+
+	originalTarget := opts.target
+	originalOutput := cmd.OutOrStdout()
+	defer func() {
+		opts.target = originalTarget
+		cmd.SetOut(originalOutput)
+	}()
+
+	result := batchCommandResult{Batch: true, Targets: make([]batchTargetResult, 0, len(targets))}
+	var failures []string
+	if opts.format == "human" {
+		_, _ = fmt.Fprintf(originalOutput, "Running %s for %d targets: %s\n", command, len(targets), joinTargets(targets))
+	}
+
+	for index, target := range targets {
+		opts.target = string(target)
+		entry := batchTargetResult{Target: string(target)}
+		var captured bytes.Buffer
+		if opts.format == "json" {
+			cmd.SetOut(&captured)
+		} else {
+			_, _ = fmt.Fprintf(originalOutput, "\n[%d/%d] %s\n", index+1, len(targets), target)
+		}
+
+		runErr := run()
+		if opts.format == "json" {
+			cmd.SetOut(originalOutput)
+			if payload := bytes.TrimSpace(captured.Bytes()); len(payload) > 0 {
+				if jsonErr := json.Unmarshal(payload, &entry.Output); jsonErr != nil {
+					runErr = fmt.Errorf("invalid %s JSON for target %s: %w", command, target, jsonErr)
+				}
+			}
+		}
+		if runErr != nil {
+			entry.Error = "command failed for this target; see the process error for details"
+			result.Failed++
+			failures = append(failures, fmt.Sprintf("%s: %v", target, runErr))
+			if opts.format == "human" {
+				_, _ = fmt.Fprintf(originalOutput, "Target %s failed: %v\n", target, runErr)
+			}
+		} else {
+			result.Succeeded++
+		}
+		result.Targets = append(result.Targets, entry)
+	}
+
+	if opts.format == "json" {
+		if err := writeJSONOutput(originalOutput, command, result); err != nil {
+			return err
+		}
+	} else {
+		_, _ = fmt.Fprintf(originalOutput, "\nCompleted: %d succeeded, %d failed.\n", result.Succeeded, result.Failed)
+	}
+	if len(failures) > 0 {
+		return fmt.Errorf("%s failed for %d of %d targets: %s", command, len(failures), len(targets), strings.Join(failures, "; "))
+	}
+	return nil
+}
+
+func joinTargets(targets []domain.ClientID) string {
+	values := make([]string, len(targets))
+	for index, target := range targets {
+		values[index] = string(target)
+	}
+	return strings.Join(values, ", ")
+}

--- a/npm/agentplugins/README.md
+++ b/npm/agentplugins/README.md
@@ -39,6 +39,7 @@ npx universal-agent-plugins doctor
 npx universal-agent-plugins list
 npx universal-agent-plugins add context7 --dry-run --target cursor
 npx universal-agent-plugins add context7 --target cursor
+npx universal-agent-plugins add context7 --target codex,cursor
 npx universal-agent-plugins update context7 --target cursor
 npx universal-agent-plugins remove context7 --target cursor
 ```
@@ -65,7 +66,10 @@ Accepted packages have either a portable root `plugin.json` with optional
 `skills/` sidecars. The downloaded binary and installed command remain
 `agentplugins`.
 
-Each mutation changes one selected client. Human TTY sessions ask before a
+Each mutation changes one or more explicitly selected clients. Use a
+comma-separated value such as `--target codex,cursor`; every target keeps its
+own lifecycle result, and a partial failure returns a non-zero status without
+rolling back successful clients. Human TTY sessions ask before each client
 change; non-TTY and JSON automation auto-confirm only when `--target` is
 explicit, without requiring `--yes`. v0.1 supports user scope and reports
 whether a client can install automatically or requires manual activation. For


### PR DESCRIPTION
## Summary
- accept ordered comma-separated targets such as `--target codex,cursor`
- run add, update, repair, and remove through the existing per-client lifecycle
- preserve successful client changes and return a non-zero batch summary on partial failure
- keep single-target and no-target behavior unchanged

## Verification
- `go test ./...` in `cli/plugin-kit-ai`
- isolated binary add/remove E2E with fresh Codex and Cursor sandbox homes
- JSON batch, deduplication, invalid target, and partial failure tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for comma-separated target selection across install, update, repair, and removal commands.
  * Targets are processed independently with deduplication, per-target results, and progress reporting.
  * Added aggregated JSON output for batch operations.
  * Successful changes are retained when another target fails, with a non-zero exit status and clear failure summaries.
  * Improved validation for unsupported, ambiguous, or unsafe target values.

* **Documentation**
  * Added examples and guidance for multi-target operations, including partial-failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->