### PR TITLE
feat: expose grouped acquisition proof

### DIFF
--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
@@ -2,6 +2,10 @@ package agentpluginscli
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -18,20 +22,41 @@ type addTargetResult struct {
 }
 
 type addMultiResult struct {
-	OperationID    string                  `json:"operation_id,omitempty"`
-	Batch          bool                    `json:"batch"`
-	Status         string                  `json:"status"`
-	Succeeded      int                     `json:"succeeded"`
-	Failed         int                     `json:"failed"`
-	Plugin         string                  `json:"plugin"`
-	Version        string                  `json:"version,omitempty"`
-	Source         string                  `json:"source"`
-	Revision       string                  `json:"revision,omitempty"`
-	TreeDigest     string                  `json:"tree_digest,omitempty"`
-	ManifestDigest string                  `json:"manifest_digest,omitempty"`
-	Directory      *domain.DirectoryOrigin `json:"directory,omitempty"`
-	DryRun         bool                    `json:"dry_run"`
-	Targets        []addTargetResult       `json:"targets"`
+	OperationID    string                    `json:"operation_id,omitempty"`
+	Batch          bool                      `json:"batch"`
+	Status         string                    `json:"status"`
+	Succeeded      int                       `json:"succeeded"`
+	Failed         int                       `json:"failed"`
+	Plugin         string                    `json:"plugin"`
+	Version        string                    `json:"version,omitempty"`
+	Source         string                    `json:"source"`
+	Revision       string                    `json:"revision,omitempty"`
+	TreeDigest     string                    `json:"tree_digest,omitempty"`
+	ManifestDigest string                    `json:"manifest_digest,omitempty"`
+	Directory      *domain.DirectoryOrigin   `json:"directory,omitempty"`
+	DryRun         bool                      `json:"dry_run"`
+	Targets        []addTargetResult         `json:"targets"`
+	Acquisition    *addAcquisitionProof      `json:"acquisition,omitempty"`
+	TargetOutcomes map[string]addTargetProof `json:"target_outcomes,omitempty"`
+}
+
+type addAcquisitionProof struct {
+	AcquisitionID    string `json:"acquisition_id"`
+	AcquisitionCount int    `json:"acquisition_count"`
+	TreeDigest       string `json:"tree_digest"`
+	ManifestDigest   string `json:"manifest_digest"`
+	ClosureDigest    string `json:"closure_digest"`
+	SourceKind       string `json:"source_kind"`
+	Fetched          bool   `json:"fetched"`
+	Validated        bool   `json:"validated"`
+}
+
+type addTargetProof struct {
+	Outcome        string `json:"outcome"`
+	AcquisitionID  string `json:"acquisition_id"`
+	TreeDigest     string `json:"tree_digest"`
+	ManifestDigest string `json:"manifest_digest"`
+	ClosureDigest  string `json:"closure_digest"`
 }
 
 // runAddMany is deliberately not implemented as repeated CLI invocations. It
@@ -110,6 +135,7 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 		output := newAddResultData(inputs[index].Envelope, result, true)
 		output.OperationID = operationID
 		combined.Targets = append(combined.Targets, addTargetResult{Target: string(selected[index].ClientID), Status: groupTargetStatus(result), Output: output, NextAction: nextLifecycleAction(result)})
+		combined.setTargetProof(selected[index].ClientID, "not_run")
 	}
 	combined.Succeeded = len(planned.Targets)
 	if err != nil {
@@ -120,6 +146,17 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 	if opts.dryRun {
 		return renderAddMultiResult(cmd, opts, combined, loaded.envelope)
 	}
+	if len(targets) > 1 {
+		proof, proofErr := newAddAcquisitionProof(loaded)
+		if proofErr != nil {
+			return proofErr
+		}
+		combined.Acquisition = &proof
+		combined.TargetOutcomes = make(map[string]addTargetProof, len(selected))
+		for _, client := range selected {
+			combined.setTargetProof(client.ClientID, "not_run")
+		}
+	}
 	writeProgress(app, opts.format, "Applying the completely preflighted multi-target plan...")
 	groupInput.DryRun, groupInput.Confirmed = false, true
 	applied, err := service.AddGroup(ctx, groupInput)
@@ -128,6 +165,7 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 		output := newAddResultData(inputs[index].Envelope, result, false)
 		output.OperationID = operationID
 		combined.Targets = append(combined.Targets, addTargetResult{Target: string(selected[index].ClientID), Status: groupTargetStatus(result), Output: output, NextAction: nextLifecycleAction(result)})
+		combined.setTargetProof(selected[index].ClientID, addTargetProofOutcome(result))
 		if result.GroupPhase == usecase.GroupTargetExternalCompleted {
 			combined.Succeeded++
 		}
@@ -148,6 +186,94 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 		return resumeInteractiveLifecycle(ctx, cmd, service, input, inputs[0].Envelope, applied.Targets[0])
 	}
 	return nil
