### PR TITLE
feat(agentplugins): reconcile native identity in info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Changes after `v1.2.4` land here.
 - The `agentplugins` lifecycle commands now accept ordered, comma-separated
   targets such as `--target codex,cursor`, with versioned batch JSON output and
   explicit partial-failure reporting that preserves successful client changes.
+- `agentplugins info <name> --target copilot --format json` now reports
+  receipt reconciliation, exact native discovery, the observed client version,
+  and path-free command evidence without changing its additive schema-version 1
+  envelope or mutating installation state.
 
 ### Fixed
 

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -2495,7 +2495,9 @@ type staticDetector struct {
 type observedProbingDetector struct {
 	readOnlyCalls int
 	probeCalls    int
+	targetedCalls int
 	clients       []domain.DetectedClient
+	targets       []domain.ClientID
 }
 
 func (detector *observedProbingDetector) Detect(context.Context) ([]domain.DetectedClient, error) {
@@ -2505,6 +2507,12 @@ func (detector *observedProbingDetector) Detect(context.Context) ([]domain.Detec
 
 func (detector *observedProbingDetector) DetectWithVersionProbe(context.Context) ([]domain.DetectedClient, error) {
 	detector.probeCalls++
+	return append([]domain.DetectedClient(nil), detector.clients...), nil
+}
+
+func (detector *observedProbingDetector) DetectTargetsWithVersionProbe(_ context.Context, targets []domain.ClientID) ([]domain.DetectedClient, error) {
+	detector.targetedCalls++
+	detector.targets = append([]domain.ClientID(nil), targets...)
 	return append([]domain.DetectedClient(nil), detector.clients...), nil
 }
 

--- a/cli/plugin-kit-ai/internal/agentpluginscli/read.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/read.go
@@ -18,6 +18,7 @@ import (
 )
 
 type publicClient struct {
+	BindingID                 string                         `json:"-"`
 	ClientID                  string                         `json:"client_id"`
 	Scope                     string                         `json:"scope"`
 	Materialization           domain.MaterializationState    `json:"materialization"`
@@ -151,8 +152,10 @@ func newInfoCommand(app App, opts *options) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("inspect signed Directory: %w", err)
 			}
-			if err := reconcileInstalledInfo(cmd.Context(), app, installation, opts.target, &public); err != nil {
-				return err
+			if strings.TrimSpace(opts.target) != "" {
+				if err := reconcileInstalledInfo(cmd.Context(), app, installation, opts.target, &public); err != nil {
+					return err
+				}
 			}
 			if opts.format == "json" {
 				return writeJSONOutput(cmd.OutOrStdout(), "info", public)
@@ -482,7 +485,8 @@ func publicInstallationView(installation domain.Installation, includeAbsent bool
 		affectedSurfaces := append([]string(nil), client.AffectedSurfaces...)
 		sort.Strings(affectedSurfaces)
 		value.Clients = append(value.Clients, publicClient{
-			ClientID: client.ClientID, Scope: client.Scope, Materialization: client.Materialization,
+			BindingID: client.ClientBindingID,
+			ClientID:  client.ClientID, Scope: client.Scope, Materialization: client.Materialization,
 			Activation: client.Activation, Authentication: client.Authentication,
 			Policy: client.Policy, Verification: client.Verification,
 			PackageRevision:  publicPackageRevision(client.PackageRevision),
@@ -577,6 +581,10 @@ func renderInstallation(writer io.Writer, installation publicInstallation) error
 	for _, client := range installation.Clients {
 		_, _ = fmt.Fprintf(writer, "  %s: materialization=%s activation=%s auth=%s verification=%s\n",
 			client.ClientID, client.Materialization, client.Activation, client.Authentication, client.Verification)
+		if client.ReceiptReconciled != nil && client.NativeDiscoveryReconciled != nil {
+			_, _ = fmt.Fprintf(writer, "    native_identity=%s receipt_reconciled=%t native_discovery_reconciled=%t client_version=%s\n",
+				client.NativeIdentityState, *client.ReceiptReconciled, *client.NativeDiscoveryReconciled, client.ClientVersion)
+		}
 	}
 	if installation.Directory != nil {
 		value := installation.Directory

--- a/cli/plugin-kit-ai/internal/agentpluginscli/read.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/read.go
@@ -18,15 +18,37 @@ import (
 )
 
 type publicClient struct {
-	ClientID         string                      `json:"client_id"`
-	Scope            string                      `json:"scope"`
-	Materialization  domain.MaterializationState `json:"materialization"`
-	Activation       domain.ActivationState      `json:"activation"`
-	Authentication   domain.AuthenticationState  `json:"authentication"`
-	Policy           domain.PolicyState          `json:"policy"`
-	Verification     domain.VerificationState    `json:"verification"`
-	PackageRevision  *publicClientRevision       `json:"package_revision,omitempty"`
-	AffectedSurfaces []string                    `json:"affected_surfaces,omitempty"`
+	ClientID                  string                         `json:"client_id"`
+	Scope                     string                         `json:"scope"`
+	Materialization           domain.MaterializationState    `json:"materialization"`
+	Activation                domain.ActivationState         `json:"activation"`
+	Authentication            domain.AuthenticationState     `json:"authentication"`
+	Policy                    domain.PolicyState             `json:"policy"`
+	Verification              domain.VerificationState       `json:"verification"`
+	PackageRevision           *publicClientRevision          `json:"package_revision,omitempty"`
+	AffectedSurfaces          []string                       `json:"affected_surfaces,omitempty"`
+	ReceiptReconciled         *bool                          `json:"receipt_reconciled,omitempty"`
+	NativeDiscoveryReconciled *bool                          `json:"native_discovery_reconciled,omitempty"`
+	NativeIdentityState       domain.NativeIdentityState     `json:"native_identity_state,omitempty"`
+	ClientVersion             string                         `json:"client_version,omitempty"`
+	NativeDiscoveryEvidence   *publicNativeDiscoveryEvidence `json:"native_discovery_evidence,omitempty"`
+}
+
+type publicNativeDiscoveryEvidence struct {
+	Basis              string                   `json:"basis"`
+	VersionOperation   publicVersionOperation   `json:"version_operation"`
+	DiscoveryOperation publicDiscoveryOperation `json:"discovery_operation"`
+}
+
+type publicVersionOperation struct {
+	Argv                  []string `json:"argv"`
+	ObservedClientVersion string   `json:"observed_client_version,omitempty"`
+}
+
+type publicDiscoveryOperation struct {
+	Argv       []string `json:"argv"`
+	Discovered bool     `json:"discovered"`
+	ProductID  string   `json:"product_id"`
 }
 
 type publicClientRevision struct {
@@ -128,6 +150,9 @@ func newInfoCommand(app App, opts *options) *cobra.Command {
 			public, err := inspectInstalledProduct(cmd.Context(), app, state, installation)
 			if err != nil {
 				return fmt.Errorf("inspect signed Directory: %w", err)
+			}
+			if err := reconcileInstalledInfo(cmd.Context(), app, installation, opts.target, &public); err != nil {
+				return err
 			}
 			if opts.format == "json" {
 				return writeJSONOutput(cmd.OutOrStdout(), "info", public)

--- a/cli/plugin-kit-ai/internal/agentpluginscli/read_reconciliation.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/read_reconciliation.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/ports"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers"
 )
 
@@ -15,11 +16,14 @@ func reconcileInstalledInfo(ctx context.Context, app App, installation domain.In
 	if err != nil {
 		return err
 	}
+	if len(targets) == 0 {
+		return nil
+	}
 	selected := make(map[domain.ClientID]bool, len(targets))
 	for _, target := range targets {
 		selected[target] = true
 	}
-	clients, err := detectClientsForLifecycleResolution(ctx, app.Detector, true)
+	clients, err := detectClientsForInfoReconciliation(ctx, app.Detector, targets)
 	if err != nil {
 		return err
 	}
@@ -28,19 +32,29 @@ func reconcileInstalledInfo(ctx context.Context, app App, installation domain.In
 		detected[client.ClientID] = client
 	}
 
-	bindings := make(map[string]domain.ClientBinding, len(installation.Clients))
-	for _, binding := range installation.Clients {
-		bindings[binding.ClientID] = binding
-	}
 	filtered := make([]publicClient, 0, len(public.Clients))
 	for _, view := range public.Clients {
 		clientID := domain.ClientID(view.ClientID)
-		if len(selected) > 0 && !selected[clientID] {
+		if !selected[clientID] {
 			continue
 		}
-		binding := bindings[view.ClientID]
-		client, detectedOK := detected[clientID]
-		result := reconcileClientIdentity(ctx, app, installation, binding, client, detectedOK)
+		binding, bindingOK := installation.Clients[view.BindingID]
+		bindingClient, detectedOK := detected[clientID]
+		observerClient := bindingClient
+		if clientID == domain.ClientVSCode {
+			copilot, copilotOK := detected[domain.ClientCopilot]
+			if !copilotOK || copilot.Status != domain.DetectionDetected || strings.TrimSpace(copilot.ExecutablePath) == "" {
+				detectedOK = false
+			} else {
+				observerClient.ConfigRoot = copilot.ConfigRoot
+				observerClient.ExecutablePath = copilot.ExecutablePath
+				observerClient.Version = copilot.Version
+			}
+		}
+		if !bindingOK || binding.ClientBindingID != view.BindingID || binding.ClientID != view.ClientID || binding.Scope != view.Scope {
+			detectedOK = false
+		}
+		result := reconcileClientIdentity(ctx, app, installation, binding, bindingClient, observerClient, detectedOK)
 		view.ReceiptReconciled = boolPointer(result.receiptReconciled)
 		view.NativeDiscoveryReconciled = boolPointer(result.nativeDiscoveryReconciled)
 		view.NativeIdentityState = result.state
@@ -48,7 +62,15 @@ func reconcileInstalledInfo(ctx context.Context, app App, installation domain.In
 		view.NativeDiscoveryEvidence = result.evidence
 		filtered = append(filtered, view)
 	}
-	sort.Slice(filtered, func(i, j int) bool { return filtered[i].ClientID < filtered[j].ClientID })
+	sort.Slice(filtered, func(i, j int) bool {
+		if filtered[i].ClientID != filtered[j].ClientID {
+			return filtered[i].ClientID < filtered[j].ClientID
+		}
+		if filtered[i].Scope != filtered[j].Scope {
+			return filtered[i].Scope < filtered[j].Scope
+		}
+		return filtered[i].BindingID < filtered[j].BindingID
+	})
 	public.Clients = filtered
 	return nil
 }
@@ -61,49 +83,63 @@ type clientIdentityReconciliation struct {
 	evidence                  *publicNativeDiscoveryEvidence
 }
 
-func reconcileClientIdentity(ctx context.Context, app App, installation domain.Installation, binding domain.ClientBinding, client domain.DetectedClient, detected bool) clientIdentityReconciliation {
+func detectClientsForInfoReconciliation(ctx context.Context, detector ports.ClientDetector, targets []domain.ClientID) ([]domain.DetectedClient, error) {
+	probeSet := make(map[domain.ClientID]struct{}, len(targets))
+	for _, target := range targets {
+		if target == domain.ClientVSCode {
+			target = domain.ClientCopilot
+		}
+		probeSet[target] = struct{}{}
+	}
+	probeTargets := make([]domain.ClientID, 0, len(probeSet))
+	for target := range probeSet {
+		probeTargets = append(probeTargets, target)
+	}
+	sort.Slice(probeTargets, func(i, j int) bool { return probeTargets[i] < probeTargets[j] })
+	if targeted, ok := detector.(ports.TargetedVersionProbingClientDetector); ok {
+		return targeted.DetectTargetsWithVersionProbe(ctx, probeTargets)
+	}
+	return detector.Detect(ctx)
+}
+
+func reconcileClientIdentity(ctx context.Context, app App, installation domain.Installation, binding domain.ClientBinding, bindingClient, observerClient domain.DetectedClient, detected bool) clientIdentityReconciliation {
 	result := clientIdentityReconciliation{state: domain.NativeIdentityIndeterminate}
 	if detected {
-		result.clientVersion = strings.TrimSpace(client.Version)
+		result.clientVersion = strings.TrimSpace(observerClient.Version)
 	}
-	if !detected || client.Status != domain.DetectionDetected || app.Lifecycle.Targets == nil || app.Lifecycle.NativeObserver == nil {
+	if !detected || bindingClient.Status != domain.DetectionDetected || app.Lifecycle.Targets == nil || app.Lifecycle.NativeObserver == nil {
 		return result
 	}
 	expectedArtifact := domain.ComputePhysicalArtifactID(installation.DeclaredName, installation.InstallationID)
 	if strings.TrimSpace(binding.PhysicalArtifact) != expectedArtifact {
 		return result
 	}
-	result.evidence = nativeCommandEvidence(client, installation.DeclaredName, expectedArtifact, result.clientVersion, false)
 	if !hasReconciledOwnershipReceipt(binding, expectedArtifact, installation.DeclaredName) {
 		return result
 	}
-	target, err := app.Lifecycle.Targets.ResolveTarget(ctx, client, domain.InstallScope(binding.Scope), expectedArtifact)
+	target, err := app.Lifecycle.Targets.ResolveTarget(ctx, bindingClient, domain.InstallScope(binding.Scope), expectedArtifact)
 	if err != nil || filepath.Clean(target.ActivePath) != filepath.Clean(binding.TargetLocator) {
 		return result
 	}
 	plan := domain.DeliveryPlan{
-		ClientID: client.ClientID, Scope: domain.InstallScope(binding.Scope), DeclaredName: installation.DeclaredName,
+		ClientID: bindingClient.ClientID, Scope: domain.InstallScope(binding.Scope), DeclaredName: installation.DeclaredName,
 		PhysicalArtifactID: expectedArtifact, TargetAnchor: target.TargetAnchor, TargetRoot: target.TargetRoot, ActivePath: target.ActivePath,
-		NativeRegistryRoot: client.ConfigRoot, NativeRegistryExecutable: client.ExecutablePath,
+		NativeRegistryRoot: observerClient.ConfigRoot, NativeRegistryExecutable: observerClient.ExecutablePath,
 	}
-	observation, observeErr := app.Lifecycle.NativeObserver.ObserveNativeIdentity(ctx, client, plan, &binding)
+	observation, observeErr := app.Lifecycle.NativeObserver.ObserveNativeIdentity(ctx, observerClient, plan, &binding)
 	result.receiptReconciled = observation.ReceiptReconciled
 	result.nativeDiscoveryReconciled = observation.NativeDiscoveryReconciled
-	if result.evidence != nil {
-		result.evidence.DiscoveryOperation.Discovered = result.nativeDiscoveryReconciled
+	if observation.NativeDiscoveryAttempted {
+		result.evidence = nativeCommandEvidence(observerClient, installation.DeclaredName, expectedArtifact, result.clientVersion, result.nativeDiscoveryReconciled)
+	}
+	if observation.State != "" {
+		result.state = observation.State
 	}
 	if observeErr != nil {
 		return result
 	}
-	result.state = observation.NativeDiscoveryState
-	if result.state == "" {
-		result.state = observation.State
-	}
-	if result.nativeDiscoveryReconciled {
-		result.state = domain.NativeIdentityIndeterminate
-		if result.receiptReconciled {
-			result.state = domain.NativeIdentityManaged
-		}
+	if result.state == domain.NativeIdentityManaged && !result.nativeDiscoveryReconciled && observation.NativeDiscoveryState != "" {
+		result.state = observation.NativeDiscoveryState
 	}
 	return result
 }
@@ -145,7 +181,8 @@ func hasReconciledOwnershipReceipt(binding domain.ClientBinding, physicalArtifac
 }
 
 func nativeCommandEvidence(client domain.DetectedClient, declaredName, physicalArtifact, version string, discovered bool) *publicNativeDiscoveryEvidence {
-	if client.ClientID != domain.ClientCopilot || strings.TrimSpace(client.ExecutablePath) == "" || strings.TrimSpace(physicalArtifact) == "" {
+	if (client.ClientID != domain.ClientCopilot && client.ClientID != domain.ClientVSCode) ||
+		strings.TrimSpace(client.ExecutablePath) == "" || strings.TrimSpace(physicalArtifact) == "" {
 		return nil
 	}
 	return &publicNativeDiscoveryEvidence{

--- a/cli/plugin-kit-ai/internal/agentpluginscli/read_reconciliation.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/read_reconciliation.go
@@ -132,14 +132,14 @@ func reconcileClientIdentity(ctx context.Context, app App, installation domain.I
 	observation, observeErr := app.Lifecycle.NativeObserver.ObserveNativeIdentity(ctx, observerClient, plan, &binding)
 	result.receiptReconciled = observation.ReceiptReconciled
 	result.nativeDiscoveryReconciled = observation.NativeDiscoveryReconciled
-	if observation.NativeDiscoveryAttempted {
-		result.evidence = nativeCommandEvidence(observerClient, installation.DeclaredName, expectedArtifact, result.clientVersion, result.nativeDiscoveryReconciled)
-	}
 	if observation.State != "" {
 		result.state = observation.State
 	}
 	if observeErr != nil {
 		return result
+	}
+	if observation.NativeDiscoveryAttempted {
+		result.evidence = nativeCommandEvidence(observerClient, installation.DeclaredName, expectedArtifact, result.clientVersion, result.nativeDiscoveryReconciled)
 	}
 	if result.state == domain.NativeIdentityManaged && !result.nativeDiscoveryReconciled && observation.NativeDiscoveryState != "" {
 		result.state = observation.NativeDiscoveryState

--- a/cli/plugin-kit-ai/internal/agentpluginscli/read_reconciliation.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/read_reconciliation.go
@@ -110,6 +110,9 @@ func reconcileClientIdentity(ctx context.Context, app App, installation domain.I
 	if !detected || bindingClient.Status != domain.DetectionDetected || app.Lifecycle.Targets == nil || app.Lifecycle.NativeObserver == nil {
 		return result
 	}
+	if strings.TrimSpace(observerClient.Version) == "" {
+		return result
+	}
 	expectedArtifact := domain.ComputePhysicalArtifactID(installation.DeclaredName, installation.InstallationID)
 	if strings.TrimSpace(binding.PhysicalArtifact) != expectedArtifact {
 		return result

--- a/cli/plugin-kit-ai/internal/agentpluginscli/read_reconciliation.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/read_reconciliation.go
@@ -1,0 +1,163 @@
+package agentpluginscli
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers"
+)
+
+func reconcileInstalledInfo(ctx context.Context, app App, installation domain.Installation, targetOption string, public *publicInstallation) error {
+	targets, err := parseTargetOption(targetOption)
+	if err != nil {
+		return err
+	}
+	selected := make(map[domain.ClientID]bool, len(targets))
+	for _, target := range targets {
+		selected[target] = true
+	}
+	clients, err := detectClientsForLifecycleResolution(ctx, app.Detector, true)
+	if err != nil {
+		return err
+	}
+	detected := make(map[domain.ClientID]domain.DetectedClient, len(clients))
+	for _, client := range clients {
+		detected[client.ClientID] = client
+	}
+
+	bindings := make(map[string]domain.ClientBinding, len(installation.Clients))
+	for _, binding := range installation.Clients {
+		bindings[binding.ClientID] = binding
+	}
+	filtered := make([]publicClient, 0, len(public.Clients))
+	for _, view := range public.Clients {
+		clientID := domain.ClientID(view.ClientID)
+		if len(selected) > 0 && !selected[clientID] {
+			continue
+		}
+		binding := bindings[view.ClientID]
+		client, detectedOK := detected[clientID]
+		result := reconcileClientIdentity(ctx, app, installation, binding, client, detectedOK)
+		view.ReceiptReconciled = boolPointer(result.receiptReconciled)
+		view.NativeDiscoveryReconciled = boolPointer(result.nativeDiscoveryReconciled)
+		view.NativeIdentityState = result.state
+		view.ClientVersion = result.clientVersion
+		view.NativeDiscoveryEvidence = result.evidence
+		filtered = append(filtered, view)
+	}
+	sort.Slice(filtered, func(i, j int) bool { return filtered[i].ClientID < filtered[j].ClientID })
+	public.Clients = filtered
+	return nil
+}
+
+type clientIdentityReconciliation struct {
+	receiptReconciled         bool
+	nativeDiscoveryReconciled bool
+	state                     domain.NativeIdentityState
+	clientVersion             string
+	evidence                  *publicNativeDiscoveryEvidence
+}
+
+func reconcileClientIdentity(ctx context.Context, app App, installation domain.Installation, binding domain.ClientBinding, client domain.DetectedClient, detected bool) clientIdentityReconciliation {
+	result := clientIdentityReconciliation{state: domain.NativeIdentityIndeterminate}
+	if detected {
+		result.clientVersion = strings.TrimSpace(client.Version)
+	}
+	if !detected || client.Status != domain.DetectionDetected || app.Lifecycle.Targets == nil || app.Lifecycle.NativeObserver == nil {
+		return result
+	}
+	expectedArtifact := domain.ComputePhysicalArtifactID(installation.DeclaredName, installation.InstallationID)
+	if strings.TrimSpace(binding.PhysicalArtifact) != expectedArtifact {
+		return result
+	}
+	result.evidence = nativeCommandEvidence(client, installation.DeclaredName, expectedArtifact, result.clientVersion, false)
+	if !hasReconciledOwnershipReceipt(binding, expectedArtifact, installation.DeclaredName) {
+		return result
+	}
+	target, err := app.Lifecycle.Targets.ResolveTarget(ctx, client, domain.InstallScope(binding.Scope), expectedArtifact)
+	if err != nil || filepath.Clean(target.ActivePath) != filepath.Clean(binding.TargetLocator) {
+		return result
+	}
+	plan := domain.DeliveryPlan{
+		ClientID: client.ClientID, Scope: domain.InstallScope(binding.Scope), DeclaredName: installation.DeclaredName,
+		PhysicalArtifactID: expectedArtifact, TargetAnchor: target.TargetAnchor, TargetRoot: target.TargetRoot, ActivePath: target.ActivePath,
+		NativeRegistryRoot: client.ConfigRoot, NativeRegistryExecutable: client.ExecutablePath,
+	}
+	observation, observeErr := app.Lifecycle.NativeObserver.ObserveNativeIdentity(ctx, client, plan, &binding)
+	result.receiptReconciled = observation.ReceiptReconciled
+	result.nativeDiscoveryReconciled = observation.NativeDiscoveryReconciled
+	if result.evidence != nil {
+		result.evidence.DiscoveryOperation.Discovered = result.nativeDiscoveryReconciled
+	}
+	if observeErr != nil {
+		return result
+	}
+	result.state = observation.NativeDiscoveryState
+	if result.state == "" {
+		result.state = observation.State
+	}
+	if result.nativeDiscoveryReconciled {
+		result.state = domain.NativeIdentityIndeterminate
+		if result.receiptReconciled {
+			result.state = domain.NativeIdentityManaged
+		}
+	}
+	return result
+}
+
+func hasReconciledOwnershipReceipt(binding domain.ClientBinding, physicalArtifact, declaredName string) bool {
+	digest := ""
+	expectedObjectID := "package:" + binding.ClientID + ":" + physicalArtifact
+	for _, object := range binding.NativeObjects {
+		if object.Kind != "managed_package_directory" {
+			continue
+		}
+		if digest != "" || object.ObjectID != expectedObjectID || object.LogicalName != declaredName || strings.TrimSpace(object.ManagedDigest) == "" {
+			return false
+		}
+		digest = object.ManagedDigest
+	}
+	if digest == "" {
+		return false
+	}
+	latestSequence := 0
+	latestDigest := ""
+	latestPhase := ""
+	sequences := make(map[int]struct{}, len(binding.Receipts))
+	for _, receipt := range binding.Receipts {
+		if receipt.ClientBindingID != binding.ClientBindingID || receipt.Sequence < 1 || strings.TrimSpace(receipt.OperationID) == "" {
+			return false
+		}
+		if _, duplicate := sequences[receipt.Sequence]; duplicate {
+			return false
+		}
+		sequences[receipt.Sequence] = struct{}{}
+		if receipt.Sequence > latestSequence {
+			latestSequence = receipt.Sequence
+			latestDigest = strings.TrimSpace(receipt.AfterDigest)
+			latestPhase = strings.TrimSpace(receipt.Phase)
+		}
+	}
+	return latestSequence > 0 && latestDigest == digest && latestPhase == "committed"
+}
+
+func nativeCommandEvidence(client domain.DetectedClient, declaredName, physicalArtifact, version string, discovered bool) *publicNativeDiscoveryEvidence {
+	if client.ClientID != domain.ClientCopilot || strings.TrimSpace(client.ExecutablePath) == "" || strings.TrimSpace(physicalArtifact) == "" {
+		return nil
+	}
+	return &publicNativeDiscoveryEvidence{
+		Basis: "native_client_command",
+		VersionOperation: publicVersionOperation{
+			Argv: []string{"copilot", "--version"}, ObservedClientVersion: version,
+		},
+		DiscoveryOperation: publicDiscoveryOperation{
+			Argv: []string{"copilot", "plugin", "list"}, Discovered: discovered,
+			ProductID: strings.TrimSpace(declaredName) + "@" + providers.ManagedMarketplaceName(physicalArtifact),
+		},
+	}
+}
+
+func boolPointer(value bool) *bool { return &value }

--- a/cli/plugin-kit-ai/internal/agentpluginscli/read_reconciliation_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/read_reconciliation_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/usecase"
 )
 
 func TestInfoReconcilesExactCopilotIdentityWithoutMutationOrPathLeak(t *testing.T) {
@@ -98,8 +99,8 @@ func TestInfoReconcilesExactCopilotIdentityWithoutMutationOrPathLeak(t *testing.
 		strings.Join(evidence.VersionOperation.Argv, " ") != "copilot --version" || strings.Join(evidence.DiscoveryOperation.Argv, " ") != "copilot plugin list" {
 		t.Fatalf("native discovery evidence = %+v", evidence)
 	}
-	if detector.probeCalls != 1 || detector.readOnlyCalls != 0 {
-		t.Fatalf("detector calls = read-only:%d probe:%d", detector.readOnlyCalls, detector.probeCalls)
+	if detector.targetedCalls != 1 || detector.probeCalls != 0 || detector.readOnlyCalls != 0 || len(detector.targets) != 1 || detector.targets[0] != domain.ClientCopilot {
+		t.Fatalf("detector calls = read-only:%d probe:%d targeted:%d targets:%v", detector.readOnlyCalls, detector.probeCalls, detector.targetedCalls, detector.targets)
 	}
 }
 
@@ -110,8 +111,137 @@ func TestInfoInvalidOwnershipReceiptIsInconclusive(t *testing.T) {
 	}
 }
 
+func TestInfoReconcilesEachSameClientBindingByExactBindingIdentity(t *testing.T) {
+	installationID := "00000000-0000-4000-8000-000000000010"
+	physical := domain.ComputePhysicalArtifactID("demo", installationID)
+	userTarget := filepath.Join(t.TempDir(), "user", physical)
+	projectTarget := filepath.Join(t.TempDir(), "project", physical)
+	user := validReconciliationBinding(installationID, domain.ClientCopilot, domain.ScopeUser, userTarget, physical)
+	project := validReconciliationBinding(installationID, domain.ClientCopilot, domain.ScopeProject, projectTarget, physical)
+	project.Receipts = nil
+	installation := domain.Installation{InstallationID: installationID, DeclaredName: "demo", Clients: map[string]domain.ClientBinding{
+		user.ClientBindingID: user, project.ClientBindingID: project,
+	}}
+	detector := &observedProbingDetector{clients: []domain.DetectedClient{{
+		ClientID: domain.ClientCopilot, Status: domain.DetectionDetected, Version: "1.0.80", ExecutablePath: "/test/bin/copilot",
+	}}}
+	app := App{Detector: detector, Lifecycle: usecase.Service{
+		Targets:        scopeTargetResolver{targets: map[domain.InstallScope]string{domain.ScopeUser: userTarget, domain.ScopeProject: projectTarget}},
+		NativeObserver: reconciledNativeObserver{},
+	}}
+	public := publicInstallationView(installation, true)
+	if err := reconcileInstalledInfo(context.Background(), app, installation, "copilot", &public); err != nil {
+		t.Fatal(err)
+	}
+	if len(public.Clients) != 2 {
+		t.Fatalf("clients = %+v", public.Clients)
+	}
+	byScope := make(map[string]publicClient, len(public.Clients))
+	for _, client := range public.Clients {
+		byScope[client.Scope] = client
+	}
+	if byScope[string(domain.ScopeUser)].ReceiptReconciled == nil || !*byScope[string(domain.ScopeUser)].ReceiptReconciled {
+		t.Fatalf("user binding was not reconciled: %+v", byScope[string(domain.ScopeUser)])
+	}
+	if byScope[string(domain.ScopeProject)].ReceiptReconciled == nil || *byScope[string(domain.ScopeProject)].ReceiptReconciled {
+		t.Fatalf("invalid project binding did not fail closed: %+v", byScope[string(domain.ScopeProject)])
+	}
+	if byScope[string(domain.ScopeProject)].NativeDiscoveryEvidence != nil {
+		t.Fatalf("invalid project binding exposed unvalidated evidence: %+v", byScope[string(domain.ScopeProject)].NativeDiscoveryEvidence)
+	}
+}
+
+func TestVSCodeInfoUsesCopilotAsAuthoritativeNativeBackend(t *testing.T) {
+	tests := []struct {
+		name        string
+		observation domain.NativeIdentityObservation
+		wantState   domain.NativeIdentityState
+		wantNative  bool
+	}{
+		{name: "exact", observation: domain.NativeIdentityObservation{State: domain.NativeIdentityManaged, ReceiptReconciled: true, NativeDiscoveryReconciled: true, NativeDiscoveryState: domain.NativeIdentityManaged, NativeDiscoveryAttempted: true}, wantState: domain.NativeIdentityManaged, wantNative: true},
+		{name: "absent", observation: domain.NativeIdentityObservation{State: domain.NativeIdentityManaged, ReceiptReconciled: true, NativeDiscoveryState: domain.NativeIdentityAbsent, NativeDiscoveryAttempted: true}, wantState: domain.NativeIdentityAbsent},
+		{name: "unknown", observation: domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate, NativeDiscoveryState: domain.NativeIdentityIndeterminate, NativeDiscoveryAttempted: true}, wantState: domain.NativeIdentityIndeterminate},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			installationID := "00000000-0000-4000-8000-000000000020"
+			physical := domain.ComputePhysicalArtifactID("demo", installationID)
+			target := filepath.Join(t.TempDir(), "vscode", physical)
+			binding := validReconciliationBinding(installationID, domain.ClientVSCode, domain.ScopeUser, target, physical)
+			installation := domain.Installation{InstallationID: installationID, DeclaredName: "demo", Clients: map[string]domain.ClientBinding{binding.ClientBindingID: binding}}
+			detector := &observedProbingDetector{clients: []domain.DetectedClient{
+				{ClientID: domain.ClientVSCode, Status: domain.DetectionDetected, Version: "9.9.9", ExecutablePath: "/test/bin/code", ConfigRoot: "/test/config/code"},
+				{ClientID: domain.ClientCopilot, Status: domain.DetectionDetected, Version: "1.0.80", ExecutablePath: "/test/bin/copilot", ConfigRoot: "/test/config/copilot"},
+			}}
+			observer := &capturingNativeObserver{observation: test.observation}
+			app := App{Detector: detector, Lifecycle: usecase.Service{
+				Targets: scopeTargetResolver{targets: map[domain.InstallScope]string{domain.ScopeUser: target}}, NativeObserver: observer,
+			}}
+			public := publicInstallationView(installation, true)
+			if err := reconcileInstalledInfo(context.Background(), app, installation, "vscode", &public); err != nil {
+				t.Fatal(err)
+			}
+			if detector.targetedCalls != 1 || len(detector.targets) != 1 || detector.targets[0] != domain.ClientCopilot {
+				t.Fatalf("targeted probes = %v", detector.targets)
+			}
+			if len(observer.clients) != 1 || observer.clients[0].ClientID != domain.ClientVSCode || observer.clients[0].ExecutablePath != "/test/bin/copilot" || observer.clients[0].ConfigRoot != "/test/config/copilot" {
+				t.Fatalf("observer clients = %+v", observer.clients)
+			}
+			got := public.Clients[0]
+			if got.ClientVersion != "1.0.80" || got.NativeIdentityState != test.wantState || got.NativeDiscoveryReconciled == nil || *got.NativeDiscoveryReconciled != test.wantNative {
+				t.Fatalf("VS Code reconciliation = %+v", got)
+			}
+			if got.NativeDiscoveryEvidence == nil || got.NativeDiscoveryEvidence.DiscoveryOperation.Discovered != test.wantNative {
+				t.Fatalf("VS Code evidence = %+v", got.NativeDiscoveryEvidence)
+			}
+		})
+	}
+}
+
+func TestInfoWithoutTargetDoesNotDetectOrProbeClients(t *testing.T) {
+	detector := &observedProbingDetector{}
+	public := publicInstallation{}
+	if err := reconcileInstalledInfo(context.Background(), App{Detector: detector}, domain.Installation{}, "", &public); err != nil {
+		t.Fatal(err)
+	}
+	if detector.readOnlyCalls != 0 || detector.probeCalls != 0 || detector.targetedCalls != 0 {
+		t.Fatalf("unexpected detector calls: %+v", detector)
+	}
+}
+
+func validReconciliationBinding(installationID string, client domain.ClientID, scope domain.InstallScope, target, physical string) domain.ClientBinding {
+	bindingID := domain.ComputeClientBindingID(installationID, string(client), string(scope), target)
+	digest := "sha256:owned"
+	return domain.ClientBinding{
+		ClientBindingID: bindingID, ClientID: string(client), Scope: string(scope), TargetLocator: target, PhysicalArtifact: physical,
+		Materialization: domain.MaterializationMaterialized,
+		NativeObjects:   []domain.NativeObjectOwnership{{ObjectID: "package:" + string(client) + ":" + physical, Kind: "managed_package_directory", LogicalName: "demo", ManagedDigest: digest}},
+		Receipts:        []domain.MutationReceipt{{OperationID: "op-" + bindingID[:12], Sequence: 1, ClientBindingID: bindingID, AfterDigest: digest, Phase: "committed"}},
+	}
+}
+
+type scopeTargetResolver struct {
+	targets map[domain.InstallScope]string
+}
+
+func (resolver scopeTargetResolver) ResolveTarget(_ context.Context, client domain.DetectedClient, scope domain.InstallScope, _ string) (domain.DeliveryTarget, error) {
+	active := resolver.targets[scope]
+	return domain.DeliveryTarget{TargetAnchor: filepath.Dir(filepath.Dir(active)), TargetRoot: filepath.Dir(active), ActivePath: active}, nil
+}
+
+type capturingNativeObserver struct {
+	observation domain.NativeIdentityObservation
+	clients     []domain.DetectedClient
+}
+
+func (observer *capturingNativeObserver) ObserveNativeIdentity(_ context.Context, client domain.DetectedClient, _ domain.DeliveryPlan, _ *domain.ClientBinding) (domain.NativeIdentityObservation, error) {
+	observer.clients = append(observer.clients, client)
+	return observer.observation, nil
+}
+
 type reconciledNativeObserver struct{}
 
 func (reconciledNativeObserver) ObserveNativeIdentity(context.Context, domain.DetectedClient, domain.DeliveryPlan, *domain.ClientBinding) (domain.NativeIdentityObservation, error) {
-	return domain.NativeIdentityObservation{State: domain.NativeIdentityManaged, ReceiptReconciled: true, NativeDiscoveryReconciled: true, NativeDiscoveryState: domain.NativeIdentityManaged}, nil
+	return domain.NativeIdentityObservation{State: domain.NativeIdentityManaged, ReceiptReconciled: true, NativeDiscoveryReconciled: true,
+		NativeDiscoveryState: domain.NativeIdentityManaged, NativeDiscoveryAttempted: true}, nil
 }

--- a/cli/plugin-kit-ai/internal/agentpluginscli/read_reconciliation_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/read_reconciliation_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -240,6 +241,35 @@ func TestInfoFailsClosedBeforeNativeDiscoveryWithoutAuthoritativeClientVersion(t
 	}
 }
 
+func TestInfoOmitsNativeEvidenceWhenDiscoveryTimesOut(t *testing.T) {
+	installationID := "00000000-0000-4000-8000-000000000040"
+	physical := domain.ComputePhysicalArtifactID("demo", installationID)
+	target := filepath.Join(t.TempDir(), "copilot", physical)
+	binding := validReconciliationBinding(installationID, domain.ClientCopilot, domain.ScopeUser, target, physical)
+	installation := domain.Installation{InstallationID: installationID, DeclaredName: "demo", Clients: map[string]domain.ClientBinding{binding.ClientBindingID: binding}}
+	detector := &observedProbingDetector{clients: []domain.DetectedClient{{
+		ClientID: domain.ClientCopilot, Status: domain.DetectionDetected, Version: "1.0.80", ExecutablePath: "/test/bin/copilot",
+	}}}
+	observer := &capturingNativeObserver{
+		observation: domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate, NativeDiscoveryState: domain.NativeIdentityIndeterminate, NativeDiscoveryAttempted: true},
+		err:         context.DeadlineExceeded,
+	}
+	app := App{Detector: detector, Lifecycle: usecase.Service{
+		Targets: scopeTargetResolver{targets: map[domain.InstallScope]string{domain.ScopeUser: target}}, NativeObserver: observer,
+	}}
+	public := publicInstallationView(installation, true)
+	if err := reconcileInstalledInfo(context.Background(), app, installation, "copilot", &public); err != nil {
+		t.Fatal(err)
+	}
+	got := public.Clients[0]
+	if got.NativeIdentityState != domain.NativeIdentityIndeterminate || got.NativeDiscoveryEvidence != nil {
+		t.Fatalf("timed-out reconciliation exposed false evidence: %+v", got)
+	}
+	if !errors.Is(observer.err, context.DeadlineExceeded) {
+		t.Fatalf("observer err = %v", observer.err)
+	}
+}
+
 func validReconciliationBinding(installationID string, client domain.ClientID, scope domain.InstallScope, target, physical string) domain.ClientBinding {
 	bindingID := domain.ComputeClientBindingID(installationID, string(client), string(scope), target)
 	digest := "sha256:owned"
@@ -263,11 +293,12 @@ func (resolver scopeTargetResolver) ResolveTarget(_ context.Context, client doma
 type capturingNativeObserver struct {
 	observation domain.NativeIdentityObservation
 	clients     []domain.DetectedClient
+	err         error
 }
 
 func (observer *capturingNativeObserver) ObserveNativeIdentity(_ context.Context, client domain.DetectedClient, _ domain.DeliveryPlan, _ *domain.ClientBinding) (domain.NativeIdentityObservation, error) {
 	observer.clients = append(observer.clients, client)
-	return observer.observation, nil
+	return observer.observation, observer.err
 }
 
 type reconciledNativeObserver struct{}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/read_reconciliation_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/read_reconciliation_test.go
@@ -1,0 +1,117 @@
+package agentpluginscli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+func TestInfoReconcilesExactCopilotIdentityWithoutMutationOrPathLeak(t *testing.T) {
+	fixture := newCLIFixture(t, nil)
+	client := domain.DetectedClient{ClientID: domain.ClientCopilot, DisplayName: "GitHub Copilot CLI", Status: domain.DetectionDetected,
+		Version: "1.0.80", ExecutablePath: "/test/bin/copilot", ConfigRoot: filepath.Join(fixture.root, "home", ".copilot")}
+	detector := &observedProbingDetector{clients: []domain.DetectedClient{client}}
+	fixture.app.Detector = detector
+	fixture.app.Lifecycle.NativeObserver = reconciledNativeObserver{}
+
+	installationID := "00000000-0000-4000-8000-000000000001"
+	physical := domain.ComputePhysicalArtifactID("demo", installationID)
+	target, err := fixture.app.Lifecycle.Targets.ResolveTarget(context.Background(), client, domain.ScopeUser, physical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bindingID := domain.ComputeClientBindingID(installationID, string(domain.ClientCopilot), string(domain.ScopeUser), target.ActivePath)
+	digest := "sha256:owned"
+	binding := domain.ClientBinding{
+		ClientBindingID: bindingID, ClientID: string(domain.ClientCopilot), Scope: string(domain.ScopeUser), TargetLocator: target.ActivePath,
+		PhysicalArtifact: physical, Materialization: domain.MaterializationMaterialized, Activation: domain.ActivationActive,
+		Authentication: domain.AuthenticationNotRequired, Policy: domain.PolicyAllowed, Verification: domain.VerificationInstalled,
+		NativeObjects: []domain.NativeObjectOwnership{{ObjectID: "package:copilot:" + physical, Kind: "managed_package_directory", LogicalName: "demo", ManagedDigest: digest}},
+		Receipts:      []domain.MutationReceipt{{OperationID: "op-0000000000000001", Sequence: 1, ClientBindingID: bindingID, AfterDigest: digest, Phase: "committed"}},
+	}
+	state := domain.StateFileV2{SchemaVersion: domain.StateSchemaVersion, Installations: []domain.Installation{{
+		InstallationID: installationID, DeclaredName: "demo",
+		Source:  domain.SourceBinding{SourceBindingID: "src_demo", RequestedSource: "demo", CanonicalSource: "https://example.test/demo", ResolvedRevision: strings.Repeat("a", 40), TreeDigest: "sha256:tree"},
+		Package: domain.PackageBinding{LoaderKind: domain.LoaderKindAgentPlugins, FormatID: domain.FormatIDAgentPluginsV1, SchemaURI: domain.PluginSchemaV1, DeclaredName: "demo", ManifestDigest: "sha256:manifest"},
+		Clients: map[string]domain.ClientBinding{bindingID: binding},
+	}}}
+	if err := fixture.store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(fixture.store.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, err := fixture.execute(false, "info", "demo", "--target", "copilot", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(fixture.store.Path)
+	if err != nil || !bytes.Equal(before, after) {
+		t.Fatalf("info mutated state: %v", err)
+	}
+	if strings.Contains(stdout, fixture.root) || strings.Contains(stdout, client.ExecutablePath) || strings.Contains(stdout, client.ConfigRoot) {
+		t.Fatalf("info leaked a local path: %s", stdout)
+	}
+	var output struct {
+		SchemaVersion int `json:"schema_version"`
+		Data          struct {
+			Clients []struct {
+				ReceiptReconciled         bool   `json:"receipt_reconciled"`
+				NativeDiscoveryReconciled bool   `json:"native_discovery_reconciled"`
+				NativeIdentityState       string `json:"native_identity_state"`
+				ClientVersion             string `json:"client_version"`
+				NativeDiscoveryEvidence   struct {
+					Basis            string `json:"basis"`
+					VersionOperation struct {
+						Argv                  []string `json:"argv"`
+						ObservedClientVersion string   `json:"observed_client_version"`
+					} `json:"version_operation"`
+					DiscoveryOperation struct {
+						Argv       []string `json:"argv"`
+						Discovered bool     `json:"discovered"`
+						ProductID  string   `json:"product_id"`
+					} `json:"discovery_operation"`
+				} `json:"native_discovery_evidence"`
+			} `json:"clients"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatal(err)
+	}
+	if output.SchemaVersion != 1 || len(output.Data.Clients) != 1 {
+		t.Fatalf("output = %s", stdout)
+	}
+	got := output.Data.Clients[0]
+	if !got.ReceiptReconciled || !got.NativeDiscoveryReconciled || got.NativeIdentityState != "managed" || got.ClientVersion != "1.0.80" {
+		t.Fatalf("reconciliation = %+v", got)
+	}
+	evidence := got.NativeDiscoveryEvidence
+	if evidence.Basis != "native_client_command" || evidence.VersionOperation.ObservedClientVersion != "1.0.80" ||
+		!evidence.DiscoveryOperation.Discovered || !strings.HasPrefix(evidence.DiscoveryOperation.ProductID, "demo@agentplugins-") ||
+		strings.Join(evidence.VersionOperation.Argv, " ") != "copilot --version" || strings.Join(evidence.DiscoveryOperation.Argv, " ") != "copilot plugin list" {
+		t.Fatalf("native discovery evidence = %+v", evidence)
+	}
+	if detector.probeCalls != 1 || detector.readOnlyCalls != 0 {
+		t.Fatalf("detector calls = read-only:%d probe:%d", detector.readOnlyCalls, detector.probeCalls)
+	}
+}
+
+func TestInfoInvalidOwnershipReceiptIsInconclusive(t *testing.T) {
+	binding := domain.ClientBinding{ClientBindingID: "binding", ClientID: "copilot", PhysicalArtifact: "demo-0123456789ab"}
+	if hasReconciledOwnershipReceipt(binding, binding.PhysicalArtifact, "demo") {
+		t.Fatal("missing ownership receipt reconciled")
+	}
+}
+
+type reconciledNativeObserver struct{}
+
+func (reconciledNativeObserver) ObserveNativeIdentity(context.Context, domain.DetectedClient, domain.DeliveryPlan, *domain.ClientBinding) (domain.NativeIdentityObservation, error) {
+	return domain.NativeIdentityObservation{State: domain.NativeIdentityManaged, ReceiptReconciled: true, NativeDiscoveryReconciled: true, NativeDiscoveryState: domain.NativeIdentityManaged}, nil
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/read_reconciliation_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/read_reconciliation_test.go
@@ -209,6 +209,37 @@ func TestInfoWithoutTargetDoesNotDetectOrProbeClients(t *testing.T) {
 	}
 }
 
+func TestInfoFailsClosedBeforeNativeDiscoveryWithoutAuthoritativeClientVersion(t *testing.T) {
+	installationID := "00000000-0000-4000-8000-000000000030"
+	physical := domain.ComputePhysicalArtifactID("demo", installationID)
+	target := filepath.Join(t.TempDir(), "copilot", physical)
+	binding := validReconciliationBinding(installationID, domain.ClientCopilot, domain.ScopeUser, target, physical)
+	installation := domain.Installation{InstallationID: installationID, DeclaredName: "demo", Clients: map[string]domain.ClientBinding{binding.ClientBindingID: binding}}
+	detector := &observedProbingDetector{clients: []domain.DetectedClient{{
+		ClientID: domain.ClientCopilot, Status: domain.DetectionDetected, ExecutablePath: "/test/bin/copilot",
+	}}}
+	observer := &capturingNativeObserver{observation: domain.NativeIdentityObservation{
+		State: domain.NativeIdentityManaged, ReceiptReconciled: true, NativeDiscoveryReconciled: true,
+		NativeDiscoveryState: domain.NativeIdentityManaged, NativeDiscoveryAttempted: true,
+	}}
+	app := App{Detector: detector, Lifecycle: usecase.Service{
+		Targets: scopeTargetResolver{targets: map[domain.InstallScope]string{domain.ScopeUser: target}}, NativeObserver: observer,
+	}}
+	public := publicInstallationView(installation, true)
+	if err := reconcileInstalledInfo(context.Background(), app, installation, "copilot", &public); err != nil {
+		t.Fatal(err)
+	}
+	got := public.Clients[0]
+	if got.ClientVersion != "" || got.NativeIdentityState != domain.NativeIdentityIndeterminate ||
+		got.ReceiptReconciled == nil || *got.ReceiptReconciled || got.NativeDiscoveryReconciled == nil || *got.NativeDiscoveryReconciled ||
+		got.NativeDiscoveryEvidence != nil {
+		t.Fatalf("missing-version reconciliation did not fail closed: %+v", got)
+	}
+	if len(observer.clients) != 0 {
+		t.Fatalf("native discovery ran without authoritative version: %+v", observer.clients)
+	}
+}
+
 func validReconciliationBinding(installationID string, client domain.ClientID, scope domain.InstallScope, target, physical string) domain.ClientBinding {
 	bindingID := domain.ComputeClientBindingID(installationID, string(client), string(scope), target)
 	digest := "sha256:owned"

--- a/install/integrationctl/adapters/process/osrunner.go
+++ b/install/integrationctl/adapters/process/osrunner.go
@@ -20,6 +20,9 @@ func (OS) Run(ctx context.Context, cmd ports.Command) (ports.CommandResult, erro
 	if err == nil {
 		return ports.CommandResult{ExitCode: 0, Stdout: stdout}, nil
 	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ports.CommandResult{}, ctxErr
+	}
 	if exitErr, ok := err.(*exec.ExitError); ok {
 		return ports.CommandResult{
 			ExitCode: exitErr.ExitCode(),

--- a/install/integrationctl/adapters/process/osrunner.go
+++ b/install/integrationctl/adapters/process/osrunner.go
@@ -3,6 +3,7 @@ package process
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os/exec"
 	"time"
 
@@ -24,9 +25,10 @@ func (OS) Run(ctx context.Context, cmd ports.Command) (ports.CommandResult, erro
 		return ports.CommandResult{}, err
 	}
 	defer tree.close()
-	var stdout, stderr bytes.Buffer
+	var stdout bytes.Buffer
+	stderr := newBoundedDiagnosticBuffer(32 * 1024)
 	c.Stdout = &stdout
-	c.Stderr = &stderr
+	c.Stderr = stderr
 	if err := c.Start(); err != nil {
 		return ports.CommandResult{}, err
 	}
@@ -50,4 +52,50 @@ func (OS) Run(ctx context.Context, cmd ports.Command) (ports.CommandResult, erro
 		}, nil
 	}
 	return ports.CommandResult{}, err
+}
+
+type boundedDiagnosticBuffer struct {
+	prefix []byte
+	suffix []byte
+	total  int
+	limit  int
+}
+
+func newBoundedDiagnosticBuffer(limit int) *boundedDiagnosticBuffer {
+	return &boundedDiagnosticBuffer{limit: limit}
+}
+
+func (buffer *boundedDiagnosticBuffer) Write(value []byte) (int, error) {
+	written := len(value)
+	buffer.total += written
+	prefixLimit := buffer.limit / 2
+	if remaining := prefixLimit - len(buffer.prefix); remaining > 0 {
+		count := min(remaining, len(value))
+		buffer.prefix = append(buffer.prefix, value[:count]...)
+		value = value[count:]
+	}
+	suffixLimit := buffer.limit - prefixLimit
+	if len(value) >= suffixLimit {
+		buffer.suffix = append(buffer.suffix[:0], value[len(value)-suffixLimit:]...)
+	} else if len(value) > 0 {
+		buffer.suffix = append(buffer.suffix, value...)
+		if overflow := len(buffer.suffix) - suffixLimit; overflow > 0 {
+			copy(buffer.suffix, buffer.suffix[overflow:])
+			buffer.suffix = buffer.suffix[:suffixLimit]
+		}
+	}
+	return written, nil
+}
+
+func (buffer *boundedDiagnosticBuffer) Bytes() []byte {
+	omitted := buffer.total - len(buffer.prefix) - len(buffer.suffix)
+	if omitted <= 0 {
+		return append(append([]byte(nil), buffer.prefix...), buffer.suffix...)
+	}
+	marker := []byte(fmt.Sprintf("\n... %d stderr bytes omitted ...\n", omitted))
+	result := make([]byte, 0, len(buffer.prefix)+len(marker)+len(buffer.suffix))
+	result = append(result, buffer.prefix...)
+	result = append(result, marker...)
+	result = append(result, buffer.suffix...)
+	return result
 }

--- a/install/integrationctl/adapters/process/osrunner.go
+++ b/install/integrationctl/adapters/process/osrunner.go
@@ -1,8 +1,10 @@
 package process
 
 import (
+	"bytes"
 	"context"
 	"os/exec"
+	"time"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/ports"
 )
@@ -16,9 +18,26 @@ func (OS) Run(ctx context.Context, cmd ports.Command) (ports.CommandResult, erro
 	c := exec.CommandContext(ctx, cmd.Argv[0], cmd.Argv[1:]...)
 	c.Env = cmd.Env
 	c.Dir = cmd.Dir
-	stdout, err := c.Output()
+	c.WaitDelay = 100 * time.Millisecond
+	tree, err := newCommandTree(c)
+	if err != nil {
+		return ports.CommandResult{}, err
+	}
+	defer tree.close()
+	var stdout, stderr bytes.Buffer
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+	if err := c.Start(); err != nil {
+		return ports.CommandResult{}, err
+	}
+	if err := tree.attach(c); err != nil {
+		_ = tree.terminate()
+		_ = c.Wait()
+		return ports.CommandResult{}, err
+	}
+	err = c.Wait()
 	if err == nil {
-		return ports.CommandResult{ExitCode: 0, Stdout: stdout}, nil
+		return ports.CommandResult{ExitCode: 0, Stdout: stdout.Bytes()}, nil
 	}
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return ports.CommandResult{}, ctxErr
@@ -26,8 +45,8 @@ func (OS) Run(ctx context.Context, cmd ports.Command) (ports.CommandResult, erro
 	if exitErr, ok := err.(*exec.ExitError); ok {
 		return ports.CommandResult{
 			ExitCode: exitErr.ExitCode(),
-			Stdout:   stdout,
-			Stderr:   exitErr.Stderr,
+			Stdout:   stdout.Bytes(),
+			Stderr:   stderr.Bytes(),
 		}, nil
 	}
 	return ports.CommandResult{}, err

--- a/install/integrationctl/adapters/process/osrunner_test.go
+++ b/install/integrationctl/adapters/process/osrunner_test.go
@@ -1,0 +1,30 @@
+package process
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/ports"
+)
+
+func TestOSRunnerPreservesCommandOutputAndExitCode(t *testing.T) {
+	if os.Getenv("AGENTPLUGINS_PROCESS_OUTPUT_HELPER") == "1" {
+		fmt.Fprint(os.Stdout, "expected stdout")
+		fmt.Fprint(os.Stderr, "expected stderr")
+		os.Exit(7)
+	}
+	environment := append([]string(nil), os.Environ()...)
+	environment = append(environment, "AGENTPLUGINS_PROCESS_OUTPUT_HELPER=1")
+	result, err := (OS{}).Run(context.Background(), ports.Command{
+		Argv: []string{os.Args[0], "-test.run=TestOSRunnerPreservesCommandOutputAndExitCode"}, Env: environment,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ExitCode != 7 || strings.TrimSpace(string(result.Stdout)) != "expected stdout" || strings.TrimSpace(string(result.Stderr)) != "expected stderr" {
+		t.Fatalf("result = %+v", result)
+	}
+}

--- a/install/integrationctl/adapters/process/osrunner_test.go
+++ b/install/integrationctl/adapters/process/osrunner_test.go
@@ -28,3 +28,25 @@ func TestOSRunnerPreservesCommandOutputAndExitCode(t *testing.T) {
 		t.Fatalf("result = %+v", result)
 	}
 }
+
+func TestOSRunnerBoundsStderrWhileRetainingDiagnosticEdges(t *testing.T) {
+	if os.Getenv("AGENTPLUGINS_PROCESS_STDERR_HELPER") == "1" {
+		fmt.Fprint(os.Stderr, "diagnostic-start:")
+		fmt.Fprint(os.Stderr, strings.Repeat("x", 256*1024))
+		fmt.Fprint(os.Stderr, ":diagnostic-end")
+		os.Exit(9)
+	}
+	environment := append([]string(nil), os.Environ()...)
+	environment = append(environment, "AGENTPLUGINS_PROCESS_STDERR_HELPER=1")
+	result, err := (OS{}).Run(context.Background(), ports.Command{
+		Argv: []string{os.Args[0], "-test.run=TestOSRunnerBoundsStderrWhileRetainingDiagnosticEdges"}, Env: environment,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	diagnostic := string(result.Stderr)
+	if result.ExitCode != 9 || len(result.Stderr) > 34*1024 || !strings.Contains(diagnostic, "diagnostic-start:") ||
+		!strings.Contains(diagnostic, ":diagnostic-end") || !strings.Contains(diagnostic, "stderr bytes omitted") {
+		t.Fatalf("bounded stderr result: exit=%d bytes=%d diagnostic=%q", result.ExitCode, len(result.Stderr), diagnostic)
+	}
+}

--- a/install/integrationctl/adapters/process/osrunner_tree_fallback.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_fallback.go
@@ -1,0 +1,29 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris && !windows
+
+package process
+
+import (
+	"os"
+	"os/exec"
+)
+
+type commandTree struct {
+	cmd *exec.Cmd
+}
+
+func newCommandTree(cmd *exec.Cmd) (*commandTree, error) {
+	tree := &commandTree{cmd: cmd}
+	cmd.Cancel = tree.terminate
+	return tree, nil
+}
+
+func (*commandTree) attach(*exec.Cmd) error { return nil }
+
+func (tree *commandTree) terminate() error {
+	if tree.cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	return tree.cmd.Process.Kill()
+}
+
+func (*commandTree) close() {}

--- a/install/integrationctl/adapters/process/osrunner_tree_unix.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_unix.go
@@ -1,0 +1,38 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package process
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+type commandTree struct {
+	cmd *exec.Cmd
+}
+
+func newCommandTree(cmd *exec.Cmd) (*commandTree, error) {
+	tree := &commandTree{cmd: cmd}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = tree.terminate
+	return tree, nil
+}
+
+func (*commandTree) attach(*exec.Cmd) error { return nil }
+
+func (tree *commandTree) terminate() error {
+	if tree.cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	if err := syscall.Kill(-tree.cmd.Process.Pid, syscall.SIGKILL); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+	return nil
+}
+
+func (*commandTree) close() {}

--- a/install/integrationctl/adapters/process/osrunner_tree_unix.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_unix.go
@@ -7,20 +7,30 @@ import (
 	"os"
 	"os/exec"
 	"syscall"
+	"time"
 )
 
 type commandTree struct {
-	cmd *exec.Cmd
+	cmd        *exec.Cmd
+	markerRead *os.File
+	markerSend *os.File
 }
 
 func newCommandTree(cmd *exec.Cmd) (*commandTree, error) {
-	tree := &commandTree{cmd: cmd}
+	markerRead, markerSend, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	tree := &commandTree{cmd: cmd, markerRead: markerRead, markerSend: markerSend}
+	cmd.ExtraFiles = append(cmd.ExtraFiles, markerSend)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = tree.terminate
 	return tree, nil
 }
 
-func (*commandTree) attach(*exec.Cmd) error { return nil }
+func (tree *commandTree) attach(*exec.Cmd) error {
+	return tree.markerSend.Close()
+}
 
 func (tree *commandTree) terminate() error {
 	if tree.cmd.Process == nil {
@@ -35,4 +45,15 @@ func (tree *commandTree) terminate() error {
 	return nil
 }
 
-func (*commandTree) close() {}
+func (tree *commandTree) close() {
+	_ = tree.markerSend.Close()
+	_ = tree.markerRead.SetReadDeadline(time.Now().Add(25 * time.Millisecond))
+	var marker [1]byte
+	_, err := tree.markerRead.Read(marker[:])
+	if timeout, ok := err.(interface{ Timeout() bool }); ok && timeout.Timeout() {
+		// A command-owned descendant still holds the inherited marker, so the
+		// original process group cannot have been released or reused.
+		_ = tree.terminate()
+	}
+	_ = tree.markerRead.Close()
+}

--- a/install/integrationctl/adapters/process/osrunner_tree_unix.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_unix.go
@@ -7,30 +7,20 @@ import (
 	"os"
 	"os/exec"
 	"syscall"
-	"time"
 )
 
 type commandTree struct {
-	cmd        *exec.Cmd
-	markerRead *os.File
-	markerSend *os.File
+	cmd *exec.Cmd
 }
 
 func newCommandTree(cmd *exec.Cmd) (*commandTree, error) {
-	markerRead, markerSend, err := os.Pipe()
-	if err != nil {
-		return nil, err
-	}
-	tree := &commandTree{cmd: cmd, markerRead: markerRead, markerSend: markerSend}
-	cmd.ExtraFiles = append(cmd.ExtraFiles, markerSend)
+	tree := &commandTree{cmd: cmd}
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = tree.terminate
 	return tree, nil
 }
 
-func (tree *commandTree) attach(*exec.Cmd) error {
-	return tree.markerSend.Close()
-}
+func (*commandTree) attach(*exec.Cmd) error { return nil }
 
 func (tree *commandTree) terminate() error {
 	if tree.cmd.Process == nil {
@@ -46,14 +36,8 @@ func (tree *commandTree) terminate() error {
 }
 
 func (tree *commandTree) close() {
-	_ = tree.markerSend.Close()
-	_ = tree.markerRead.SetReadDeadline(time.Now().Add(25 * time.Millisecond))
-	var marker [1]byte
-	_, err := tree.markerRead.Read(marker[:])
-	if timeout, ok := err.(interface{ Timeout() bool }); ok && timeout.Timeout() {
-		// A command-owned descendant still holds the inherited marker, so the
-		// original process group cannot have been released or reused.
-		_ = tree.terminate()
-	}
-	_ = tree.markerRead.Close()
+	// Cancellation terminates the whole group while the command leader is a
+	// live, stable identity. After Wait reaps that leader, its PGID may be
+	// reused, so normal-exit descendants are deliberately not force-killed.
+	// Callers use this runner only for trusted, short-lived native commands.
 }

--- a/install/integrationctl/adapters/process/osrunner_tree_windows.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_windows.go
@@ -1,0 +1,109 @@
+//go:build windows
+
+package process
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type commandTree struct {
+	cmd      *exec.Cmd
+	job      windows.Handle
+	mu       sync.Mutex
+	attached bool
+	once     sync.Once
+}
+
+func newCommandTree(cmd *exec.Cmd) (*commandTree, error) {
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create process job: %w", err)
+	}
+	limits := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{}
+	limits.BasicLimitInformation.LimitFlags = windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+	if _, err := windows.SetInformationJobObject(job, windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&limits)), uint32(unsafe.Sizeof(limits))); err != nil {
+		windows.CloseHandle(job)
+		return nil, fmt.Errorf("configure process job: %w", err)
+	}
+	tree := &commandTree{cmd: cmd, job: job}
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_SUSPENDED}
+	cmd.Cancel = tree.terminate
+	return tree, nil
+}
+
+func (tree *commandTree) attach(cmd *exec.Cmd) error {
+	process, err := windows.OpenProcess(windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE, false, uint32(cmd.Process.Pid))
+	if err != nil {
+		return fmt.Errorf("open suspended process: %w", err)
+	}
+	defer windows.CloseHandle(process)
+	if err := windows.AssignProcessToJobObject(tree.job, process); err != nil {
+		return fmt.Errorf("assign process job: %w", err)
+	}
+	tree.mu.Lock()
+	tree.attached = true
+	tree.mu.Unlock()
+	thread, err := suspendedProcessThread(uint32(cmd.Process.Pid))
+	if err != nil {
+		return err
+	}
+	defer windows.CloseHandle(thread)
+	if _, err := windows.ResumeThread(thread); err != nil {
+		return fmt.Errorf("resume process thread: %w", err)
+	}
+	return nil
+}
+
+func suspendedProcessThread(pid uint32) (windows.Handle, error) {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPTHREAD, 0)
+	if err != nil {
+		return 0, fmt.Errorf("snapshot suspended process threads: %w", err)
+	}
+	defer windows.CloseHandle(snapshot)
+	entry := windows.ThreadEntry32{Size: uint32(unsafe.Sizeof(windows.ThreadEntry32{}))}
+	for err = windows.Thread32First(snapshot, &entry); err == nil; err = windows.Thread32Next(snapshot, &entry) {
+		if entry.OwnerProcessID != pid {
+			continue
+		}
+		thread, openErr := windows.OpenThread(windows.THREAD_SUSPEND_RESUME, false, entry.ThreadID)
+		if openErr != nil {
+			return 0, fmt.Errorf("open suspended process thread: %w", openErr)
+		}
+		return thread, nil
+	}
+	if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+		return 0, fmt.Errorf("suspended process thread not found")
+	}
+	return 0, fmt.Errorf("enumerate suspended process threads: %w", err)
+}
+
+func (tree *commandTree) terminate() error {
+	tree.mu.Lock()
+	attached := tree.attached
+	tree.mu.Unlock()
+	if attached {
+		if err := windows.TerminateJobObject(tree.job, 1); err == nil {
+			return nil
+		}
+	}
+	if tree.cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	if err := tree.cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return err
+	}
+	return nil
+}
+
+func (tree *commandTree) close() {
+	tree.once.Do(func() { _ = windows.CloseHandle(tree.job) })
+}

--- a/install/integrationctl/adapters/process/osrunner_tree_windows_test.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_windows_test.go
@@ -1,0 +1,95 @@
+//go:build windows
+
+package process
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/ports"
+	"golang.org/x/sys/windows"
+)
+
+func TestOSRunnerTerminatesWindowsGrandchildTree(t *testing.T) {
+	powershell, err := exec.LookPath("powershell.exe")
+	if err != nil {
+		t.Skip("powershell.exe is unavailable")
+	}
+	root := t.TempDir()
+	childScript := filepath.Join(root, "child.ps1")
+	parentScript := filepath.Join(root, "parent.ps1")
+	pidPath := filepath.Join(root, "tree.pid")
+	if err := os.WriteFile(childScript, []byte("Start-Sleep -Seconds 60\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	quote := func(value string) string { return strings.ReplaceAll(value, "'", "''") }
+	parent := fmt.Sprintf("$child = Start-Process -FilePath '%s' -ArgumentList '-NoProfile','-File','%s' -PassThru\n\"$PID $($child.Id)\" | Set-Content -NoNewline -Path '%s'\nWait-Process -Id $child.Id\n",
+		quote(powershell), quote(childScript), quote(pidPath))
+	if err := os.WriteFile(parentScript, []byte(parent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	started := time.Now()
+	runResult := make(chan error, 1)
+	go func() {
+		_, runErr := (OS{}).Run(ctx, ports.Command{Argv: []string{powershell, "-NoProfile", "-File", parentScript}, Env: os.Environ()})
+		runResult <- runErr
+	}()
+	var body []byte
+	readyDeadline := time.Now().Add(10 * time.Second)
+	for len(strings.Fields(string(body))) != 2 && time.Now().Before(readyDeadline) {
+		body, _ = os.ReadFile(pidPath)
+		time.Sleep(20 * time.Millisecond)
+	}
+	cancel()
+	var runErr error
+	select {
+	case runErr = <-runResult:
+	case <-time.After(3 * time.Second):
+		t.Fatal("process tree termination exceeded bound")
+	}
+	if !errors.Is(runErr, context.Canceled) {
+		t.Fatalf("run error = %v, want context canceled", runErr)
+	}
+	if elapsed := time.Since(started); elapsed > 13*time.Second {
+		t.Fatalf("process tree test took %s", elapsed)
+	}
+	if len(strings.Fields(string(body))) != 2 {
+		t.Fatalf("process tree pids = %q", body)
+	}
+	for _, field := range strings.Fields(string(body)) {
+		pid, err := strconv.Atoi(field)
+		if err != nil {
+			t.Fatalf("parse process pid %q: %v", field, err)
+		}
+		if windowsProcessAlive(uint32(pid)) {
+			t.Fatalf("process %d remained alive after job termination", pid)
+		}
+	}
+}
+
+func windowsProcessAlive(pid uint32) bool {
+	const stillActive = 259
+	process, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_TERMINATE, false, pid)
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(process)
+	var exitCode uint32
+	if err := windows.GetExitCodeProcess(process, &exitCode); err != nil {
+		return false
+	}
+	if exitCode == stillActive {
+		_ = windows.TerminateProcess(process, 1)
+		return true
+	}
+	return false
+}

--- a/install/integrationctl/agentplugins/adapters/clientdetect/detector.go
+++ b/install/integrationctl/agentplugins/adapters/clientdetect/detector.go
@@ -59,19 +59,37 @@ func NewOS(homeDir string) Detector {
 }
 
 func (detector Detector) Detect(ctx context.Context) ([]domain.DetectedClient, error) {
-	return detector.detect(ctx, false)
+	return detector.detect(ctx, false, nil)
 }
 
 // DetectWithVersionProbe is reserved for explicit lifecycle resolution that
 // needs the installed client version to bind signed Directory evidence. Detect
 // itself is strictly observational and never executes a discovered binary.
 func (detector Detector) DetectWithVersionProbe(ctx context.Context) ([]domain.DetectedClient, error) {
-	return detector.detect(ctx, true)
+	return detector.detect(ctx, true, nil)
 }
 
-func (detector Detector) detect(ctx context.Context, probeVersion bool) ([]domain.DetectedClient, error) {
+func (detector Detector) DetectTargetsWithVersionProbe(ctx context.Context, targets []domain.ClientID) ([]domain.DetectedClient, error) {
+	selected := make(map[domain.ClientID]struct{}, len(targets))
+	for _, target := range targets {
+		selected[target] = struct{}{}
+	}
+	return detector.detect(ctx, true, selected)
+}
+
+func (detector Detector) detect(ctx context.Context, probeVersion bool, selected map[domain.ClientID]struct{}) ([]domain.DetectedClient, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
+	}
+	probe := func(clientID domain.ClientID) bool {
+		if !probeVersion {
+			return false
+		}
+		if selected == nil {
+			return true
+		}
+		_, ok := selected[clientID]
+		return ok
 	}
 	if strings.TrimSpace(detector.HomeDir) == "" {
 		return nil, fmt.Errorf("client detector home directory is required")
@@ -80,12 +98,12 @@ func (detector Detector) detect(ctx context.Context, probeVersion bool) ([]domai
 		return nil, fmt.Errorf("client detector probes are required")
 	}
 	clients := []domain.DetectedClient{
-		detector.detectCodex(ctx, probeVersion),
-		detector.detectChatGPT(ctx, probeVersion),
-		detector.detectCursor(ctx, probeVersion),
-		detector.detectCopilot(ctx, probeVersion),
-		detector.detectVSCode(ctx, probeVersion),
-		detector.detectKiro(ctx, probeVersion),
+		detector.detectCodex(ctx, probe(domain.ClientCodex)),
+		detector.detectChatGPT(ctx, probe(domain.ClientChatGPT)),
+		detector.detectCursor(ctx, probe(domain.ClientCursor)),
+		detector.detectCopilot(ctx, probe(domain.ClientCopilot)),
+		detector.detectVSCode(ctx, probe(domain.ClientVSCode)),
+		detector.detectKiro(ctx, probe(domain.ClientKiro)),
 	}
 	sort.Slice(clients, func(i, j int) bool { return clients[i].ClientID < clients[j].ClientID })
 	return clients, nil
@@ -342,6 +360,11 @@ func probeExecutableVersion(ctx context.Context, executable string) (string, err
 	command := exec.CommandContext(ctx, executable, "--version")
 	command.Dir = isolatedDir
 	command.Env = []string{}
+	if path := os.Getenv("PATH"); strings.TrimSpace(path) != "" {
+		// PATH is the sole inherited variable so /usr/bin/env shebangs can
+		// resolve their runtime without exposing HOME, tokens, or credentials.
+		command.Env = append(command.Env, "PATH="+path)
+	}
 	command.Stdin = strings.NewReader("")
 	command.Stdout, command.Stderr = output, output
 	command.WaitDelay = 100 * time.Millisecond

--- a/install/integrationctl/agentplugins/adapters/clientdetect/detector.go
+++ b/install/integrationctl/agentplugins/adapters/clientdetect/detector.go
@@ -354,6 +354,9 @@ func probeExecutableVersion(ctx context.Context, executable string) (string, err
 func normalizeVersion(value string) string {
 	for _, field := range strings.Fields(value) {
 		candidate := strings.Trim(field, "vV,;()[]{}")
+		if strings.HasSuffix(candidate, ".") {
+			candidate = strings.TrimSuffix(candidate, ".")
+		}
 		parts := strings.SplitN(strings.SplitN(candidate, "+", 2)[0], "-", 2)
 		core := strings.Split(parts[0], ".")
 		if len(core) < 2 {

--- a/install/integrationctl/agentplugins/adapters/clientdetect/detector.go
+++ b/install/integrationctl/agentplugins/adapters/clientdetect/detector.go
@@ -18,16 +18,17 @@ import (
 )
 
 type Detector struct {
-	HomeDir               string
-	GOOS                  string
-	Environment           map[string]string
-	SystemApplicationsDir string
-	WindowsProgramFiles   []string
-	LinuxApplicationDirs  []string
-	LookPath              func(string) (string, error)
-	Lstat                 func(string) (fs.FileInfo, error)
-	ProbeVersion          func(context.Context, string) (string, error)
-	VersionTimeout        time.Duration
+	HomeDir                string
+	GOOS                   string
+	Environment            map[string]string
+	SystemApplicationsDir  string
+	WindowsProgramFiles    []string
+	LinuxApplicationDirs   []string
+	LookPath               func(string) (string, error)
+	Lstat                  func(string) (fs.FileInfo, error)
+	ProbeVersion           func(context.Context, string) (string, error)
+	VersionTimeout         time.Duration
+	TargetedVersionTimeout time.Duration
 }
 
 func NewOS(homeDir string) Detector {
@@ -51,10 +52,11 @@ func NewOS(homeDir string) Detector {
 			userApplications,
 			"/usr/local/share/applications", "/usr/share/applications",
 		),
-		LookPath:       exec.LookPath,
-		Lstat:          os.Lstat,
-		ProbeVersion:   probeExecutableVersion,
-		VersionTimeout: 2 * time.Second,
+		LookPath:               exec.LookPath,
+		Lstat:                  os.Lstat,
+		ProbeVersion:           probeExecutableVersion,
+		VersionTimeout:         2 * time.Second,
+		TargetedVersionTimeout: 10 * time.Second,
 	}
 }
 
@@ -74,6 +76,11 @@ func (detector Detector) DetectTargetsWithVersionProbe(ctx context.Context, targ
 	for _, target := range targets {
 		selected[target] = struct{}{}
 	}
+	timeout := detector.TargetedVersionTimeout
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	detector.VersionTimeout = timeout
 	return detector.detect(ctx, true, selected)
 }
 

--- a/install/integrationctl/agentplugins/adapters/clientdetect/detector_test.go
+++ b/install/integrationctl/agentplugins/adapters/clientdetect/detector_test.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -262,6 +264,32 @@ func TestNormalizeVersionRejectsMalformedTrailingPunctuation(t *testing.T) {
 	}
 }
 
+func TestTargetedVersionProbeExecutesOnlySelectedClient(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	copilotPath := filepath.Join(home, "bin", "copilot")
+	codePath := filepath.Join(home, "bin", "code")
+	detector := testDetector(home, map[string]string{"copilot": copilotPath, "code": codePath})
+	var probed []string
+	detector.ProbeVersion = func(_ context.Context, executable string) (string, error) {
+		probed = append(probed, executable)
+		return "1.0.80.", nil
+	}
+	clients, err := detector.DetectTargetsWithVersionProbe(context.Background(), []domain.ClientID{domain.ClientCopilot})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(probed, []string{copilotPath}) {
+		t.Fatalf("probed executables = %#v", probed)
+	}
+	if version := clientOf(clients, domain.ClientCopilot).Version; version != "1.0.80" {
+		t.Fatalf("Copilot version = %q", version)
+	}
+	if version := clientOf(clients, domain.ClientVSCode).Version; version != "" {
+		t.Fatalf("VS Code version was unexpectedly probed: %q", version)
+	}
+}
+
 func TestExplicitDetectorBoundsInjectedVersionProbe(t *testing.T) {
 	t.Parallel()
 	home := t.TempDir()
@@ -308,12 +336,44 @@ func TestExecutableVersionProbeIsSanitizedAndIsolated(t *testing.T) {
 	}
 	for _, value := range observed.Env {
 		name, _, _ := strings.Cut(value, "=")
-		if !strings.EqualFold(name, "SYSTEMROOT") {
+		if !strings.EqualFold(name, "SYSTEMROOT") && !strings.EqualFold(name, "PATH") {
 			t.Fatalf("probe inherited unexpected environment value %q", value)
 		}
 	}
 	if observed.Stdin != "" {
 		t.Fatalf("probe stdin = %q, want EOF", observed.Stdin)
+	}
+}
+
+func TestExecutableVersionProbeSupportsEnvRuntimeShebangWithoutSecrets(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("env shebang behavior is Unix-specific")
+	}
+	bin := t.TempDir()
+	node := filepath.Join(bin, "node")
+	copilot := filepath.Join(bin, "copilot")
+	nodeScript := `#!/bin/sh
+if [ -n "${HOME+x}" ] || [ -n "${GITHUB_TOKEN+x}" ] || [ -n "${AGENTPLUGINS_TEST_CREDENTIAL+x}" ]; then
+  exit 91
+fi
+printf 'GitHub Copilot CLI 1.0.80.\n'
+`
+	if err := os.WriteFile(node, []byte(nodeScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(copilot, []byte("#!/usr/bin/env node\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin)
+	t.Setenv("HOME", "/must-not-leak")
+	t.Setenv("GITHUB_TOKEN", "must-not-leak")
+	t.Setenv("AGENTPLUGINS_TEST_CREDENTIAL", "must-not-leak")
+	output, err := probeExecutableVersion(context.Background(), copilot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version := normalizeVersion(output); version != "1.0.80" {
+		t.Fatalf("shebang Copilot version = %q from %q", version, output)
 	}
 }
 

--- a/install/integrationctl/agentplugins/adapters/clientdetect/detector_test.go
+++ b/install/integrationctl/agentplugins/adapters/clientdetect/detector_test.go
@@ -221,6 +221,47 @@ func TestExplicitDetectorProbeNormalizesClientVersionWithoutMakingDetectionFatal
 	}
 }
 
+func TestExplicitDetectorProbeNormalizesOfficialCopilotVersionOutput(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	copilotPath := filepath.Join(home, "bin", "copilot")
+	detector := testDetector(home, map[string]string{"copilot": copilotPath})
+	detector.ProbeVersion = func(_ context.Context, executable string) (string, error) {
+		if executable != copilotPath {
+			t.Fatalf("version probe executable = %q", executable)
+		}
+		return "GitHub Copilot CLI 1.0.80.\nA newer version is available.", nil
+	}
+	clients, err := detector.DetectWithVersionProbe(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version := clientOf(clients, domain.ClientCopilot).Version; version != "1.0.80" {
+		t.Fatalf("Copilot version = %q, want 1.0.80", version)
+	}
+}
+
+func TestNormalizeVersionRejectsMalformedTrailingPunctuation(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		value string
+		want  string
+	}{
+		{value: "GitHub Copilot CLI 1.0.80.", want: "1.0.80"},
+		{value: "GitHub Copilot CLI v1.0.80.", want: "1.0.80"},
+		{value: "GitHub Copilot CLI 1.0.80.."},
+		{value: "GitHub Copilot CLI .1.0.80."},
+		{value: "GitHub Copilot CLI 1..80."},
+		{value: "GitHub Copilot CLI 1.0.x."},
+		{value: "GitHub Copilot CLI 1.0.80beta."},
+	}
+	for _, test := range tests {
+		if got := normalizeVersion(test.value); got != test.want {
+			t.Errorf("normalizeVersion(%q) = %q, want %q", test.value, got, test.want)
+		}
+	}
+}
+
 func TestExplicitDetectorBoundsInjectedVersionProbe(t *testing.T) {
 	t.Parallel()
 	home := t.TempDir()

--- a/install/integrationctl/agentplugins/adapters/clientdetect/detector_test.go
+++ b/install/integrationctl/agentplugins/adapters/clientdetect/detector_test.go
@@ -290,6 +290,53 @@ func TestTargetedVersionProbeExecutesOnlySelectedClient(t *testing.T) {
 	}
 }
 
+func TestTargetedVersionProbeAllowsSlowAuthoritativeClientWithinExplicitBound(t *testing.T) {
+	home := t.TempDir()
+	copilotPath := filepath.Join(home, "bin", "copilot")
+	detector := testDetector(home, map[string]string{"copilot": copilotPath})
+	detector.VersionTimeout = 2 * time.Second
+	detector.TargetedVersionTimeout = 3 * time.Second
+	detector.ProbeVersion = func(ctx context.Context, executable string) (string, error) {
+		if executable != copilotPath {
+			t.Fatalf("version probe executable = %q", executable)
+		}
+		select {
+		case <-time.After(2100 * time.Millisecond):
+			return "GitHub Copilot CLI 1.0.80.", nil
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+	clients, err := detector.DetectTargetsWithVersionProbe(context.Background(), []domain.ClientID{domain.ClientCopilot})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version := clientOf(clients, domain.ClientCopilot).Version; version != "1.0.80" {
+		t.Fatalf("Copilot version = %q, want 1.0.80", version)
+	}
+}
+
+func TestTargetedVersionProbeStillBoundsAuthoritativeClientTimeout(t *testing.T) {
+	home := t.TempDir()
+	detector := testDetector(home, map[string]string{"copilot": filepath.Join(home, "bin", "copilot")})
+	detector.TargetedVersionTimeout = 10 * time.Millisecond
+	detector.ProbeVersion = func(ctx context.Context, _ string) (string, error) {
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+	started := time.Now()
+	clients, err := detector.DetectTargetsWithVersionProbe(context.Background(), []domain.ClientID{domain.ClientCopilot})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("bounded targeted version probe took %s", elapsed)
+	}
+	if version := clientOf(clients, domain.ClientCopilot).Version; version != "" {
+		t.Fatalf("timed-out Copilot version = %q, want empty", version)
+	}
+}
+
 func TestExplicitDetectorBoundsInjectedVersionProbe(t *testing.T) {
 	t.Parallel()
 	home := t.TempDir()

--- a/install/integrationctl/agentplugins/domain/state.go
+++ b/install/integrationctl/agentplugins/domain/state.go
@@ -66,6 +66,7 @@ type NativeIdentityObservation struct {
 	ReceiptReconciled         bool                `json:"receipt_reconciled,omitempty"`
 	NativeDiscoveryReconciled bool                `json:"native_discovery_reconciled,omitempty"`
 	NativeDiscoveryState      NativeIdentityState `json:"-"`
+	NativeDiscoveryAttempted  bool                `json:"-"`
 }
 
 const (

--- a/install/integrationctl/agentplugins/domain/state.go
+++ b/install/integrationctl/agentplugins/domain/state.go
@@ -61,8 +61,11 @@ type PluginDataDecision struct {
 }
 
 type NativeIdentityObservation struct {
-	State  NativeIdentityState `json:"state"`
-	Digest string              `json:"digest,omitempty"`
+	State                     NativeIdentityState `json:"state"`
+	Digest                    string              `json:"digest,omitempty"`
+	ReceiptReconciled         bool                `json:"receipt_reconciled,omitempty"`
+	NativeDiscoveryReconciled bool                `json:"native_discovery_reconciled,omitempty"`
+	NativeDiscoveryState      NativeIdentityState `json:"-"`
 }
 
 const (

--- a/install/integrationctl/agentplugins/ports/interfaces.go
+++ b/install/integrationctl/agentplugins/ports/interfaces.go
@@ -53,6 +53,12 @@ type VersionProbingClientDetector interface {
 	DetectWithVersionProbe(context.Context) ([]domain.DetectedClient, error)
 }
 
+// TargetedVersionProbingClientDetector observes versions only for explicitly
+// selected clients while retaining read-only surface detection for all clients.
+type TargetedVersionProbingClientDetector interface {
+	DetectTargetsWithVersionProbe(context.Context, []domain.ClientID) ([]domain.DetectedClient, error)
+}
+
 type DeliveryPlanner interface {
 	Plan(context.Context, domain.PackageEnvelope, domain.DetectedClient, domain.InstallScope, string) (domain.DeliveryPlan, error)
 }

--- a/install/integrationctl/agentplugins/providers/marketplaces.go
+++ b/install/integrationctl/agentplugins/providers/marketplaces.go
@@ -15,6 +15,12 @@ func managedMarketplaceName(physicalArtifactID string) string {
 	return "agentplugins-" + hex.EncodeToString(sum[:6])
 }
 
+// ManagedMarketplaceName returns the deterministic native marketplace identity
+// used by client adapters and read-only reconciliation output.
+func ManagedMarketplaceName(physicalArtifactID string) string {
+	return managedMarketplaceName(physicalArtifactID)
+}
+
 func projectCopilotMarketplace(root string, envelope domain.PackageEnvelope, plan domain.DeliveryPlan) error {
 	version := strings.TrimSpace(envelope.Manifest.Version)
 	if version == "" {

--- a/install/integrationctl/agentplugins/providers/native_identity.go
+++ b/install/integrationctl/agentplugins/providers/native_identity.go
@@ -53,43 +53,58 @@ func (observer NativeIdentityObserver) ObserveNativeIdentity(ctx context.Context
 	}
 	native, err := observer.inspectNativeRegistry(ctx, client, plan, managed)
 	if err != nil {
-		return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate}, err
+		return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate, NativeDiscoveryState: domain.NativeIdentityIndeterminate}, err
+	}
+	discoveryState := domain.NativeIdentityAbsent
+	discoveryReconciled := false
+	switch native {
+	case registryExpected:
+		discoveryState = domain.NativeIdentityManaged
+		discoveryReconciled = managed != nil
+	case registryCollision:
+		discoveryState = domain.NativeIdentityUnmanaged
+	case registryIndeterminate:
+		discoveryState = domain.NativeIdentityIndeterminate
 	}
 	for _, finding := range []registryFinding{prepared, native} {
 		switch finding {
 		case registryCollision:
-			return domain.NativeIdentityObservation{State: domain.NativeIdentityUnmanaged}, nil
+			return domain.NativeIdentityObservation{State: domain.NativeIdentityUnmanaged, NativeDiscoveryState: discoveryState}, nil
 		case registryIndeterminate:
-			return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate}, nil
+			return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate, NativeDiscoveryState: domain.NativeIdentityIndeterminate}, nil
 		case registryExpected:
 			if managed == nil {
-				return domain.NativeIdentityObservation{State: domain.NativeIdentityUnmanaged}, nil
+				return domain.NativeIdentityObservation{State: domain.NativeIdentityUnmanaged, NativeDiscoveryState: domain.NativeIdentityUnmanaged}, nil
 			}
 		}
 	}
 
 	_, statErr := os.Lstat(plan.ActivePath)
 	if os.IsNotExist(statErr) {
-		return domain.NativeIdentityObservation{State: domain.NativeIdentityAbsent}, nil
+		return domain.NativeIdentityObservation{State: domain.NativeIdentityAbsent, NativeDiscoveryReconciled: discoveryReconciled, NativeDiscoveryState: discoveryState}, nil
 	}
 	if statErr != nil {
-		return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate}, statErr
+		return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate, NativeDiscoveryReconciled: discoveryReconciled, NativeDiscoveryState: discoveryState}, statErr
 	}
 	if managed == nil {
-		return domain.NativeIdentityObservation{State: domain.NativeIdentityUnmanaged}, nil
+		return domain.NativeIdentityObservation{State: domain.NativeIdentityUnmanaged, NativeDiscoveryReconciled: discoveryReconciled, NativeDiscoveryState: discoveryState}, nil
 	}
 	expected := managedPackageDigest(*managed)
 	if expected == "" || observer.Stager == nil {
-		return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate}, nil
+		return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate, NativeDiscoveryReconciled: discoveryReconciled, NativeDiscoveryState: discoveryState}, nil
 	}
 	if err := observer.Stager.Verify(ctx, plan.ActivePath, expected); err != nil {
 		var verification *ports.VerificationError
 		if errors.As(err, &verification) && verification.Kind == ports.VerificationDigestMismatch {
-			return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate, Digest: verification.ActualDigest}, nil
+			return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate, Digest: verification.ActualDigest,
+				NativeDiscoveryReconciled: discoveryReconciled, NativeDiscoveryState: discoveryState}, nil
 		}
-		return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate}, err
+		return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate,
+			NativeDiscoveryReconciled: discoveryReconciled, NativeDiscoveryState: discoveryState}, err
 	}
-	return domain.NativeIdentityObservation{State: domain.NativeIdentityManaged, Digest: expected}, nil
+	return domain.NativeIdentityObservation{State: domain.NativeIdentityManaged, Digest: expected,
+		ReceiptReconciled: true, NativeDiscoveryReconciled: discoveryReconciled,
+		NativeDiscoveryState: discoveryState}, nil
 }
 
 func (observer NativeIdentityObserver) inspectNativeRegistry(ctx context.Context, client domain.DetectedClient, plan domain.DeliveryPlan, managed *domain.ClientBinding) (registryFinding, error) {
@@ -215,11 +230,18 @@ func (observer NativeIdentityObserver) inspectCopilotCLI(ctx context.Context, pl
 }
 
 func copilotRegistryFinding(stdout []byte, name, expectedMarketplace string, owned bool) registryFinding {
+	normalized := strings.ReplaceAll(string(stdout), "\r\n", "\n")
+	if strings.TrimSpace(normalized) == "No plugins installed.\n\nUse 'copilot plugin install <source>' to install a plugin." {
+		return registryClear
+	}
+	if strings.TrimSpace(normalized) == "No plugins installed." {
+		return registryClear
+	}
 	inInstalled := false
 	recognized := false
 	finding := registryClear
 	seen := map[string]bool{}
-	for _, line := range strings.Split(strings.ReplaceAll(string(stdout), "\r\n", "\n"), "\n") {
+	for _, line := range strings.Split(normalized, "\n") {
 		if strings.TrimSpace(line) == "Installed plugins:" {
 			if inInstalled || recognized {
 				return registryIndeterminate

--- a/install/integrationctl/agentplugins/providers/native_identity.go
+++ b/install/integrationctl/agentplugins/providers/native_identity.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/ports"
@@ -25,9 +26,12 @@ type packageVerifier interface {
 // free: another prepared marketplace, local plugin, installed CLI entry, or
 // native config entry can already claim the same manifest identity.
 type NativeIdentityObserver struct {
-	Stager packageVerifier
-	Runner CommandRunner
+	Stager           packageVerifier
+	Runner           CommandRunner
+	DiscoveryTimeout time.Duration
 }
+
+const defaultNativeDiscoveryTimeout = 15 * time.Second
 
 type registryFinding uint8
 
@@ -53,7 +57,17 @@ func (observer NativeIdentityObserver) ObserveNativeIdentity(ctx context.Context
 	}
 	nativeAttempted := observer.Runner != nil && strings.TrimSpace(plan.NativeRegistryExecutable) != "" &&
 		(client.ClientID == domain.ClientCodex || client.ClientID == domain.ClientCopilot || client.ClientID == domain.ClientVSCode)
-	native, err := observer.inspectNativeRegistry(ctx, client, plan, managed)
+	nativeCtx := ctx
+	cancelNative := func() {}
+	if nativeAttempted {
+		timeout := observer.DiscoveryTimeout
+		if timeout <= 0 {
+			timeout = defaultNativeDiscoveryTimeout
+		}
+		nativeCtx, cancelNative = context.WithTimeout(ctx, timeout)
+	}
+	native, err := observer.inspectNativeRegistry(nativeCtx, client, plan, managed)
+	cancelNative()
 	if err != nil {
 		return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate, NativeDiscoveryState: domain.NativeIdentityIndeterminate,
 			NativeDiscoveryAttempted: nativeAttempted}, err
@@ -166,6 +180,9 @@ func (observer NativeIdentityObserver) inspectCodexCLI(ctx context.Context, plan
 	}
 	result, err := observer.Runner.Run(ctx, legacyports.Command{Argv: []string{plan.NativeRegistryExecutable, "plugin", "list", "--json"}})
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return registryIndeterminate, ctxErr
+		}
 		return registryIndeterminate, err
 	}
 	if result.ExitCode != 0 {
@@ -229,6 +246,9 @@ func (observer NativeIdentityObserver) inspectCopilotCLI(ctx context.Context, pl
 	}
 	result, err := observer.Runner.Run(ctx, legacyports.Command{Argv: []string{plan.NativeRegistryExecutable, "plugin", "list"}})
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return registryIndeterminate, ctxErr
+		}
 		return registryIndeterminate, err
 	}
 	if result.ExitCode != 0 {

--- a/install/integrationctl/agentplugins/providers/native_identity.go
+++ b/install/integrationctl/agentplugins/providers/native_identity.go
@@ -47,13 +47,16 @@ func (observer NativeIdentityObserver) ObserveNativeIdentity(ctx context.Context
 		return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate}, nil
 	}
 
-	prepared, err := inspectPreparedRegistry(plan, name, managed != nil)
-	if err != nil {
-		return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate}, err
+	prepared, preparedErr := inspectPreparedRegistry(plan, name, managed != nil)
+	if preparedErr != nil {
+		prepared = registryIndeterminate
 	}
+	nativeAttempted := observer.Runner != nil && strings.TrimSpace(plan.NativeRegistryExecutable) != "" &&
+		(client.ClientID == domain.ClientCodex || client.ClientID == domain.ClientCopilot || client.ClientID == domain.ClientVSCode)
 	native, err := observer.inspectNativeRegistry(ctx, client, plan, managed)
 	if err != nil {
-		return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate, NativeDiscoveryState: domain.NativeIdentityIndeterminate}, err
+		return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate, NativeDiscoveryState: domain.NativeIdentityIndeterminate,
+			NativeDiscoveryAttempted: nativeAttempted}, err
 	}
 	discoveryState := domain.NativeIdentityAbsent
 	discoveryReconciled := false
@@ -66,45 +69,50 @@ func (observer NativeIdentityObserver) ObserveNativeIdentity(ctx context.Context
 	case registryIndeterminate:
 		discoveryState = domain.NativeIdentityIndeterminate
 	}
-	for _, finding := range []registryFinding{prepared, native} {
-		switch finding {
-		case registryCollision:
-			return domain.NativeIdentityObservation{State: domain.NativeIdentityUnmanaged, NativeDiscoveryState: discoveryState}, nil
-		case registryIndeterminate:
-			return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate, NativeDiscoveryState: domain.NativeIdentityIndeterminate}, nil
-		case registryExpected:
-			if managed == nil {
-				return domain.NativeIdentityObservation{State: domain.NativeIdentityUnmanaged, NativeDiscoveryState: domain.NativeIdentityUnmanaged}, nil
-			}
-		}
+	observed := func(state domain.NativeIdentityState) domain.NativeIdentityObservation {
+		return domain.NativeIdentityObservation{State: state, NativeDiscoveryState: discoveryState,
+			NativeDiscoveryReconciled: discoveryReconciled, NativeDiscoveryAttempted: nativeAttempted}
+	}
+	if preparedErr != nil {
+		return observed(domain.NativeIdentityIndeterminate), preparedErr
+	}
+	if prepared == registryCollision || native == registryCollision {
+		return observed(domain.NativeIdentityUnmanaged), nil
+	}
+	if prepared == registryIndeterminate || native == registryIndeterminate {
+		return observed(domain.NativeIdentityIndeterminate), nil
+	}
+	if managed == nil && (prepared == registryExpected || native == registryExpected) {
+		return observed(domain.NativeIdentityUnmanaged), nil
 	}
 
 	_, statErr := os.Lstat(plan.ActivePath)
 	if os.IsNotExist(statErr) {
-		return domain.NativeIdentityObservation{State: domain.NativeIdentityAbsent, NativeDiscoveryReconciled: discoveryReconciled, NativeDiscoveryState: discoveryState}, nil
+		return observed(domain.NativeIdentityAbsent), nil
 	}
 	if statErr != nil {
-		return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate, NativeDiscoveryReconciled: discoveryReconciled, NativeDiscoveryState: discoveryState}, statErr
+		return observed(domain.NativeIdentityIndeterminate), statErr
 	}
 	if managed == nil {
-		return domain.NativeIdentityObservation{State: domain.NativeIdentityUnmanaged, NativeDiscoveryReconciled: discoveryReconciled, NativeDiscoveryState: discoveryState}, nil
+		return observed(domain.NativeIdentityUnmanaged), nil
 	}
 	expected := managedPackageDigest(*managed)
 	if expected == "" || observer.Stager == nil {
-		return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate, NativeDiscoveryReconciled: discoveryReconciled, NativeDiscoveryState: discoveryState}, nil
+		return observed(domain.NativeIdentityIndeterminate), nil
 	}
 	if err := observer.Stager.Verify(ctx, plan.ActivePath, expected); err != nil {
 		var verification *ports.VerificationError
 		if errors.As(err, &verification) && verification.Kind == ports.VerificationDigestMismatch {
-			return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate, Digest: verification.ActualDigest,
-				NativeDiscoveryReconciled: discoveryReconciled, NativeDiscoveryState: discoveryState}, nil
+			result := observed(domain.NativeIdentityIndeterminate)
+			result.Digest = verification.ActualDigest
+			return result, nil
 		}
-		return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate,
-			NativeDiscoveryReconciled: discoveryReconciled, NativeDiscoveryState: discoveryState}, err
+		return observed(domain.NativeIdentityIndeterminate), err
 	}
-	return domain.NativeIdentityObservation{State: domain.NativeIdentityManaged, Digest: expected,
-		ReceiptReconciled: true, NativeDiscoveryReconciled: discoveryReconciled,
-		NativeDiscoveryState: discoveryState}, nil
+	result := observed(domain.NativeIdentityManaged)
+	result.Digest = expected
+	result.ReceiptReconciled = true
+	return result, nil
 }
 
 func (observer NativeIdentityObserver) inspectNativeRegistry(ctx context.Context, client domain.DetectedClient, plan domain.DeliveryPlan, managed *domain.ClientBinding) (registryFinding, error) {
@@ -231,33 +239,36 @@ func (observer NativeIdentityObserver) inspectCopilotCLI(ctx context.Context, pl
 
 func copilotRegistryFinding(stdout []byte, name, expectedMarketplace string, owned bool) registryFinding {
 	normalized := strings.ReplaceAll(string(stdout), "\r\n", "\n")
-	if strings.TrimSpace(normalized) == "No plugins installed.\n\nUse 'copilot plugin install <source>' to install a plugin." {
-		return registryClear
-	}
-	if strings.TrimSpace(normalized) == "No plugins installed." {
+	document := strings.TrimSuffix(normalized, "\n")
+	if document == "No plugins installed.\n\nUse 'copilot plugin install <source>' to install a plugin." {
 		return registryClear
 	}
 	inInstalled := false
-	recognized := false
+	recognizedHeader := false
+	recognizedEmpty := false
+	recognizedEntry := false
 	finding := registryClear
 	seen := map[string]bool{}
-	for _, line := range strings.Split(normalized, "\n") {
+	for _, line := range strings.Split(document, "\n") {
 		if strings.TrimSpace(line) == "Installed plugins:" {
-			if inInstalled || recognized {
+			if inInstalled || recognizedHeader {
 				return registryIndeterminate
 			}
-			inInstalled, recognized = true, true
+			inInstalled, recognizedHeader = true, true
 			continue
 		}
 		if !inInstalled {
-			continue
+			return registryIndeterminate
 		}
 		if line != "" && line[0] != ' ' && line[0] != '\t' {
-			inInstalled = false
-			continue
+			return registryIndeterminate
 		}
 		match := copilotInstalledEntry.FindStringSubmatch(line)
 		if len(match) == 2 {
+			if recognizedEmpty {
+				return registryIndeterminate
+			}
+			recognizedEntry = true
 			identity := match[1]
 			if seen[identity] {
 				return registryIndeterminate
@@ -276,12 +287,13 @@ func copilotRegistryFinding(stdout []byte, name, expectedMarketplace string, own
 			continue
 		}
 		trimmed := strings.TrimSpace(line)
-		if trimmed == "" || trimmed == "No plugins installed." || trimmed == "No plugins installed" {
+		if (trimmed == "No plugins installed." || trimmed == "No plugins installed") && !recognizedEntry && !recognizedEmpty {
+			recognizedEmpty = true
 			continue
 		}
 		return registryIndeterminate
 	}
-	if !recognized {
+	if !recognizedHeader || (!recognizedEntry && !recognizedEmpty) {
 		return registryIndeterminate
 	}
 	return finding

--- a/install/integrationctl/agentplugins/providers/native_identity.go
+++ b/install/integrationctl/agentplugins/providers/native_identity.go
@@ -25,6 +25,10 @@ type packageVerifier interface {
 // registry. A manager-owned path is not proof that the logical identity is
 // free: another prepared marketplace, local plugin, installed CLI entry, or
 // native config entry can already claim the same manifest identity.
+// Native registry discovery executes trusted, short-lived list commands. On
+// Unix, cancellation kills their live process group, but descendants surviving
+// a normal leader exit are not force-killed after Wait because the PGID can be
+// reused; stronger normal-exit containment is deferred to an OS-native slice.
 type NativeIdentityObserver struct {
 	Stager           packageVerifier
 	Runner           CommandRunner

--- a/install/integrationctl/agentplugins/providers/native_identity_test.go
+++ b/install/integrationctl/agentplugins/providers/native_identity_test.go
@@ -2,10 +2,12 @@ package providers
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 	legacyports "github.com/777genius/plugin-kit-ai/install/integrationctl/ports"
@@ -14,6 +16,16 @@ import (
 type identityRunner struct {
 	result   legacyports.CommandResult
 	commands [][]string
+}
+
+type blockingIdentityRunner struct {
+	returned chan struct{}
+}
+
+func (runner blockingIdentityRunner) Run(ctx context.Context, _ legacyports.Command) (legacyports.CommandResult, error) {
+	<-ctx.Done()
+	close(runner.returned)
+	return legacyports.CommandResult{}, ctx.Err()
 }
 
 func (runner *identityRunner) Run(_ context.Context, command legacyports.Command) (legacyports.CommandResult, error) {
@@ -147,6 +159,27 @@ func TestNativeIdentityObservationExposesReceiptAndExactDiscovery(t *testing.T) 
 	observation, err := (NativeIdentityObserver{Runner: runner, Stager: acceptingPackageVerifier{}}).ObserveNativeIdentity(context.Background(), domain.DetectedClient{ClientID: domain.ClientCopilot}, plan, managed)
 	if err != nil || observation.State != domain.NativeIdentityManaged || !observation.ReceiptReconciled || !observation.NativeDiscoveryReconciled || observation.NativeDiscoveryState != domain.NativeIdentityManaged {
 		t.Fatalf("observation = %+v, err = %v", observation, err)
+	}
+}
+
+func TestNativeIdentityBoundsHungAuthoritativeDiscovery(t *testing.T) {
+	plan := identityPlan(filepath.Join(t.TempDir(), "prepared"))
+	plan.NativeRegistryExecutable = "/test/bin/copilot"
+	returned := make(chan struct{})
+	observation, err := (NativeIdentityObserver{
+		Runner: blockingIdentityRunner{returned: returned}, DiscoveryTimeout: 10 * time.Millisecond,
+	}).ObserveNativeIdentity(context.Background(), domain.DetectedClient{ClientID: domain.ClientCopilot}, plan, nil)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want deadline exceeded", err)
+	}
+	if observation.State != domain.NativeIdentityIndeterminate || observation.NativeDiscoveryState != domain.NativeIdentityIndeterminate ||
+		!observation.NativeDiscoveryAttempted || observation.NativeDiscoveryReconciled {
+		t.Fatalf("observation = %+v", observation)
+	}
+	select {
+	case <-returned:
+	default:
+		t.Fatal("hung discovery runner remained active after timeout")
 	}
 }
 

--- a/install/integrationctl/agentplugins/providers/native_identity_test.go
+++ b/install/integrationctl/agentplugins/providers/native_identity_test.go
@@ -115,9 +115,14 @@ func TestCopilotRegistryFindingRequiresExactNativeIdentity(t *testing.T) {
 		{name: "exact", body: "Installed plugins:\n  • demo@" + marketplace + " (v1.0.0)\n", want: registryExpected},
 		{name: "unrelated", body: "Installed plugins:\n  • other@" + marketplace + " (v1.0.0)\n", want: registryClear},
 		{name: "duplicate", body: "Installed plugins:\n  • demo@" + marketplace + " (v1.0.0)\n  • demo@" + marketplace + " (v1.0.0)\n", want: registryIndeterminate},
-		{name: "absent_short", body: "No plugins installed.\n", want: registryClear},
+		{name: "absent_short", body: "No plugins installed.\n", want: registryIndeterminate},
 		{name: "absent_official_1_0_80", body: "No plugins installed.\n\nUse 'copilot plugin install <source>' to install a plugin.\n", want: registryClear},
+		{name: "absent_official_with_prefix", body: "\nNo plugins installed.\n\nUse 'copilot plugin install <source>' to install a plugin.\n", want: registryIndeterminate},
+		{name: "absent_official_with_suffix", body: "No plugins installed.\n\nUse 'copilot plugin install <source>' to install a plugin.\n\n", want: registryIndeterminate},
 		{name: "unknown", body: "Copilot plugins are unavailable right now\n", want: registryIndeterminate},
+		{name: "unknown_prefix", body: "experimental output\nInstalled plugins:\n  • demo@" + marketplace + " (v1.0.0)\n", want: registryIndeterminate},
+		{name: "unknown_suffix", body: "Installed plugins:\n  • demo@" + marketplace + " (v1.0.0)\nupdate available\n", want: registryIndeterminate},
+		{name: "unknown_unindented_entry", body: "Installed plugins:\ndemo@" + marketplace + " (v1.0.0)\n", want: registryIndeterminate},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -142,6 +147,38 @@ func TestNativeIdentityObservationExposesReceiptAndExactDiscovery(t *testing.T) 
 	observation, err := (NativeIdentityObserver{Runner: runner, Stager: acceptingPackageVerifier{}}).ObserveNativeIdentity(context.Background(), domain.DetectedClient{ClientID: domain.ClientCopilot}, plan, managed)
 	if err != nil || observation.State != domain.NativeIdentityManaged || !observation.ReceiptReconciled || !observation.NativeDiscoveryReconciled || observation.NativeDiscoveryState != domain.NativeIdentityManaged {
 		t.Fatalf("observation = %+v, err = %v", observation, err)
+	}
+}
+
+func TestNativeIdentityPreservesNativeDiscoveryWhenPreparedRegistryBlocksOverallIdentity(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		manifest  string
+		wantState domain.NativeIdentityState
+		wantError bool
+	}{
+		{name: "collision", manifest: `{"name":"demo"}`, wantState: domain.NativeIdentityUnmanaged},
+		{name: "malformed", manifest: `{"name":`, wantState: domain.NativeIdentityIndeterminate, wantError: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			plan := identityPlan(filepath.Join(t.TempDir(), "prepared"))
+			plan.NativeRegistryExecutable = "/test/bin/copilot"
+			writeIdentityFile(t, filepath.Join(plan.TargetRoot, "foreign", "plugin.json"), test.manifest)
+			marketplace := managedMarketplaceName(plan.PhysicalArtifactID)
+			managed := &domain.ClientBinding{}
+			runner := &identityRunner{result: legacyports.CommandResult{Stdout: []byte("Installed plugins:\n  • demo@" + marketplace + " (v1.0.0)\n")}}
+
+			observation, err := (NativeIdentityObserver{Runner: runner}).ObserveNativeIdentity(context.Background(), domain.DetectedClient{ClientID: domain.ClientCopilot}, plan, managed)
+			if (err != nil) != test.wantError {
+				t.Fatalf("err = %v, want error %t", err, test.wantError)
+			}
+			if observation.State != test.wantState || !observation.NativeDiscoveryAttempted || !observation.NativeDiscoveryReconciled || observation.NativeDiscoveryState != domain.NativeIdentityManaged {
+				t.Fatalf("observation = %+v", observation)
+			}
+			if !reflect.DeepEqual(runner.commands, [][]string{{"/test/bin/copilot", "plugin", "list"}}) {
+				t.Fatalf("commands = %#v", runner.commands)
+			}
+		})
 	}
 }
 

--- a/install/integrationctl/agentplugins/providers/native_identity_test.go
+++ b/install/integrationctl/agentplugins/providers/native_identity_test.go
@@ -105,6 +105,50 @@ func TestNativeIdentityCopilotAndVSCodeUseSharedAuthoritativeBackend(t *testing.
 	}
 }
 
+func TestCopilotRegistryFindingRequiresExactNativeIdentity(t *testing.T) {
+	marketplace := "agentplugins-demo-0123456789ab"
+	tests := []struct {
+		name string
+		body string
+		want registryFinding
+	}{
+		{name: "exact", body: "Installed plugins:\n  • demo@" + marketplace + " (v1.0.0)\n", want: registryExpected},
+		{name: "unrelated", body: "Installed plugins:\n  • other@" + marketplace + " (v1.0.0)\n", want: registryClear},
+		{name: "duplicate", body: "Installed plugins:\n  • demo@" + marketplace + " (v1.0.0)\n  • demo@" + marketplace + " (v1.0.0)\n", want: registryIndeterminate},
+		{name: "absent_short", body: "No plugins installed.\n", want: registryClear},
+		{name: "absent_official_1_0_80", body: "No plugins installed.\n\nUse 'copilot plugin install <source>' to install a plugin.\n", want: registryClear},
+		{name: "unknown", body: "Copilot plugins are unavailable right now\n", want: registryIndeterminate},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := copilotRegistryFinding([]byte(test.body), "demo", marketplace, true); got != test.want {
+				t.Fatalf("finding = %d, want %d", got, test.want)
+			}
+		})
+	}
+}
+
+func TestNativeIdentityObservationExposesReceiptAndExactDiscovery(t *testing.T) {
+	plan := identityPlan(filepath.Join(t.TempDir(), "prepared"))
+	plan.NativeRegistryExecutable = "/test/bin/copilot"
+	if err := os.MkdirAll(plan.ActivePath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeIdentityFile(t, filepath.Join(plan.ActivePath, "plugin.json"), `{"name":"demo"}`)
+	marketplace := managedMarketplaceName(plan.PhysicalArtifactID)
+	digest := "sha256:owned"
+	managed := &domain.ClientBinding{NativeObjects: []domain.NativeObjectOwnership{{Kind: "managed_package_directory", ManagedDigest: digest}}}
+	runner := &identityRunner{result: legacyports.CommandResult{Stdout: []byte("Installed plugins:\n  • demo@" + marketplace + " (v1.0.0)\n")}}
+	observation, err := (NativeIdentityObserver{Runner: runner, Stager: acceptingPackageVerifier{}}).ObserveNativeIdentity(context.Background(), domain.DetectedClient{ClientID: domain.ClientCopilot}, plan, managed)
+	if err != nil || observation.State != domain.NativeIdentityManaged || !observation.ReceiptReconciled || !observation.NativeDiscoveryReconciled || observation.NativeDiscoveryState != domain.NativeIdentityManaged {
+		t.Fatalf("observation = %+v, err = %v", observation, err)
+	}
+}
+
+type acceptingPackageVerifier struct{}
+
+func (acceptingPackageVerifier) Verify(context.Context, string, string) error { return nil }
+
 func TestNativeIdentityManualRemoteAndUnknownSharedBackendsFailClosed(t *testing.T) {
 	plan := identityPlan(filepath.Join(t.TempDir(), "prepared"))
 	for _, test := range []struct {

--- a/install/integrationctl/agentplugins/providers/native_identity_timeout_unix_test.go
+++ b/install/integrationctl/agentplugins/providers/native_identity_timeout_unix_test.go
@@ -5,8 +5,10 @@ package providers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -21,7 +23,7 @@ func TestNativeIdentityTimeoutReapsAuthoritativeDiscoveryChild(t *testing.T) {
 	root := t.TempDir()
 	pidPath := filepath.Join(root, "child.pid")
 	executable := filepath.Join(root, "copilot")
-	script := "#!/bin/sh\nprintf '%s' \"$$\" > \"$AGENTPLUGINS_TEST_PID\"\nexec sleep 60\n"
+	script := "#!/bin/sh\nsleep 60 &\nprintf '%s %s' \"$$\" \"$!\" > \"$AGENTPLUGINS_TEST_PID\"\nwait\n"
 	if err := os.WriteFile(executable, []byte(script), 0o700); err != nil {
 		t.Fatal(err)
 	}
@@ -38,14 +40,43 @@ func TestNativeIdentityTimeoutReapsAuthoritativeDiscoveryChild(t *testing.T) {
 	if readErr != nil {
 		t.Fatalf("read child pid: %v", readErr)
 	}
-	pid, parseErr := strconv.Atoi(strings.TrimSpace(string(body)))
-	if parseErr != nil {
-		t.Fatalf("parse child pid: %v", parseErr)
+	pidFields := strings.Fields(string(body))
+	if len(pidFields) != 2 {
+		t.Fatalf("process tree pids = %q", body)
 	}
-	if signalErr := syscall.Kill(pid, 0); signalErr == nil {
-		_ = syscall.Kill(pid, syscall.SIGKILL)
-		t.Fatal("authoritative discovery child remained alive after timeout")
-	} else if !errors.Is(signalErr, syscall.ESRCH) {
-		t.Fatalf("inspect child process: %v", signalErr)
+	for _, field := range pidFields {
+		pid, parseErr := strconv.Atoi(field)
+		if parseErr != nil {
+			t.Fatalf("parse process tree pid %q: %v", field, parseErr)
+		}
+		if err := waitProcessGone(pid, 2*time.Second); err != nil {
+			_ = syscall.Kill(pid, syscall.SIGKILL)
+			t.Fatal(err)
+		}
+	}
+}
+
+func waitProcessGone(pid int, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		err := syscall.Kill(pid, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		if runtime.GOOS == "linux" {
+			if stat, readErr := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat")); readErr == nil {
+				fields := strings.Fields(string(stat))
+				if len(fields) > 2 && fields[2] == "Z" {
+					return nil
+				}
+			}
+		}
+		if err != nil {
+			return fmt.Errorf("inspect process %d: %w", pid, err)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("authoritative discovery process %d remained alive after timeout", pid)
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 }

--- a/install/integrationctl/agentplugins/providers/native_identity_timeout_unix_test.go
+++ b/install/integrationctl/agentplugins/providers/native_identity_timeout_unix_test.go
@@ -56,6 +56,41 @@ func TestNativeIdentityTimeoutReapsAuthoritativeDiscoveryChild(t *testing.T) {
 	}
 }
 
+func TestNativeIdentityNormalExitReapsBackgroundDiscoveryGrandchild(t *testing.T) {
+	root := t.TempDir()
+	pidPath := filepath.Join(root, "grandchild.pid")
+	executable := filepath.Join(root, "copilot")
+	script := "#!/bin/sh\nsleep 60 &\nprintf '%s' \"$!\" > \"$AGENTPLUGINS_TEST_PID\"\nexit 0\n"
+	if err := os.WriteFile(executable, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AGENTPLUGINS_TEST_PID", pidPath)
+	plan := identityPlan(filepath.Join(root, "prepared"))
+	plan.NativeRegistryExecutable = executable
+	started := time.Now()
+	observation, err := (NativeIdentityObserver{
+		Runner: processadapter.OS{}, DiscoveryTimeout: 5 * time.Second,
+	}).ObserveNativeIdentity(context.Background(), domain.DetectedClient{ClientID: domain.ClientCopilot}, plan, nil)
+	if err == nil || observation.State != domain.NativeIdentityIndeterminate {
+		t.Fatalf("observation = %+v, err = %v", observation, err)
+	}
+	if elapsed := time.Since(started); elapsed > 2*time.Second {
+		t.Fatalf("normal-exit background cleanup took %s", elapsed)
+	}
+	body, readErr := os.ReadFile(pidPath)
+	if readErr != nil {
+		t.Fatalf("read grandchild pid: %v", readErr)
+	}
+	pid, parseErr := strconv.Atoi(strings.TrimSpace(string(body)))
+	if parseErr != nil {
+		t.Fatalf("parse grandchild pid: %v", parseErr)
+	}
+	if err := waitProcessGone(pid, 2*time.Second); err != nil {
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+		t.Fatal(err)
+	}
+}
+
 func waitProcessGone(pid int, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for {

--- a/install/integrationctl/agentplugins/providers/native_identity_timeout_unix_test.go
+++ b/install/integrationctl/agentplugins/providers/native_identity_timeout_unix_test.go
@@ -56,7 +56,7 @@ func TestNativeIdentityTimeoutReapsAuthoritativeDiscoveryChild(t *testing.T) {
 	}
 }
 
-func TestNativeIdentityNormalExitReapsBackgroundDiscoveryGrandchild(t *testing.T) {
+func TestNativeIdentityNormalExitDoesNotKillByReapedLeaderPGID(t *testing.T) {
 	root := t.TempDir()
 	pidPath := filepath.Join(root, "grandchild.pid")
 	executable := filepath.Join(root, "copilot")
@@ -85,9 +85,11 @@ func TestNativeIdentityNormalExitReapsBackgroundDiscoveryGrandchild(t *testing.T
 	if parseErr != nil {
 		t.Fatalf("parse grandchild pid: %v", parseErr)
 	}
-	if err := waitProcessGone(pid, 2*time.Second); err != nil {
-		_ = syscall.Kill(pid, syscall.SIGKILL)
-		t.Fatal(err)
+	if signalErr := syscall.Kill(pid, 0); signalErr != nil {
+		t.Fatalf("normal-exit descendant was unexpectedly killed: %v", signalErr)
+	}
+	if killErr := syscall.Kill(pid, syscall.SIGKILL); killErr != nil && !errors.Is(killErr, syscall.ESRCH) {
+		t.Fatalf("clean up normal-exit descendant: %v", killErr)
 	}
 }
 

--- a/install/integrationctl/agentplugins/providers/native_identity_timeout_unix_test.go
+++ b/install/integrationctl/agentplugins/providers/native_identity_timeout_unix_test.go
@@ -1,0 +1,51 @@
+//go:build !windows
+
+package providers
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	processadapter "github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/process"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+func TestNativeIdentityTimeoutReapsAuthoritativeDiscoveryChild(t *testing.T) {
+	root := t.TempDir()
+	pidPath := filepath.Join(root, "child.pid")
+	executable := filepath.Join(root, "copilot")
+	script := "#!/bin/sh\nprintf '%s' \"$$\" > \"$AGENTPLUGINS_TEST_PID\"\nexec sleep 60\n"
+	if err := os.WriteFile(executable, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AGENTPLUGINS_TEST_PID", pidPath)
+	plan := identityPlan(filepath.Join(root, "prepared"))
+	plan.NativeRegistryExecutable = executable
+	observation, err := (NativeIdentityObserver{
+		Runner: processadapter.OS{}, DiscoveryTimeout: 500 * time.Millisecond,
+	}).ObserveNativeIdentity(context.Background(), domain.DetectedClient{ClientID: domain.ClientCopilot}, plan, nil)
+	if !errors.Is(err, context.DeadlineExceeded) || observation.State != domain.NativeIdentityIndeterminate {
+		t.Fatalf("observation = %+v, err = %v", observation, err)
+	}
+	body, readErr := os.ReadFile(pidPath)
+	if readErr != nil {
+		t.Fatalf("read child pid: %v", readErr)
+	}
+	pid, parseErr := strconv.Atoi(strings.TrimSpace(string(body)))
+	if parseErr != nil {
+		t.Fatalf("parse child pid: %v", parseErr)
+	}
+	if signalErr := syscall.Kill(pid, 0); signalErr == nil {
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+		t.Fatal("authoritative discovery child remained alive after timeout")
+	} else if !errors.Is(signalErr, syscall.ESRCH) {
+		t.Fatalf("inspect child process: %v", signalErr)
+	}
+}


### PR DESCRIPTION
## What
- reconcile stored ownership receipts with the real native client identity in `info`
- expose additive receipt, discovery, client-version, and safe command evidence fields
- recognize the official empty output from GitHub Copilot CLI 1.0.80 while keeping unknown output fail-closed

## Verification
- `go test -count=1 ./internal/agentpluginscli`
- provider tests
- full `install/integrationctl go test -count=1 ./...`
- byte-identical zero-mutation and path-leak regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `agentplugins info --format json` output with client versions, receipt reconciliation, native discovery status, and command evidence.
  * Added clearer reporting for managed plugin identity and installation state.
* **Bug Fixes**
  * Improved detection of empty plugin registries and exact native plugin matches.
  * Added bounded discovery and targeted version checks for more reliable results.
  * Invalid ownership information is now reported as inconclusive rather than trusted.
* **Documentation**
  * Added an Unreleased changelog entry describing the enhanced JSON output while preserving the existing schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->