### PR TITLE
fix(agentplugins): verify batch lifecycle proof output

### DIFF
--- a/npm/agentplugins/scripts/platform-proof.js
+++ b/npm/agentplugins/scripts/platform-proof.js
@@ -112,6 +112,26 @@ function lifecycleCommands(synthetic) {
   ];
 }
 
+function lifecycleResult(output, command, target) {
+  if (!output || output.schema_version !== 1 || output.command !== command || output.result !== "success" ||
+      !output.data || typeof output.data !== "object") {
+    fail(`agentplugins ${command} did not return a successful lifecycle envelope`);
+  }
+  if (output.data.result && typeof output.data.result === "object") {
+    if (output.data.targets !== undefined) {
+      fail(`agentplugins ${command} returned ambiguous direct and batch lifecycle results`);
+    }
+    return output.data.result;
+  }
+  const targets = output.data.targets;
+  if (output.data.batch !== true || output.data.succeeded !== 1 || output.data.failed !== 0 ||
+      !Array.isArray(targets) || targets.length !== 1 || targets[0]?.target !== target ||
+      !targets[0]?.output?.result || typeof targets[0].output.result !== "object") {
+    fail(`agentplugins ${command} did not return exactly one successful ${target} lifecycle result`);
+  }
+  return targets[0].output.result;
+}
+
 function main() {
   const [tarballArg, version, expectedTarget, lifecycleArg, resultArg, expectedCommit, bootstrapModeArg, releaseAssetsArg] = process.argv.slice(2);
   if (!tarballArg || !version || !expectedTarget || !lifecycleArg || !resultArg || !expectedCommit || !bootstrapModeArg || !releaseAssetsArg) {
@@ -247,10 +267,14 @@ function main() {
     const complete = invokeJSON(completeCommand);
     const update = invokeJSON(updateCommand);
     const remove = invokeJSON(removeCommand);
-    if (add.data.result.mutated !== true || add.data.result.activation.authentication !== "not_checked" ||
-        complete.data.result.mutated !== true || complete.data.result.activation.activation_attested !== true ||
-        complete.data.result.activation.authentication_attested !== true || update.data.result.no_change !== true ||
-        update.data.result.mutated !== false || remove.data.result.mutated !== true) {
+    const addResult = lifecycleResult(add, "add", "cursor");
+    const completeResult = lifecycleResult(complete, "add", "cursor");
+    const updateResult = lifecycleResult(update, "update", "cursor");
+    const removeResult = lifecycleResult(remove, "remove", "cursor");
+    if (addResult.mutated !== true || addResult.activation.authentication !== "not_checked" ||
+        completeResult.mutated !== true || completeResult.activation.activation_attested !== true ||
+        completeResult.activation.authentication_attested !== true || updateResult.no_change !== true ||
+        updateResult.mutated !== false || removeResult.mutated !== true) {
       fail("isolated synthetic add/update/remove lifecycle contract failed");
     }
     const after = invokeJSON(["list"]);
@@ -297,4 +321,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { assertPublicJSONPathFree, frozenReleaseAsset, lifecycleCommands, npmInvocation, parseBootstrapMode, parseLifecycle };
+module.exports = { assertPublicJSONPathFree, frozenReleaseAsset, lifecycleCommands, lifecycleResult, npmInvocation, parseBootstrapMode, parseLifecycle };

--- a/npm/agentplugins/scripts/platform-proof.js
+++ b/npm/agentplugins/scripts/platform-proof.js
@@ -118,7 +118,7 @@ function lifecycleResult(output, command, target) {
     fail(`agentplugins ${command} did not return a successful lifecycle envelope`);
   }
   if (output.data.result && typeof output.data.result === "object") {
-    if (output.data.targets !== undefined) {
+    if (output.data.batch === true || output.data.targets !== undefined) {
       fail(`agentplugins ${command} returned ambiguous direct and batch lifecycle results`);
     }
     return output.data.result;

--- a/npm/agentplugins/test/platform-proof.test.js
+++ b/npm/agentplugins/test/platform-proof.test.js
@@ -89,6 +89,13 @@ test("platform proof reads exact single-target results from direct and batch env
 
   assert.throws(() => lifecycleResult({
     schema_version: 1,
+    command: "add",
+    result: "success",
+    data: { batch: true, result: { mutated: true } }
+  }, "add", "cursor"), /ambiguous direct and batch lifecycle results/);
+
+  assert.throws(() => lifecycleResult({
+    schema_version: 1,
     command: "remove",
     result: "success",
     data: {

--- a/npm/agentplugins/test/platform-proof.test.js
+++ b/npm/agentplugins/test/platform-proof.test.js
@@ -12,6 +12,7 @@ const {
   assertPublicJSONPathFree,
   frozenReleaseAsset,
   lifecycleCommands,
+  lifecycleResult,
   npmInvocation,
   parseBootstrapMode,
   parseLifecycle
@@ -62,6 +63,41 @@ test("platform proof lifecycle commands use the default no-confirmation flow", (
   for (const command of commands) {
     assert.equal(command.includes("--yes"), false, `unexpected --yes in ${command.join(" ")}`);
   }
+});
+
+test("platform proof reads exact single-target results from direct and batch envelopes", () => {
+  const direct = lifecycleResult({
+    schema_version: 1,
+    command: "add",
+    result: "success",
+    data: { result: { mutated: true } }
+  }, "add", "cursor");
+  assert.deepEqual(direct, { mutated: true });
+
+  const batch = lifecycleResult({
+    schema_version: 1,
+    command: "update",
+    result: "success",
+    data: {
+      batch: true,
+      succeeded: 1,
+      failed: 0,
+      targets: [{ target: "cursor", output: { result: { no_change: true } } }]
+    }
+  }, "update", "cursor");
+  assert.deepEqual(batch, { no_change: true });
+
+  assert.throws(() => lifecycleResult({
+    schema_version: 1,
+    command: "remove",
+    result: "success",
+    data: {
+      batch: true,
+      succeeded: 1,
+      failed: 0,
+      targets: [{ target: "codex", output: { result: { mutated: true } } }]
+    }
+  }, "remove", "cursor"), /exactly one successful cursor lifecycle result/);
 });
 
 test("platform proof accepts only explicit bootstrap evidence modes", () => {


### PR DESCRIPTION
## What changed

- read lifecycle results from both the direct and the single-target batch JSON contracts
- fail closed on ambiguous, failed, multi-target, or wrong-target proof output
- add contract tests for direct, batch, and wrong-target envelopes

## Evidence

- npm package tests: 31 passed
- exact 0.1.9 Linux amd64 frozen release proof: passed add, activation completion, update, and remove in a disposable client root

The 0.1.9 release remains a non-public draft. A new immutable release version will be cut after this fix merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of lifecycle responses for both direct and batch operations.
  * Lifecycle checks now consistently handle normalized results across add, completion, update, and removal actions.
  * Added validation to reject batch responses for an unexpected target.

* **Tests**
  * Added coverage for direct and batch lifecycle response formats, including target matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->