+}
+
+func newAddAcquisitionProof(loaded loadedPackage) (addAcquisitionProof, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return addAcquisitionProof{}, fmt.Errorf("create acquisition ID: %w", err)
+	}
+	sourceKind := acquisitionSourceKind(loaded)
+	return addAcquisitionProof{
+		AcquisitionID:    "acq-" + hex.EncodeToString(value[:]),
+		AcquisitionCount: 1,
+		TreeDigest:       loaded.envelope.TreeDigest,
+		ManifestDigest:   loaded.envelope.ManifestDigest,
+		ClosureDigest:    groupedAcquisitionClosureDigest(sourceKind, loaded.envelope.Source, loaded.envelope.TreeDigest, loaded.envelope.ManifestDigest),
+		SourceKind:       sourceKind,
+		Fetched:          loaded.envelope.Source.Repository != "",
+		Validated:        true,
+	}, nil
+}
+
+func acquisitionSourceKind(loaded loadedPackage) string {
+	if loaded.origin == domain.OriginModeDirectory {
+		return "directory"
+	}
+	if loaded.envelope.Source.Repository != "" {
+		return "github"
+	}
+	return "local"
+}
+
+// groupedAcquisitionClosureDigest is the domain-separated SHA-256 of a
+// length-prefixed tuple:
+//
+//	source kind, repository, package subpath, resolved revision,
+//	validated tree digest, validated manifest digest
+//
+// The agentplugins/grouped-acquisition-closure/v1 domain makes this a distinct
+// identity from a package tree digest. Requested and canonical source strings
+// are deliberately excluded because they may contain local, host-specific
+// paths. For local acquisitions, source kind plus the two validated package
+// identities form the closure; immutable remote acquisitions additionally bind
+// repository, subpath, and revision.
+func groupedAcquisitionClosureDigest(sourceKind string, source domain.SourceIdentity, treeDigest, manifestDigest string) string {
+	hash := sha256.New()
+	fields := []string{
+		"agentplugins/grouped-acquisition-closure/v1",
+		sourceKind,
+		strings.TrimSpace(source.Repository),
+		strings.TrimSpace(source.PackageSubpath),
+		strings.TrimSpace(source.ResolvedRevision),
+		strings.TrimSpace(treeDigest),
+		strings.TrimSpace(manifestDigest),
+	}
+	var size [8]byte
+	for _, field := range fields {
+		binary.BigEndian.PutUint64(size[:], uint64(len(field)))
+		_, _ = hash.Write(size[:])
+		_, _ = hash.Write([]byte(field))
+	}
+	return "sha256:" + hex.EncodeToString(hash.Sum(nil))
+}
+
+func (result *addMultiResult) setTargetProof(target domain.ClientID, outcome string) {
+	if result.Acquisition == nil || result.TargetOutcomes == nil {
+		return
+	}
+	proof := result.Acquisition
+	result.TargetOutcomes[string(target)] = addTargetProof{
+		Outcome: outcome, AcquisitionID: proof.AcquisitionID,
+		TreeDigest: proof.TreeDigest, ManifestDigest: proof.ManifestDigest, ClosureDigest: proof.ClosureDigest,
+	}
+}
+
+func addTargetProofOutcome(result usecase.AddResult) string {
+	switch result.GroupPhase {
+	case usecase.GroupTargetExternalCompleted:
+		return "passed"
+	case usecase.GroupTargetExternalFailed:
+		return "failed"
+	case usecase.GroupTargetManagedRolledBack:
+		return "rolled_back"
+	case usecase.GroupTargetManagedUnknown:
+		return "unknown"
+	case usecase.GroupTargetExternalPartial:
+		return "partial"
+	default:
+		return "not_completed"
+	}
 }
 
 func groupFailureStatus(phase usecase.GroupPhase) string {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -3,7 +3,6 @@ package agentpluginscli
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -359,43 +358,143 @@ func TestCodexCursorKiroUseOneAcquisitionAndGroupedCommit(t *testing.T) {
 	}
 }
 
