### PR TITLE
fix(agentplugins): project Kiro stdio runtime paths

### DIFF
--- a/install/integrationctl/agentplugins/providers/stager.go
+++ b/install/integrationctl/agentplugins/providers/stager.go
@@ -186,6 +186,11 @@ func (stager Stager) stage(
 			}
 		}
 	}
+	if plan.ClientID == domain.ClientKiro {
+		if err := projectKiroMCP(stagingPath, envelope, plan, pluginDataPath); err != nil {
+			return domain.StagedDelivery{}, err
+		}
+	}
 	if plan.ClientID == domain.ClientCopilot || plan.ClientID == domain.ClientVSCode {
 		if err := projectCopilotMarketplace(stagingPath, envelope, plan); err != nil {
 			return domain.StagedDelivery{}, err
@@ -468,6 +473,28 @@ func projectOpenAIMCP(root string, envelope domain.PackageEnvelope, serverNames 
 	return writeJSON(filepath.Join(root, ".mcp.json"), map[string]any{"mcpServers": servers})
 }
 
+func projectKiroMCP(root string, envelope domain.PackageEnvelope, plan domain.DeliveryPlan, dataPath string) error {
+	serverNames := supportedMCPNames(plan)
+	if len(serverNames) == 0 {
+		return nil
+	}
+	servers := make(map[string]map[string]any, len(serverNames))
+	for _, name := range serverNames {
+		server := envelope.MCP.Servers[name]
+		config := cloneObject(server.Decoded)
+		if server.Type == "stdio" {
+			if err := applyStdioDataContract(config, plan.ActivePath, dataPath); err != nil {
+				return fmt.Errorf("project Kiro stdio MCP server %s: %w", name, err)
+			}
+		}
+		servers[name] = config
+	}
+	return writeJSON(filepath.Join(root, "mcp.json"), map[string]any{
+		"$schema":    domain.MCPSchemaV1,
+		"mcpServers": servers,
+	})
+}
+
 func projectChatGPT(root string, envelope domain.PackageEnvelope, plan domain.DeliveryPlan, hints domain.CompatibilityHints, dataPath string) error {
 	manifest, err := projectedOpenAIManifest(envelope)
 	if err != nil {
@@ -606,6 +633,13 @@ func applyStdioDataContract(config map[string]any, pluginRoot, dataPath string) 
 			args[index] = expand(args[index])
 		}
 	}
+	if command, ok := config["command"].(string); ok && strings.HasPrefix(command, "./") {
+		command = filepath.Clean(filepath.Join(pluginRoot, filepath.FromSlash(strings.TrimPrefix(command, "./"))))
+		if !pathContainedBy(pluginRoot, command) {
+			return fmt.Errorf("stdio command escapes PLUGIN_ROOT")
+		}
+		config["command"] = command
+	}
 	if cwd, ok := config["cwd"].(string); ok && cwd != "" {
 		cwd = expand(cwd)
 		if !filepath.IsAbs(cwd) {
@@ -616,6 +650,8 @@ func applyStdioDataContract(config map[string]any, pluginRoot, dataPath string) 
 			return fmt.Errorf("stdio cwd escapes PLUGIN_ROOT and PLUGIN_DATA")
 		}
 		config["cwd"] = cwd
+	} else {
+		config["cwd"] = pluginRoot
 	}
 	return nil
 }

--- a/install/integrationctl/agentplugins/providers/stager_test.go
+++ b/install/integrationctl/agentplugins/providers/stager_test.go
@@ -95,6 +95,49 @@ func TestStagerProjectsExactOwnedPluginDataContract(t *testing.T) {
 	}
 }
 
+func TestStagerProjectsKiroStdioRuntimeContractBeforeNativeImport(t *testing.T) {
+	t.Parallel()
+	envelope := stagingEnvelope(t)
+	server := domain.MCPServer{Name: "local", Type: "stdio", Decoded: map[string]any{
+		"type": "stdio", "command": "node",
+		"args": []any{"${PLUGIN_ROOT}/runtime/launcher.mjs", "${PLUGIN_DATA}/cache"},
+		"env":  map[string]any{"CACHE": "${PLUGIN_DATA}/cache"},
+	}}
+	envelope.MCP.Servers = map[string]domain.MCPServer{"local": server}
+	plan := stagingPlan(t, domain.ClientKiro, domain.PackageNative)
+	plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "local", Support: domain.SupportNative}}
+	ownedData := filepath.Join(t.TempDir(), "owned-plugin-data")
+	delivery, err := (Stager{}).StageWithPluginData(context.Background(), envelope, plan, "operation-kiro-data", domain.CompatibilityHints{}, ownedData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	document := readObject(t, filepath.Join(delivery.StagingPath, "mcp.json"))
+	projected := document["mcpServers"].(map[string]any)["local"].(map[string]any)
+	args := projected["args"].([]any)
+	env := projected["env"].(map[string]any)
+	if args[0] != filepath.Join(plan.ActivePath, "runtime", "launcher.mjs") || args[1] != filepath.Join(ownedData, "cache") {
+		t.Fatalf("Kiro args = %+v", args)
+	}
+	if env["PLUGIN_ROOT"] != plan.ActivePath || env["PLUGIN_DATA"] != ownedData || env["CACHE"] != filepath.Join(ownedData, "cache") {
+		t.Fatalf("Kiro env = %+v", env)
+	}
+	if projected["cwd"] != plan.ActivePath {
+		t.Fatalf("Kiro cwd = %v, want %v", projected["cwd"], plan.ActivePath)
+	}
+}
+
+func TestStagerResolvesBundledStdioCommandForNativeProjection(t *testing.T) {
+	t.Parallel()
+	config := map[string]any{"command": "./bin/server"}
+	pluginRoot, dataPath := filepath.Join(t.TempDir(), "plugin"), filepath.Join(t.TempDir(), "data")
+	if err := applyStdioDataContract(config, pluginRoot, dataPath); err != nil {
+		t.Fatal(err)
+	}
+	if config["command"] != filepath.Join(pluginRoot, "bin", "server") || config["cwd"] != pluginRoot {
+		t.Fatalf("projected stdio config = %+v", config)
+	}
+}
+
 func TestStagerBuildsChatGPTAppProjectionWithBundledMCPParity(t *testing.T) {
 	t.Parallel()
 	envelope := stagingEnvelope(t)


### PR DESCRIPTION
Projects Agent Plugins 1.0 PLUGIN_ROOT and PLUGIN_DATA placeholders to native absolute paths before Kiro MCP import. Also resolves bundled stdio commands and supplies the client-managed runtime environment. Verified with the full agentplugins Go test suite and a real disposable Kiro CLI runtime call through Context7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kiro staging now supports MCP projections for compatible servers.
  * Relative stdio commands resolve from the plugin root, with support for plugin root and data path variables.
  * Working directories default to the plugin root when unspecified.
* **Bug Fixes**
  * Prevented relative commands from resolving outside the plugin directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->