### PR TITLE
fix(agentplugins): complete Cursor native projection

### DIFF
--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -580,6 +580,9 @@ func lifecycleAction(result usecase.AddResult, includePrivate bool) string {
 	}
 	if result.Activation.Authentication == domain.AuthenticationNotChecked {
 		if action != "" {
+			if strings.Contains(strings.ToLower(action), "verify this plugin's authentication requirements") {
+				return action
+			}
 			return action + "; verify this plugin's authentication requirements before using it"
 		}
 		return "verify this plugin's authentication requirements before using it"

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -151,6 +151,20 @@ func TestLifecycleOutputKeepsPrivatePathsOutOfPublicJSON(t *testing.T) {
 	}
 }
 
+func TestLifecycleOutputDoesNotDuplicateAuthenticationGuidance(t *testing.T) {
+	t.Parallel()
+	action := "verify this plugin's authentication requirements before using it"
+	result := usecase.AddResult{
+		Plan: domain.DeliveryPlan{UserActions: []string{action}},
+		Activation: domain.ActivationOutcome{
+			Authentication: domain.AuthenticationNotChecked,
+		},
+	}
+	if got := nextLifecycleAction(result); got != action {
+		t.Fatalf("next action = %q, want %q", got, action)
+	}
+}
+
 func TestAutomatedAddRequiresExplicitTargetButNotYes(t *testing.T) {
 	t.Parallel()
 	fixture := newCLIFixture(t, []domain.DetectedClient{

--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -487,7 +487,7 @@ func codexPluginStatus(body []byte, name, marketplace string) codexStatus {
 	required := []string{"pluginId", "name", "marketplaceName", "installed", "enabled"}
 	for _, value := range entries {
 		entry, ok := value.(map[string]any)
-		if !ok || len(entry) != len(required) {
+		if !ok {
 			return codexStatusUnknown
 		}
 		for _, field := range required {

--- a/install/integrationctl/agentplugins/providers/activator_test.go
+++ b/install/integrationctl/agentplugins/providers/activator_test.go
@@ -166,7 +166,7 @@ func TestCodexVerificationRequiresExactEnabledManagedEntry(t *testing.T) {
 		"wrong enabled type":      {`{"installed":[{"pluginId":"demo@managed","name":"demo","marketplaceName":"managed","installed":true,"enabled":1}]}`, codexStatusUnknown},
 		"missing plugin id":       {`{"installed":[{"name":"demo","marketplaceName":"managed","installed":true,"enabled":true}]}`, codexStatusUnknown},
 		"missing enabled":         {`{"installed":[{"pluginId":"demo@managed","name":"demo","marketplaceName":"managed","installed":true}]}`, codexStatusUnknown},
-		"unknown entry field":     {`{"installed":[{"pluginId":"demo@managed","name":"demo","marketplaceName":"managed","installed":true,"enabled":true,"status":"active"}]}`, codexStatusUnknown},
+		"additive entry fields":   {`{"installed":[{"pluginId":"demo@managed","name":"demo","marketplaceName":"managed","installed":true,"enabled":true,"source":{"source":"local"},"installPolicy":"AVAILABLE"}]}`, codexStatusInstalled},
 		"enabled case variant":    {`{"installed":[{"pluginId":"demo@managed","name":"demo","marketplaceName":"managed","installed":true,"Enabled":true}]}`, codexStatusUnknown},
 		"duplicate enabled":       {`{"installed":[{"pluginId":"demo@managed","name":"demo","marketplaceName":"managed","installed":true,"enabled":true,"enabled":false}]}`, codexStatusUnknown},
 		"duplicate installed":     {`{"installed":[{"pluginId":"demo@managed","name":"demo","marketplaceName":"managed","installed":true,"installed":false,"enabled":true}]}`, codexStatusUnknown},

--- a/install/integrationctl/agentplugins/providers/stager.go
+++ b/install/integrationctl/agentplugins/providers/stager.go
@@ -191,6 +191,11 @@ func (stager Stager) stage(
 			return domain.StagedDelivery{}, err
 		}
 	}
+	if plan.ClientID == domain.ClientCursor {
+		if err := projectCursor(stagingPath, envelope, plan, pluginDataPath); err != nil {
+			return domain.StagedDelivery{}, err
+		}
+	}
 	if plan.ClientID == domain.ClientCopilot || plan.ClientID == domain.ClientVSCode {
 		if err := projectCopilotMarketplace(stagingPath, envelope, plan); err != nil {
 			return domain.StagedDelivery{}, err
@@ -493,6 +498,67 @@ func projectKiroMCP(root string, envelope domain.PackageEnvelope, plan domain.De
 		"$schema":    domain.MCPSchemaV1,
 		"mcpServers": servers,
 	})
+}
+
+func projectCursor(root string, envelope domain.PackageEnvelope, plan domain.DeliveryPlan, dataPath string) error {
+	manifest := map[string]any{"name": envelope.Manifest.Name}
+	copyString := func(key, value string) {
+		if strings.TrimSpace(value) != "" {
+			manifest[key] = value
+		}
+	}
+	copyString("version", envelope.Manifest.Version)
+	copyString("description", envelope.Manifest.Description)
+	copyString("homepage", envelope.Manifest.Homepage)
+	copyString("repository", envelope.Manifest.Repository)
+	copyString("license", envelope.Manifest.License)
+	if envelope.Manifest.Author != nil && strings.TrimSpace(envelope.Manifest.Author.Name) != "" {
+		author := map[string]string{"name": envelope.Manifest.Author.Name}
+		if strings.TrimSpace(envelope.Manifest.Author.Email) != "" {
+			author["email"] = envelope.Manifest.Author.Email
+		}
+		manifest["author"] = author
+	}
+	if len(envelope.Manifest.Keywords) > 0 {
+		manifest["keywords"] = envelope.Manifest.Keywords
+	}
+	if hasSupported(plan, domain.ComponentSkill) {
+		manifest["skills"] = "./skills/"
+	}
+	serverNames := supportedMCPNames(plan)
+	if len(serverNames) > 0 {
+		manifest["mcpServers"] = "./mcp.json"
+	}
+	if err := writeJSON(filepath.Join(root, ".cursor-plugin", "plugin.json"), manifest); err != nil {
+		return fmt.Errorf("write Cursor plugin manifest: %w", err)
+	}
+	return projectCursorMCP(root, envelope, serverNames, plan.ActivePath, dataPath)
+}
+
+func projectCursorMCP(root string, envelope domain.PackageEnvelope, serverNames []string, pluginRoot, dataPath string) error {
+	if len(serverNames) == 0 {
+		return nil
+	}
+	servers := make(map[string]map[string]any, len(serverNames))
+	for _, name := range serverNames {
+		server := envelope.MCP.Servers[name]
+		config := cloneObject(server.Decoded)
+		switch server.Type {
+		case "stdio":
+			delete(config, "type")
+			if err := applyStdioDataContract(config, pluginRoot, dataPath); err != nil {
+				return fmt.Errorf("project Cursor stdio MCP server %s: %w", name, err)
+			}
+		case "streamable-http":
+			config["type"] = "http"
+		case "sse":
+			config["type"] = "sse"
+		default:
+			continue
+		}
+		servers[name] = config
+	}
+	return writeJSON(filepath.Join(root, "mcp.json"), map[string]any{"mcpServers": servers})
 }
 
 func projectChatGPT(root string, envelope domain.PackageEnvelope, plan domain.DeliveryPlan, hints domain.CompatibilityHints, dataPath string) error {

--- a/install/integrationctl/agentplugins/providers/stager_test.go
+++ b/install/integrationctl/agentplugins/providers/stager_test.go
@@ -126,6 +126,45 @@ func TestStagerProjectsKiroStdioRuntimeContractBeforeNativeImport(t *testing.T) 
 	}
 }
 
+func TestStagerProjectsCursorNativeManifestAndRuntimeContract(t *testing.T) {
+	t.Parallel()
+	envelope := stagingEnvelope(t)
+	envelope.Manifest.Author = &domain.Author{Name: "Demo Author", Email: "demo@example.com", URL: "https://example.com/author"}
+	server := domain.MCPServer{Name: "local", Type: "stdio", Decoded: map[string]any{
+		"type": "stdio", "command": "node",
+		"args": []any{"${PLUGIN_ROOT}/runtime/launcher.mjs", "${PLUGIN_DATA}/cache"},
+	}}
+	envelope.MCP.Servers = map[string]domain.MCPServer{"local": server}
+	plan := stagingPlan(t, domain.ClientCursor, domain.PackageNative)
+	plan.Components = []domain.ComponentDecision{
+		{Kind: domain.ComponentSkill, Name: "good", Support: domain.SupportNative},
+		{Kind: domain.ComponentMCPServer, Name: "local", Support: domain.SupportNative},
+	}
+	ownedData := filepath.Join(t.TempDir(), "owned-plugin-data")
+	delivery, err := (Stager{}).StageWithPluginData(context.Background(), envelope, plan, "operation-cursor-data", domain.CompatibilityHints{}, ownedData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := readObject(t, filepath.Join(delivery.StagingPath, ".cursor-plugin", "plugin.json"))
+	if manifest["name"] != "demo" || manifest["mcpServers"] != "./mcp.json" || manifest["skills"] != "./skills/" {
+		t.Fatalf("Cursor manifest = %+v", manifest)
+	}
+	author := manifest["author"].(map[string]any)
+	if author["name"] != "Demo Author" || author["email"] != "demo@example.com" || author["url"] != nil {
+		t.Fatalf("Cursor author = %+v", author)
+	}
+	document := readObject(t, filepath.Join(delivery.StagingPath, "mcp.json"))
+	projected := document["mcpServers"].(map[string]any)["local"].(map[string]any)
+	args := projected["args"].([]any)
+	env := projected["env"].(map[string]any)
+	if projected["type"] != nil || args[0] != filepath.Join(plan.ActivePath, "runtime", "launcher.mjs") || args[1] != filepath.Join(ownedData, "cache") {
+		t.Fatalf("Cursor MCP = %+v", projected)
+	}
+	if env["PLUGIN_ROOT"] != plan.ActivePath || env["PLUGIN_DATA"] != ownedData || projected["cwd"] != plan.ActivePath {
+		t.Fatalf("Cursor runtime contract = %+v", projected)
+	}
+}
+
 func TestStagerResolvesBundledStdioCommandForNativeProjection(t *testing.T) {
 	t.Parallel()
 	config := map[string]any{"command": "./bin/server"}
@@ -228,6 +267,10 @@ func TestStagerKeepsNativePackageAndSanitizesFailureBoundaries(t *testing.T) {
 	servers := mcp["mcpServers"].(map[string]any)
 	if len(servers) != 1 || servers["notion"] == nil {
 		t.Fatalf("sanitized servers = %+v", servers)
+	}
+	cursorManifest := readObject(t, filepath.Join(delivery.StagingPath, ".cursor-plugin", "plugin.json"))
+	if cursorManifest["name"] != "demo" || cursorManifest["mcpServers"] != "./mcp.json" || cursorManifest["skills"] != "./skills/" {
+		t.Fatalf("Cursor compatibility manifest = %+v", cursorManifest)
 	}
 }
 


### PR DESCRIPTION
## What changed

- generate the official `.cursor-plugin/plugin.json` projection for portable Agent Plugins 1.0 packages
- project Cursor MCP definitions with stable native paths and managed `PLUGIN_ROOT` / `PLUGIN_DATA`
- accept additive fields in current `codex plugin list --json` output while keeping identity and duplicate-key checks strict

## Evidence

- `go test ./install/integrationctl/agentplugins/...`
- real Cursor Agent runtime loaded the projected Chrome DevTools plugin and completed `list_pages`
- current Codex CLI installed and enabled the same package; its expanded JSON listing is covered by the parser regression test

All runtime work used disposable E2E workspaces and persistent test-only client containers.