-func TestGroupedAcquisitionClosureDigestIsDeterministicAndDomainSeparated(t *testing.T) {
+func TestGroupedAcquisitionClosureDigestGoldenVectorAndFieldBindings(t *testing.T) {
 	t.Parallel()
 	source := domain.SourceIdentity{Repository: "owner/repo", PackageSubpath: "plugins/demo", ResolvedRevision: strings.Repeat("b", 40)}
 	treeDigest := "sha256:" + strings.Repeat("1", 64)
 	manifestDigest := "sha256:" + strings.Repeat("2", 64)
-	first := groupedAcquisitionClosureDigest("github", source, treeDigest, manifestDigest)
-	second := groupedAcquisitionClosureDigest("github", source, treeDigest, manifestDigest)
-	if first != second || len(first) != len("sha256:")+64 || !strings.HasPrefix(first, "sha256:") {
-		t.Fatalf("closure digest shape/determinism: first=%q second=%q", first, second)
+	const expected = "sha256:7cb4354b53d4154f6c93c2c2963bdc38aab5b3d998893493914d24dd4ac899f4"
+	baseline := groupedAcquisitionClosureDigest("github", source, treeDigest, manifestDigest)
+	if baseline != expected {
+		t.Fatalf("closure digest golden vector = %q, want %q", baseline, expected)
 	}
-	plain := sha256.Sum256([]byte(strings.Join([]string{"github", source.Repository, source.PackageSubpath, source.ResolvedRevision, treeDigest, manifestDigest}, "")))
-	if first == treeDigest || first == fmt.Sprintf("sha256:%x", plain[:]) {
-		t.Fatalf("closure digest was not distinct and domain-separated: closure=%q tree=%q", first, treeDigest)
+
+	mutations := []struct {
+		name           string
+		sourceKind     string
+		source         domain.SourceIdentity
+		treeDigest     string
+		manifestDigest string
+	}{
+		{name: "source kind", sourceKind: "directory", source: source, treeDigest: treeDigest, manifestDigest: manifestDigest},
+		{name: "repository", sourceKind: "github", source: domain.SourceIdentity{Repository: "owner/other", PackageSubpath: source.PackageSubpath, ResolvedRevision: source.ResolvedRevision}, treeDigest: treeDigest, manifestDigest: manifestDigest},
+		{name: "package subpath", sourceKind: "github", source: domain.SourceIdentity{Repository: source.Repository, PackageSubpath: "plugins/other", ResolvedRevision: source.ResolvedRevision}, treeDigest: treeDigest, manifestDigest: manifestDigest},
+		{name: "resolved revision", sourceKind: "github", source: domain.SourceIdentity{Repository: source.Repository, PackageSubpath: source.PackageSubpath, ResolvedRevision: strings.Repeat("c", 40)}, treeDigest: treeDigest, manifestDigest: manifestDigest},
+		{name: "tree digest", sourceKind: "github", source: source, treeDigest: "sha256:" + strings.Repeat("3", 64), manifestDigest: manifestDigest},
+		{name: "manifest digest", sourceKind: "github", source: source, treeDigest: treeDigest, manifestDigest: "sha256:" + strings.Repeat("4", 64)},
 	}
-	if first == groupedAcquisitionClosureDigest("directory", source, treeDigest, manifestDigest) {
-		t.Fatal("closure digest did not bind source kind")
+	for _, mutation := range mutations {
+		mutation := mutation
+		t.Run(mutation.name, func(t *testing.T) {
+			t.Parallel()
+			got := groupedAcquisitionClosureDigest(mutation.sourceKind, mutation.source, mutation.treeDigest, mutation.manifestDigest)
+			if got == baseline {
+				t.Fatalf("mutation did not change closure digest %q", got)
+			}
+		})
 	}
 }
 
-func TestGroupedLocalAddDoesNotClaimNetworkFetch(t *testing.T) {
+func TestGroupedAcquisitionClosureDigestSeparatesFramingBoundaries(t *testing.T) {
 	t.Parallel()
-	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCodex), fixtureClient(t, domain.ClientCursor)})
-	stdout, _, err := fixture.execute(false, "add", writeCLIPlugin(t), "--target", "codex,cursor", "--format", "json")
+	treeDigest := "sha256:" + strings.Repeat("1", 64)
+	manifestDigest := "sha256:" + strings.Repeat("2", 64)
+	left := groupedAcquisitionClosureDigest("github", domain.SourceIdentity{Repository: "ab", PackageSubpath: "c"}, treeDigest, manifestDigest)
+	right := groupedAcquisitionClosureDigest("github", domain.SourceIdentity{Repository: "a", PackageSubpath: "bc"}, treeDigest, manifestDigest)
+	if left == right {
+		t.Fatalf("length-prefix framing collision: (ab, c) and (a, bc) both produced %q", left)
+	}
+}
+
+func TestGroupedLocalAddProofIsIndependentOfActualSourcePath(t *testing.T) {
+	t.Parallel()
+	type result struct {
+		stdout string
+		proof  *addAcquisitionProof
+	}
+	pluginPaths := []string{writeCLIPlugin(t), writeCLIPlugin(t)}
+	if pluginPaths[0] == pluginPaths[1] {
+		t.Fatalf("local fixtures unexpectedly shared path %q", pluginPaths[0])
+	}
+	results := make([]result, 0, len(pluginPaths))
+	for _, pluginPath := range pluginPaths {
+		fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCodex), fixtureClient(t, domain.ClientCursor)})
+		stdout, _, err := fixture.execute(false, "add", pluginPath, "--target", "codex,cursor", "--format", "json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		var output struct {
+			Data addMultiResult `json:"data"`
+		}
+		if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+			t.Fatal(err)
+		}
+		if output.Data.Acquisition == nil || output.Data.Acquisition.Fetched || output.Data.Acquisition.SourceKind != "local" || !output.Data.Acquisition.Validated {
+			t.Fatalf("local acquisition proof for %q = %+v", pluginPath, output.Data.Acquisition)
+		}
+		results = append(results, result{stdout: stdout, proof: output.Data.Acquisition})
+	}
+	if results[0].proof.ClosureDigest != results[1].proof.ClosureDigest {
+		t.Fatalf("identical local contents at different paths produced closures %q and %q", results[0].proof.ClosureDigest, results[1].proof.ClosureDigest)
+	}
+	for index, result := range results {
+		for _, pluginPath := range pluginPaths {
+			if strings.Contains(result.stdout, pluginPath) {
+				t.Fatalf("JSON result %d leaked actual plugin source path %q: %s", index, pluginPath, result.stdout)
+			}
+		}
+	}
+}
+
+func TestGroupedDirectoryAcquisitionProofBindsSourceIdentity(t *testing.T) {
+	t.Parallel()
+	source := domain.SourceIdentity{Repository: "owner/directory", PackageSubpath: "plugins/demo", ResolvedRevision: strings.Repeat("d", 40)}
+	loaded := loadedPackage{
+		origin: domain.OriginModeDirectory,
+		envelope: domain.PackageEnvelope{
+			Source: source, TreeDigest: "sha256:" + strings.Repeat("5", 64), ManifestDigest: "sha256:" + strings.Repeat("6", 64),
+		},
+	}
+	proof, err := newAddAcquisitionProof(loaded)
 	if err != nil {
 		t.Fatal(err)
 	}
-	var output struct {
-		Data addMultiResult `json:"data"`
+	if proof.SourceKind != "directory" || !proof.Fetched || !proof.Validated {
+		t.Fatalf("Directory acquisition proof = %+v", proof)
 	}
-	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
-		t.Fatal(err)
+	const want = "sha256:99db46552e756e40dae4128875f94b5adcd9103bb368bccc3994b2c97db05206"
+	if proof.ClosureDigest != want {
+		t.Fatalf("Directory closure = %q, want %q", proof.ClosureDigest, want)
 	}
-	if output.Data.Acquisition == nil || output.Data.Acquisition.Fetched || output.Data.Acquisition.SourceKind != "local" || !output.Data.Acquisition.Validated {
-		t.Fatalf("local acquisition proof = %+v", output.Data.Acquisition)
+	mutated := source
+	mutated.Repository = "owner/other-directory"
+	if proof.ClosureDigest == groupedAcquisitionClosureDigest("directory", mutated, loaded.envelope.TreeDigest, loaded.envelope.ManifestDigest) {
+		t.Fatalf("Directory closure did not bind source identity: %q", proof.ClosureDigest)
 	}
-	if strings.Contains(stdout, fixture.root) {
-		t.Fatalf("local acquisition proof leaked a host path: %s", stdout)
+}
+
+func TestAddTargetProofOutcomeMappings(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		phase usecase.GroupTargetPhase
+		want  string
+	}{
+		{name: "rollback", phase: usecase.GroupTargetManagedRolledBack, want: "rolled_back"},
+		{name: "unknown", phase: usecase.GroupTargetManagedUnknown, want: "unknown"},
+		{name: "partial", phase: usecase.GroupTargetExternalPartial, want: "partial"},
+		{name: "failed", phase: usecase.GroupTargetExternalFailed, want: "failed"},
+		{name: "passed", phase: usecase.GroupTargetExternalCompleted, want: "passed"},
+		{name: "default not completed", phase: usecase.GroupTargetPhase("unrecognized"), want: "not_completed"},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := addTargetProofOutcome(usecase.AddResult{GroupPhase: test.phase}); got != test.want {
+				t.Fatalf("addTargetProofOutcome(%q) = %q, want %q", test.phase, got, test.want)
+			}
+		})
 	}
 }
 

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -3,6 +3,7 @@ package agentpluginscli
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -307,23 +308,41 @@ func TestCodexCursorKiroUseOneAcquisitionAndGroupedCommit(t *testing.T) {
 	fixture := newCLIFixture(t, []domain.DetectedClient{
 		fixtureClient(t, domain.ClientKiro), fixtureClient(t, domain.ClientCursor), fixtureClient(t, domain.ClientCodex),
 	})
-	counter := &countingSourceAcquirer{delegate: fixture.app.SourceAcquirer}
-	fixture.app.SourceAcquirer = counter
 	plugin := writeCLIPlugin(t)
-	stdout, _, err := fixture.execute(false, "add", plugin, "--target", "kiro,codex,cursor", "--format", "json")
+	revision := strings.Repeat("a", 40)
+	acquirer := &localBackedSourceAcquirer{delegate: fixture.app.SourceAcquirer, root: plugin}
+	fixture.app.SourceAcquirer = acquirer
+	stdout, _, err := fixture.execute(false, "add", "owner/repo@"+revision+"//plugins/demo", "--target", "kiro,codex,cursor", "--format", "json")
 	if err != nil {
 		t.Fatal(err)
 	}
 	var output struct {
 		Data struct {
-			Targets []addTargetResult `json:"targets"`
+			OperationID    string                    `json:"operation_id"`
+			Acquisition    addAcquisitionProof       `json:"acquisition"`
+			TargetOutcomes map[string]addTargetProof `json:"target_outcomes"`
+			Targets        []addTargetResult         `json:"targets"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
 		t.Fatal(err)
 	}
-	if counter.calls != 1 || len(output.Data.Targets) != 3 || output.Data.Targets[0].Target != "codex" || output.Data.Targets[1].Target != "cursor" || output.Data.Targets[2].Target != "kiro" {
-		t.Fatalf("three-target combined plan = %+v; source resolutions = %d", output.Data.Targets, counter.calls)
+	if acquirer.directGitCalls != 1 || len(output.Data.Targets) != 3 || output.Data.Targets[0].Target != "codex" || output.Data.Targets[1].Target != "cursor" || output.Data.Targets[2].Target != "kiro" {
+		t.Fatalf("three-target combined plan = %+v; source resolutions = %d", output.Data.Targets, acquirer.directGitCalls)
+	}
+	proof := output.Data.Acquisition
+	if proof.AcquisitionID == "" || proof.AcquisitionCount != 1 || !proof.Fetched || !proof.Validated || proof.SourceKind != "github" {
+		t.Fatalf("group acquisition proof = %+v", proof)
+	}
+	installationID := output.Data.Targets[0].Output.Result.InstallationID
+	if proof.AcquisitionID == output.Data.OperationID || proof.AcquisitionID == installationID || len(output.Data.TargetOutcomes) != 3 {
+		t.Fatalf("acquisition identity or target cardinality = acquisition:%q operation:%q installation:%q targets:%+v", proof.AcquisitionID, output.Data.OperationID, installationID, output.Data.TargetOutcomes)
+	}
+	for _, target := range []string{"codex", "cursor", "kiro"} {
+		binding, ok := output.Data.TargetOutcomes[target]
+		if !ok || binding.Outcome != "passed" || binding.AcquisitionID != proof.AcquisitionID || binding.TreeDigest != proof.TreeDigest || binding.ManifestDigest != proof.ManifestDigest || binding.ClosureDigest != proof.ClosureDigest {
+			t.Fatalf("target %s acquisition binding = %+v", target, binding)
+		}
 	}
 	state, err := fixture.store.Load()
 	if err != nil {
@@ -337,6 +356,92 @@ func TestCodexCursorKiroUseOneAcquisitionAndGroupedCommit(t *testing.T) {
 		if len(binding.Receipts) != 1 || binding.Receipts[0].OperationGroupID != groupID {
 			t.Fatalf("three-target grouped receipt = %+v", binding)
 		}
+	}
+}
+
+func TestGroupedAcquisitionClosureDigestIsDeterministicAndDomainSeparated(t *testing.T) {
+	t.Parallel()
+	source := domain.SourceIdentity{Repository: "owner/repo", PackageSubpath: "plugins/demo", ResolvedRevision: strings.Repeat("b", 40)}
+	treeDigest := "sha256:" + strings.Repeat("1", 64)
+	manifestDigest := "sha256:" + strings.Repeat("2", 64)
+	first := groupedAcquisitionClosureDigest("github", source, treeDigest, manifestDigest)
+	second := groupedAcquisitionClosureDigest("github", source, treeDigest, manifestDigest)
+	if first != second || len(first) != len("sha256:")+64 || !strings.HasPrefix(first, "sha256:") {
+		t.Fatalf("closure digest shape/determinism: first=%q second=%q", first, second)
+	}
+	plain := sha256.Sum256([]byte(strings.Join([]string{"github", source.Repository, source.PackageSubpath, source.ResolvedRevision, treeDigest, manifestDigest}, "")))
+	if first == treeDigest || first == fmt.Sprintf("sha256:%x", plain[:]) {
+		t.Fatalf("closure digest was not distinct and domain-separated: closure=%q tree=%q", first, treeDigest)
+	}
+	if first == groupedAcquisitionClosureDigest("directory", source, treeDigest, manifestDigest) {
+		t.Fatal("closure digest did not bind source kind")
+	}
+}
+
+func TestGroupedLocalAddDoesNotClaimNetworkFetch(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCodex), fixtureClient(t, domain.ClientCursor)})
+	stdout, _, err := fixture.execute(false, "add", writeCLIPlugin(t), "--target", "codex,cursor", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output struct {
+		Data addMultiResult `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatal(err)
+	}
+	if output.Data.Acquisition == nil || output.Data.Acquisition.Fetched || output.Data.Acquisition.SourceKind != "local" || !output.Data.Acquisition.Validated {
+		t.Fatalf("local acquisition proof = %+v", output.Data.Acquisition)
+	}
+	if strings.Contains(stdout, fixture.root) {
+		t.Fatalf("local acquisition proof leaked a host path: %s", stdout)
+	}
+}
+
+func TestGroupedDryRunOmitsCompletedAcquisitionProof(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCodex), fixtureClient(t, domain.ClientCursor)})
+	stdout, _, err := fixture.execute(false, "add", writeCLIPlugin(t), "--target", "codex,cursor", "--dry-run", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output struct {
+		Data addMultiResult `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatal(err)
+	}
+	if output.Data.Acquisition != nil || output.Data.TargetOutcomes != nil || strings.Contains(stdout, `"acquisition_count"`) {
+		t.Fatalf("dry-run exposed completed acquisition proof: %s", stdout)
+	}
+}
+
+func TestGroupedPartialFailureDoesNotMarkEveryTargetPassed(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCodex), fixtureClient(t, domain.ClientCursor), fixtureClient(t, domain.ClientKiro)})
+	fixture.app.Lifecycle.Activator = &failSecondCLIGroupActivator{}
+	stdout, _, err := fixture.execute(false, "add", writeCLIPlugin(t), "--target", "codex,cursor,kiro", "--format", "json")
+	if err == nil || !strings.Contains(err.Error(), "injected grouped activation failure") {
+		t.Fatalf("grouped partial failure = %v", err)
+	}
+	var output struct {
+		Data addMultiResult `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatal(err)
+	}
+	passed := 0
+	for target, targetProof := range output.Data.TargetOutcomes {
+		if targetProof.Outcome == "passed" {
+			passed++
+		}
+		if targetProof.AcquisitionID != output.Data.Acquisition.AcquisitionID {
+			t.Fatalf("failed target %s lost acquisition binding: %+v", target, targetProof)
+		}
+	}
+	if len(output.Data.TargetOutcomes) != 3 || passed != 1 || output.Data.TargetOutcomes["cursor"].Outcome != "failed" || output.Data.TargetOutcomes["kiro"].Outcome == "passed" {
+		t.Fatalf("partial failure target outcomes = %+v", output.Data.TargetOutcomes)
 	}
 }
 
@@ -2540,6 +2645,28 @@ type cliObservedActivator struct {
 	outcome domain.ActivationOutcome
 	err     error
 	calls   int
+}
+
+type failSecondCLIGroupActivator struct {
+	calls int
+}
+
+func (activator *failSecondCLIGroupActivator) Activate(context.Context, domain.ActivationRequest) (domain.ActivationOutcome, error) {
+	activator.calls++
+	outcome := domain.ActivationOutcome{
+		Activation: domain.ActivationActive, Authentication: domain.AuthenticationNotRequired,
+		Policy: domain.PolicyAllowed, Verification: domain.VerificationInstalled,
+	}
+	if activator.calls == 2 {
+		outcome.Activation = domain.ActivationFailed
+		outcome.Verification = domain.VerificationFailed
+		return outcome, errors.New("injected grouped activation failure")
+	}
+	return outcome, nil
+}
+
+func (*failSecondCLIGroupActivator) Deactivate(context.Context, domain.DeactivationRequest) (domain.DeactivationOutcome, error) {
+	return domain.DeactivationOutcome{}, errors.New("unexpected deactivation")
 }
 
 func (activator *cliObservedActivator) Activate(context.Context, domain.ActivationRequest) (domain.ActivationOutcome, error) {

--- a/npm/agentplugins/README.md
+++ b/npm/agentplugins/README.md
@@ -51,6 +51,20 @@ reapplies or reactivates the recorded revision; it does not update or change
 source. `switch` moves the complete installation to a qualified Directory
 distribution or exact source, so it uses `--to` instead of `--target`.
 
+A successful non-dry-run, multi-target `add --format json` includes one
+`data.acquisition` proof and a `data.target_outcomes` object keyed by every
+requested target. The acquisition count is exactly one and every passed target
+binds the same acquisition ID, validated tree digest, manifest digest, and
+closure digest. `fetched` is true only for a remote GitHub or Directory source;
+`source_kind` distinguishes `github`, `directory`, and `local` acquisitions.
+The closure digest is SHA-256 over the length-prefixed tuple of source kind,
+repository, package subpath, resolved revision, tree digest, and manifest
+digest, prefixed by the domain `agentplugins/grouped-acquisition-closure/v1`.
+The domain is itself the first length-prefixed field. The digest excludes
+requested and canonical source strings so local paths and
+host-specific data never enter the public proof. Dry runs omit this completed
+proof, and failed or partial group outcomes never label every target `passed`.
+
 Short names resolve through the signed
 [Universal Agent Plugins Directory](https://github.com/777genius/universal-agent-plugins).
 The CLI shows the selected immutable release, publisher, source, and verification


### PR DESCRIPTION
## Summary

- expose a single grouped acquisition proof for multi-target JSON installs
- bind every target outcome to the same tree, manifest, and closure digests
- keep dry-run, single-target, human output, and local path privacy unchanged
- add independent golden, framing, mutation, source-kind, and path-leak regression tests

## Verification

- `go test ./internal/agentpluginscli ./cmd/agentplugins/... -count=1`
- exact `agentplugins 0.1.14` binary built and exercised in disposable Docker
- Context7 add to Codex, Cursor, and Kiro proved one acquisition and three matching target bindings
- dry-run remained mutation-free and emitted no completed acquisition proof
- final independent xhigh review: PASS, no P0-P3 findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Multi-target add operations now report shared acquisition details, including source type, package digests, and closure verification.
  - Results include per-target outcomes, making successful, failed, partial, and incomplete applications clearer.

- **Bug Fixes**
  - Partial failures now accurately reflect each target’s result instead of marking all targets as successful.
  - Dry-run results omit completed acquisition proof data.

- **Documentation**
  - Added guidance on acquisition proof behavior, verification, and dry-run and partial-operation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->