### PR TITLE
feat(agentplugins): activate Kiro plugins automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,14 @@ Kiro must load its installed native configuration and report connected servers
 with enabled tools. The verifier drains a bounded quiet settlement window,
 rejects EOF, partial bytes, or trailing contradictions, then stops and reaps the
 long-lived ACP process through supervised containment. Automatic Kiro ACP
-verification is currently available only on Linux hosts that prove delegated
-cgroup v2 creation, atomic CLONE_INTO_CGROUP placement, and cgroup.kill before
-native mutation. Windows, macOS, and other unsupported hosts report the accurate
-manual activation step instead of relying on weaker process or pipe semantics.
-This is activation evidence, not a runtime tool E2E claim.
-Failure to start the ACP executable itself leaves a manual verification action.
+verification is available only on Linux after capability preflight proves
+delegated cgroup v2 creation, atomic CLONE_INTO_CGROUP placement, and
+cgroup.kill. macOS, Windows, and Linux hosts without every required proof fail
+preflight before any native mutation. On those hosts, install or import the
+package manually in Kiro, activate it in Kiro's UI, and verify its servers
+there; that workflow is outside this automatic CLI path. Failure to start ACP
+after a supported preflight may still leave a manual verification action. This
+is activation evidence, not a runtime tool E2E claim.
 Once the ACP process starts, companion-launch failure (including a missing
 `kiro-cli-chat`), EOF, timeout, authentication failure, malformed or partial
 output, contradiction, and non-clean exit are authoritative activation

--- a/README.md
+++ b/README.md
@@ -66,6 +66,24 @@ activate automatically, while others finish as prepared and print a manual
 activation step. OAuth and consent prompts stay visible and user-controlled;
 cancelling one preserves the package and reports authentication as pending or
 cancelled.
+For native MCP-only Kiro packages, supported Kiro CLI versions are checked
+after import through a bounded structured ACP v1 initialize/session handshake.
+It sends no prompt or model/tool turn and does not inject package endpoints;
+Kiro must load its installed native configuration and report connected servers
+with enabled tools. The verifier drains a bounded quiet settlement window,
+rejects EOF, partial bytes, or trailing contradictions, then stops and reaps the
+long-lived ACP process through supervised containment. Automatic Kiro ACP
+verification is currently available only on Linux hosts that prove delegated
+cgroup v2 creation, atomic CLONE_INTO_CGROUP placement, and cgroup.kill before
+native mutation. Windows, macOS, and other unsupported hosts report the accurate
+manual activation step instead of relying on weaker process or pipe semantics.
+This is activation evidence, not a runtime tool E2E claim.
+Failure to start the ACP executable itself leaves a manual verification action.
+Once the ACP process starts, companion-launch failure (including a missing
+`kiro-cli-chat`), EOF, timeout, authentication failure, malformed or partial
+output, contradiction, and non-clean exit are authoritative activation
+failures; the managed package remains committed for explicit repair and is
+never reported active.
 Verification is reported for the exact plugin, client, runtime, and OAuth
 evidence available—not as a claim that every combination has been tested.
 

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/dirswap"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/locks"
@@ -29,6 +30,37 @@ import (
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/usecase"
 	legacyports "github.com/777genius/plugin-kit-ai/install/integrationctl/ports"
 )
+
+func TestRepairSourceResolutionIsDeadlineAndCancellationResponsive(t *testing.T) {
+	for name, contextFor := range map[string]func() (context.Context, context.CancelFunc){
+		"phase deadline": func() (context.Context, context.CancelFunc) {
+			return context.Background(), func() {}
+		},
+		"caller cancellation": func() (context.Context, context.CancelFunc) {
+			return context.WithCancel(context.Background())
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := contextFor()
+			if name == "caller cancellation" {
+				cancel()
+			} else {
+				defer cancel()
+			}
+			started := time.Now()
+			_, err := resolveRepairSource(ctx, 20*time.Millisecond, func(inner context.Context) (loadedPackage, error) {
+				<-inner.Done()
+				return loadedPackage{}, inner.Err()
+			})
+			if err == nil || (!errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled)) {
+				t.Fatalf("repair resolution error = %v", err)
+			}
+			if elapsed := time.Since(started); elapsed > 250*time.Millisecond {
+				t.Fatalf("repair resolution cancellation took %s", elapsed)
+			}
+		})
+	}
+}
 
 func TestHelpKeepsAutomationConfirmationFlagOutOfUserFlow(t *testing.T) {
 	t.Parallel()
@@ -640,7 +672,8 @@ func TestMissingManagedStdioRuntimeFailsAutomaticActivationPreflightWithoutMutat
 			client := fixtureClient(t, test.client)
 			client.ExecutablePath = test.executable
 			fixture := newCLIFixture(t, []domain.DetectedClient{client})
-			fixture.app.Lifecycle.Activator = providers.Activator{Runner: &cliCommandRunner{}}
+			runner := &cliCommandRunner{}
+			fixture.app.Lifecycle.Activator = providers.Activator{Runner: runner}
 			plugin := writeCLIPlugin(t)
 			mcp := `{"$schema":"https://agent-plugins.org/schemas/1.0.0/mcp.schema.json","mcpServers":{"demo":{"type":"stdio","command":"uap-runtime-that-does-not-exist"}}}`
 			if err := os.WriteFile(filepath.Join(plugin, "mcp.json"), []byte(mcp), 0o644); err != nil {
@@ -657,7 +690,47 @@ func TestMissingManagedStdioRuntimeFailsAutomaticActivationPreflightWithoutMutat
 			if len(state.Installations) != 0 {
 				t.Fatalf("missing runtime mutated state: %+v", state)
 			}
+			if runner.calls != 0 {
+				t.Fatalf("missing runtime reached automatic activation runner %d times", runner.calls)
+			}
 		})
+	}
+}
+
+func TestKiroMissingDuplexFailsLifecyclePreflightWithoutMutation(t *testing.T) {
+	t.Parallel()
+	client := fixtureClient(t, domain.ClientKiro)
+	client.ExecutablePath = "/test/bin/kiro-cli"
+	fixture := newCLIFixture(t, []domain.DetectedClient{client})
+	runner := &cliRunOnlyRunner{}
+	fixture.app.Lifecycle.Activator = providers.Activator{Runner: runner}
+	plugin := writeCLIPlugin(t)
+	writeCLIMCP(t, plugin)
+
+	_, _, err := fixture.execute(false, "add", plugin, "--target", string(domain.ClientKiro))
+	if err == nil || !strings.Contains(err.Error(), "requires an ACP duplex process runner") {
+		t.Fatalf("duplex preflight error = %v", err)
+	}
+	state, loadErr := fixture.store.Load()
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if len(state.Installations) != 0 || runner.calls != 0 {
+		t.Fatalf("duplex preflight mutated state or invoked Kiro: state=%+v calls=%d", state, runner.calls)
+	}
+	_, _, retryErr := fixture.execute(false, "add", plugin, "--target", string(domain.ClientKiro))
+	if retryErr == nil || !strings.Contains(retryErr.Error(), "requires an ACP duplex process runner") {
+		t.Fatalf("duplex preflight retry = %v", retryErr)
+	}
+	state, loadErr = fixture.store.Load()
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if len(state.Installations) != 0 || runner.calls != 0 {
+		t.Fatalf("duplex retry entered verify-only or mutated: state=%+v calls=%d", state, runner.calls)
+	}
+	if _, statErr := os.Stat(client.ConfigRoot); !os.IsNotExist(statErr) {
+		t.Fatalf("duplex preflight created Kiro package/config root %q: %v", client.ConfigRoot, statErr)
 	}
 }
 
@@ -2782,12 +2855,40 @@ type cliCommandRunner struct {
 	run   func(int, legacyports.Command) legacyports.CommandResult
 }
 
+type cliRunOnlyRunner struct {
+	calls int
+}
+
+type cliDiscardWriteCloser struct{ io.Writer }
+
+func (cliDiscardWriteCloser) Close() error { return nil }
+
+func (*cliCommandRunner) DuplexCapability() error { return nil }
+
+func (runner *cliRunOnlyRunner) Run(context.Context, legacyports.Command) (legacyports.CommandResult, error) {
+	runner.calls++
+	return legacyports.CommandResult{}, nil
+}
+
 func (runner *cliCommandRunner) Run(_ context.Context, command legacyports.Command) (legacyports.CommandResult, error) {
 	runner.calls++
 	if runner.run != nil {
 		return runner.run(runner.calls, command), nil
 	}
 	return legacyports.CommandResult{}, nil
+}
+
+func (runner *cliCommandRunner) RunDuplexWithPlannedShutdown(_ context.Context, command legacyports.Command, exchange func(io.Writer, io.Reader) error) error {
+	runner.calls++
+	output := "{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{\"protocolVersion\":1}}\n" +
+		"{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"sessionId\":\"s\"}}\n" +
+		"{\"jsonrpc\":\"2.0\",\"method\":\"_kiro/mcp/status\",\"params\":{\"sessionId\":\"s\",\"serverName\":\"demo\",\"status\":\"connected\",\"tools\":[{\"name\":\"tool\",\"disabled\":false}]}}\n"
+	reader, writer := io.Pipe()
+	go func() { _, _ = io.WriteString(writer, output) }()
+	err := exchange(cliDiscardWriteCloser{Writer: io.Discard}, reader)
+	_ = writer.Close()
+	_ = reader.Close()
+	return err
 }
 
 func (stub *cliLegacyLifecycleStub) Exists(context.Context, string) (bool, error) {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/repair_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/repair_multi.go
@@ -5,11 +5,14 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"time"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/usecase"
 	"github.com/spf13/cobra"
 )
+
+const repairSourceResolutionTimeout = 2 * time.Minute
 
 type repairTargetResult struct {
 	Target     string           `json:"target"`
@@ -99,11 +102,12 @@ func runRepairMany(ctx context.Context, cmd *cobra.Command, app App, opts *optio
 	for _, key := range keys {
 		request := requests[key]
 		var loaded loadedPackage
-		if installation.OriginMode == domain.OriginModeDirectory {
-			loaded, err = app.loadInstalledPackage(ctx, installation, request.targets, domain.DirectoryRepair, request.sequence, request.revision, detected)
-		} else {
-			loaded, err = app.loadPackageFor(ctx, request.source, packageResolutionRequest{Targets: request.targets, Operation: domain.DirectoryRepair, Clients: detected})
-		}
+		loaded, err = resolveRepairSource(ctx, repairSourceResolutionTimeout, func(resolutionCtx context.Context) (loadedPackage, error) {
+			if installation.OriginMode == domain.OriginModeDirectory {
+				return app.loadInstalledPackage(resolutionCtx, installation, request.targets, domain.DirectoryRepair, request.sequence, request.revision, detected)
+			}
+			return app.loadPackageFor(resolutionCtx, request.source, packageResolutionRequest{Targets: request.targets, Operation: domain.DirectoryRepair, Clients: detected})
+		})
 		if err != nil {
 			return err
 		}
@@ -177,6 +181,12 @@ func runRepairMany(ctx context.Context, cmd *cobra.Command, app App, opts *optio
 	}
 	result.Status = string(appliedGroup.Phase)
 	return renderRepairMultiResult(cmd, opts, result)
+}
+
+func resolveRepairSource(ctx context.Context, timeout time.Duration, resolve func(context.Context) (loadedPackage, error)) (loadedPackage, error) {
+	bounded, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return resolve(bounded)
 }
 
 func renderRepairMultiResult(cmd *cobra.Command, opts *options, result repairMultiResult) error {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/source_directory_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/source_directory_test.go
@@ -870,6 +870,7 @@ func TestProductionGitHubAcquirerOutputResolvesAsDirectExactSource(t *testing.T)
 	fixture := newCLIFixture(t, nil)
 	fixture.app.SourceAcquirer = sourceacquisition.Acquirer{
 		TempRoot: fixture.root,
+		Runner:   directGitTestRunner{},
 		URLForRepo: func(repository string) string {
 			if repository != "owner/repo" {
 				t.Fatalf("unexpected repository %q", repository)
@@ -887,6 +888,14 @@ func TestProductionGitHubAcquirerOutputResolvesAsDirectExactSource(t *testing.T)
 	if loaded.envelope.Source.CanonicalSource != wantCanonical || loaded.envelope.Source.RequestedSource != requested {
 		t.Fatalf("production acquisition identity = %+v", loaded.envelope.Source)
 	}
+}
+
+type directGitTestRunner struct{}
+
+func (directGitTestRunner) Run(ctx context.Context, command sourceacquisition.Command) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", command.Args...)
+	cmd.Dir = command.Dir
+	return cmd.CombinedOutput()
 }
 
 func TestExistingRelativeDirectoryDoesNotOverrideShortNameForAddOrSwitch(t *testing.T) {

--- a/install/integrationctl/adapters/process/osrunner.go
+++ b/install/integrationctl/adapters/process/osrunner.go
@@ -3,8 +3,12 @@ package process
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"os"
 	"os/exec"
+	"sync"
 	"time"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/ports"
@@ -12,49 +16,575 @@ import (
 
 type OS struct{}
 
+type terminationResult struct {
+	leaderStopped bool
+	forcedMembers bool
+	err           error
+}
+
+type onceWriteCloser struct {
+	io.WriteCloser
+	once sync.Once
+	err  error
+}
+
+func (writer *onceWriteCloser) Close() error {
+	writer.once.Do(func() { writer.err = writer.WriteCloser.Close() })
+	return writer.err
+}
+
+// Race-instrumented Go clients can take slightly over a second to complete
+// runtime shutdown after stdin EOF; retain a bounded but realistic exit grace.
+const duplexExitGrace = 2 * time.Second
+const processReapTimeout = time.Second
+
+type duplexPipeFactory struct {
+	output      func() (*os.File, *os.File, error)
+	input       func(*exec.Cmd) (io.WriteCloser, error)
+	containment func(*exec.Cmd) (duplexCommandContainment, error)
+}
+
+type duplexCommandContainment interface {
+	attach(*exec.Cmd) error
+	terminate() terminationResult
+	exited() (bool, error)
+	close() error
+}
+
+// latchedExitObservation turns an edge-triggered process-exit notification
+// into persistent state. Platform observers may be polled by supervision,
+// settlement, and termination in succession; only the first poll must consume
+// the underlying kernel event.
+type latchedExitObservation struct {
+	mu       sync.Mutex
+	observed bool
+}
+
+func (observation *latchedExitObservation) latch() {
+	observation.mu.Lock()
+	observation.observed = true
+	observation.mu.Unlock()
+}
+
+func (observation *latchedExitObservation) observe(poll func() (bool, error)) (bool, error) {
+	observation.mu.Lock()
+	defer observation.mu.Unlock()
+	if observation.observed {
+		return true, nil
+	}
+	exited, err := poll()
+	if exited {
+		observation.observed = true
+	}
+	return exited, err
+}
+
+var defaultDuplexPipeFactory = duplexPipeFactory{
+	output: os.Pipe,
+	input:  func(cmd *exec.Cmd) (io.WriteCloser, error) { return cmd.StdinPipe() },
+	containment: func(cmd *exec.Cmd) (duplexCommandContainment, error) {
+		return newDuplexCommandContainment(cmd)
+	},
+}
+
+// RunDuplex runs one bounded-lifetime interactive exchange over a child's
+// standard input and output. A successful exchange closes stdin and gives the
+// child a bounded opportunity to report its own exit status. Platform cleanup
+// is explicit and is always performed before the single Wait reaps the leader.
+// It supervises the trusted, pinned client and its observable descendants; it
+// is not an arbitrary hostile-process sandbox.
+func (OS) RunDuplex(ctx context.Context, command ports.Command, exchange func(io.Writer, io.Reader) error) error {
+	if err := duplexContainmentPreflight(); err != nil {
+		return err
+	}
+	return runDuplex(ctx, command, exchange, defaultDuplexPipeFactory)
+}
+
+// RunDuplexWithPlannedShutdown runs an exchange whose nil return explicitly
+// requests termination of a deliberately long-lived process tree. It is for
+// protocols such as Kiro ACP where completing the verified exchange, rather
+// than natural process exit, is the success boundary. Requested termination is
+// successful only when containment proves the leader and every descendant are
+// gone before the leader's sole reap.
+func (OS) RunDuplexWithPlannedShutdown(ctx context.Context, command ports.Command, exchange func(io.Writer, io.Reader) error) error {
+	if err := duplexContainmentPreflight(); err != nil {
+		return err
+	}
+	return runDuplexMode(ctx, command, exchange, defaultDuplexPipeFactory, true)
+}
+
+// DuplexCapability proves that both duplex lifecycle modes can place a child
+// and every process it creates inside a kernel-enforced containment boundary.
+// Callers use this before materializing package state or invoking a native
+// client mutation.
+func (OS) DuplexCapability() error { return duplexContainmentPreflight() }
+
+func runDuplex(ctx context.Context, command ports.Command, exchange func(io.Writer, io.Reader) error, pipes duplexPipeFactory) error {
+	return runDuplexMode(ctx, command, exchange, pipes, false)
+}
+
+func runDuplexMode(ctx context.Context, command ports.Command, exchange func(io.Writer, io.Reader) error, pipes duplexPipeFactory, plannedShutdownEnabled bool) (resultErr error) {
+	if len(command.Argv) == 0 {
+		return exec.ErrNotFound
+	}
+	if exchange == nil {
+		return fmt.Errorf("duplex process exchange is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	cmd := exec.Command(command.Argv[0], command.Argv[1:]...)
+	cmd.Env = command.Env
+	cmd.Dir = command.Dir
+	// Allocate the independently-owned output pipe first. If it fails, no
+	// command-owned stdin pipe exists to leak before Start can arrange cleanup.
+	stdout, childStdout, err := pipes.output()
+	if err != nil {
+		if stdout != nil {
+			_ = stdout.Close()
+		}
+		if childStdout != nil {
+			_ = childStdout.Close()
+		}
+		return err
+	}
+	containmentFactory := pipes.containment
+	if containmentFactory == nil {
+		containmentFactory = func(cmd *exec.Cmd) (duplexCommandContainment, error) {
+			return newCommandContainment(cmd)
+		}
+	}
+	containment, err := containmentFactory(cmd)
+	if err != nil {
+		_ = stdout.Close()
+		_ = childStdout.Close()
+		return err
+	}
+	// StdinPipe retains its child-side descriptor inside exec.Cmd until Start
+	// transfers ownership. Establish containment first so a pre-Start
+	// containment failure cannot strand that descriptor.
+	stdin, err := pipes.input(cmd)
+	if err != nil {
+		if stdin != nil {
+			_ = stdin.Close()
+		}
+		_ = stdout.Close()
+		_ = childStdout.Close()
+		return errors.Join(err, containment.close())
+	}
+	stdin = &onceWriteCloser{WriteCloser: stdin}
+	containmentClosed := false
+	var containmentCloseMu sync.Mutex
+	closeContainment := func() error {
+		containmentCloseMu.Lock()
+		defer containmentCloseMu.Unlock()
+		if containmentClosed {
+			return nil
+		}
+		err := containment.close()
+		containmentClosed = err == nil
+		return err
+	}
+	defer func() { resultErr = errors.Join(resultErr, closeContainment()) }()
+	defer stdout.Close()
+	cmd.Stdout = childStdout
+	stderr := newBoundedDiagnosticBuffer(32 * 1024)
+	cmd.Stderr = stderr
+	cmd.WaitDelay = 100 * time.Millisecond
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		_ = childStdout.Close()
+		return err
+	}
+	_ = childStdout.Close()
+	if err := containment.attach(cmd); err != nil {
+		_ = stdin.Close()
+		return cleanupAttachFailure(err, containment.terminate, cmd.Process.Kill, containment.exited, closeContainment, cmd.Wait)
+	}
+	exchanged := make(chan error, 1)
+	go func() { exchanged <- exchange(stdin, stdout) }()
+
+	poll := time.NewTicker(5 * time.Millisecond)
+	defer poll.Stop()
+	exited := false
+	exchangeDone := false
+	var exchangeErr error
+	var supervisionErr error
+	for !exited && !exchangeDone && supervisionErr == nil {
+		select {
+		case exchangeErr = <-exchanged:
+			exchangeDone = true
+		case <-poll.C:
+			exited, err = containment.exited()
+			if err != nil {
+				supervisionErr = fmt.Errorf("observe duplex process exit: %w", err)
+			}
+		case <-ctx.Done():
+			supervisionErr = ctx.Err()
+		}
+	}
+	// Cancellation and exchange completion can become ready in the same
+	// scheduling turn. Preserve the context cause even when the buffered
+	// exchange result wins the select.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		supervisionErr = errors.Join(supervisionErr, ctxErr)
+	}
+	if exchangeDone && supervisionErr == nil && !exited {
+		// Close the observation gap between the exchange result winning the
+		// select and a planned teardown request. A long-lived protocol process
+		// that is already waitable did not reach the planned-shutdown boundary.
+		exited, err = containment.exited()
+		if err != nil {
+			supervisionErr = fmt.Errorf("observe duplex process before planned shutdown: %w", err)
+		}
+	}
+
+	earlyExit := exited && (!exchangeDone || plannedShutdownEnabled)
+	plannedShutdown := plannedShutdownEnabled && exchangeDone && exchangeErr == nil && supervisionErr == nil && !exited
+	_ = stdin.Close()
+	forced := false
+	if plannedShutdown {
+		// The successful exchange explicitly established the protocol's success
+		// boundary. Terminate now, while the unreaped leader still anchors a
+		// stable process-tree identity; do not wait for a natural exit that the
+		// protocol intentionally never performs.
+	} else if !exited && exchangeDone && exchangeErr == nil {
+		grace := time.NewTimer(duplexExitGrace)
+		defer grace.Stop()
+		exited, exchangeErr = awaitDuplexExit(ctx, poll.C, grace.C, containment.exited)
+		forced = !exited || exchangeErr != nil
+	} else if !exited {
+		forced = true
+	}
+	termination := terminationResult{leaderStopped: exited}
+	if plannedShutdown || forced || (exited && naturalExitNeedsContainmentCleanup()) {
+		// The leader is still an unreaped, stable identity here, including after
+		// exited reported a waitable zombie. Thus group/job cleanup cannot target
+		// a recycled numeric process identity. Natural exit cleanup is part of
+		// the bounded-process contract and retains the leader's exact status.
+		termination = containment.terminate()
+		if errors.Is(termination.err, os.ErrProcessDone) {
+			// ESRCH/ErrProcessDone means the pre-reap group/job identity no longer has
+			// any signalable members, so cleanup is complete rather than uncertain.
+			termination.err = nil
+		}
+		if !termination.leaderStopped && !exited {
+			termination = stopLeaderAfterContainmentFailure(termination, cmd.Process.Kill, containment.exited)
+		}
+	}
+	_ = stdout.Close()
+	// Every successfully started leader has exactly one owned Wait. Even when
+	// termination could not prove shutdown, the buffered sole-reaper goroutine
+	// retains ownership until a later exit while caller cleanup stays bounded.
+	waitErr := closeContainmentAndWait(closeContainment, cmd.Wait, processReapTimeout)
+	if !exchangeDone {
+		observedExchangeErr := <-exchanged
+		exchangeDone = true
+		exchangeErr = observedExchangeErr
+	}
+	exchangeErr = errors.Join(exchangeErr, supervisionErr)
+	// Cancellation can arrive while containment closes or the sole Wait reaps.
+	// Recheck after cleanup before accepting protocol success.
+	exchangeErr = errors.Join(exchangeErr, ctx.Err())
+	if !exited && !termination.leaderStopped && exchangeErr == nil {
+		// This can only happen when a platform cannot observe exit without reaping.
+		forced = true
+	}
+	if plannedShutdown {
+		if exchangeErr != nil {
+			return withDuplexDiagnostic(errors.Join(exchangeErr, termination.err, waitErr), stderr.Bytes())
+		}
+		if !termination.leaderStopped {
+			return withDuplexDiagnostic(errors.Join(fmt.Errorf("planned duplex process-tree shutdown did not prove the leader stopped"), termination.err, waitErr), stderr.Bytes())
+		}
+		if termination.err != nil {
+			return withDuplexDiagnostic(fmt.Errorf("planned duplex process-tree shutdown failed: %w", errors.Join(termination.err, waitErr)), stderr.Bytes())
+		}
+		if waitErr == nil {
+			return nil
+		}
+		if _, expectedTerminationStatus := waitErr.(*exec.ExitError); expectedTerminationStatus {
+			// The runner caused this status only after the exchange explicitly
+			// requested planned shutdown and containment proved the tree empty.
+			return nil
+		}
+		return withDuplexDiagnostic(fmt.Errorf("reap planned duplex process-tree shutdown: %w", waitErr), stderr.Bytes())
+	}
+	if forced {
+		forcedErr := fmt.Errorf("duplex process required forced supervised cleanup after its exit grace")
+		return withDuplexDiagnostic(errors.Join(exchangeErr, forcedErr, termination.err, waitErr), stderr.Bytes())
+	}
+	if termination.forcedMembers && !plannedShutdown {
+		return withDuplexDiagnostic(errors.Join(exchangeErr, fmt.Errorf("duplex process left live descendants that required forced cleanup"), termination.err, waitErr), stderr.Bytes())
+	}
+	if earlyExit {
+		earlyMessage := "duplex process exited before the exchange completed"
+		if plannedShutdownEnabled && exchangeDone {
+			earlyMessage = "duplex process exited before planned process-tree shutdown could begin"
+		}
+		earlyErr := errors.New(earlyMessage)
+		return withDuplexDiagnostic(errors.Join(exchangeErr, earlyErr, termination.err, waitErr), stderr.Bytes())
+	}
+	if exchangeErr != nil {
+		return withDuplexDiagnostic(errors.Join(exchangeErr, termination.err, waitErr), stderr.Bytes())
+	}
+	if termination.err != nil {
+		return withDuplexDiagnostic(joinCleanupAndWaitError("terminate duplex supervised process", termination.err, waitErr), stderr.Bytes())
+	}
+	if waitErr != nil {
+		return withDuplexDiagnostic(waitErr, stderr.Bytes())
+	}
+	return nil
+}
+
+func awaitDuplexExit(ctx context.Context, poll, grace <-chan time.Time, exited func() (bool, error)) (bool, error) {
+	for {
+		select {
+		case <-poll:
+			done, err := exited()
+			if err != nil {
+				return false, fmt.Errorf("observe duplex process exit: %w", err)
+			}
+			if !done {
+				continue
+			}
+			// Cancellation can become observable while exit polling wins the
+			// select. Recheck it before accepting a natural successful exit.
+			return true, ctx.Err()
+		case <-grace:
+			return false, ctx.Err()
+		case <-ctx.Done():
+			return false, ctx.Err()
+		}
+	}
+}
+
+func cleanupAttachFailure(attachErr error, terminate func() terminationResult, killLeader func() error, exited func() (bool, error), closeContainment, wait func() error) error {
+	return cleanupAttachFailureWithin(attachErr, terminate, killLeader, exited, closeContainment, wait, processReapTimeout)
+}
+
+func cleanupAttachFailureWithin(attachErr error, terminate func() terminationResult, killLeader func() error, exited func() (bool, error), closeContainment, wait func() error, timeout time.Duration) error {
+	termination := terminate()
+	if errors.Is(termination.err, os.ErrProcessDone) {
+		termination.err = nil
+	}
+	if !termination.leaderStopped {
+		termination = stopLeaderAfterContainmentFailure(termination, killLeader, exited)
+	}
+	return errors.Join(attachErr, termination.err, closeContainmentAndWait(closeContainment, wait, timeout))
+}
+
+func closeContainmentAndWait(closeContainment, wait func() error, timeout time.Duration) error {
+	closeErr := closeContainment()
+	waitErr := boundedProcessWait(func() error {
+		waitErr := wait()
+		// A close that could not finish while the process was alive (for
+		// example, removal of a populated cgroup) remains owned by the sole
+		// reaper. Retry after Wait so eventual exit also releases containment
+		// resources even when the bounded caller has already returned.
+		if closeErr != nil {
+			return errors.Join(waitErr, closeContainment())
+		}
+		return waitErr
+	}, timeout)
+	if closeErr == nil {
+		// Preserve *exec.ExitError so callers can retain natural exit status.
+		return waitErr
+	}
+	return errors.Join(closeErr, waitErr)
+}
+
+func boundedProcessWait(wait func() error, timeout time.Duration) error {
+	// All runner-owned containment handles and pipes are already closed. The
+	// buffered result gives the sole reaper clear ownership until process exit,
+	// including when shutdown could not be proved, while keeping the caller's
+	// cleanup deadline real and preventing a future zombie.
+	result := make(chan error, 1)
+	go func() { result <- wait() }()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case err := <-result:
+		return err
+	case <-timer.C:
+		return fmt.Errorf("process wait/reap exceeded cleanup deadline of %s; sole reaper retains ownership until process exit", timeout)
+	}
+}
+
+func stopLeaderAfterContainmentFailure(termination terminationResult, killLeader func() error, exited func() (bool, error)) terminationResult {
+	if termination.leaderStopped {
+		return termination
+	}
+	killErr := killLeader()
+	if killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
+		termination.err = errors.Join(termination.err, fmt.Errorf("kill process leader after supervised cleanup failure: %w", killErr))
+		return termination
+	}
+	deadline := time.Now().Add(processReapTimeout)
+	for {
+		stopped, observeErr := exited()
+		if stopped {
+			termination.leaderStopped = true
+			return termination
+		}
+		if observeErr != nil {
+			termination.err = errors.Join(termination.err, fmt.Errorf("confirm process leader stopped after fallback kill: %w", observeErr))
+			return termination
+		}
+		if time.Now().After(deadline) {
+			termination.err = errors.Join(termination.err, fmt.Errorf("fallback leader kill was requested but shutdown was not observed before cleanup deadline"))
+			return termination
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func withDuplexDiagnostic(err error, diagnostic []byte) error {
+	if len(diagnostic) == 0 {
+		return err
+	}
+	return fmt.Errorf("%w (client diagnostic: %s)", err, diagnostic)
+}
+
 func (OS) Run(ctx context.Context, cmd ports.Command) (ports.CommandResult, error) {
+	return runCommand(ctx, cmd, time.Second, false)
+}
+
+// RunWithTreeExitGrace is used for trusted commands such as Git that may leave
+// a protocol/helper process completing natural shutdown after the leader exits.
+// The grace never converts forced cleanup into success.
+func (OS) RunWithTreeExitGrace(ctx context.Context, cmd ports.Command, treeExitGrace time.Duration) (ports.CommandResult, error) {
+	return runCommand(ctx, cmd, treeExitGrace, true)
+}
+
+func runCommand(ctx context.Context, cmd ports.Command, treeExitGrace time.Duration, processGroupOnly bool) (ports.CommandResult, error) {
 	if len(cmd.Argv) == 0 {
 		return ports.CommandResult{}, exec.ErrNotFound
 	}
-	c := exec.CommandContext(ctx, cmd.Argv[0], cmd.Argv[1:]...)
-	c.Env = cmd.Env
-	c.Dir = cmd.Dir
-	c.WaitDelay = 100 * time.Millisecond
-	tree, err := newCommandTree(c)
-	if err != nil {
+	if err := ctx.Err(); err != nil {
 		return ports.CommandResult{}, err
 	}
-	defer tree.close()
+	// Every production command is explicitly supervised. Even commands that are
+	// nominally diagnostic can load client configuration and start helpers, and
+	// lifecycle commands can mutate or acquire state. On Linux the containment
+	// constructor uses CLONE_INTO_CGROUP, so there is no post-Start sampling
+	// window in which a descendant can escape.
+	return runExplicit(ctx, cmd, treeExitGrace, processGroupOnly)
+}
+
+func runExplicit(ctx context.Context, command ports.Command, treeExitGrace time.Duration, processGroupOnly bool) (result ports.CommandResult, resultErr error) {
+	c := exec.Command(command.Argv[0], command.Argv[1:]...)
+	c.Env = command.Env
+	c.Dir = command.Dir
+	c.WaitDelay = 100 * time.Millisecond
 	var stdout bytes.Buffer
 	stderr := newBoundedDiagnosticBuffer(32 * 1024)
 	c.Stdout = &stdout
 	c.Stderr = stderr
+	containment, err := newCommandContainment(c)
+	if err != nil {
+		return ports.CommandResult{}, err
+	}
+	if processGroupOnly {
+		containment.limitToProcessGroup()
+	}
+	containmentClosed := false
+	var containmentCloseMu sync.Mutex
+	closeContainment := func() error {
+		containmentCloseMu.Lock()
+		defer containmentCloseMu.Unlock()
+		if containmentClosed {
+			return nil
+		}
+		err := containment.close()
+		containmentClosed = err == nil
+		return err
+	}
+	defer func() { resultErr = errors.Join(resultErr, closeContainment()) }()
 	if err := c.Start(); err != nil {
 		return ports.CommandResult{}, err
 	}
-	if err := tree.attach(c); err != nil {
-		_ = tree.terminate()
-		_ = c.Wait()
-		return ports.CommandResult{}, err
+	if err := containment.attach(c); err != nil {
+		return ports.CommandResult{}, cleanupAttachFailure(err, containment.terminate, c.Process.Kill, containment.exited, closeContainment, c.Wait)
 	}
-	err = c.Wait()
-	if err == nil {
-		return ports.CommandResult{ExitCode: 0, Stdout: stdout.Bytes()}, nil
+
+	poll := time.NewTicker(5 * time.Millisecond)
+	defer poll.Stop()
+	supervisionErr := superviseExplicit(ctx, poll.C, containment.exited)
+
+	termination := terminationResult{leaderStopped: supervisionErr == nil}
+	if supervisionErr != nil || naturalExitNeedsContainmentCleanup() {
+		if supervisionErr == nil {
+			// A well-behaved command may have a just-exiting helper still visible
+			// when the leader first becomes waitable. Give only observed helpers a
+			// bounded natural shutdown grace; anything still live afterward is
+			// forced and reported with explicit termination causality.
+			_, settleErr := containment.settleNaturalExit(ctx, treeExitGrace)
+			supervisionErr = errors.Join(settleErr, ctx.Err())
+		}
+		// Explicit cleanup happens while the leader is unreaped, so its numeric
+		// process/group identity cannot have been recycled.
+		termination = containment.terminate()
+		if errors.Is(termination.err, os.ErrProcessDone) {
+			termination.err = nil
+		}
+		if !termination.leaderStopped && supervisionErr != nil {
+			termination = stopLeaderAfterContainmentFailure(termination, c.Process.Kill, containment.exited)
+		}
+	}
+	// Wait may remain blocked if shutdown could not be proved. Close containment
+	// first, then give the sole reaper durable ownership while bounding caller
+	// return; no second Wait or Process.Release may abandon a future zombie.
+	waitErr := closeContainmentAndWait(closeContainment, c.Wait, processReapTimeout)
+	if supervisionErr != nil {
+		return ports.CommandResult{}, withDuplexDiagnostic(errors.Join(supervisionErr, termination.err, waitErr), stderr.Bytes())
 	}
 	if ctxErr := ctx.Err(); ctxErr != nil {
-		return ports.CommandResult{}, ctxErr
+		return ports.CommandResult{}, withDuplexDiagnostic(errors.Join(ctxErr, termination.err, waitErr), stderr.Bytes())
 	}
-	if exitErr, ok := err.(*exec.ExitError); ok {
-		return ports.CommandResult{
-			ExitCode: exitErr.ExitCode(),
-			Stdout:   stdout.Bytes(),
-			Stderr:   stderr.Bytes(),
-		}, nil
+	if termination.forcedMembers {
+		return ports.CommandResult{}, withDuplexDiagnostic(errors.Join(fmt.Errorf("process left live descendants that required forced cleanup"), termination.err, waitErr), stderr.Bytes())
 	}
-	return ports.CommandResult{}, err
+	if termination.err != nil {
+		return ports.CommandResult{}, withDuplexDiagnostic(joinCleanupAndWaitError("terminate supervised process", termination.err, waitErr), stderr.Bytes())
+	}
+	if waitErr == nil {
+		return ports.CommandResult{ExitCode: 0, Stdout: stdout.Bytes()}, nil
+	}
+	if exitErr, ok := waitErr.(*exec.ExitError); ok {
+		return ports.CommandResult{ExitCode: exitErr.ExitCode(), Stdout: stdout.Bytes(), Stderr: stderr.Bytes()}, nil
+	}
+	return ports.CommandResult{}, waitErr
+}
+
+func joinCleanupAndWaitError(operation string, cleanupErr, waitErr error) error {
+	return fmt.Errorf("%s: %w", operation, errors.Join(cleanupErr, waitErr))
+}
+
+func superviseExplicit(ctx context.Context, poll <-chan time.Time, exited func() (bool, error)) error {
+	var supervisionErr error
+	for {
+		select {
+		case <-ctx.Done():
+			supervisionErr = ctx.Err()
+		case <-poll:
+			done, observeErr := exited()
+			if observeErr != nil {
+				supervisionErr = fmt.Errorf("observe process exit: %w", observeErr)
+			} else if !done {
+				continue
+			}
+		}
+		break
+	}
+	// The poll observation and cancellation can become ready in the same
+	// scheduling turn. Re-check after observation so a natural exit cannot hide
+	// cancellation and incorrectly retain a successful command result.
+	return errors.Join(supervisionErr, ctx.Err())
 }
 
 type boundedDiagnosticBuffer struct {
+	mu     sync.Mutex
 	prefix []byte
 	suffix []byte
 	total  int
@@ -66,6 +596,8 @@ func newBoundedDiagnosticBuffer(limit int) *boundedDiagnosticBuffer {
 }
 
 func (buffer *boundedDiagnosticBuffer) Write(value []byte) (int, error) {
+	buffer.mu.Lock()
+	defer buffer.mu.Unlock()
 	written := len(value)
 	buffer.total += written
 	prefixLimit := buffer.limit / 2
@@ -88,6 +620,8 @@ func (buffer *boundedDiagnosticBuffer) Write(value []byte) (int, error) {
 }
 
 func (buffer *boundedDiagnosticBuffer) Bytes() []byte {
+	buffer.mu.Lock()
+	defer buffer.mu.Unlock()
 	omitted := buffer.total - len(buffer.prefix) - len(buffer.suffix)
 	if omitted <= 0 {
 		return append(append([]byte(nil), buffer.prefix...), buffer.suffix...)

--- a/install/integrationctl/adapters/process/osrunner.go
+++ b/install/integrationctl/adapters/process/osrunner.go
@@ -17,9 +17,10 @@ import (
 type OS struct{}
 
 type terminationResult struct {
-	leaderStopped bool
-	forcedMembers bool
-	err           error
+	leaderStopped              bool
+	leaderTerminationInitiated bool
+	forcedMembers              bool
+	err                        error
 }
 
 type onceWriteCloser struct {
@@ -300,10 +301,21 @@ func runDuplexMode(ctx context.Context, command ports.Command, exchange func(io.
 		if termination.err != nil {
 			return withDuplexDiagnostic(fmt.Errorf("planned duplex process-tree shutdown failed: %w", errors.Join(termination.err, waitErr)), stderr.Bytes())
 		}
-		if waitErr == nil {
-			return nil
+		if !termination.leaderTerminationInitiated {
+			// An exit status alone cannot establish cleanup causality. The leader
+			// may have exited naturally after the final pre-teardown observation
+			// but before containment took action. Require the platform boundary to
+			// prove it observed a live leader and successfully requested its stop.
+			return withDuplexDiagnostic(errors.Join(errors.New("duplex process exited before planned process-tree shutdown could begin"), waitErr), stderr.Bytes())
 		}
-		if _, expectedTerminationStatus := waitErr.(*exec.ExitError); expectedTerminationStatus {
+		if waitErr == nil {
+			// A clean status proves that the process completed its own exit. In
+			// particular, stdout can reach EOF just before waitid reports the
+			// leader as waitable; accepting that status would let this narrow
+			// exit/teardown race masquerade as runner-requested shutdown.
+			return withDuplexDiagnostic(errors.New("duplex process exited before planned process-tree shutdown could begin"), stderr.Bytes())
+		}
+		if plannedTerminationExitExpected(waitErr) {
 			// The runner caused this status only after the exchange explicitly
 			// requested planned shutdown and containment proved the tree empty.
 			return nil
@@ -377,21 +389,79 @@ func cleanupAttachFailureWithin(attachErr error, terminate func() terminationRes
 func closeContainmentAndWait(closeContainment, wait func() error, timeout time.Duration) error {
 	closeErr := closeContainment()
 	waitErr := boundedProcessWait(func() error {
-		waitErr := wait()
+		processWaitErr := wait()
 		// A close that could not finish while the process was alive (for
 		// example, removal of a populated cgroup) remains owned by the sole
 		// reaper. Retry after Wait so eventual exit also releases containment
 		// resources even when the bounded caller has already returned.
 		if closeErr != nil {
-			return errors.Join(waitErr, closeContainment())
+			if retryErr := closeContainment(); retryErr != nil {
+				return &containmentWaitError{cleanupErr: retryErr, waitErr: processWaitErr}
+			}
 		}
-		return waitErr
+		return processWaitErr
 	}, timeout)
 	if closeErr == nil {
 		// Preserve *exec.ExitError so callers can retain natural exit status.
 		return waitErr
 	}
-	return errors.Join(closeErr, waitErr)
+	return &containmentWaitError{cleanupErr: closeErr, waitErr: waitErr}
+}
+
+// containmentWaitError keeps the process's exact Wait result separate from
+// containment uncertainty.  Its multi-error unwrap preserves errors.Is for
+// cleanup callers, while command-result extraction below only trusts this
+// runner-owned structure (never an arbitrary errors.Join containing an
+// unrelated *exec.ExitError).
+type containmentWaitError struct {
+	cleanupErr error
+	waitErr    error
+}
+
+func (err *containmentWaitError) Error() string {
+	joined := errors.Join(err.cleanupErr, err.waitErr)
+	if joined == nil {
+		return "containment wait failed without a recorded cause"
+	}
+	return joined.Error()
+}
+
+func (err *containmentWaitError) Unwrap() []error {
+	causes := make([]error, 0, 2)
+	if err.cleanupErr != nil {
+		causes = append(causes, err.cleanupErr)
+	}
+	if err.waitErr != nil {
+		causes = append(causes, err.waitErr)
+	}
+	return causes
+}
+
+func splitCommandWaitError(err error) (exitErr *exec.ExitError, cleanupErr error, ok bool) {
+	switch typed := err.(type) {
+	case *exec.ExitError:
+		return typed, nil, true
+	case *containmentWaitError:
+		innerExit, innerCleanup, innerOK := splitCommandWaitError(typed.waitErr)
+		if !innerOK {
+			return nil, nil, false
+		}
+		return innerExit, errors.Join(typed.cleanupErr, innerCleanup), true
+	default:
+		return nil, nil, false
+	}
+}
+
+func commandResultFromWait(waitErr error, stdout, stderr []byte) (ports.CommandResult, error, bool) {
+	exitErr, cleanupErr, ok := splitCommandWaitError(waitErr)
+	if !ok {
+		return ports.CommandResult{}, nil, false
+	}
+	result := ports.CommandResult{ExitCode: exitErr.ExitCode(), Stdout: stdout, Stderr: stderr}
+	if cleanupErr != nil {
+		return result, withDuplexDiagnostic(fmt.Errorf("close supervised process containment: %w", cleanupErr), stderr), true
+	}
+	return result, nil, true
 }
 
 func boundedProcessWait(wait func() error, timeout time.Duration) error {
@@ -466,9 +536,9 @@ func runCommand(ctx context.Context, cmd ports.Command, treeExitGrace time.Durat
 	}
 	// Every production command is explicitly supervised. Even commands that are
 	// nominally diagnostic can load client configuration and start helpers, and
-	// lifecycle commands can mutate or acquire state. On Linux the containment
-	// constructor uses CLONE_INTO_CGROUP, so there is no post-Start sampling
-	// window in which a descendant can escape.
+	// lifecycle commands can mutate or acquire state. Ordinary trusted commands
+	// retain bounded platform tree/process-group cleanup; strict duplex commands
+	// use the separate fail-closed containment constructor above.
 	return runExplicit(ctx, cmd, treeExitGrace, processGroupOnly)
 }
 
@@ -476,12 +546,15 @@ func runExplicit(ctx context.Context, command ports.Command, treeExitGrace time.
 	c := exec.Command(command.Argv[0], command.Argv[1:]...)
 	c.Env = command.Env
 	c.Dir = command.Dir
-	c.WaitDelay = 100 * time.Millisecond
+	// Reuse the runner's bounded reap deadline for inherited I/O descriptors.
+	// A shorter independent delay can report exec.ErrWaitDelay for a rapid,
+	// otherwise clean command when its copy goroutines are briefly descheduled.
+	c.WaitDelay = processReapTimeout
 	var stdout bytes.Buffer
 	stderr := newBoundedDiagnosticBuffer(32 * 1024)
 	c.Stdout = &stdout
 	c.Stderr = stderr
-	containment, err := newCommandContainment(c)
+	containment, err := newOrdinaryCommandContainment(c, treeExitGrace)
 	if err != nil {
 		return ports.CommandResult{}, err
 	}
@@ -545,16 +618,32 @@ func runExplicit(ctx context.Context, command ports.Command, treeExitGrace time.
 	if termination.forcedMembers {
 		return ports.CommandResult{}, withDuplexDiagnostic(errors.Join(fmt.Errorf("process left live descendants that required forced cleanup"), termination.err, waitErr), stderr.Bytes())
 	}
-	if termination.err != nil {
-		return ports.CommandResult{}, withDuplexDiagnostic(joinCleanupAndWaitError("terminate supervised process", termination.err, waitErr), stderr.Bytes())
+	return finishExplicitCommand(termination.err, waitErr, stdout.Bytes(), stderr.Bytes())
+}
+
+func finishExplicitCommand(terminationErr, waitErr error, stdout, stderr []byte) (ports.CommandResult, error) {
+	// Termination and close failures are runner-owned cleanup causes. Keep them
+	// structurally separate from Wait so an exact natural *exec.ExitError can be
+	// trusted without accepting an arbitrary joined error supplied by a caller.
+	trustedWaitErr := waitErr
+	if terminationErr != nil {
+		trustedWaitErr = &containmentWaitError{
+			cleanupErr: fmt.Errorf("terminate supervised process: %w", terminationErr),
+			waitErr:    waitErr,
+		}
 	}
-	if waitErr == nil {
-		return ports.CommandResult{ExitCode: 0, Stdout: stdout.Bytes()}, nil
+	if trustedWaitErr != nil {
+		if result, resultErr, ok := commandResultFromWait(trustedWaitErr, stdout, stderr); ok {
+			return result, resultErr
+		}
 	}
-	if exitErr, ok := waitErr.(*exec.ExitError); ok {
-		return ports.CommandResult{ExitCode: exitErr.ExitCode(), Stdout: stdout.Bytes(), Stderr: stderr.Bytes()}, nil
+	if terminationErr != nil {
+		return ports.CommandResult{}, withDuplexDiagnostic(joinCleanupAndWaitError("terminate supervised process", terminationErr, waitErr), stderr)
 	}
-	return ports.CommandResult{}, waitErr
+	if waitErr != nil {
+		return ports.CommandResult{}, waitErr
+	}
+	return ports.CommandResult{ExitCode: 0, Stdout: stdout}, nil
 }
 
 func joinCleanupAndWaitError(operation string, cleanupErr, waitErr error) error {

--- a/install/integrationctl/adapters/process/osrunner.go
+++ b/install/integrationctl/adapters/process/osrunner.go
@@ -609,16 +609,17 @@ func runExplicit(ctx context.Context, command ports.Command, treeExitGrace time.
 	// first, then give the sole reaper durable ownership while bounding caller
 	// return; no second Wait or Process.Release may abandon a future zombie.
 	waitErr := closeContainmentAndWait(closeContainment, c.Wait, processReapTimeout)
+	capturedResult, capturedErr := finishExplicitCommand(termination.err, waitErr, stdout.Bytes(), stderr.Bytes())
 	if supervisionErr != nil {
-		return ports.CommandResult{}, withDuplexDiagnostic(errors.Join(supervisionErr, termination.err, waitErr), stderr.Bytes())
+		return capturedResult, withDuplexDiagnostic(errors.Join(supervisionErr, capturedErr), stderr.Bytes())
 	}
 	if ctxErr := ctx.Err(); ctxErr != nil {
-		return ports.CommandResult{}, withDuplexDiagnostic(errors.Join(ctxErr, termination.err, waitErr), stderr.Bytes())
+		return capturedResult, withDuplexDiagnostic(errors.Join(ctxErr, capturedErr), stderr.Bytes())
 	}
 	if termination.forcedMembers {
-		return ports.CommandResult{}, withDuplexDiagnostic(errors.Join(fmt.Errorf("process left live descendants that required forced cleanup"), termination.err, waitErr), stderr.Bytes())
+		return capturedResult, withDuplexDiagnostic(errors.Join(fmt.Errorf("process left live descendants that required forced cleanup"), capturedErr), stderr.Bytes())
 	}
-	return finishExplicitCommand(termination.err, waitErr, stdout.Bytes(), stderr.Bytes())
+	return capturedResult, capturedErr
 }
 
 func finishExplicitCommand(terminationErr, waitErr error, stdout, stderr []byte) (ports.CommandResult, error) {
@@ -638,12 +639,13 @@ func finishExplicitCommand(terminationErr, waitErr error, stdout, stderr []byte)
 		}
 	}
 	if terminationErr != nil {
-		return ports.CommandResult{}, withDuplexDiagnostic(joinCleanupAndWaitError("terminate supervised process", terminationErr, waitErr), stderr)
+		result := ports.CommandResult{ExitCode: 0, Stdout: stdout, Stderr: stderr}
+		return result, withDuplexDiagnostic(joinCleanupAndWaitError("terminate supervised process", terminationErr, waitErr), stderr)
 	}
 	if waitErr != nil {
 		return ports.CommandResult{}, waitErr
 	}
-	return ports.CommandResult{ExitCode: 0, Stdout: stdout}, nil
+	return ports.CommandResult{ExitCode: 0, Stdout: stdout, Stderr: stderr}, nil
 }
 
 func joinCleanupAndWaitError(operation string, cleanupErr, waitErr error) error {

--- a/install/integrationctl/adapters/process/osrunner.go
+++ b/install/integrationctl/adapters/process/osrunner.go
@@ -242,7 +242,9 @@ func runDuplexMode(ctx context.Context, command ports.Command, exchange func(io.
 
 	earlyExit := exited && (!exchangeDone || plannedShutdownEnabled)
 	plannedShutdown := plannedShutdownEnabled && exchangeDone && exchangeErr == nil && supervisionErr == nil && !exited
-	_ = stdin.Close()
+	if !plannedShutdown {
+		_ = stdin.Close()
+	}
 	forced := false
 	if plannedShutdown {
 		// The successful exchange explicitly established the protocol's success
@@ -272,6 +274,14 @@ func runDuplexMode(ctx context.Context, command ports.Command, exchange func(io.
 		if !termination.leaderStopped && !exited {
 			termination = stopLeaderAfterContainmentFailure(termination, cmd.Process.Kill, containment.exited)
 		}
+	}
+	if plannedShutdown {
+		// Keep stdin open until containment has initiated and proved the requested
+		// termination. Closing it first lets an EOF-driven protocol process exit
+		// naturally in the scheduling gap and destroys planned-shutdown causality.
+		// The close remains unconditional after the bounded termination attempt so
+		// every return path releases the runner-owned pipe.
+		_ = stdin.Close()
 	}
 	_ = stdout.Close()
 	// Every successfully started leader has exactly one owned Wait. Even when
@@ -437,27 +447,33 @@ func (err *containmentWaitError) Unwrap() []error {
 	return causes
 }
 
-func splitCommandWaitError(err error) (exitErr *exec.ExitError, cleanupErr error, ok bool) {
+func splitCommandWaitError(err error) (exitCode int, cleanupErr error, ok bool) {
 	switch typed := err.(type) {
 	case *exec.ExitError:
-		return typed, nil, true
+		return typed.ExitCode(), nil, true
 	case *containmentWaitError:
-		innerExit, innerCleanup, innerOK := splitCommandWaitError(typed.waitErr)
-		if !innerOK {
-			return nil, nil, false
+		// A nil Wait result is the exact natural zero status. Preserve it when a
+		// runner-owned containment diagnostic is wrapped around that successful
+		// reap, just as the nonzero *exec.ExitError path is preserved below.
+		if typed.waitErr == nil {
+			return 0, typed.cleanupErr, true
 		}
-		return innerExit, errors.Join(typed.cleanupErr, innerCleanup), true
+		innerExitCode, innerCleanup, innerOK := splitCommandWaitError(typed.waitErr)
+		if !innerOK {
+			return 0, nil, false
+		}
+		return innerExitCode, errors.Join(typed.cleanupErr, innerCleanup), true
 	default:
-		return nil, nil, false
+		return 0, nil, false
 	}
 }
 
 func commandResultFromWait(waitErr error, stdout, stderr []byte) (ports.CommandResult, error, bool) {
-	exitErr, cleanupErr, ok := splitCommandWaitError(waitErr)
+	exitCode, cleanupErr, ok := splitCommandWaitError(waitErr)
 	if !ok {
 		return ports.CommandResult{}, nil, false
 	}
-	result := ports.CommandResult{ExitCode: exitErr.ExitCode(), Stdout: stdout, Stderr: stderr}
+	result := ports.CommandResult{ExitCode: exitCode, Stdout: stdout, Stderr: stderr}
 	if cleanupErr != nil {
 		return result, withDuplexDiagnostic(fmt.Errorf("close supervised process containment: %w", cleanupErr), stderr), true
 	}
@@ -550,9 +566,9 @@ func runExplicit(ctx context.Context, command ports.Command, treeExitGrace time.
 	// A shorter independent delay can report exec.ErrWaitDelay for a rapid,
 	// otherwise clean command when its copy goroutines are briefly descheduled.
 	c.WaitDelay = processReapTimeout
-	var stdout bytes.Buffer
+	stdout := newSynchronizedOutputBuffer()
 	stderr := newBoundedDiagnosticBuffer(32 * 1024)
-	c.Stdout = &stdout
+	c.Stdout = stdout
 	c.Stderr = stderr
 	containment, err := newOrdinaryCommandContainment(c, treeExitGrace)
 	if err != nil {
@@ -672,6 +688,30 @@ func superviseExplicit(ctx context.Context, poll <-chan time.Time, exited func()
 	// scheduling turn. Re-check after observation so a natural exit cannot hide
 	// cancellation and incorrectly retain a successful command result.
 	return errors.Join(supervisionErr, ctx.Err())
+}
+
+// synchronizedOutputBuffer allows the sole Wait owner and exec's pipe-copy
+// goroutine to outlive the bounded caller without racing a returned result.
+// Bytes always returns an immutable snapshot rather than bytes.Buffer's alias.
+type synchronizedOutputBuffer struct {
+	mu     sync.Mutex
+	buffer bytes.Buffer
+}
+
+func newSynchronizedOutputBuffer() *synchronizedOutputBuffer {
+	return &synchronizedOutputBuffer{}
+}
+
+func (buffer *synchronizedOutputBuffer) Write(value []byte) (int, error) {
+	buffer.mu.Lock()
+	defer buffer.mu.Unlock()
+	return buffer.buffer.Write(value)
+}
+
+func (buffer *synchronizedOutputBuffer) Bytes() []byte {
+	buffer.mu.Lock()
+	defer buffer.mu.Unlock()
+	return append([]byte(nil), buffer.buffer.Bytes()...)
 }
 
 type boundedDiagnosticBuffer struct {

--- a/install/integrationctl/adapters/process/osrunner_duplex_unix_test.go
+++ b/install/integrationctl/adapters/process/osrunner_duplex_unix_test.go
@@ -1,0 +1,49 @@
+//go:build !windows
+
+package process
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/ports"
+)
+
+func TestOSRunnerDuplexPreservesNaturalSIGKILLStatus(t *testing.T) {
+	requireDuplexCapability(t)
+	if os.Getenv("AGENTPLUGINS_PROCESS_NATURAL_SIGKILL_HELPER") == "1" {
+		fmt.Fprintln(os.Stdout, "ready")
+		if line, err := bufio.NewReader(os.Stdin).ReadString('\n'); err != nil || line != "exit\n" {
+			os.Exit(51)
+		}
+		_ = syscall.Kill(os.Getpid(), syscall.SIGKILL)
+		os.Exit(52)
+	}
+	environment := append(os.Environ(), "AGENTPLUGINS_PROCESS_NATURAL_SIGKILL_HELPER=1")
+	err := (OS{}).RunDuplex(context.Background(), ports.Command{
+		Argv: []string{os.Args[0], "-test.run=TestOSRunnerDuplexPreservesNaturalSIGKILLStatus"}, Env: environment,
+	}, func(stdin io.Writer, stdout io.Reader) error {
+		reader := bufio.NewReader(stdout)
+		if line, err := reader.ReadString('\n'); err != nil || line != "ready\n" {
+			return fmt.Errorf("ready barrier = %q: %w", line, err)
+		}
+		if _, err := io.WriteString(stdin, "exit\n"); err != nil {
+			return err
+		}
+		_, err := reader.ReadByte()
+		if !errors.Is(err, io.EOF) {
+			return fmt.Errorf("natural exit barrier: %w", err)
+		}
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "signal: killed") {
+		t.Fatalf("error = %v, want unsuppressed natural SIGKILL status", err)
+	}
+}

--- a/install/integrationctl/adapters/process/osrunner_test.go
+++ b/install/integrationctl/adapters/process/osrunner_test.go
@@ -1,16 +1,38 @@
 package process
 
 import (
+	"bufio"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/ports"
 )
 
+type noopDuplexCommandContainment struct{}
+
+func (*noopDuplexCommandContainment) attach(*exec.Cmd) error { return nil }
+
+func (*noopDuplexCommandContainment) terminate() terminationResult {
+	return terminationResult{leaderStopped: true}
+}
+
+func (*noopDuplexCommandContainment) exited() (bool, error) { return false, nil }
+
+func (*noopDuplexCommandContainment) close() error { return nil }
+
+func successfulNoopDuplexContainment(*exec.Cmd) (duplexCommandContainment, error) {
+	return &noopDuplexCommandContainment{}, nil
+}
+
 func TestOSRunnerPreservesCommandOutputAndExitCode(t *testing.T) {
+	requireDuplexCapability(t)
 	if os.Getenv("AGENTPLUGINS_PROCESS_OUTPUT_HELPER") == "1" {
 		fmt.Fprint(os.Stdout, "expected stdout")
 		fmt.Fprint(os.Stderr, "expected stderr")
@@ -29,7 +51,649 @@ func TestOSRunnerPreservesCommandOutputAndExitCode(t *testing.T) {
 	}
 }
 
+func TestOSRunnerCleanExitWithoutOtherGroupMembersRemainsSuccess(t *testing.T) {
+	requireDuplexCapability(t)
+	if os.Getenv("AGENTPLUGINS_PROCESS_CLEAN_EXIT_HELPER") == "1" {
+		fmt.Fprint(os.Stdout, "clean")
+		os.Exit(0)
+	}
+	environment := append(os.Environ(), "AGENTPLUGINS_PROCESS_CLEAN_EXIT_HELPER=1")
+	result, err := (OS{}).Run(context.Background(), ports.Command{
+		Argv: []string{os.Args[0], "-test.run=TestOSRunnerCleanExitWithoutOtherGroupMembersRemainsSuccess"}, Env: environment,
+	})
+	if err != nil || result.ExitCode != 0 || string(result.Stdout) != "clean" {
+		t.Fatalf("result = %+v error = %v, want clean natural success", result, err)
+	}
+}
+
+func TestEdgeTriggeredExitObservationRemainsLatchedThroughTermination(t *testing.T) {
+	var observation latchedExitObservation
+	polls := 0
+	poll := func() (bool, error) {
+		polls++
+		return polls == 1, nil
+	}
+	for phase := 0; phase < 3; phase++ {
+		exited, err := observation.observe(poll)
+		if err != nil || !exited {
+			t.Fatalf("exit observation phase %d = %v, %v; want persistent natural exit", phase, exited, err)
+		}
+	}
+	// Darwin termination observes the leader again after process-group cleanup.
+	// An EV_CLEAR NOTE_EXIT has already been consumed at this point, so this
+	// final observation must use the latch rather than poll the kqueue again.
+	exited, err := observation.observe(poll)
+	if err != nil || !exited || polls != 1 {
+		t.Fatalf("termination observation = %v, %v, polls %d; want one consumed event", exited, err, polls)
+	}
+}
+
+func TestExitObservationDoesNotLatchFailedPoll(t *testing.T) {
+	var observation latchedExitObservation
+	want := errors.New("exit observation failed")
+	polls := 0
+	poll := func() (bool, error) {
+		polls++
+		if polls == 1 {
+			return false, want
+		}
+		return true, nil
+	}
+	if exited, err := observation.observe(poll); exited || !errors.Is(err, want) {
+		t.Fatalf("failed observation = %v, %v", exited, err)
+	}
+	if exited, err := observation.observe(poll); err != nil || !exited {
+		t.Fatalf("successful observation = %v, %v", exited, err)
+	}
+	if exited, err := observation.observe(poll); err != nil || !exited || polls != 2 {
+		t.Fatalf("latched observation = %v, %v, polls %d", exited, err, polls)
+	}
+}
+
+func TestExplicitSupervisionPreservesCancellationAtNaturalExitBoundary(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	poll := make(chan time.Time, 1)
+	poll <- time.Now()
+
+	err := superviseExplicit(ctx, poll, func() (bool, error) {
+		// Deterministically model the select race: the poll case was selected,
+		// then cancellation became observable while the natural exit was checked.
+		cancel()
+		return true, nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("supervision error = %v, want context cancellation at natural-exit boundary", err)
+	}
+}
+
+func TestDuplexGracePreservesCancellationAtNaturalExitBoundary(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	poll := make(chan time.Time, 1)
+	grace := make(chan time.Time)
+	poll <- time.Now()
+
+	exited, err := awaitDuplexExit(ctx, poll, grace, func() (bool, error) {
+		cancel()
+		return true, nil
+	})
+	if !exited || !errors.Is(err, context.Canceled) {
+		t.Fatalf("exited = %v error = %v, want observed exit plus context cancellation", exited, err)
+	}
+}
+
+func TestAttachFailureCleanupWaitsWithoutRedundantLeaderKillAfterContainmentTermination(t *testing.T) {
+	attachErr := errors.New("attach failed")
+	containmentErr := errors.New("containment members incompletely terminated")
+	waitErr := errors.New("wait failed")
+	killCalls := 0
+	waitCalls := 0
+	err := cleanupAttachFailure(attachErr, func() terminationResult {
+		return terminationResult{leaderStopped: true, err: containmentErr}
+	}, func() error {
+		killCalls++
+		return errors.New("redundant leader kill failed")
+	}, func() (bool, error) { return true, nil }, func() error { return nil }, func() error {
+		waitCalls++
+		return waitErr
+	})
+	if killCalls != 0 || waitCalls != 1 || !errors.Is(err, attachErr) || !errors.Is(err, containmentErr) || !errors.Is(err, waitErr) {
+		t.Fatalf("kill calls = %d wait calls = %d error = %v, want no redundant kill and one synchronous wait", killCalls, waitCalls, err)
+	}
+}
+
+func TestAttachFailureCleanupWaitsAfterLeaderFallbackSuccessAndPreservesContainmentError(t *testing.T) {
+	attachErr := errors.New("attach failed")
+	containmentErr := errors.New("containment cleanup failed")
+	waitErr := errors.New("wait failed")
+	waitCalls := 0
+	err := cleanupAttachFailure(attachErr, func() terminationResult { return terminationResult{err: containmentErr} }, func() error { return os.ErrProcessDone }, func() (bool, error) { return true, nil }, func() error { return nil }, func() error {
+		waitCalls++
+		return waitErr
+	})
+	if waitCalls != 1 || !errors.Is(err, attachErr) || !errors.Is(err, containmentErr) || !errors.Is(err, waitErr) {
+		t.Fatalf("wait calls = %d error = %v, want one synchronous wait with attach, containment, and wait errors", waitCalls, err)
+	}
+}
+
+func TestAttachFailureCleanupOwnsSoleWaitWhenLeaderStopCannotBeProven(t *testing.T) {
+	attachErr := errors.New("attach failed")
+	containmentErr := errors.New("containment cleanup failed")
+	killErr := errors.New("leader kill failed")
+	waitCalls := 0
+	waitRelease := make(chan struct{})
+	waitStarted := make(chan struct{})
+	ownedCleanupDone := make(chan struct{})
+	closeCalls := 0
+	closeErr := errors.New("containment close blocked by live process")
+	defer func() {
+		close(waitRelease)
+		select {
+		case <-ownedCleanupDone:
+		case <-time.After(time.Second):
+			t.Fatal("owned sole Wait did not finish containment cleanup after simulated process exit")
+		}
+	}()
+	timeout := 10 * time.Millisecond
+	started := time.Now()
+	err := cleanupAttachFailureWithin(attachErr, func() terminationResult { return terminationResult{err: containmentErr} }, func() error { return killErr }, func() (bool, error) { return false, nil }, func() error {
+		closeCalls++
+		if closeCalls == 1 {
+			return closeErr
+		}
+		close(ownedCleanupDone)
+		return nil
+	}, func() error {
+		waitCalls++
+		close(waitStarted)
+		<-waitRelease
+		return nil
+	}, timeout)
+	<-waitStarted
+	if elapsed := time.Since(started); elapsed < timeout || elapsed > time.Second {
+		t.Fatalf("failed termination cleanup duration = %s, want genuine %s bound", elapsed, timeout)
+	}
+	if waitCalls != 1 || closeCalls != 1 || !errors.Is(err, attachErr) || !errors.Is(err, containmentErr) || !errors.Is(err, killErr) || !errors.Is(err, closeErr) || !strings.Contains(err.Error(), "sole reaper retains ownership until process exit") {
+		t.Fatalf("wait calls = %d error = %v, want bounded cleanup with one retained Wait and all failure causes", waitCalls, err)
+	}
+}
+
+func TestBoundedProcessWaitReturnsAtTheRealDeadline(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+	started := time.Now()
+	err := boundedProcessWait(func() error {
+		<-release
+		return nil
+	}, time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "exceeded cleanup deadline") {
+		t.Fatalf("error = %v, want real bounded deadline", err)
+	}
+	if elapsed := time.Since(started); elapsed > 100*time.Millisecond {
+		t.Fatalf("bounded wait returned too slowly after %s", elapsed)
+	}
+}
+
+func TestCleanupFailurePreservesNaturalLeaderExitStatus(t *testing.T) {
+	cleanupErr := errors.New("containment cleanup failed")
+	waitErr := errors.New("leader exited with status 47")
+	err := joinCleanupAndWaitError("terminate supervised process", cleanupErr, waitErr)
+	if !errors.Is(err, cleanupErr) || !errors.Is(err, waitErr) {
+		t.Fatalf("cleanup error = %v, want both cleanup and natural wait status", err)
+	}
+}
+
+func TestAttachFailureClosesContainmentBeforeStartingWait(t *testing.T) {
+	closed := false
+	err := cleanupAttachFailure(errors.New("attach failed"), func() terminationResult {
+		return terminationResult{leaderStopped: true}
+	}, func() error {
+		t.Fatal("leader kill must not be repeated")
+		return nil
+	}, func() (bool, error) { return true, nil }, func() error {
+		closed = true
+		return nil
+	}, func() error {
+		if !closed {
+			t.Fatal("Wait started before containment closed")
+		}
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "attach failed") {
+		t.Fatalf("error = %v, want attach failure", err)
+	}
+}
+
+func TestBoundedDiagnosticBufferSupportsConcurrentWaitTimeoutDiagnostics(t *testing.T) {
+	buffer := newBoundedDiagnosticBuffer(1024)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 1000 {
+			_, _ = buffer.Write([]byte("diagnostic"))
+		}
+	}()
+	for range 1000 {
+		_ = buffer.Bytes()
+	}
+	<-done
+}
+
+func TestOSRunnerDuplexReportsForcedShutdownAfterSuccessfulExchange(t *testing.T) {
+	requireDuplexCapability(t)
+	if os.Getenv("AGENTPLUGINS_PROCESS_DUPLEX_HELPER") == "1" {
+		reader := bufio.NewReader(os.Stdin)
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			os.Exit(8)
+		}
+		fmt.Fprint(os.Stdout, line)
+		for {
+			time.Sleep(time.Hour)
+		}
+	}
+	environment := append([]string(nil), os.Environ()...)
+	environment = append(environment, "AGENTPLUGINS_PROCESS_DUPLEX_HELPER=1")
+	err := (OS{}).RunDuplex(context.Background(), ports.Command{
+		Argv: []string{os.Args[0], "-test.run=TestOSRunnerDuplexReportsForcedShutdownAfterSuccessfulExchange"}, Env: environment,
+	}, func(stdin io.Writer, stdout io.Reader) error {
+		if _, err := io.WriteString(stdin, "request\n"); err != nil {
+			return err
+		}
+		line, err := bufio.NewReader(stdout).ReadString('\n')
+		if err != nil {
+			return err
+		}
+		if line != "request\n" {
+			return fmt.Errorf("duplex response = %q", line)
+		}
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "required forced supervised cleanup") {
+		t.Fatalf("forced long-lived shutdown error = %v, want explicit cleanup failure", err)
+	}
+}
+
+func TestOSRunnerDuplexPlannedShutdownAcceptsOnlyRequestedLongLivedCleanup(t *testing.T) {
+	requireDuplexCapability(t)
+	if os.Getenv("AGENTPLUGINS_PROCESS_PLANNED_DUPLEX_HELPER") == "1" {
+		line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		if err != nil {
+			os.Exit(8)
+		}
+		fmt.Fprint(os.Stdout, line)
+		for {
+			time.Sleep(time.Hour)
+		}
+	}
+	environment := append(os.Environ(), "AGENTPLUGINS_PROCESS_PLANNED_DUPLEX_HELPER=1")
+	err := (OS{}).RunDuplexWithPlannedShutdown(context.Background(), ports.Command{
+		Argv: []string{os.Args[0], "-test.run=TestOSRunnerDuplexPlannedShutdownAcceptsOnlyRequestedLongLivedCleanup"}, Env: environment,
+	}, func(stdin io.Writer, stdout io.Reader) error {
+		if _, err := io.WriteString(stdin, "verified\n"); err != nil {
+			return err
+		}
+		line, err := bufio.NewReader(stdout).ReadString('\n')
+		if err != nil {
+			return err
+		}
+		if line != "verified\n" {
+			return fmt.Errorf("duplex response = %q", line)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("explicitly planned long-lived shutdown failed: %v", err)
+	}
+}
+
+func TestOSRunnerDuplexPlannedShutdownRejectsExitBeforeTeardownRequest(t *testing.T) {
+	requireDuplexCapability(t)
+	if os.Getenv("AGENTPLUGINS_PROCESS_PREMATURE_PLANNED_HELPER") == "1" {
+		fmt.Fprintln(os.Stdout, "verified")
+		os.Exit(0)
+	}
+	environment := append(os.Environ(), "AGENTPLUGINS_PROCESS_PREMATURE_PLANNED_HELPER=1")
+	err := (OS{}).RunDuplexWithPlannedShutdown(context.Background(), ports.Command{
+		Argv: []string{os.Args[0], "-test.run=TestOSRunnerDuplexPlannedShutdownRejectsExitBeforeTeardownRequest"}, Env: environment,
+	}, func(_ io.Writer, stdout io.Reader) error {
+		body, err := io.ReadAll(stdout)
+		if err != nil {
+			return err
+		}
+		if string(body) != "verified\n" {
+			return fmt.Errorf("duplex response = %q", body)
+		}
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "exited before planned process-tree shutdown") {
+		t.Fatalf("premature planned-process exit error = %v", err)
+	}
+}
+
+func TestOSRunnerDuplexPlannedShutdownDoesNotHideCancellationAtProofBoundary(t *testing.T) {
+	requireDuplexCapability(t)
+	if os.Getenv("AGENTPLUGINS_PROCESS_CANCELED_PLANNED_HELPER") == "1" {
+		line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		if err != nil {
+			os.Exit(8)
+		}
+		fmt.Fprint(os.Stdout, line)
+		for {
+			time.Sleep(time.Hour)
+		}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	environment := append(os.Environ(), "AGENTPLUGINS_PROCESS_CANCELED_PLANNED_HELPER=1")
+	err := (OS{}).RunDuplexWithPlannedShutdown(ctx, ports.Command{
+		Argv: []string{os.Args[0], "-test.run=TestOSRunnerDuplexPlannedShutdownDoesNotHideCancellationAtProofBoundary"}, Env: environment,
+	}, func(stdin io.Writer, stdout io.Reader) error {
+		if _, err := io.WriteString(stdin, "verified\n"); err != nil {
+			return err
+		}
+		if line, err := bufio.NewReader(stdout).ReadString('\n'); err != nil || line != "verified\n" {
+			return fmt.Errorf("duplex response = %q: %w", line, err)
+		}
+		cancel()
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("planned-shutdown cancellation error = %v, want context cancellation", err)
+	}
+}
+
+func TestOSRunnerDuplexOutputPipeFailureDoesNotAllocateStdinPipe(t *testing.T) {
+	want := errors.New("forced stdout pipe allocation failure")
+	stdinCalls := 0
+	err := runDuplex(context.Background(), ports.Command{Argv: []string{"unused"}}, func(io.Writer, io.Reader) error {
+		return nil
+	}, duplexPipeFactory{
+		output: func() (*os.File, *os.File, error) { return nil, nil, want },
+		input: func(*exec.Cmd) (io.WriteCloser, error) {
+			stdinCalls++
+			return nil, errors.New("stdin must not be allocated")
+		},
+	})
+	if !errors.Is(err, want) || stdinCalls != 0 {
+		t.Fatalf("error = %v stdin allocations = %d, want output failure before stdin allocation", err, stdinCalls)
+	}
+}
+
+func TestOSRunnerDuplexOutputPipeFailureClosesReturnedEndpoints(t *testing.T) {
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := errors.New("forced partial stdout pipe allocation failure")
+	err = runDuplex(context.Background(), ports.Command{Argv: []string{"unused"}}, func(io.Writer, io.Reader) error {
+		return nil
+	}, duplexPipeFactory{
+		output: func() (*os.File, *os.File, error) { return readPipe, writePipe, want },
+		input: func(*exec.Cmd) (io.WriteCloser, error) {
+			t.Fatal("stdin must not be allocated after output allocation failure")
+			return nil, nil
+		},
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("error = %v, want output allocation failure", err)
+	}
+	if _, readErr := readPipe.Read(make([]byte, 1)); !errors.Is(readErr, os.ErrClosed) {
+		t.Fatalf("returned output reader remains open: %v", readErr)
+	}
+	if _, writeErr := writePipe.Write([]byte("x")); !errors.Is(writeErr, os.ErrClosed) {
+		t.Fatalf("returned output writer remains open: %v", writeErr)
+	}
+}
+
+func TestOSRunnerDuplexRepeatedContainmentFailureDoesNotAllocateOrLeakPipeDescriptors(t *testing.T) {
+	want := errors.New("forced containment allocation failure")
+	stdinCalls := 0
+	const attempts = 128
+	for attempt := 0; attempt < attempts; attempt++ {
+		var readPipe, writePipe *os.File
+		err := runDuplex(context.Background(), ports.Command{Argv: []string{"unused"}}, func(io.Writer, io.Reader) error {
+			return nil
+		}, duplexPipeFactory{
+			output: func() (*os.File, *os.File, error) {
+				var err error
+				readPipe, writePipe, err = os.Pipe()
+				return readPipe, writePipe, err
+			},
+			input: func(cmd *exec.Cmd) (io.WriteCloser, error) {
+				stdinCalls++
+				return cmd.StdinPipe()
+			},
+			containment: func(*exec.Cmd) (duplexCommandContainment, error) { return nil, want },
+		})
+		if !errors.Is(err, want) {
+			t.Fatalf("attempt %d error = %v, want containment failure", attempt, err)
+		}
+		if _, err := readPipe.Read(make([]byte, 1)); !errors.Is(err, os.ErrClosed) {
+			t.Fatalf("attempt %d retained output reader descriptor: %v", attempt, err)
+		}
+		if _, err := writePipe.Write([]byte("x")); !errors.Is(err, os.ErrClosed) {
+			t.Fatalf("attempt %d retained output writer descriptor: %v", attempt, err)
+		}
+	}
+	if stdinCalls != 0 {
+		t.Fatalf("stdin pipe allocations = %d, want zero before repeated containment failures", stdinCalls)
+	}
+}
+
+func TestOSRunnerDuplexStdinPipeFailureClosesOwnedOutputEndpoints(t *testing.T) {
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := errors.New("forced stdin pipe allocation failure")
+	err = runDuplex(context.Background(), ports.Command{Argv: []string{"unused"}}, func(io.Writer, io.Reader) error {
+		return nil
+	}, duplexPipeFactory{
+		output:      func() (*os.File, *os.File, error) { return readPipe, writePipe, nil },
+		input:       func(*exec.Cmd) (io.WriteCloser, error) { return nil, want },
+		containment: successfulNoopDuplexContainment,
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("error = %v, want stdin allocation failure", err)
+	}
+	if _, readErr := readPipe.Read(make([]byte, 1)); !errors.Is(readErr, os.ErrClosed) {
+		t.Fatalf("owned output reader remains open: %v", readErr)
+	}
+	if _, writeErr := writePipe.Write([]byte("x")); !errors.Is(writeErr, os.ErrClosed) {
+		t.Fatalf("owned output writer remains open: %v", writeErr)
+	}
+}
+
+func TestOSRunnerDuplexStdinPipeFailureClosesReturnedStdinEndpoint(t *testing.T) {
+	readOutput, writeOutput, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	readInput, writeInput, err := os.Pipe()
+	if err != nil {
+		_ = readOutput.Close()
+		_ = writeOutput.Close()
+		t.Fatal(err)
+	}
+	defer readInput.Close()
+	want := errors.New("forced partial stdin pipe allocation failure")
+	err = runDuplex(context.Background(), ports.Command{Argv: []string{"unused"}}, func(io.Writer, io.Reader) error {
+		return nil
+	}, duplexPipeFactory{
+		output:      func() (*os.File, *os.File, error) { return readOutput, writeOutput, nil },
+		input:       func(*exec.Cmd) (io.WriteCloser, error) { return writeInput, want },
+		containment: successfulNoopDuplexContainment,
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("error = %v, want stdin allocation failure", err)
+	}
+	if _, writeErr := writeInput.Write([]byte("x")); !errors.Is(writeErr, os.ErrClosed) {
+		t.Fatalf("returned stdin writer remains open: %v", writeErr)
+	}
+	if _, readErr := readOutput.Read(make([]byte, 1)); !errors.Is(readErr, os.ErrClosed) {
+		t.Fatalf("owned output reader remains open: %v", readErr)
+	}
+	if _, writeErr := writeOutput.Write([]byte("x")); !errors.Is(writeErr, os.ErrClosed) {
+		t.Fatalf("owned output writer remains open: %v", writeErr)
+	}
+}
+
+func TestOSRunnerDuplexClosesStdinAndPreservesCleanExit(t *testing.T) {
+	requireDuplexCapability(t)
+	if os.Getenv("AGENTPLUGINS_PROCESS_DUPLEX_CLEAN_HELPER") == "1" {
+		reader := bufio.NewReader(os.Stdin)
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			os.Exit(40)
+		}
+		fmt.Fprint(os.Stdout, line)
+		if _, err := reader.ReadByte(); !errors.Is(err, io.EOF) {
+			os.Exit(41)
+		}
+		os.Exit(0)
+	}
+	environment := append(os.Environ(), "AGENTPLUGINS_PROCESS_DUPLEX_CLEAN_HELPER=1")
+	err := (OS{}).RunDuplex(context.Background(), ports.Command{
+		Argv: []string{os.Args[0], "-test.run=TestOSRunnerDuplexClosesStdinAndPreservesCleanExit"}, Env: environment,
+	}, func(stdin io.Writer, stdout io.Reader) error {
+		if _, err := io.WriteString(stdin, "request\n"); err != nil {
+			return err
+		}
+		line, err := bufio.NewReader(stdout).ReadString('\n')
+		if err != nil || line != "request\n" {
+			return fmt.Errorf("duplex response = %q: %w", line, err)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOSRunnerDuplexReturnsNaturalChildExitAndDiagnostic(t *testing.T) {
+	requireDuplexCapability(t)
+	if os.Getenv("AGENTPLUGINS_PROCESS_DUPLEX_EXIT_HELPER") == "1" {
+		fmt.Fprintln(os.Stdout, "connected")
+		if line, err := bufio.NewReader(os.Stdin).ReadString('\n'); err != nil || line != "exit\n" {
+			os.Exit(22)
+		}
+		fmt.Fprint(os.Stderr, "fatal after connected")
+		os.Exit(23)
+	}
+	environment := append([]string(nil), os.Environ()...)
+	environment = append(environment, "AGENTPLUGINS_PROCESS_DUPLEX_EXIT_HELPER=1")
+	err := (OS{}).RunDuplex(context.Background(), ports.Command{
+		Argv: []string{os.Args[0], "-test.run=TestOSRunnerDuplexReturnsNaturalChildExitAndDiagnostic"}, Env: environment,
+	}, func(stdin io.Writer, stdout io.Reader) error {
+		reader := bufio.NewReader(stdout)
+		line, err := reader.ReadString('\n')
+		if err != nil || line != "connected\n" {
+			return fmt.Errorf("duplex response = %q: %w", line, err)
+		}
+		// The stdin/stdout handoff is a deterministic barrier: the child cannot
+		// exit until the exchange releases it, and the exchange cannot return
+		// until the child's stdout closes. Thus Wait and exchange completion are
+		// both ready at the cleanup scheduling boundary.
+		if _, err := io.WriteString(stdin, "exit\n"); err != nil {
+			return err
+		}
+		if _, err := reader.ReadByte(); !errors.Is(err, io.EOF) {
+			return fmt.Errorf("wait for natural exit barrier: %w", err)
+		}
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "exit status 23") || !strings.Contains(err.Error(), "fatal after connected") {
+		t.Fatalf("error = %v, want child exit status and fatal diagnostic", err)
+	}
+}
+
+func TestOSRunnerDuplexLeaderExitWithInheritedPipeGroupMemberDoesNotHang(t *testing.T) {
+	requireDuplexCapability(t)
+	if os.Getenv("AGENTPLUGINS_PROCESS_INHERITED_PIPE_GRANDCHILD") == "1" {
+		for {
+			time.Sleep(time.Hour)
+		}
+	}
+	if os.Getenv("AGENTPLUGINS_PROCESS_INHERITED_PIPE_LEADER") == "1" {
+		grandchild := exec.Command(os.Args[0], "-test.run=TestOSRunnerDuplexLeaderExitWithInheritedPipeGroupMemberDoesNotHang")
+		grandchild.Env = append(os.Environ(), "AGENTPLUGINS_PROCESS_INHERITED_PIPE_GRANDCHILD=1")
+		grandchild.Stdout = os.Stdout
+		grandchild.Stderr = os.Stderr
+		if err := grandchild.Start(); err != nil {
+			os.Exit(31)
+		}
+		fmt.Fprintln(os.Stdout, "leader-exiting")
+		os.Exit(0)
+	}
+
+	environment := append(os.Environ(), "AGENTPLUGINS_PROCESS_INHERITED_PIPE_LEADER=1")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	started := time.Now()
+	err := (OS{}).RunDuplex(ctx, ports.Command{
+		Argv: []string{os.Args[0], "-test.run=TestOSRunnerDuplexLeaderExitWithInheritedPipeGroupMemberDoesNotHang"}, Env: environment,
+	}, func(_ io.Writer, stdout io.Reader) error {
+		reader := bufio.NewReader(stdout)
+		if line, readErr := reader.ReadString('\n'); readErr != nil || line != "leader-exiting\n" {
+			return fmt.Errorf("leader barrier = %q: %w", line, readErr)
+		}
+		_, readErr := reader.ReadByte()
+		return readErr
+	})
+	if err == nil || errors.Is(err, context.DeadlineExceeded) || !strings.Contains(err.Error(), "live descendants that required forced cleanup") {
+		t.Fatalf("error = %v, want prompt natural-exit process-group cleanup failure", err)
+	}
+	if elapsed := time.Since(started); elapsed >= 1500*time.Millisecond {
+		t.Fatalf("inherited output pipe was not unblocked promptly: %s", elapsed)
+	}
+}
+
+func TestOSRunnerDuplexPreservesExchangeErrorWhenContextIsCanceled(t *testing.T) {
+	requireDuplexCapability(t)
+	if os.Getenv("AGENTPLUGINS_PROCESS_CANCEL_HELPER") == "1" {
+		for {
+			time.Sleep(time.Hour)
+		}
+	}
+	environment := append([]string(nil), os.Environ()...)
+	environment = append(environment, "AGENTPLUGINS_PROCESS_CANCEL_HELPER=1")
+	ctx, cancel := context.WithCancel(context.Background())
+	negative := errors.New("recognized negative exchange evidence")
+	err := (OS{}).RunDuplex(ctx, ports.Command{
+		Argv: []string{os.Args[0], "-test.run=TestOSRunnerDuplexPreservesExchangeErrorWhenContextIsCanceled"}, Env: environment,
+	}, func(io.Writer, io.Reader) error {
+		cancel()
+		<-ctx.Done()
+		return negative
+	})
+	if !errors.Is(err, negative) || !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want both exchange evidence and context cancellation", err)
+	}
+}
+
+func requireDuplexCapability(t *testing.T) {
+	t.Helper()
+	for _, helper := range []string{
+		"AGENTPLUGINS_PROCESS_DUPLEX_HELPER",
+		"AGENTPLUGINS_PROCESS_DUPLEX_CLEAN_HELPER",
+		"AGENTPLUGINS_PROCESS_DUPLEX_EXIT_HELPER",
+		"AGENTPLUGINS_PROCESS_INHERITED_PIPE_GRANDCHILD",
+		"AGENTPLUGINS_PROCESS_INHERITED_PIPE_LEADER",
+		"AGENTPLUGINS_PROCESS_CANCEL_HELPER",
+		"AGENTPLUGINS_PROCESS_NATURAL_SIGKILL_HELPER",
+		"AGENTPLUGINS_DUPLEX_CGROUP_ESCAPE_CHILD",
+		"AGENTPLUGINS_DUPLEX_CGROUP_ESCAPE_PID",
+	} {
+		if os.Getenv(helper) == "1" {
+			return
+		}
+	}
+	if err := (OS{}).DuplexCapability(); err != nil {
+		t.Skipf("kernel duplex containment is not delegated to this test environment: %v", err)
+	}
+}
+
 func TestOSRunnerBoundsStderrWhileRetainingDiagnosticEdges(t *testing.T) {
+	requireDuplexCapability(t)
 	if os.Getenv("AGENTPLUGINS_PROCESS_STDERR_HELPER") == "1" {
 		fmt.Fprint(os.Stderr, "diagnostic-start:")
 		fmt.Fprint(os.Stderr, strings.Repeat("x", 256*1024))

--- a/install/integrationctl/adapters/process/osrunner_test.go
+++ b/install/integrationctl/adapters/process/osrunner_test.go
@@ -262,9 +262,9 @@ func TestContainmentCloseFailurePreservesExactExitStatusWithoutTrustingArbitrary
 	}
 	err := closeContainmentAndWait(func() error { return cleanupErr }, func() error { return exitErr }, time.Second)
 
-	gotExit, gotCleanup, ok := splitCommandWaitError(err)
-	if !ok || gotExit != exitErr || !errors.Is(gotCleanup, cleanupErr) {
-		t.Fatalf("split result = (%v, %v, %v), want exact exit status and cleanup error", gotExit, gotCleanup, ok)
+	gotExitCode, gotCleanup, ok := splitCommandWaitError(err)
+	if !ok || gotExitCode != exitErr.ExitCode() || !errors.Is(gotCleanup, cleanupErr) {
+		t.Fatalf("split result = (%v, %v, %v), want exact exit status and cleanup error", gotExitCode, gotCleanup, ok)
 	}
 	if _, _, ok := splitCommandWaitError(errors.Join(cleanupErr, exitErr)); ok {
 		t.Fatal("arbitrary joined ExitError was incorrectly trusted as a command wait result")
@@ -306,6 +306,18 @@ func TestExplicitCleanupFailurePreservesNaturalZeroResultAndDiagnostics(t *testi
 	}
 }
 
+func TestContainmentWaitCleanupFailurePreservesNaturalZeroResultAndDiagnostics(t *testing.T) {
+	cleanupErr := errors.New("containment status cleanup failed")
+	waitErr := &containmentWaitError{cleanupErr: cleanupErr, waitErr: nil}
+	result, err, ok := commandResultFromWait(waitErr, []byte("zero-exit output"), []byte("zero-exit diagnostic"))
+	if !ok || result.ExitCode != 0 || string(result.Stdout) != "zero-exit output" || string(result.Stderr) != "zero-exit diagnostic" {
+		t.Fatalf("command result = (%+v, %v), want captured natural-zero result", result, ok)
+	}
+	if !errors.Is(err, cleanupErr) || !strings.Contains(err.Error(), "zero-exit diagnostic") {
+		t.Fatalf("command error = %v, want containment cleanup failure and diagnostic", err)
+	}
+}
+
 func TestAttachFailureClosesContainmentBeforeStartingWait(t *testing.T) {
 	closed := false
 	err := cleanupAttachFailure(errors.New("attach failed"), func() terminationResult {
@@ -340,6 +352,33 @@ func TestBoundedDiagnosticBufferSupportsConcurrentWaitTimeoutDiagnostics(t *test
 		_ = buffer.Bytes()
 	}
 	<-done
+}
+
+func TestSynchronizedOutputSnapshotIsImmutableWhileSoleReaperFinishesLateWrite(t *testing.T) {
+	buffer := newSynchronizedOutputBuffer()
+	if _, err := buffer.Write([]byte("early")); err != nil {
+		t.Fatal(err)
+	}
+	release := make(chan struct{})
+	finished := make(chan struct{})
+	waitErr := boundedProcessWait(func() error {
+		<-release
+		_, _ = buffer.Write([]byte("-late"))
+		close(finished)
+		return nil
+	}, time.Millisecond)
+	if waitErr == nil || !strings.Contains(waitErr.Error(), "sole reaper retains ownership") {
+		t.Fatalf("bounded wait error = %v, want retained late writer", waitErr)
+	}
+	snapshot := buffer.Bytes()
+	close(release)
+	<-finished
+	if string(snapshot) != "early" {
+		t.Fatalf("returned snapshot changed after late write: %q", snapshot)
+	}
+	if current := string(buffer.Bytes()); current != "early-late" {
+		t.Fatalf("current output = %q, want completed late write", current)
+	}
 }
 
 func TestOSRunnerDuplexReportsForcedShutdownAfterSuccessfulExchange(t *testing.T) {

--- a/install/integrationctl/adapters/process/osrunner_test.go
+++ b/install/integrationctl/adapters/process/osrunner_test.go
@@ -295,6 +295,17 @@ func TestExplicitCleanupFailurePreservesNaturalNonzeroResultAndStderr(t *testing
 	}
 }
 
+func TestExplicitCleanupFailurePreservesNaturalZeroResultAndDiagnostics(t *testing.T) {
+	cleanupErr := errors.New("supervisor status cleanup failed")
+	result, err := finishExplicitCommand(cleanupErr, nil, []byte("zero-exit output"), []byte("zero-exit diagnostic"))
+	if result.ExitCode != 0 || string(result.Stdout) != "zero-exit output" || string(result.Stderr) != "zero-exit diagnostic" {
+		t.Fatalf("command result = %+v, want captured zero-exit stdout/stderr", result)
+	}
+	if !errors.Is(err, cleanupErr) || !strings.Contains(err.Error(), "zero-exit diagnostic") {
+		t.Fatalf("command error = %v, want cleanup failure and structured diagnostic", err)
+	}
+}
+
 func TestAttachFailureClosesContainmentBeforeStartingWait(t *testing.T) {
 	closed := false
 	err := cleanupAttachFailure(errors.New("attach failed"), func() terminationResult {

--- a/install/integrationctl/adapters/process/osrunner_test.go
+++ b/install/integrationctl/adapters/process/osrunner_test.go
@@ -31,6 +31,16 @@ func successfulNoopDuplexContainment(*exec.Cmd) (duplexCommandContainment, error
 	return &noopDuplexCommandContainment{}, nil
 }
 
+type naturalExitBoundaryContainment struct{}
+
+func (*naturalExitBoundaryContainment) attach(*exec.Cmd) error { return nil }
+func (*naturalExitBoundaryContainment) terminate() terminationResult {
+	// Model containment finding an already-stopped leader and an empty tree.
+	return terminationResult{leaderStopped: true}
+}
+func (*naturalExitBoundaryContainment) exited() (bool, error) { return false, nil }
+func (*naturalExitBoundaryContainment) close() error          { return nil }
+
 func TestOSRunnerPreservesCommandOutputAndExitCode(t *testing.T) {
 	requireDuplexCapability(t)
 	if os.Getenv("AGENTPLUGINS_PROCESS_OUTPUT_HELPER") == "1" {
@@ -242,6 +252,49 @@ func TestCleanupFailurePreservesNaturalLeaderExitStatus(t *testing.T) {
 	}
 }
 
+func TestContainmentCloseFailurePreservesExactExitStatusWithoutTrustingArbitraryJoin(t *testing.T) {
+	cleanupErr := errors.New("containment cleanup failed")
+	command := exec.Command("/bin/sh", "-c", "exit 47")
+	runErr := command.Run()
+	exitErr, ok := runErr.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("helper error = %v, want *exec.ExitError", runErr)
+	}
+	err := closeContainmentAndWait(func() error { return cleanupErr }, func() error { return exitErr }, time.Second)
+
+	gotExit, gotCleanup, ok := splitCommandWaitError(err)
+	if !ok || gotExit != exitErr || !errors.Is(gotCleanup, cleanupErr) {
+		t.Fatalf("split result = (%v, %v, %v), want exact exit status and cleanup error", gotExit, gotCleanup, ok)
+	}
+	if _, _, ok := splitCommandWaitError(errors.Join(cleanupErr, exitErr)); ok {
+		t.Fatal("arbitrary joined ExitError was incorrectly trusted as a command wait result")
+	}
+	result, resultErr, ok := commandResultFromWait(err, []byte("command output"), []byte("command diagnostic"))
+	if !ok || result.ExitCode != 47 || string(result.Stdout) != "command output" || string(result.Stderr) != "command diagnostic" {
+		t.Fatalf("command result = (%+v, %v), want exact exit code/stdout/stderr", result, ok)
+	}
+	if !errors.Is(resultErr, cleanupErr) || !strings.Contains(resultErr.Error(), "command diagnostic") {
+		t.Fatalf("command error = %v, want cleanup uncertainty and diagnostic", resultErr)
+	}
+}
+
+func TestExplicitCleanupFailurePreservesNaturalNonzeroResultAndStderr(t *testing.T) {
+	cleanupErr := errors.New("supervisor cleanup failed")
+	command := exec.Command("/bin/sh", "-c", "exit 47")
+	waitErr := command.Run()
+	if _, ok := waitErr.(*exec.ExitError); !ok {
+		t.Fatalf("helper error = %v, want *exec.ExitError", waitErr)
+	}
+
+	result, err := finishExplicitCommand(cleanupErr, waitErr, []byte("command output"), []byte("command diagnostic"))
+	if result.ExitCode != 47 || string(result.Stdout) != "command output" || string(result.Stderr) != "command diagnostic" {
+		t.Fatalf("command result = %+v, want exact natural exit code/stdout/stderr", result)
+	}
+	if !errors.Is(err, cleanupErr) || !strings.Contains(err.Error(), "command diagnostic") {
+		t.Fatalf("command error = %v, want supervisor cleanup failure with stderr diagnostic", err)
+	}
+}
+
 func TestAttachFailureClosesContainmentBeforeStartingWait(t *testing.T) {
 	closed := false
 	err := cleanupAttachFailure(errors.New("attach failed"), func() terminationResult {
@@ -367,6 +420,36 @@ func TestOSRunnerDuplexPlannedShutdownRejectsExitBeforeTeardownRequest(t *testin
 	})
 	if err == nil || !strings.Contains(err.Error(), "exited before planned process-tree shutdown") {
 		t.Fatalf("premature planned-process exit error = %v", err)
+	}
+}
+
+func TestOSRunnerDuplexPlannedShutdownRejectsNaturalNonzeroExitAtTeardownBoundary(t *testing.T) {
+	if os.Getenv("AGENTPLUGINS_PROCESS_NATURAL_NONZERO_BOUNDARY_HELPER") == "1" {
+		if _, err := bufio.NewReader(os.Stdin).ReadString('\n'); err != nil {
+			os.Exit(46)
+		}
+		os.Exit(47)
+	}
+	environment := append(os.Environ(), "AGENTPLUGINS_PROCESS_NATURAL_NONZERO_BOUNDARY_HELPER=1")
+	err := runDuplexMode(context.Background(), ports.Command{
+		Argv: []string{os.Args[0], "-test.run=TestOSRunnerDuplexPlannedShutdownRejectsNaturalNonzeroExitAtTeardownBoundary"}, Env: environment,
+	}, func(stdin io.Writer, stdout io.Reader) error {
+		if _, err := io.WriteString(stdin, "verified\n"); err != nil {
+			return err
+		}
+		// EOF proves the helper closed its last inherited output descriptor. The
+		// scripted observer then models the narrow stale pre-teardown poll.
+		_, err := io.ReadAll(stdout)
+		return err
+	}, duplexPipeFactory{
+		output: os.Pipe,
+		input:  func(cmd *exec.Cmd) (io.WriteCloser, error) { return cmd.StdinPipe() },
+		containment: func(*exec.Cmd) (duplexCommandContainment, error) {
+			return &naturalExitBoundaryContainment{}, nil
+		},
+	}, true)
+	if err == nil || !strings.Contains(err.Error(), "exited before planned process-tree shutdown") {
+		t.Fatalf("natural nonzero teardown-boundary exit error = %v", err)
 	}
 }
 

--- a/install/integrationctl/adapters/process/osrunner_tree_darwin.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_darwin.go
@@ -1,0 +1,158 @@
+//go:build darwin
+
+package process
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// Darwin can safely supervise a trusted one-shot command's process group while
+// its unreaped leader keeps the numeric PGID from reuse. It cannot safely
+// signal arbitrary start-time-checked descendant PIDs, so duplex Kiro
+// verification (which must contain possible setsid descendants) fails closed.
+type commandContainment struct {
+	cmd              *exec.Cmd
+	kqueue           int
+	exitObservation  latchedExitObservation
+	liveGroupMembers func(int) (int, error)
+	killGroup        func(int, syscall.Signal) error
+}
+
+func explicitContainmentSupervision() bool { return true }
+
+func duplexContainmentPreflight() error {
+	return fmt.Errorf("safe duplex process containment unavailable on Darwin; manual activation required")
+}
+
+func naturalExitNeedsContainmentCleanup() bool { return true }
+
+func newCommandContainment(cmd *exec.Cmd) (*commandContainment, error) {
+	kqueue, err := unix.Kqueue()
+	if err != nil {
+		return nil, err
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	return &commandContainment{
+		cmd:              cmd,
+		kqueue:           kqueue,
+		liveGroupMembers: darwinLiveGroupMembers,
+		killGroup:        syscall.Kill,
+	}, nil
+}
+
+func newDuplexCommandContainment(cmd *exec.Cmd) (*commandContainment, error) {
+	return nil, duplexContainmentPreflight()
+}
+
+func (containment *commandContainment) attach(cmd *exec.Cmd) error {
+	change := unix.Kevent_t{}
+	unix.SetKevent(&change, cmd.Process.Pid, unix.EVFILT_PROC, unix.EV_ADD|unix.EV_ENABLE|unix.EV_CLEAR)
+	change.Fflags = unix.NOTE_EXIT
+	_, err := unix.Kevent(containment.kqueue, []unix.Kevent_t{change}, nil, nil)
+	if errors.Is(err, syscall.ESRCH) {
+		containment.exitObservation.latch()
+		return nil
+	}
+	return err
+}
+
+func (*commandContainment) limitToProcessGroup() {}
+
+func (containment *commandContainment) terminate() terminationResult {
+	if containment.cmd.Process == nil {
+		return terminationResult{err: os.ErrProcessDone}
+	}
+	members, inspectErr := containment.groupMembers(containment.cmd.Process.Pid)
+	killErr := containment.signalGroup(-containment.cmd.Process.Pid, syscall.SIGKILL)
+	if errors.Is(killErr, syscall.ESRCH) {
+		killErr = nil
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		stopped, observeErr := containment.exited()
+		remaining, groupErr := containment.groupMembers(containment.cmd.Process.Pid)
+		if stopped && remaining == 0 {
+			return terminationResult{leaderStopped: true, forcedMembers: members > 0, err: errors.Join(inspectErr, killErr, observeErr, groupErr)}
+		}
+		if observeErr != nil || groupErr != nil {
+			return terminationResult{leaderStopped: stopped, forcedMembers: members > 0, err: errors.Join(inspectErr, killErr, observeErr, groupErr)}
+		}
+		if time.Now().After(deadline) {
+			return terminationResult{leaderStopped: stopped, forcedMembers: members > 0, err: errors.Join(inspectErr, killErr, fmt.Errorf("Darwin process group remained active after cleanup deadline"))}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func darwinLiveGroupMembers(pgid int) (int, error) {
+	processes, err := unix.SysctlKinfoProcSlice("kern.proc.all")
+	if err != nil {
+		return 0, fmt.Errorf("inspect Darwin process group: %w", err)
+	}
+	const zombieState = 5
+	members := 0
+	for _, process := range processes {
+		if int(process.Proc.P_pid) != pgid && int(process.Eproc.Pgid) == pgid && process.Proc.P_stat != zombieState {
+			members++
+		}
+	}
+	return members, nil
+}
+
+func (containment *commandContainment) exited() (bool, error) {
+	return containment.exitObservation.observe(func() (bool, error) {
+		events := make([]unix.Kevent_t, 1)
+		timeout := unix.Timespec{}
+		n, err := unix.Kevent(containment.kqueue, nil, events, &timeout)
+		return err == nil && n > 0 && events[0].Fflags&unix.NOTE_EXIT != 0, err
+	})
+}
+
+func (containment *commandContainment) groupMembers(pgid int) (int, error) {
+	if containment.liveGroupMembers != nil {
+		return containment.liveGroupMembers(pgid)
+	}
+	return darwinLiveGroupMembers(pgid)
+}
+
+func (containment *commandContainment) signalGroup(pid int, signal syscall.Signal) error {
+	if containment.killGroup != nil {
+		return containment.killGroup(pid, signal)
+	}
+	return syscall.Kill(pid, signal)
+}
+
+func (containment *commandContainment) settleNaturalExit(ctx context.Context, timeout time.Duration) (bool, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		members, err := containment.groupMembers(containment.cmd.Process.Pid)
+		if err != nil || members == 0 {
+			return members == 0, err
+		}
+		if time.Now().After(deadline) {
+			return false, nil
+		}
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}
+
+func (containment *commandContainment) close() error {
+	if containment.kqueue < 0 {
+		return nil
+	}
+	err := unix.Close(containment.kqueue)
+	containment.kqueue = -1
+	return err
+}

--- a/install/integrationctl/adapters/process/osrunner_tree_darwin.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_darwin.go
@@ -34,6 +34,15 @@ func duplexContainmentPreflight() error {
 
 func naturalExitNeedsContainmentCleanup() bool { return true }
 
+func plannedTerminationExitExpected(err error) bool {
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		return false
+	}
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	return ok && status.Signaled() && status.Signal() == syscall.SIGKILL
+}
+
 func newCommandContainment(cmd *exec.Cmd) (*commandContainment, error) {
 	kqueue, err := unix.Kqueue()
 	if err != nil {
@@ -46,6 +55,10 @@ func newCommandContainment(cmd *exec.Cmd) (*commandContainment, error) {
 		liveGroupMembers: darwinLiveGroupMembers,
 		killGroup:        syscall.Kill,
 	}, nil
+}
+
+func newOrdinaryCommandContainment(cmd *exec.Cmd, _ time.Duration) (*commandContainment, error) {
+	return newCommandContainment(cmd)
 }
 
 func newDuplexCommandContainment(cmd *exec.Cmd) (*commandContainment, error) {

--- a/install/integrationctl/adapters/process/osrunner_tree_fallback.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_fallback.go
@@ -22,8 +22,14 @@ func duplexContainmentPreflight() error {
 
 func naturalExitNeedsContainmentCleanup() bool { return false }
 
+func plannedTerminationExitExpected(error) bool { return false }
+
 func newCommandContainment(cmd *exec.Cmd) (*commandContainment, error) {
 	return nil, fmt.Errorf("process execution is unsupported on %s", runtime.GOOS)
+}
+
+func newOrdinaryCommandContainment(cmd *exec.Cmd, _ time.Duration) (*commandContainment, error) {
+	return newCommandContainment(cmd)
 }
 
 func newDuplexCommandContainment(cmd *exec.Cmd) (*commandContainment, error) {

--- a/install/integrationctl/adapters/process/osrunner_tree_fallback.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_fallback.go
@@ -3,27 +3,43 @@
 package process
 
 import (
-	"os"
+	"context"
+	"fmt"
 	"os/exec"
+	"runtime"
+	"time"
 )
 
-type commandTree struct {
+type commandContainment struct {
 	cmd *exec.Cmd
 }
 
-func newCommandTree(cmd *exec.Cmd) (*commandTree, error) {
-	tree := &commandTree{cmd: cmd}
-	cmd.Cancel = tree.terminate
-	return tree, nil
+func explicitContainmentSupervision() bool { return true }
+
+func duplexContainmentPreflight() error {
+	return fmt.Errorf("safe duplex process containment unavailable on this platform; manual activation required")
 }
 
-func (*commandTree) attach(*exec.Cmd) error { return nil }
+func naturalExitNeedsContainmentCleanup() bool { return false }
 
-func (tree *commandTree) terminate() error {
-	if tree.cmd.Process == nil {
-		return os.ErrProcessDone
-	}
-	return tree.cmd.Process.Kill()
+func newCommandContainment(cmd *exec.Cmd) (*commandContainment, error) {
+	return nil, fmt.Errorf("process execution is unsupported on %s", runtime.GOOS)
 }
 
-func (*commandTree) close() {}
+func newDuplexCommandContainment(cmd *exec.Cmd) (*commandContainment, error) {
+	return nil, duplexContainmentPreflight()
+}
+
+func (*commandContainment) attach(*exec.Cmd) error { return nil }
+
+func (*commandContainment) limitToProcessGroup() {}
+
+func (*commandContainment) terminate() terminationResult { return terminationResult{} }
+
+func (*commandContainment) exited() (bool, error) { return false, nil }
+
+func (*commandContainment) settleNaturalExit(context.Context, time.Duration) (bool, error) {
+	return false, nil
+}
+
+func (*commandContainment) close() error { return nil }

--- a/install/integrationctl/adapters/process/osrunner_tree_linux.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_linux.go
@@ -218,6 +218,12 @@ func runLinuxOrdinarySupervisor() int {
 	specFile := os.NewFile(3, "plugin-kit-ai-command")
 	request := os.NewFile(4, "plugin-kit-ai-command-cleanup")
 	status := os.NewFile(5, "plugin-kit-ai-command-status")
+	// ExtraFiles deliberately clears CLOEXEC while launching this supervisor.
+	// Restore it before starting the supervised command: descriptors 3-5 are
+	// supervisor authority and must never be available to the command itself.
+	for _, fd := range []int{3, 4, 5} {
+		unix.CloseOnExec(fd)
+	}
 	result := linuxOrdinarySupervisorResult{}
 	writeResult := func() {
 		_ = json.NewEncoder(status).Encode(result)
@@ -246,14 +252,16 @@ func runLinuxOrdinarySupervisor() int {
 		writeResult()
 		return 125
 	}
-	waited := make(chan error, 1)
-	go func() { waited <- child.Wait() }()
 	requested := make(chan struct{}, 1)
 	go func() {
 		_, _ = io.Copy(io.Discard, request)
 		requested <- struct{}{}
 	}()
-	waitErr, cleanupErr, forced := superviseLinuxOrdinaryChildren(child.Process.Pid, waited, requested, spec.Grace)
+	cleanupErr, forced := superviseLinuxOrdinaryChildren(child.Process.Pid, requested, spec.Grace)
+	// Wait only after supervision has stopped using the leader as the stable
+	// process-group anchor. Until this sole reap, its numeric PID/PGID cannot be
+	// recycled, so no group signal can target an unrelated process.
+	waitErr := child.Wait()
 	result.Forced = forced
 	if cleanupErr != nil {
 		result.Error = cleanupErr.Error()
@@ -274,61 +282,87 @@ func runLinuxOrdinarySupervisor() int {
 	return 125
 }
 
-func superviseLinuxOrdinaryChildren(leaderPID int, waited <-chan error, requested <-chan struct{}, grace time.Duration) (error, error, bool) {
-	var waitErr error
+func superviseLinuxOrdinaryChildren(leaderPID int, requested <-chan struct{}, grace time.Duration) (error, bool) {
 	waitComplete := false
 	forced := false
-	select {
-	case waitErr = <-waited:
-		waitComplete = true
-	case <-requested:
-		forced = true
-	}
-	deadline := time.Now().Add(grace)
-	if forced {
-		deadline = time.Now().Add(processReapTimeout)
-	}
+	var deadline time.Time
 	var cleanupErr error
+	emptyBoundary := linuxQuiescentBoundary{required: 3}
+	groupSignaled := false
 	for {
 		live, inspectErr := linuxSupervisorLiveDescendants(os.Getpid())
-		cleanupErr = errors.Join(cleanupErr, inspectErr)
-		waitObservedThisPass := false
 		if !waitComplete {
-			select {
-			case waitErr = <-waited:
+			var info unix.Siginfo
+			if err := unix.Waitid(unix.P_PID, leaderPID, &info, unix.WEXITED|unix.WNOWAIT|unix.WNOHANG, nil); err != nil {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("observe supervised command exit: %w", err))
+			} else if info.Signo != 0 {
 				waitComplete = true
-				waitObservedThisPass = true
-			default:
+				deadline = time.Now().Add(grace)
 			}
 		}
 		select {
 		case <-requested:
-			forced = true
-			deadline = time.Now().Add(processReapTimeout)
+			if !forced {
+				forced = true
+				deadline = time.Now().Add(processReapTimeout)
+			}
 		default:
 		}
-		if forced || (live > 0 && time.Now().After(deadline)) {
+		if waitComplete && live > 0 && !deadline.IsZero() && time.Now().After(deadline) && !forced {
 			forced = true
-			if err := syscall.Kill(-leaderPID, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
-				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("terminate supervised command group: %w", err))
+			deadline = time.Now().Add(processReapTimeout)
+		}
+		if forced {
+			// The leader is deliberately unreaped here. Signal its numeric group at
+			// most once and only while that stable anchor is still controllably
+			// live; after natural exit, cleanup uses pidfd-bound descendants only.
+			if !groupSignaled {
+				groupSignaled = true
+				if err := signalOwnedLinuxProcessGroup(leaderPID, waitComplete, syscall.Kill); err != nil && !errors.Is(err, syscall.ESRCH) {
+					cleanupErr = errors.Join(cleanupErr, fmt.Errorf("terminate supervised command group: %w", err))
+				}
 			}
 			cleanupErr = errors.Join(cleanupErr, killLinuxSupervisorDescendants(os.Getpid()))
 		}
-		if live == 0 && waitComplete && !waitObservedThisPass {
-			return waitErr, cleanupErr, forced
+		// A single non-atomic procfs traversal can race a fork/reparent. Require
+		// three error-free, time-separated empty snapshots after leader exit.
+		if emptyBoundary.observe(waitComplete && live == 0, inspectErr) {
+			return cleanupErr, forced
+		} else {
+			if inspectErr != nil {
+				cleanupErr = errors.Join(cleanupErr, inspectErr)
+			}
 		}
-		if waitObservedThisPass {
-			// The descendant snapshot preceded Wait. Reaping the leader can
-			// reparent a detached child to this subreaper, so that snapshot is
-			// not evidence that the isolated boundary is empty. Rescan only
-			// after Wait's reparenting side effects are observable.
-			continue
-		}
-		if time.Now().After(deadline) && forced {
-			return waitErr, errors.Join(cleanupErr, fmt.Errorf("isolated ordinary-command supervisor did not empty before cleanup deadline")), forced
+		if forced && !deadline.IsZero() && time.Now().After(deadline) {
+			return errors.Join(cleanupErr, fmt.Errorf("isolated ordinary-command supervisor did not empty before cleanup deadline")), forced
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
+}
+
+// signalOwnedLinuxProcessGroup prohibits numeric PGID signaling once leader
+// exit has been observed. The leader remains unreaped throughout supervision,
+// but an exited leader no longer proves that its process group is the intended
+// live ownership boundary; detached members are handled through stable pidfds.
+func signalOwnedLinuxProcessGroup(leaderPID int, leaderExited bool, signal func(int, syscall.Signal) error) error {
+	if leaderExited {
+		return nil
+	}
+	return signal(-leaderPID, syscall.SIGKILL)
+}
+
+type linuxQuiescentBoundary struct {
+	required int
+	passes   int
+}
+
+func (boundary *linuxQuiescentBoundary) observe(empty bool, scanErr error) bool {
+	if !empty || scanErr != nil {
+		boundary.passes = 0
+		return false
+	}
+	boundary.passes++
+	return boundary.passes >= boundary.required
 }
 
 func linuxSupervisorLiveDescendants(root int) (int, error) {
@@ -681,7 +715,18 @@ func (containment *commandContainment) readSupervisorResult() error {
 		return nil
 	}
 	containment.supervisorRead = true
-	err := json.NewDecoder(containment.supervisorStatus).Decode(&containment.supervisorResult)
+	decoder := json.NewDecoder(containment.supervisorStatus)
+	decoder.DisallowUnknownFields()
+	err := decoder.Decode(&containment.supervisorResult)
+	if err == nil {
+		var trailing any
+		if trailingErr := decoder.Decode(&trailing); !errors.Is(trailingErr, io.EOF) {
+			if trailingErr == nil {
+				trailingErr = fmt.Errorf("additional JSON value")
+			}
+			err = fmt.Errorf("isolated ordinary-command supervisor returned trailing status data: %w", trailingErr)
+		}
+	}
 	closeErr := containment.supervisorStatus.Close()
 	containment.supervisorStatus = nil
 	if errors.Is(err, io.EOF) {

--- a/install/integrationctl/adapters/process/osrunner_tree_linux.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_linux.go
@@ -1,0 +1,627 @@
+//go:build linux
+
+package process
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+type commandContainment struct {
+	cmd              *exec.Cmd
+	mu               sync.Mutex
+	descendants      map[int]linuxTrackedProcess
+	scanErr          error
+	stop             chan struct{}
+	done             chan struct{}
+	trackerStarted   bool
+	groupOnly        bool
+	cgroupPath       string
+	cgroupDir        *os.File
+	closeTransferred bool
+	observeExit      func() (bool, error)
+	observeEmpty     func() (bool, error)
+}
+
+// This interval is frequent enough to observe normal Kiro startup forks while
+// avoiding high-frequency process inspection for long-lived clients.
+const linuxDescendantScanInterval = 25 * time.Millisecond
+
+const linuxStartupDescendantScanInterval = time.Millisecond
+const linuxStartupDescendantScanWindow = 250 * time.Millisecond
+
+func explicitContainmentSupervision() bool { return true }
+
+const linuxCgroupRoot = "/sys/fs/cgroup"
+
+func duplexContainmentPreflight() error {
+	cmd := exec.Command("/bin/sh", "-c", "while :; do :; done")
+	containment, err := newDuplexCommandContainment(cmd)
+	if err != nil {
+		return fmt.Errorf("safe duplex process containment unavailable; manual activation required: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return errors.Join(fmt.Errorf("prove CLONE_INTO_CGROUP process creation: %w", err), containment.close())
+	}
+	if err := containment.attach(cmd); err != nil {
+		return fmt.Errorf("attach duplex containment primitive probe: %w", cleanupAttachFailure(err, containment.terminate, cmd.Process.Kill, containment.exited, containment.close, cmd.Wait))
+	}
+	termination := containment.terminate()
+	if !termination.leaderStopped {
+		termination = stopLeaderAfterContainmentFailure(termination, cmd.Process.Kill, containment.exited)
+	}
+	return finishDuplexContainmentProbe(termination, containment.close, cmd.Wait, processReapTimeout)
+}
+
+func finishDuplexContainmentProbe(termination terminationResult, closeContainment, wait func() error, timeout time.Duration) error {
+	// Close probe-owned containment descriptors before starting its sole Wait.
+	// If shutdown cannot be proved or Wait itself stalls, the buffered reaper
+	// keeps ownership until actual exit while this capability check fails closed
+	// within a real deadline.
+	waitErr := closeContainmentAndWait(closeContainment, wait, timeout)
+	var proofErr error
+	if !termination.leaderStopped {
+		proofErr = fmt.Errorf("probe leader shutdown was not proved")
+	}
+	if termination.err != nil || proofErr != nil {
+		return fmt.Errorf("safe duplex process containment primitive probe failed: %w", errors.Join(termination.err, proofErr, waitErr))
+	}
+	if waitErr != nil {
+		if _, expectedKill := waitErr.(*exec.ExitError); !expectedKill {
+			return fmt.Errorf("reap duplex containment primitive probe: %w", waitErr)
+		}
+	}
+	return nil
+}
+
+func naturalExitNeedsContainmentCleanup() bool { return true }
+
+func newCommandContainment(cmd *exec.Cmd) (*commandContainment, error) {
+	// Tree-aware non-duplex commands (notably Git acquisition) require the same
+	// atomic kernel boundary as duplex ACP. Sampling /proc cannot prove cleanup
+	// for a sub-millisecond setsid/double-fork escape.
+	return newDuplexCommandContainment(cmd)
+}
+
+func newDuplexCommandContainment(cmd *exec.Cmd) (*commandContainment, error) {
+	path, directory, err := createDelegatedCgroup()
+	if err != nil {
+		return nil, fmt.Errorf("create duplex cgroup containment: %w", err)
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, UseCgroupFD: true, CgroupFD: int(directory.Fd())}
+	return &commandContainment{cmd: cmd, cgroupPath: path, cgroupDir: directory}, nil
+}
+
+func createDelegatedCgroup() (string, *os.File, error) {
+	return createDelegatedCgroupAt(linuxCgroupRoot)
+}
+
+func createDelegatedCgroupAt(root string) (string, *os.File, error) {
+	value, err := os.ReadFile("/proc/self/cgroup")
+	if err != nil {
+		return "", nil, err
+	}
+	var relative string
+	for _, line := range strings.Split(string(value), "\n") {
+		if strings.HasPrefix(line, "0::") {
+			relative = strings.TrimPrefix(line, "0::")
+			break
+		}
+	}
+	if relative == "" || !filepath.IsAbs(relative) {
+		return "", nil, fmt.Errorf("unified cgroup v2 membership is unavailable")
+	}
+	base := filepath.Join(root, filepath.Clean(relative))
+	var filesystem unix.Statfs_t
+	if err := unix.Statfs(base, &filesystem); err != nil {
+		return "", nil, fmt.Errorf("inspect cgroup filesystem: %w", err)
+	}
+	if filesystem.Type != unix.CGROUP2_SUPER_MAGIC {
+		return "", nil, fmt.Errorf("unified cgroup v2 filesystem is unavailable")
+	}
+	path, err := os.MkdirTemp(base, "agentplugins-duplex-")
+	if err != nil {
+		return "", nil, fmt.Errorf("delegated cgroup v2 subtree is unavailable: %w", err)
+	}
+	directory, err := os.Open(path)
+	if err != nil {
+		_ = os.Remove(path)
+		return "", nil, err
+	}
+	for _, control := range []string{"cgroup.events", "cgroup.kill", "cgroup.procs"} {
+		if _, err := os.Stat(filepath.Join(path, control)); err != nil {
+			_ = directory.Close()
+			_ = os.Remove(path)
+			return "", nil, fmt.Errorf("required cgroup v2 control %s is unavailable: %w", control, err)
+		}
+	}
+	return path, directory, nil
+}
+
+func (containment *commandContainment) attach(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return fmt.Errorf("process supervision cannot attach before start")
+	}
+	if containment.cgroupPath != "" {
+		return nil // CLONE_INTO_CGROUP attached the child atomically at creation.
+	}
+	if containment.groupOnly {
+		return nil
+	}
+	identity, err := readLinuxProcessIdentity(cmd.Process.Pid)
+	if err != nil {
+		return fmt.Errorf("read Linux process leader identity: %w", err)
+	}
+	pidfd, err := unix.PidfdOpen(identity.pid, 0)
+	if err != nil {
+		return fmt.Errorf("open stable Linux process handle: %w", err)
+	}
+	containment.mu.Lock()
+	containment.descendants[identity.pid] = linuxTrackedProcess{startTime: identity.startTime, pidfd: pidfd}
+	containment.mu.Unlock()
+	if err := containment.scanDescendants(); err != nil {
+		return err
+	}
+	containment.trackerStarted = true
+	go containment.trackDescendants()
+	return nil
+}
+
+func (containment *commandContainment) limitToProcessGroup() { containment.groupOnly = true }
+
+func (containment *commandContainment) terminate() terminationResult {
+	if containment.cmd.Process == nil {
+		return terminationResult{err: os.ErrProcessDone}
+	}
+	if containment.cgroupPath != "" {
+		return containment.terminateCgroup()
+	}
+	scanErr := containment.scanDescendants()
+	forcedMembers := false
+	groupMembers, groupScanErr := liveLinuxProcessGroupMembers(containment.cmd.Process.Pid)
+	if groupMembers > 0 {
+		forcedMembers = true
+	}
+	scanErr = errors.Join(scanErr, groupScanErr)
+	containment.mu.Lock()
+	for pid, tracked := range containment.descendants {
+		if pid != containment.cmd.Process.Pid && linuxPidfdAlive(tracked.pidfd) {
+			forcedMembers = true
+		}
+	}
+	containment.mu.Unlock()
+	groupErr := syscall.Kill(-containment.cmd.Process.Pid, syscall.SIGKILL)
+	if errors.Is(groupErr, syscall.ESRCH) {
+		groupErr = nil
+	}
+	containment.mu.Lock()
+	identities := make(map[int]linuxTrackedProcess, len(containment.descendants))
+	for pid, tracked := range containment.descendants {
+		identities[pid] = tracked
+	}
+	trackerErr := containment.scanErr
+	containment.mu.Unlock()
+	var cleanupErr = errors.Join(scanErr, trackerErr)
+	for pid, tracked := range identities {
+		if pid == containment.cmd.Process.Pid {
+			continue
+		}
+		identity, err := readLinuxProcessIdentity(pid)
+		if errors.Is(err, os.ErrNotExist) || (err == nil && identity.zombie) {
+			continue
+		}
+		if err != nil || identity.startTime != tracked.startTime {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("prove tracked descendant %d identity before cleanup: %w", pid, err))
+			continue
+		}
+		if err := unix.PidfdSendSignal(tracked.pidfd, unix.SIGKILL, nil, 0); err != nil && !errors.Is(err, syscall.ESRCH) {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("terminate tracked descendant %d through pidfd: %w", pid, err))
+		}
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		leaderStopped, observeErr := containment.exited()
+		remaining := 0
+		for pid, tracked := range identities {
+			if pid == containment.cmd.Process.Pid {
+				continue
+			}
+			identity, err := readLinuxProcessIdentity(pid)
+			if err == nil && identity.startTime == tracked.startTime && !identity.zombie && linuxPidfdAlive(tracked.pidfd) {
+				remaining++
+			} else if err != nil && linuxPidfdAlive(tracked.pidfd) {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("prove tracked descendant %d stopped: %w", pid, err))
+			}
+		}
+		if leaderStopped && remaining == 0 {
+			return terminationResult{leaderStopped: true, forcedMembers: forcedMembers, err: errors.Join(groupErr, cleanupErr)}
+		}
+		if observeErr != nil {
+			cleanupErr = errors.Join(cleanupErr, observeErr)
+		}
+		if time.Now().After(deadline) {
+			if !leaderStopped {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("process leader did not become waitable before cleanup deadline"))
+			}
+			if remaining != 0 {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("%d tracked descendant process(es) survived cleanup deadline", remaining))
+			}
+			return terminationResult{leaderStopped: leaderStopped, forcedMembers: forcedMembers, err: errors.Join(groupErr, cleanupErr)}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func (containment *commandContainment) exited() (bool, error) {
+	if containment.observeExit != nil {
+		return containment.observeExit()
+	}
+	if containment.cmd.Process == nil {
+		return false, nil
+	}
+	var info unix.Siginfo
+	if err := unix.Waitid(unix.P_PID, containment.cmd.Process.Pid, &info, unix.WEXITED|unix.WNOWAIT|unix.WNOHANG, nil); err != nil {
+		return false, err
+	}
+	return info.Signo != 0, nil
+}
+
+func (containment *commandContainment) settleNaturalExit(ctx context.Context, timeout time.Duration) (bool, error) {
+	if containment.cgroupPath != "" {
+		return containment.settleCgroup(ctx, timeout)
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		members, err := liveLinuxProcessGroupMembers(containment.cmd.Process.Pid)
+		if err != nil {
+			return false, err
+		}
+		containment.mu.Lock()
+		for pid, tracked := range containment.descendants {
+			if pid == containment.cmd.Process.Pid {
+				continue
+			}
+			identity, identityErr := readLinuxProcessIdentity(pid)
+			if identityErr == nil && !identity.zombie && linuxPidfdAlive(tracked.pidfd) {
+				members++
+			}
+		}
+		containment.mu.Unlock()
+		if members == 0 {
+			return true, nil
+		}
+		if time.Now().After(deadline) {
+			return false, nil
+		}
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}
+
+func (containment *commandContainment) close() error {
+	if containment.closeTransferred {
+		return fmt.Errorf("Linux descendant tracker ownership was transferred to its reaper")
+	}
+	if containment.cgroupPath != "" {
+		if containment.cgroupDir != nil {
+			_ = containment.cgroupDir.Close()
+			containment.cgroupDir = nil
+		}
+		if err := os.Remove(containment.cgroupPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove duplex cgroup scope: %w", err)
+		}
+		containment.cgroupPath = ""
+		return nil
+	}
+	if containment.cmd.Process == nil {
+		return nil
+	}
+	var resultErr error
+	if containment.trackerStarted {
+		select {
+		case <-containment.stop:
+		default:
+			close(containment.stop)
+		}
+		select {
+		case <-containment.done:
+		case <-time.After(500 * time.Millisecond):
+			containment.closeTransferred = true
+			go containment.closeTrackedHandlesAfterStop()
+			return fmt.Errorf("Linux descendant tracker ownership transferred to reaper after stop deadline")
+		}
+	}
+	containment.mu.Lock()
+	for pid, tracked := range containment.descendants {
+		if err := unix.Close(tracked.pidfd); err != nil {
+			resultErr = errors.Join(resultErr, fmt.Errorf("close stable process handle for %d: %w", pid, err))
+		}
+	}
+	containment.descendants = nil
+	containment.mu.Unlock()
+	return resultErr
+}
+
+func (containment *commandContainment) closeTrackedHandlesAfterStop() {
+	<-containment.done
+	containment.mu.Lock()
+	defer containment.mu.Unlock()
+	for _, tracked := range containment.descendants {
+		_ = unix.Close(tracked.pidfd)
+	}
+	containment.descendants = nil
+}
+
+var readCgroupProcs = os.ReadFile
+var writeCgroupKill = os.WriteFile
+
+func (containment *commandContainment) terminateCgroup() terminationResult {
+	return containment.terminateCgroupWithin(time.Second)
+}
+
+func (containment *commandContainment) terminateCgroupWithin(timeout time.Duration) terminationResult {
+	members, inspectErr := readCgroupProcs(filepath.Join(containment.cgroupPath, "cgroup.procs"))
+	forced, inspectErr := cgroupForcedMemberCausality(containment.cmd.Process.Pid, members, inspectErr)
+	killErr := writeCgroupKill(filepath.Join(containment.cgroupPath, "cgroup.kill"), []byte("1"), 0)
+	if errors.Is(killErr, os.ErrNotExist) {
+		killErr = nil
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		exited, observeErr := containment.exited()
+		empty, emptyErr := containment.cgroupEmpty()
+		if exited && empty {
+			return terminationResult{leaderStopped: true, forcedMembers: forced, err: errors.Join(inspectErr, killErr, observeErr, emptyErr)}
+		}
+		if time.Now().After(deadline) {
+			return terminationResult{leaderStopped: exited, forcedMembers: forced, err: errors.Join(inspectErr, killErr, observeErr, emptyErr, fmt.Errorf("duplex cgroup did not empty before cleanup deadline"))}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func cgroupForcedMemberCausality(leaderPID int, members []byte, inspectErr error) (bool, error) {
+	if inspectErr != nil {
+		// Once cgroup.kill is requested, inability to inventory the scope makes
+		// descendant causality uncertain. Fail closed so a natural-looking leader
+		// status cannot turn possibly forced cleanup into success.
+		return true, fmt.Errorf("inspect cgroup members before forced cleanup: %w", inspectErr)
+	}
+	for _, raw := range strings.Fields(string(members)) {
+		if raw != strconv.Itoa(leaderPID) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (containment *commandContainment) settleCgroup(ctx context.Context, timeout time.Duration) (bool, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		empty, err := containment.cgroupEmpty()
+		if err != nil || empty {
+			return empty, err
+		}
+		if time.Now().After(deadline) {
+			return false, nil
+		}
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}
+
+func (containment *commandContainment) cgroupEmpty() (bool, error) {
+	if containment.observeEmpty != nil {
+		return containment.observeEmpty()
+	}
+	value, err := os.ReadFile(filepath.Join(containment.cgroupPath, "cgroup.events"))
+	if err != nil {
+		return false, err
+	}
+	for _, line := range strings.Split(string(value), "\n") {
+		if strings.TrimSpace(line) == "populated 0" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+type linuxProcessIdentity struct {
+	pid       int
+	ppid      int
+	pgid      int
+	startTime uint64
+	zombie    bool
+}
+
+func readLinuxProcessIdentity(pid int) (linuxProcessIdentity, error) {
+	value, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return linuxProcessIdentity{}, err
+	}
+	closing := strings.LastIndexByte(string(value), ')')
+	if closing < 0 || closing+2 >= len(value) {
+		return linuxProcessIdentity{}, fmt.Errorf("malformed /proc stat for pid %d", pid)
+	}
+	fields := strings.Fields(string(value[closing+2:]))
+	if len(fields) < 20 {
+		return linuxProcessIdentity{}, fmt.Errorf("short /proc stat for pid %d", pid)
+	}
+	startTime, err := strconv.ParseUint(fields[19], 10, 64)
+	if err != nil {
+		return linuxProcessIdentity{}, err
+	}
+	ppid, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return linuxProcessIdentity{}, err
+	}
+	pgid, err := strconv.Atoi(fields[2])
+	if err != nil {
+		return linuxProcessIdentity{}, err
+	}
+	return linuxProcessIdentity{pid: pid, ppid: ppid, pgid: pgid, startTime: startTime, zombie: fields[0] == "Z"}, nil
+}
+
+func liveLinuxProcessGroupMembers(pgid int) (int, error) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return 0, fmt.Errorf("inspect Linux process table for group containment: %w", err)
+	}
+	members := 0
+	for _, entry := range entries {
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil || pid == pgid {
+			continue
+		}
+		identity, err := readLinuxProcessIdentity(pid)
+		if err != nil {
+			continue // unrelated processes routinely exit during a table snapshot
+		}
+		if identity.pgid == pgid && !identity.zombie {
+			members++
+		}
+	}
+	return members, nil
+}
+
+type linuxTrackedProcess struct {
+	startTime uint64
+	pidfd     int
+}
+
+func linuxPidfdAlive(pidfd int) bool {
+	err := unix.PidfdSendSignal(pidfd, 0, nil, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+func (containment *commandContainment) trackDescendants() {
+	defer close(containment.done)
+	ticker := time.NewTicker(linuxStartupDescendantScanInterval)
+	defer ticker.Stop()
+	startup := time.NewTimer(linuxStartupDescendantScanWindow)
+	defer startup.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if err := containment.scanDescendants(); err != nil {
+				containment.mu.Lock()
+				containment.scanErr = errors.Join(containment.scanErr, err)
+				containment.mu.Unlock()
+			}
+		case <-startup.C:
+			ticker.Reset(linuxDescendantScanInterval)
+		case <-containment.stop:
+			return
+		}
+	}
+}
+
+func (containment *commandContainment) scanDescendants() error {
+	containment.mu.Lock()
+	defer containment.mu.Unlock()
+	queue := make([]int, 0, len(containment.descendants)+1)
+	queue = append(queue, containment.cmd.Process.Pid)
+	for pid, tracked := range containment.descendants {
+		if identity, err := readLinuxProcessIdentity(pid); err == nil && identity.startTime == tracked.startTime && !identity.zombie {
+			queue = append(queue, pid)
+		}
+	}
+	var scanErr error
+	seen := make(map[int]struct{}, len(queue))
+	for len(queue) != 0 {
+		pid := queue[0]
+		queue = queue[1:]
+		if _, duplicate := seen[pid]; duplicate {
+			continue
+		}
+		seen[pid] = struct{}{}
+		tasks, err := os.ReadDir(fmt.Sprintf("/proc/%d/task", pid))
+		if err != nil {
+			if tracked, ok := containment.descendants[pid]; ok && linuxPidfdAlive(tracked.pidfd) {
+				scanErr = errors.Join(scanErr, fmt.Errorf("inspect tasks for live tracked process %d: %w", pid, err))
+			}
+			continue
+		}
+		for _, task := range tasks {
+			children, err := os.ReadFile(fmt.Sprintf("/proc/%d/task/%s/children", pid, task.Name()))
+			if err != nil {
+				// Threads can disappear between ReadDir and opening their children
+				// file. The remaining live threads are still inspected in this same
+				// snapshot, so this race is not an ancestry blind spot.
+				if errors.Is(err, os.ErrNotExist) {
+					continue
+				}
+				if tracked, ok := containment.descendants[pid]; ok && linuxPidfdAlive(tracked.pidfd) {
+					scanErr = errors.Join(scanErr, fmt.Errorf("inspect children for live tracked process %d: %w", pid, err))
+				}
+				continue
+			}
+			for _, rawChild := range strings.Fields(string(children)) {
+				child, err := strconv.Atoi(rawChild)
+				if err != nil {
+					continue
+				}
+				identity, err := readLinuxProcessIdentity(child)
+				if err != nil {
+					scanErr = errors.Join(scanErr, fmt.Errorf("read observed child %d of %d: %w", child, pid, err))
+					continue
+				}
+				pidfd, err := unix.PidfdOpen(child, 0)
+				if err != nil {
+					scanErr = errors.Join(scanErr, fmt.Errorf("open stable handle for observed child %d: %w", child, err))
+					continue
+				}
+				revalidated, err := readLinuxProcessIdentity(child)
+				if err != nil || revalidated.startTime != identity.startTime {
+					_ = unix.Close(pidfd)
+					if err != nil {
+						scanErr = errors.Join(scanErr, fmt.Errorf("revalidate observed child %d identity: %w", child, err))
+					} else {
+						scanErr = errors.Join(scanErr, fmt.Errorf("revalidate observed child %d identity: process start time changed", child))
+					}
+					continue
+				}
+				if revalidated.ppid != pid {
+					parent, parentErr := readLinuxProcessIdentity(pid)
+					if parentErr == nil && !parent.zombie {
+						_ = unix.Close(pidfd)
+						scanErr = errors.Join(scanErr, fmt.Errorf("revalidate observed child %d parentage: live parent changed from %d to %d", child, pid, revalidated.ppid))
+						continue
+					}
+				}
+				// Re-read parentage after acquiring the pidfd. A changed parent is
+				// safe only because the kernel children file already established the
+				// relationship and the stable handle proves the same process survived
+				// while its parent exited/reparented it. Numeric signaling is never used.
+				if previous, exists := containment.descendants[child]; exists {
+					_ = unix.Close(pidfd)
+					if previous.startTime != revalidated.startTime {
+						scanErr = errors.Join(scanErr, fmt.Errorf("tracked child PID %d changed identity", child))
+						continue
+					}
+				} else {
+					containment.descendants[child] = linuxTrackedProcess{startTime: revalidated.startTime, pidfd: pidfd}
+				}
+				queue = append(queue, child)
+			}
+		}
+	}
+	return scanErr
+}

--- a/install/integrationctl/adapters/process/osrunner_tree_linux.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_linux.go
@@ -4,8 +4,10 @@ package process
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -19,19 +21,24 @@ import (
 )
 
 type commandContainment struct {
-	cmd              *exec.Cmd
-	mu               sync.Mutex
-	descendants      map[int]linuxTrackedProcess
-	scanErr          error
-	stop             chan struct{}
-	done             chan struct{}
-	trackerStarted   bool
-	groupOnly        bool
-	cgroupPath       string
-	cgroupDir        *os.File
-	closeTransferred bool
-	observeExit      func() (bool, error)
-	observeEmpty     func() (bool, error)
+	cmd                      *exec.Cmd
+	mu                       sync.Mutex
+	descendants              map[int]linuxTrackedProcess
+	scanErr                  error
+	stop                     chan struct{}
+	done                     chan struct{}
+	trackerStarted           bool
+	supervisorRequest        *os.File
+	supervisorStatus         *os.File
+	supervisorResult         linuxOrdinarySupervisorResult
+	supervisorRead           bool
+	cgroupPath               string
+	cgroupDir                *os.File
+	closeTransferred         bool
+	observeExit              func() (bool, error)
+	observeEmpty             func() (bool, error)
+	inspectLive              func(int) (bool, error)
+	prepareLeaderTermination func(int, time.Duration) (bool, error)
 }
 
 // This interval is frequent enough to observe normal Kiro startup forks while
@@ -40,6 +47,28 @@ const linuxDescendantScanInterval = 25 * time.Millisecond
 
 const linuxStartupDescendantScanInterval = time.Millisecond
 const linuxStartupDescendantScanWindow = 250 * time.Millisecond
+
+const linuxOrdinarySupervisorEnvironment = "PLUGIN_KIT_AI_ORDINARY_PROCESS_SUPERVISOR=1"
+
+type linuxOrdinarySupervisorSpec struct {
+	Path  string
+	Args  []string
+	Env   []string
+	Dir   string
+	Grace time.Duration
+}
+
+type linuxOrdinarySupervisorResult struct {
+	Forced bool
+	Error  string
+}
+
+func init() {
+	if os.Getenv("PLUGIN_KIT_AI_ORDINARY_PROCESS_SUPERVISOR") != "1" {
+		return
+	}
+	os.Exit(runLinuxOrdinarySupervisor())
+}
 
 func explicitContainmentSupervision() bool { return true }
 
@@ -73,6 +102,8 @@ func finishDuplexContainmentProbe(termination terminationResult, closeContainmen
 	var proofErr error
 	if !termination.leaderStopped {
 		proofErr = fmt.Errorf("probe leader shutdown was not proved")
+	} else if !termination.leaderTerminationInitiated {
+		proofErr = fmt.Errorf("probe leader shutdown was not initiated by containment")
 	}
 	if termination.err != nil || proofErr != nil {
 		return fmt.Errorf("safe duplex process containment primitive probe failed: %w", errors.Join(termination.err, proofErr, waitErr))
@@ -87,11 +118,288 @@ func finishDuplexContainmentProbe(termination terminationResult, closeContainmen
 
 func naturalExitNeedsContainmentCleanup() bool { return true }
 
+func plannedTerminationExitExpected(err error) bool {
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		return false
+	}
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	return ok && status.Signaled() && status.Signal() == syscall.SIGKILL
+}
+
 func newCommandContainment(cmd *exec.Cmd) (*commandContainment, error) {
-	// Tree-aware non-duplex commands (notably Git acquisition) require the same
-	// atomic kernel boundary as duplex ACP. Sampling /proc cannot prove cleanup
-	// for a sub-millisecond setsid/double-fork escape.
-	return newDuplexCommandContainment(cmd)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	return &commandContainment{
+		cmd:         cmd,
+		descendants: make(map[int]linuxTrackedProcess),
+		stop:        make(chan struct{}),
+		done:        make(chan struct{}),
+	}, nil
+}
+
+func newOrdinaryCommandContainment(cmd *exec.Cmd, grace time.Duration) (*commandContainment, error) {
+	request, status, err := wrapLinuxOrdinaryCommand(cmd, grace)
+	if err != nil {
+		return nil, err
+	}
+	containment, err := newCommandContainment(cmd)
+	if err != nil {
+		_ = request.Close()
+		_ = status.Close()
+		return nil, err
+	}
+	containment.supervisorRequest = request
+	containment.supervisorStatus = status
+	return containment, nil
+}
+
+func wrapLinuxOrdinaryCommand(cmd *exec.Cmd, grace time.Duration) (*os.File, *os.File, error) {
+	if len(cmd.ExtraFiles) != 0 {
+		return nil, nil, fmt.Errorf("Linux ordinary-command supervisor requires unallocated extra descriptors")
+	}
+	commandEnvironment := cmd.Env
+	if commandEnvironment == nil {
+		commandEnvironment = os.Environ()
+	}
+	spec := linuxOrdinarySupervisorSpec{Path: cmd.Path, Args: append([]string(nil), cmd.Args...), Env: append([]string(nil), commandEnvironment...), Dir: cmd.Dir, Grace: grace}
+	encoded, err := json.Marshal(spec)
+	if err != nil {
+		return nil, nil, fmt.Errorf("encode Linux ordinary-command supervisor request: %w", err)
+	}
+	fd, err := unix.MemfdCreate("plugin-kit-ai-command", unix.MFD_CLOEXEC)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create Linux ordinary-command supervisor request: %w", err)
+	}
+	specFile := os.NewFile(uintptr(fd), "plugin-kit-ai-command")
+	cleanupSpec := true
+	defer func() {
+		if cleanupSpec {
+			_ = specFile.Close()
+		}
+	}()
+	if _, err := specFile.Write(encoded); err != nil {
+		return nil, nil, fmt.Errorf("write Linux ordinary-command supervisor request: %w", err)
+	}
+	if _, err := specFile.Seek(0, io.SeekStart); err != nil {
+		return nil, nil, fmt.Errorf("rewind Linux ordinary-command supervisor request: %w", err)
+	}
+	requestReader, requestWriter, err := os.Pipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	statusReader, statusWriter, err := os.Pipe()
+	if err != nil {
+		_ = requestReader.Close()
+		_ = requestWriter.Close()
+		return nil, nil, err
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		_ = requestReader.Close()
+		_ = requestWriter.Close()
+		_ = statusReader.Close()
+		_ = statusWriter.Close()
+		return nil, nil, fmt.Errorf("locate Linux ordinary-command supervisor: %w", err)
+	}
+	cmd.Path = executable
+	cmd.Args = []string{executable}
+	cmd.Env = append(os.Environ(), linuxOrdinarySupervisorEnvironment)
+	cmd.Dir = ""
+	cmd.ExtraFiles = append(cmd.ExtraFiles, specFile, requestReader, statusWriter)
+	cleanupSpec = false
+	// These child-side descriptors are closed by attach after Start has copied
+	// them into the isolated supervisor. Keep them on the containment so every
+	// pre-Start and attach failure also has one cleanup owner.
+	cmd.Cancel = nil
+	return requestWriter, statusReader, nil
+}
+
+func runLinuxOrdinarySupervisor() int {
+	specFile := os.NewFile(3, "plugin-kit-ai-command")
+	request := os.NewFile(4, "plugin-kit-ai-command-cleanup")
+	status := os.NewFile(5, "plugin-kit-ai-command-status")
+	result := linuxOrdinarySupervisorResult{}
+	writeResult := func() {
+		_ = json.NewEncoder(status).Encode(result)
+		_ = status.Close()
+	}
+	var spec linuxOrdinarySupervisorSpec
+	if err := json.NewDecoder(specFile).Decode(&spec); err != nil {
+		result.Error = fmt.Sprintf("decode supervisor request: %v", err)
+		writeResult()
+		return 125
+	}
+	_ = specFile.Close()
+	if err := unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0); err != nil {
+		result.Error = fmt.Sprintf("establish isolated child-subreaper boundary: %v", err)
+		writeResult()
+		return 125
+	}
+	child := exec.Command(spec.Path, spec.Args[1:]...)
+	child.Env = spec.Env
+	child.Dir = spec.Dir
+	child.Stdout = os.Stdout
+	child.Stderr = os.Stderr
+	child.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := child.Start(); err != nil {
+		result.Error = fmt.Sprintf("start supervised command: %v", err)
+		writeResult()
+		return 125
+	}
+	waited := make(chan error, 1)
+	go func() { waited <- child.Wait() }()
+	requested := make(chan struct{}, 1)
+	go func() {
+		_, _ = io.Copy(io.Discard, request)
+		requested <- struct{}{}
+	}()
+	waitErr, cleanupErr, forced := superviseLinuxOrdinaryChildren(child.Process.Pid, waited, requested, spec.Grace)
+	result.Forced = forced
+	if cleanupErr != nil {
+		result.Error = cleanupErr.Error()
+	}
+	writeResult()
+	if waitErr == nil {
+		return 0
+	}
+	if exitErr, ok := waitErr.(*exec.ExitError); ok {
+		if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Signaled() {
+			_ = syscall.Kill(os.Getpid(), status.Signal())
+			return 125
+		}
+		if exitErr.ExitCode() >= 0 {
+			return exitErr.ExitCode()
+		}
+	}
+	return 125
+}
+
+func superviseLinuxOrdinaryChildren(leaderPID int, waited <-chan error, requested <-chan struct{}, grace time.Duration) (error, error, bool) {
+	var waitErr error
+	waitComplete := false
+	forced := false
+	select {
+	case waitErr = <-waited:
+		waitComplete = true
+	case <-requested:
+		forced = true
+	}
+	deadline := time.Now().Add(grace)
+	if forced {
+		deadline = time.Now().Add(processReapTimeout)
+	}
+	var cleanupErr error
+	for {
+		live, inspectErr := linuxSupervisorLiveDescendants(os.Getpid())
+		cleanupErr = errors.Join(cleanupErr, inspectErr)
+		waitObservedThisPass := false
+		if !waitComplete {
+			select {
+			case waitErr = <-waited:
+				waitComplete = true
+				waitObservedThisPass = true
+			default:
+			}
+		}
+		select {
+		case <-requested:
+			forced = true
+			deadline = time.Now().Add(processReapTimeout)
+		default:
+		}
+		if forced || (live > 0 && time.Now().After(deadline)) {
+			forced = true
+			if err := syscall.Kill(-leaderPID, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("terminate supervised command group: %w", err))
+			}
+			cleanupErr = errors.Join(cleanupErr, killLinuxSupervisorDescendants(os.Getpid()))
+		}
+		if live == 0 && waitComplete && !waitObservedThisPass {
+			return waitErr, cleanupErr, forced
+		}
+		if waitObservedThisPass {
+			// The descendant snapshot preceded Wait. Reaping the leader can
+			// reparent a detached child to this subreaper, so that snapshot is
+			// not evidence that the isolated boundary is empty. Rescan only
+			// after Wait's reparenting side effects are observable.
+			continue
+		}
+		if time.Now().After(deadline) && forced {
+			return waitErr, errors.Join(cleanupErr, fmt.Errorf("isolated ordinary-command supervisor did not empty before cleanup deadline")), forced
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func linuxSupervisorLiveDescendants(root int) (int, error) {
+	identities, err := linuxDescendantIdentities(root)
+	if err != nil {
+		return 0, err
+	}
+	live := 0
+	for _, identity := range identities {
+		if identity.zombie {
+			continue
+		}
+		live++
+	}
+	return live, nil
+}
+
+func killLinuxSupervisorDescendants(root int) error {
+	identities, err := linuxDescendantIdentities(root)
+	var resultErr = err
+	for pid, identity := range identities {
+		if identity.zombie {
+			continue
+		}
+		pidfd, err := unix.PidfdOpen(pid, 0)
+		if err != nil {
+			if !errors.Is(err, syscall.ESRCH) {
+				resultErr = errors.Join(resultErr, fmt.Errorf("open stable supervisor child handle for %d: %w", pid, err))
+			}
+			continue
+		}
+		current, err := readLinuxProcessIdentity(pid)
+		if err == nil && current.startTime == identity.startTime && !current.zombie {
+			if err := unix.PidfdSendSignal(pidfd, unix.SIGKILL, nil, 0); err != nil && !errors.Is(err, syscall.ESRCH) {
+				resultErr = errors.Join(resultErr, fmt.Errorf("terminate stable supervisor child %d: %w", pid, err))
+			}
+		}
+		_ = unix.Close(pidfd)
+	}
+	return resultErr
+}
+
+func linuxDescendantIdentities(root int) (map[int]linuxProcessIdentity, error) {
+	result := make(map[int]linuxProcessIdentity)
+	queue := []int{root}
+	for len(queue) > 0 {
+		parent := queue[0]
+		queue = queue[1:]
+		children, err := linuxDirectChildIdentities(parent)
+		if err != nil {
+			if linuxProcessGone(err) {
+				continue
+			}
+			return result, err
+		}
+		for pid := range children {
+			if _, exists := result[pid]; exists {
+				continue
+			}
+			identity, err := readLinuxProcessIdentity(pid)
+			if linuxProcessGone(err) {
+				continue
+			}
+			if err != nil {
+				return result, err
+			}
+			result[pid] = identity
+			queue = append(queue, pid)
+		}
+	}
+	return result, nil
 }
 
 func newDuplexCommandContainment(cmd *exec.Cmd) (*commandContainment, error) {
@@ -156,15 +464,31 @@ func (containment *commandContainment) attach(cmd *exec.Cmd) error {
 	if containment.cgroupPath != "" {
 		return nil // CLONE_INTO_CGROUP attached the child atomically at creation.
 	}
-	if containment.groupOnly {
-		return nil
+	if containment.supervisorRequest != nil {
+		for _, file := range cmd.ExtraFiles {
+			if err := file.Close(); err != nil {
+				return fmt.Errorf("close inherited Linux supervisor descriptor: %w", err)
+			}
+		}
+		cmd.ExtraFiles = nil
 	}
 	identity, err := readLinuxProcessIdentity(cmd.Process.Pid)
 	if err != nil {
+		// A trusted command can complete between Start and attachment. Its
+		// process group remains the containment boundary and Wait still owns the
+		// exact exit status; there is no live leader identity left to stabilize.
+		// Treat this narrow natural-exit race as successful attachment instead of
+		// turning a rapid successful command into a runner failure.
+		if linuxProcessGone(err) {
+			return nil
+		}
 		return fmt.Errorf("read Linux process leader identity: %w", err)
 	}
 	pidfd, err := unix.PidfdOpen(identity.pid, 0)
 	if err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
 		return fmt.Errorf("open stable Linux process handle: %w", err)
 	}
 	containment.mu.Lock()
@@ -178,7 +502,10 @@ func (containment *commandContainment) attach(cmd *exec.Cmd) error {
 	return nil
 }
 
-func (containment *commandContainment) limitToProcessGroup() { containment.groupOnly = true }
+// Git and other tree-grace callers need the same detached-descendant proof as
+// every ordinary command. Retain this hook for platform-neutral call sites;
+// Linux intentionally does not reduce containment to a process group.
+func (containment *commandContainment) limitToProcessGroup() {}
 
 func (containment *commandContainment) terminate() terminationResult {
 	if containment.cmd.Process == nil {
@@ -187,7 +514,12 @@ func (containment *commandContainment) terminate() terminationResult {
 	if containment.cgroupPath != "" {
 		return containment.terminateCgroup()
 	}
+	if containment.supervisorRequest != nil {
+		return containment.terminateSupervisor()
+	}
 	scanErr := containment.scanDescendants()
+	leaderLive, leaderInspectErr := linuxProcessLive(containment.cmd.Process.Pid)
+	scanErr = errors.Join(scanErr, leaderInspectErr)
 	forcedMembers := false
 	groupMembers, groupScanErr := liveLinuxProcessGroupMembers(containment.cmd.Process.Pid)
 	if groupMembers > 0 {
@@ -196,12 +528,22 @@ func (containment *commandContainment) terminate() terminationResult {
 	scanErr = errors.Join(scanErr, groupScanErr)
 	containment.mu.Lock()
 	for pid, tracked := range containment.descendants {
-		if pid != containment.cmd.Process.Pid && linuxPidfdAlive(tracked.pidfd) {
+		if pid == containment.cmd.Process.Pid {
+			continue
+		}
+		live, err := liveLinuxTrackedProcess(pid, tracked)
+		if err != nil {
+			scanErr = errors.Join(scanErr, fmt.Errorf("classify tracked descendant %d before cleanup: %w", pid, err))
+			// If identity cannot be classified, preserve forced-cleanup
+			// causality rather than accepting a natural-looking command exit.
+			forcedMembers = true
+		} else if live {
 			forcedMembers = true
 		}
 	}
 	containment.mu.Unlock()
 	groupErr := syscall.Kill(-containment.cmd.Process.Pid, syscall.SIGKILL)
+	leaderTerminationInitiated := leaderLive && groupErr == nil
 	if errors.Is(groupErr, syscall.ESRCH) {
 		groupErr = nil
 	}
@@ -230,7 +572,35 @@ func (containment *commandContainment) terminate() terminationResult {
 		}
 	}
 	deadline := time.Now().Add(time.Second)
+	emptyPasses := 0
 	for {
+		// Killing a tracked parent can expose a child that forked after the
+		// previous snapshot. As the active subreaper, recover each newly adopted
+		// identity and repeat until a full pass proves that no live member remains.
+		if err := containment.scanDescendants(); err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
+		}
+		containment.mu.Lock()
+		for pid, tracked := range containment.descendants {
+			if _, known := identities[pid]; known {
+				continue
+			}
+			identities[pid] = tracked
+			if pid == containment.cmd.Process.Pid {
+				continue
+			}
+			live, err := liveLinuxTrackedProcess(pid, tracked)
+			if err != nil {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("classify newly adopted descendant %d before cleanup: %w", pid, err))
+				forcedMembers = true
+			} else if live {
+				forcedMembers = true
+				if err := unix.PidfdSendSignal(tracked.pidfd, unix.SIGKILL, nil, 0); err != nil && !errors.Is(err, syscall.ESRCH) {
+					cleanupErr = errors.Join(cleanupErr, fmt.Errorf("terminate newly adopted descendant %d through pidfd: %w", pid, err))
+				}
+			}
+		}
+		containment.mu.Unlock()
 		leaderStopped, observeErr := containment.exited()
 		remaining := 0
 		for pid, tracked := range identities {
@@ -238,6 +608,13 @@ func (containment *commandContainment) terminate() terminationResult {
 				continue
 			}
 			identity, err := readLinuxProcessIdentity(pid)
+			if err == nil && identity.startTime == tracked.startTime && identity.zombie && identity.ppid == os.Getpid() {
+				var info unix.Siginfo
+				if reapErr := unix.Waitid(unix.P_PID, pid, &info, unix.WEXITED|unix.WNOHANG, nil); reapErr != nil && !errors.Is(reapErr, syscall.ECHILD) && !errors.Is(reapErr, syscall.ESRCH) {
+					cleanupErr = errors.Join(cleanupErr, fmt.Errorf("reap adopted tracked descendant %d: %w", pid, reapErr))
+				}
+				continue
+			}
 			if err == nil && identity.startTime == tracked.startTime && !identity.zombie && linuxPidfdAlive(tracked.pidfd) {
 				remaining++
 			} else if err != nil && linuxPidfdAlive(tracked.pidfd) {
@@ -245,7 +622,12 @@ func (containment *commandContainment) terminate() terminationResult {
 			}
 		}
 		if leaderStopped && remaining == 0 {
-			return terminationResult{leaderStopped: true, forcedMembers: forcedMembers, err: errors.Join(groupErr, cleanupErr)}
+			emptyPasses++
+			if emptyPasses >= 2 {
+				return terminationResult{leaderStopped: true, leaderTerminationInitiated: leaderTerminationInitiated, forcedMembers: forcedMembers, err: errors.Join(groupErr, cleanupErr)}
+			}
+		} else {
+			emptyPasses = 0
 		}
 		if observeErr != nil {
 			cleanupErr = errors.Join(cleanupErr, observeErr)
@@ -257,10 +639,55 @@ func (containment *commandContainment) terminate() terminationResult {
 			if remaining != 0 {
 				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("%d tracked descendant process(es) survived cleanup deadline", remaining))
 			}
-			return terminationResult{leaderStopped: leaderStopped, forcedMembers: forcedMembers, err: errors.Join(groupErr, cleanupErr)}
+			return terminationResult{leaderStopped: leaderStopped, leaderTerminationInitiated: leaderTerminationInitiated, forcedMembers: forcedMembers, err: errors.Join(groupErr, cleanupErr)}
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
+}
+
+func (containment *commandContainment) terminateSupervisor() terminationResult {
+	alreadyExited, observeErr := containment.exited()
+	requestErr := containment.supervisorRequest.Close()
+	containment.supervisorRequest = nil
+	if errors.Is(requestErr, os.ErrClosed) {
+		requestErr = nil
+	}
+	deadline := time.Now().Add(processReapTimeout)
+	exited := alreadyExited
+	for !exited && observeErr == nil && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+		exited, observeErr = containment.exited()
+	}
+	if !exited && observeErr == nil {
+		observeErr = fmt.Errorf("isolated ordinary-command supervisor did not stop before cleanup deadline")
+	}
+	var statusErr error
+	if exited {
+		statusErr = containment.readSupervisorResult()
+		if containment.supervisorResult.Error != "" {
+			statusErr = errors.Join(statusErr, errors.New(containment.supervisorResult.Error))
+		}
+	}
+	return terminationResult{
+		leaderStopped:              exited,
+		leaderTerminationInitiated: !alreadyExited && requestErr == nil,
+		forcedMembers:              containment.supervisorResult.Forced,
+		err:                        errors.Join(requestErr, observeErr, statusErr),
+	}
+}
+
+func (containment *commandContainment) readSupervisorResult() error {
+	if containment.supervisorRead || containment.supervisorStatus == nil {
+		return nil
+	}
+	containment.supervisorRead = true
+	err := json.NewDecoder(containment.supervisorStatus).Decode(&containment.supervisorResult)
+	closeErr := containment.supervisorStatus.Close()
+	containment.supervisorStatus = nil
+	if errors.Is(err, io.EOF) {
+		err = fmt.Errorf("isolated ordinary-command supervisor returned no cleanup proof")
+	}
+	return errors.Join(err, closeErr)
 }
 
 func (containment *commandContainment) exited() (bool, error) {
@@ -312,7 +739,7 @@ func (containment *commandContainment) settleNaturalExit(ctx context.Context, ti
 	}
 }
 
-func (containment *commandContainment) close() error {
+func (containment *commandContainment) close() (resultErr error) {
 	if containment.closeTransferred {
 		return fmt.Errorf("Linux descendant tracker ownership was transferred to its reaper")
 	}
@@ -327,10 +754,21 @@ func (containment *commandContainment) close() error {
 		containment.cgroupPath = ""
 		return nil
 	}
+	if containment.supervisorRequest != nil {
+		resultErr = errors.Join(resultErr, containment.supervisorRequest.Close())
+		containment.supervisorRequest = nil
+	}
+	if containment.supervisorStatus != nil {
+		resultErr = errors.Join(resultErr, containment.supervisorStatus.Close())
+		containment.supervisorStatus = nil
+	}
+	for _, file := range containment.cmd.ExtraFiles {
+		resultErr = errors.Join(resultErr, file.Close())
+	}
+	containment.cmd.ExtraFiles = nil
 	if containment.cmd.Process == nil {
 		return nil
 	}
-	var resultErr error
 	if containment.trackerStarted {
 		select {
 		case <-containment.stop:
@@ -374,9 +812,19 @@ func (containment *commandContainment) terminateCgroup() terminationResult {
 }
 
 func (containment *commandContainment) terminateCgroupWithin(timeout time.Duration) terminationResult {
-	members, inspectErr := readCgroupProcs(filepath.Join(containment.cgroupPath, "cgroup.procs"))
-	forced, inspectErr := cgroupForcedMemberCausality(containment.cmd.Process.Pid, members, inspectErr)
+	procsPath := filepath.Join(containment.cgroupPath, "cgroup.procs")
+	members, inspectErr := readCgroupProcs(procsPath)
+	forced, memberInspectErr, releaseMemberIdentities := containment.cgroupForcedMemberCausality(procsPath, members, inspectErr)
+	defer releaseMemberIdentities()
+	inspectErr = memberInspectErr
+	prepare := containment.prepareLeaderTermination
+	if prepare == nil {
+		prepare = prepareLinuxLeaderTermination
+	}
+	leaderPrepared, leaderInspectErr := prepare(containment.cmd.Process.Pid, timeout)
+	inspectErr = errors.Join(inspectErr, leaderInspectErr)
 	killErr := writeCgroupKill(filepath.Join(containment.cgroupPath, "cgroup.kill"), []byte("1"), 0)
+	leaderTerminationInitiated := leaderPrepared && killErr == nil
 	if errors.Is(killErr, os.ErrNotExist) {
 		killErr = nil
 	}
@@ -385,16 +833,155 @@ func (containment *commandContainment) terminateCgroupWithin(timeout time.Durati
 		exited, observeErr := containment.exited()
 		empty, emptyErr := containment.cgroupEmpty()
 		if exited && empty {
-			return terminationResult{leaderStopped: true, forcedMembers: forced, err: errors.Join(inspectErr, killErr, observeErr, emptyErr)}
+			return terminationResult{leaderStopped: true, leaderTerminationInitiated: leaderTerminationInitiated, forcedMembers: forced, err: errors.Join(inspectErr, killErr, observeErr, emptyErr)}
 		}
 		if time.Now().After(deadline) {
-			return terminationResult{leaderStopped: exited, forcedMembers: forced, err: errors.Join(inspectErr, killErr, observeErr, emptyErr, fmt.Errorf("duplex cgroup did not empty before cleanup deadline"))}
+			return terminationResult{leaderStopped: exited, leaderTerminationInitiated: leaderTerminationInitiated, forcedMembers: forced, err: errors.Join(inspectErr, killErr, observeErr, emptyErr, fmt.Errorf("duplex cgroup did not empty before cleanup deadline"))}
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
 }
 
+func (containment *commandContainment) cgroupForcedMemberCausality(procsPath string, members []byte, inspectErr error) (bool, error, func()) {
+	if containment.inspectLive != nil {
+		forced, err := cgroupForcedMemberCausalityWithInspect(containment.cmd.Process.Pid, members, inspectErr, containment.inspectLive)
+		return forced, err, func() {}
+	}
+	return stableCgroupForcedMemberCausality(containment.cmd.Process.Pid, procsPath, members, inspectErr)
+}
+
+// stableCgroupForcedMemberCausality binds every pre-signal liveness decision to
+// a pidfd and procfs start time. cgroup.procs contains numeric PIDs, so using a
+// later unbound /proc lookup could attribute cleanup either to a naturally
+// exited zombie or to a recycled identity. The second membership snapshot
+// closes the list-to-pidfd race; retained pidfds keep each classified identity
+// stable through cgroup.kill.
+func stableCgroupForcedMemberCausality(leaderPID int, procsPath string, members []byte, inspectErr error) (bool, error, func()) {
+	type candidate struct {
+		identity linuxProcessIdentity
+		pidfd    int
+	}
+	candidates := make(map[int]candidate)
+	release := func() {
+		for _, candidate := range candidates {
+			_ = unix.Close(candidate.pidfd)
+		}
+	}
+	if inspectErr != nil {
+		return true, fmt.Errorf("inspect cgroup members before forced cleanup: %w", inspectErr), release
+	}
+	for _, raw := range strings.Fields(string(members)) {
+		pid, err := strconv.Atoi(raw)
+		if err != nil {
+			return true, fmt.Errorf("parse cgroup member %q before forced cleanup: %w", raw, err), release
+		}
+		if pid == leaderPID {
+			continue
+		}
+		identity, err := readLinuxProcessIdentity(pid)
+		if linuxProcessGone(err) {
+			continue
+		}
+		if err != nil {
+			return true, fmt.Errorf("inspect cgroup member %d identity before forced cleanup: %w", pid, err), release
+		}
+		pidfd, err := unix.PidfdOpen(pid, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			continue
+		}
+		if err != nil {
+			return true, fmt.Errorf("open stable cgroup member handle for %d: %w", pid, err), release
+		}
+		candidates[pid] = candidate{identity: identity, pidfd: pidfd}
+	}
+	confirmedMembers, err := readCgroupProcs(procsPath)
+	if err != nil {
+		return true, fmt.Errorf("confirm stable cgroup members before forced cleanup: %w", err), release
+	}
+	confirmed := make(map[int]bool)
+	for _, raw := range strings.Fields(string(confirmedMembers)) {
+		pid, parseErr := strconv.Atoi(raw)
+		if parseErr != nil {
+			return true, fmt.Errorf("parse confirmed cgroup member %q before forced cleanup: %w", raw, parseErr), release
+		}
+		confirmed[pid] = true
+	}
+	forced := false
+	for pid, candidate := range candidates {
+		if !confirmed[pid] {
+			continue
+		}
+		current, err := readLinuxProcessIdentity(pid)
+		if linuxProcessGone(err) || !linuxPidfdAlive(candidate.pidfd) {
+			continue
+		}
+		if err != nil {
+			return true, fmt.Errorf("confirm cgroup member %d identity before forced cleanup: %w", pid, err), release
+		}
+		if current.startTime != candidate.identity.startTime {
+			return true, fmt.Errorf("cgroup member %d identity changed before forced cleanup", pid), release
+		}
+		if !current.zombie {
+			forced = true
+		}
+	}
+	return forced, nil, release
+}
+
+// prepareLinuxLeaderTermination establishes a causal boundary before
+// cgroup.kill. Merely observing a live /proc entry is insufficient: a leader
+// can already be inside natural exit and receive SIGKILL before it becomes a
+// waitable zombie. A leader that accepts SIGSTOP and reaches a stopped state is
+// still controllably live after planned teardown was requested; a leader that
+// becomes a zombie first must be reported as a premature natural exit.
+func prepareLinuxLeaderTermination(pid int, timeout time.Duration) (bool, error) {
+	identity, err := readLinuxProcessIdentity(pid)
+	if linuxProcessGone(err) || (err == nil && identity.zombie) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("inspect process leader before termination boundary: %w", err)
+	}
+	pidfd, err := unix.PidfdOpen(pid, 0)
+	if errors.Is(err, syscall.ESRCH) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("open stable process leader handle before termination boundary: %w", err)
+	}
+	defer unix.Close(pidfd)
+	if err := unix.PidfdSendSignal(pidfd, unix.SIGSTOP, nil, 0); errors.Is(err, syscall.ESRCH) {
+		return false, nil
+	} else if err != nil {
+		return false, fmt.Errorf("stop process leader at termination boundary: %w", err)
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		current, err := readLinuxProcessIdentity(pid)
+		if linuxProcessGone(err) || (err == nil && current.startTime == identity.startTime && current.zombie) {
+			return false, nil
+		}
+		if err != nil {
+			return false, fmt.Errorf("observe process leader termination boundary: %w", err)
+		}
+		if current.startTime != identity.startTime {
+			return false, fmt.Errorf("process leader identity changed at termination boundary")
+		}
+		if current.stopped {
+			return true, nil
+		}
+		if time.Now().After(deadline) {
+			return false, fmt.Errorf("process leader did not stop before termination boundary deadline")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
 func cgroupForcedMemberCausality(leaderPID int, members []byte, inspectErr error) (bool, error) {
+	return cgroupForcedMemberCausalityWithInspect(leaderPID, members, inspectErr, linuxProcessLive)
+}
+
+func cgroupForcedMemberCausalityWithInspect(leaderPID int, members []byte, inspectErr error, inspect func(int) (bool, error)) (bool, error) {
 	if inspectErr != nil {
 		// Once cgroup.kill is requested, inability to inventory the scope makes
 		// descendant causality uncertain. Fail closed so a natural-looking leader
@@ -402,11 +989,44 @@ func cgroupForcedMemberCausality(leaderPID int, members []byte, inspectErr error
 		return true, fmt.Errorf("inspect cgroup members before forced cleanup: %w", inspectErr)
 	}
 	for _, raw := range strings.Fields(string(members)) {
-		if raw != strconv.Itoa(leaderPID) {
+		pid, err := strconv.Atoi(raw)
+		if err != nil {
+			return true, fmt.Errorf("parse cgroup member %q before forced cleanup: %w", raw, err)
+		}
+		if pid == leaderPID {
+			continue
+		}
+		live, err := inspect(pid)
+		if err != nil {
+			return true, fmt.Errorf("classify cgroup member %d before forced cleanup: %w", pid, err)
+		}
+		if live {
 			return true, nil
 		}
 	}
 	return false, nil
+}
+
+func (containment *commandContainment) processLive(pid int) (bool, error) {
+	if containment.inspectLive != nil {
+		return containment.inspectLive(pid)
+	}
+	return linuxProcessLive(pid)
+}
+
+// linuxProcessLive classifies the exact, currently installed procfs identity.
+// A zombie is already naturally exited and must not be attributed to a later
+// cleanup signal; disappearance during inspection likewise proves there is no
+// remaining identity to signal.
+func linuxProcessLive(pid int) (bool, error) {
+	identity, err := readLinuxProcessIdentity(pid)
+	if linuxProcessGone(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return !identity.zombie, nil
 }
 
 func (containment *commandContainment) settleCgroup(ctx context.Context, timeout time.Duration) (bool, error) {
@@ -449,6 +1069,7 @@ type linuxProcessIdentity struct {
 	pgid      int
 	startTime uint64
 	zombie    bool
+	stopped   bool
 }
 
 func readLinuxProcessIdentity(pid int) (linuxProcessIdentity, error) {
@@ -476,7 +1097,7 @@ func readLinuxProcessIdentity(pid int) (linuxProcessIdentity, error) {
 	if err != nil {
 		return linuxProcessIdentity{}, err
 	}
-	return linuxProcessIdentity{pid: pid, ppid: ppid, pgid: pgid, startTime: startTime, zombie: fields[0] == "Z"}, nil
+	return linuxProcessIdentity{pid: pid, ppid: ppid, pgid: pgid, startTime: startTime, zombie: fields[0] == "Z", stopped: fields[0] == "T" || fields[0] == "t"}, nil
 }
 
 func liveLinuxProcessGroupMembers(pgid int) (int, error) {
@@ -509,6 +1130,64 @@ type linuxTrackedProcess struct {
 func linuxPidfdAlive(pidfd int) bool {
 	err := unix.PidfdSendSignal(pidfd, 0, nil, 0)
 	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+func linuxProcessGone(err error) bool {
+	return errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ENOENT) || errors.Is(err, syscall.ESRCH)
+}
+
+// liveLinuxTrackedProcess distinguishes a live descendant from an exited but
+// unreaped zombie. pidfd signal checks alone report zombies as present, which
+// would incorrectly attribute forced cleanup to a helper that exited naturally.
+// The start time binds the /proc observation to the identity represented by the
+// pidfd; disappearance after the pidfd check is an ordinary exit race.
+func liveLinuxTrackedProcess(pid int, tracked linuxTrackedProcess) (bool, error) {
+	if !linuxPidfdAlive(tracked.pidfd) {
+		return false, nil
+	}
+	identity, err := readLinuxProcessIdentity(pid)
+	if linuxProcessGone(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if identity.startTime != tracked.startTime {
+		return false, fmt.Errorf("process start time changed")
+	}
+	return !identity.zombie, nil
+}
+
+func linuxDirectChildIdentities(pid int) (map[int]uint64, error) {
+	childrenByIdentity := make(map[int]uint64)
+	tasks, err := os.ReadDir(fmt.Sprintf("/proc/%d/task", pid))
+	if err != nil {
+		return nil, err
+	}
+	for _, task := range tasks {
+		children, err := os.ReadFile(fmt.Sprintf("/proc/%d/task/%s/children", pid, task.Name()))
+		if err != nil {
+			if linuxProcessGone(err) {
+				continue
+			}
+			return nil, err
+		}
+		for _, rawChild := range strings.Fields(string(children)) {
+			child, err := strconv.Atoi(rawChild)
+			if err != nil {
+				continue
+			}
+			identity, err := readLinuxProcessIdentity(child)
+			if linuxProcessGone(err) {
+				continue
+			}
+			if err != nil {
+				return nil, err
+			}
+			childrenByIdentity[child] = identity.startTime
+		}
+	}
+	return childrenByIdentity, nil
 }
 
 func (containment *commandContainment) trackDescendants() {
@@ -554,8 +1233,13 @@ func (containment *commandContainment) scanDescendants() error {
 		seen[pid] = struct{}{}
 		tasks, err := os.ReadDir(fmt.Sprintf("/proc/%d/task", pid))
 		if err != nil {
-			if tracked, ok := containment.descendants[pid]; ok && linuxPidfdAlive(tracked.pidfd) {
-				scanErr = errors.Join(scanErr, fmt.Errorf("inspect tasks for live tracked process %d: %w", pid, err))
+			if tracked, ok := containment.descendants[pid]; ok {
+				live, classifyErr := liveLinuxTrackedProcess(pid, tracked)
+				if classifyErr != nil {
+					scanErr = errors.Join(scanErr, fmt.Errorf("classify tracked process %d after task inspection failed: %w", pid, classifyErr))
+				} else if live {
+					scanErr = errors.Join(scanErr, fmt.Errorf("inspect tasks for live tracked process %d: %w", pid, err))
+				}
 			}
 			continue
 		}
@@ -565,11 +1249,16 @@ func (containment *commandContainment) scanDescendants() error {
 				// Threads can disappear between ReadDir and opening their children
 				// file. The remaining live threads are still inspected in this same
 				// snapshot, so this race is not an ancestry blind spot.
-				if errors.Is(err, os.ErrNotExist) {
+				if linuxProcessGone(err) {
 					continue
 				}
-				if tracked, ok := containment.descendants[pid]; ok && linuxPidfdAlive(tracked.pidfd) {
-					scanErr = errors.Join(scanErr, fmt.Errorf("inspect children for live tracked process %d: %w", pid, err))
+				if tracked, ok := containment.descendants[pid]; ok {
+					live, classifyErr := liveLinuxTrackedProcess(pid, tracked)
+					if classifyErr != nil {
+						scanErr = errors.Join(scanErr, fmt.Errorf("classify tracked process %d after child inspection failed: %w", pid, classifyErr))
+					} else if live {
+						scanErr = errors.Join(scanErr, fmt.Errorf("inspect children for live tracked process %d: %w", pid, err))
+					}
 				}
 				continue
 			}
@@ -580,11 +1269,27 @@ func (containment *commandContainment) scanDescendants() error {
 				}
 				identity, err := readLinuxProcessIdentity(child)
 				if err != nil {
+					// A child can exit after the kernel children snapshot but
+					// before /proc/<pid>/stat is opened. There is no process left
+					// to contain in that case, so this ordinary exit race is not a
+					// loss of containment evidence.
+					if linuxProcessGone(err) {
+						continue
+					}
 					scanErr = errors.Join(scanErr, fmt.Errorf("read observed child %d of %d: %w", child, pid, err))
 					continue
 				}
 				pidfd, err := unix.PidfdOpen(child, 0)
 				if err != nil {
+					// Kernels can report ESRCH or EINVAL when that same observed
+					// child exits before the stable handle is acquired. Accept the
+					// race only after /proc proves the observed identity is no
+					// longer live; every failure for a surviving child remains
+					// fail-closed.
+					current, currentErr := readLinuxProcessIdentity(child)
+					if linuxProcessGone(currentErr) || (currentErr == nil && (current.zombie || current.startTime != identity.startTime)) {
+						continue
+					}
 					scanErr = errors.Join(scanErr, fmt.Errorf("open stable handle for observed child %d: %w", child, err))
 					continue
 				}
@@ -592,6 +1297,12 @@ func (containment *commandContainment) scanDescendants() error {
 				if err != nil || revalidated.startTime != identity.startTime {
 					_ = unix.Close(pidfd)
 					if err != nil {
+						// The pidfd pins the identity against reuse. If /proc now
+						// reports it gone, the observed child completed naturally;
+						// there is no descendant left to track or signal.
+						if linuxProcessGone(err) {
+							continue
+						}
 						scanErr = errors.Join(scanErr, fmt.Errorf("revalidate observed child %d identity: %w", child, err))
 					} else {
 						scanErr = errors.Join(scanErr, fmt.Errorf("revalidate observed child %d identity: process start time changed", child))
@@ -601,6 +1312,11 @@ func (containment *commandContainment) scanDescendants() error {
 				if revalidated.ppid != pid {
 					parent, parentErr := readLinuxProcessIdentity(pid)
 					if parentErr == nil && !parent.zombie {
+						current, currentErr := readLinuxProcessIdentity(child)
+						if linuxProcessGone(currentErr) || (currentErr == nil && (current.zombie || current.startTime != identity.startTime)) {
+							_ = unix.Close(pidfd)
+							continue
+						}
 						_ = unix.Close(pidfd)
 						scanErr = errors.Join(scanErr, fmt.Errorf("revalidate observed child %d parentage: live parent changed from %d to %d", child, pid, revalidated.ppid))
 						continue

--- a/install/integrationctl/adapters/process/osrunner_tree_linux_test.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_linux_test.go
@@ -1,0 +1,409 @@
+//go:build linux
+
+package process
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/ports"
+)
+
+func TestOSRunnerPlannedDuplexShutdownContainsImmediateSetsidDescendant(t *testing.T) {
+	requireDuplexCapability(t)
+	if os.Getenv("AGENTPLUGINS_DUPLEX_CGROUP_ESCAPE_CHILD") == "1" {
+		_, _ = syscall.Setsid()
+		for {
+			time.Sleep(time.Hour)
+		}
+	}
+	if pidPath := os.Getenv("AGENTPLUGINS_DUPLEX_CGROUP_ESCAPE_PID"); pidPath != "" {
+		child := exec.Command(os.Args[0], "-test.run=TestOSRunnerPlannedDuplexShutdownContainsImmediateSetsidDescendant")
+		child.Env = append(os.Environ(), "AGENTPLUGINS_DUPLEX_CGROUP_ESCAPE_CHILD=1")
+		if err := child.Start(); err != nil {
+			os.Exit(81)
+		}
+		if err := os.WriteFile(pidPath, []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil {
+			os.Exit(82)
+		}
+		fmt.Fprintln(os.Stdout, "ready")
+		for {
+			time.Sleep(time.Hour)
+		}
+	}
+	pidPath := t.TempDir() + "/escape.pid"
+	environment := append(os.Environ(), "AGENTPLUGINS_DUPLEX_CGROUP_ESCAPE_PID="+pidPath)
+	err := (OS{}).RunDuplexWithPlannedShutdown(context.Background(), ports.Command{
+		Argv: []string{os.Args[0], "-test.run=TestOSRunnerPlannedDuplexShutdownContainsImmediateSetsidDescendant"}, Env: environment,
+	}, func(_ io.Writer, stdout io.Reader) error {
+		line, err := bufio.NewReader(stdout).ReadString('\n')
+		if err != nil || line != "ready\n" {
+			return fmt.Errorf("escape helper readiness = %q: %w", line, err)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(pidPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid, err := strconv.Atoi(string(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Kill(pid, 0); err == nil || !errors.Is(err, syscall.ESRCH) {
+		t.Fatalf("immediate setsid descendant %d survived cgroup cleanup: %v", pid, err)
+	}
+}
+
+func TestOSRunnerCancellationContainsImmediateSetsidDescendant(t *testing.T) {
+	requireDuplexCapability(t)
+	if os.Getenv("AGENTPLUGINS_RUN_CANCEL_ESCAPE_CHILD") == "1" {
+		_, _ = syscall.Setsid()
+		for {
+			time.Sleep(time.Hour)
+		}
+	}
+	if pidPath := os.Getenv("AGENTPLUGINS_RUN_CANCEL_ESCAPE_PID"); pidPath != "" {
+		child := exec.Command(os.Args[0], "-test.run=TestOSRunnerCancellationContainsImmediateSetsidDescendant")
+		child.Env = append(os.Environ(), "AGENTPLUGINS_RUN_CANCEL_ESCAPE_CHILD=1")
+		if err := child.Start(); err != nil {
+			os.Exit(91)
+		}
+		if err := os.WriteFile(pidPath, []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil {
+			os.Exit(92)
+		}
+		for {
+			time.Sleep(time.Hour)
+		}
+	}
+
+	pidPath := t.TempDir() + "/escape.pid"
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := (OS{}).Run(ctx, ports.Command{
+			Argv: []string{os.Args[0], "-test.run=TestOSRunnerCancellationContainsImmediateSetsidDescendant"},
+			Env:  append(os.Environ(), "AGENTPLUGINS_RUN_CANCEL_ESCAPE_PID="+pidPath),
+		})
+		done <- err
+	}()
+	deadline := time.Now().Add(time.Second)
+	for {
+		if _, err := os.Stat(pidPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("escape descendant was not started")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run cancellation error = %v, want context cancellation", err)
+	}
+	body, err := os.ReadFile(pidPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid, err := strconv.Atoi(string(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if processStillRunning(pid) {
+		t.Fatalf("setsid descendant %d survived Run cancellation", pid)
+	}
+}
+
+func TestDuplexCapabilityRejectsNonCgroupDelegationBeforeStart(t *testing.T) {
+	_, _, err := createDelegatedCgroupAt(t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "cgroup") {
+		t.Fatalf("capability primitive error = %v, want honest pre-start unsupported result", err)
+	}
+}
+
+func TestDuplexCapabilityProbeUnprovedShutdownWaitIsHardBoundAndRetainsSoleReaper(t *testing.T) {
+	waitRelease := make(chan struct{})
+	waitStarted := make(chan struct{})
+	waitReturned := make(chan struct{})
+	defer func() {
+		close(waitRelease)
+		select {
+		case <-waitReturned:
+		case <-time.After(time.Second):
+			t.Fatal("probe's owned Wait did not finish after simulated exit")
+		}
+	}()
+	started := time.Now()
+	terminationErr := errors.New("containment and fallback shutdown failed")
+	err := finishDuplexContainmentProbe(terminationResult{err: terminationErr}, func() error { return nil }, func() error {
+		close(waitStarted)
+		<-waitRelease
+		close(waitReturned)
+		return nil
+	}, time.Millisecond)
+	<-waitStarted
+	if err == nil || !errors.Is(err, terminationErr) || !strings.Contains(err.Error(), "shutdown was not proved") || !strings.Contains(err.Error(), "exceeded cleanup deadline") || !strings.Contains(err.Error(), "sole reaper retains ownership until process exit") {
+		t.Fatalf("unproved stuck probe Wait error = %v, want bounded fail-closed owned-reaper failure", err)
+	}
+	if elapsed := time.Since(started); elapsed > 100*time.Millisecond {
+		t.Fatalf("stuck probe Wait returned too slowly after %s", elapsed)
+	}
+}
+
+func TestDuplexCapabilityProbeCannotSucceedWithoutProvenLeaderStop(t *testing.T) {
+	waitCalls := 0
+	err := finishDuplexContainmentProbe(terminationResult{}, func() error { return nil }, func() error {
+		waitCalls++
+		return nil
+	}, time.Second)
+	if err == nil || !strings.Contains(err.Error(), "shutdown was not proved") || waitCalls != 1 {
+		t.Fatalf("unproved probe cleanup error = %v wait calls = %d, want fail-closed sole reap", err, waitCalls)
+	}
+}
+
+func TestLinuxTrackerTimeoutTransfersHandleOwnershipUntilJoin(t *testing.T) {
+	done := make(chan struct{})
+	containment := &commandContainment{
+		cmd: &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}, descendants: make(map[int]linuxTrackedProcess),
+		stop: make(chan struct{}), done: done, trackerStarted: true,
+	}
+	err := containment.close()
+	if err == nil || !strings.Contains(err.Error(), "ownership transferred") {
+		t.Fatalf("stalled tracker close error = %v", err)
+	}
+	containment.mu.Lock()
+	owned := containment.descendants != nil
+	containment.mu.Unlock()
+	if !owned {
+		t.Fatal("tracker-owned map was released before the tracker joined")
+	}
+	close(done)
+	deadline := time.Now().Add(time.Second)
+	for {
+		containment.mu.Lock()
+		released := containment.descendants == nil
+		containment.mu.Unlock()
+		if released {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("owned tracker reaper did not release handles after join")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestOSRunnerCleansSameProcessGroupMemberAfterLeaderNaturalExit(t *testing.T) {
+	requireDuplexCapability(t)
+	if os.Getenv("AGENTPLUGINS_PROCESS_RUN_DESCENDANT") == "1" {
+		for {
+			time.Sleep(time.Hour)
+		}
+	}
+	if pidPath := os.Getenv("AGENTPLUGINS_PROCESS_RUN_LEADER_PID_PATH"); pidPath != "" {
+		child := exec.Command(os.Args[0], "-test.run=TestOSRunnerCleansSameProcessGroupMemberAfterLeaderNaturalExit")
+		child.Env = append(os.Environ(), "AGENTPLUGINS_PROCESS_RUN_DESCENDANT=1")
+		devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+		if err != nil {
+			os.Exit(61)
+		}
+		child.Stdin = devNull
+		child.Stdout = devNull
+		child.Stderr = devNull
+		if err := child.Start(); err != nil {
+			os.Exit(62)
+		}
+		if err := os.WriteFile(pidPath, []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil {
+			os.Exit(63)
+		}
+		os.Exit(0)
+	}
+
+	pidPath := t.TempDir() + "/descendant.pid"
+	environment := append(os.Environ(), "AGENTPLUGINS_PROCESS_RUN_LEADER_PID_PATH="+pidPath)
+	_, err := (OS{}).RunWithTreeExitGrace(context.Background(), ports.Command{
+		Argv: []string{os.Args[0], "-test.run=TestOSRunnerCleansSameProcessGroupMemberAfterLeaderNaturalExit"},
+		Env:  environment,
+	}, time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "live descendants that required forced cleanup") {
+		t.Fatalf("clean leader exit error = %v, want forced-descendant causality", err)
+	}
+	body, readErr := os.ReadFile(pidPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	pid, parseErr := strconv.Atoi(string(body))
+	if parseErr != nil {
+		t.Fatal(parseErr)
+	}
+	deadline := time.Now().Add(time.Second)
+	for processStillRunning(pid) && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if processStillRunning(pid) {
+		t.Fatalf("same-process-group member %d survived leader cleanup", pid)
+	}
+}
+
+func TestOSRunnerPreservesDiagnosticAndStatusWhileCleaningNaturalExitGroup(t *testing.T) {
+	requireDuplexCapability(t)
+	if os.Getenv("AGENTPLUGINS_PROCESS_DIAGNOSTIC_DESCENDANT") == "1" {
+		for {
+			time.Sleep(time.Hour)
+		}
+	}
+	if pidPath := os.Getenv("AGENTPLUGINS_PROCESS_DIAGNOSTIC_LEADER_PID_PATH"); pidPath != "" {
+		child := exec.Command(os.Args[0], "-test.run=TestOSRunnerPreservesDiagnosticAndStatusWhileCleaningNaturalExitGroup")
+		child.Env = append(os.Environ(), "AGENTPLUGINS_PROCESS_DIAGNOSTIC_DESCENDANT=1")
+		devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+		if err != nil {
+			os.Exit(71)
+		}
+		child.Stdin = devNull
+		child.Stdout = devNull
+		child.Stderr = devNull
+		if err := child.Start(); err != nil {
+			os.Exit(72)
+		}
+		if err := os.WriteFile(pidPath, []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil {
+			os.Exit(73)
+		}
+		fmt.Fprint(os.Stderr, "fatal bounded-process diagnostic")
+		os.Exit(47)
+	}
+
+	pidPath := t.TempDir() + "/descendant.pid"
+	environment := append(os.Environ(), "AGENTPLUGINS_PROCESS_DIAGNOSTIC_LEADER_PID_PATH="+pidPath)
+	_, err := (OS{}).RunWithTreeExitGrace(context.Background(), ports.Command{
+		Argv: []string{os.Args[0], "-test.run=TestOSRunnerPreservesDiagnosticAndStatusWhileCleaningNaturalExitGroup"},
+		Env:  environment,
+	}, time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "live descendants that required forced cleanup") || !strings.Contains(err.Error(), "fatal bounded-process diagnostic") {
+		t.Fatalf("error = %v, want forced-descendant causality and bounded diagnostic", err)
+	}
+	body, readErr := os.ReadFile(pidPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	pid, parseErr := strconv.Atoi(string(body))
+	if parseErr != nil {
+		t.Fatal(parseErr)
+	}
+	deadline := time.Now().Add(time.Second)
+	for processStillRunning(pid) && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if processStillRunning(pid) {
+		t.Fatalf("same-process-group member %d survived diagnostic leader cleanup", pid)
+	}
+}
+
+func TestOSRunnerCleansTrackedDescendantThatCreatesNewSession(t *testing.T) {
+	requireDuplexCapability(t)
+	if os.Getenv("AGENTPLUGINS_PROCESS_SETSID_DESCENDANT") == "1" {
+		for {
+			time.Sleep(time.Hour)
+		}
+	}
+	if pidPath := os.Getenv("AGENTPLUGINS_PROCESS_SETSID_LEADER_PID_PATH"); pidPath != "" {
+		child := exec.Command(os.Args[0], "-test.run=TestOSRunnerCleansTrackedDescendantThatCreatesNewSession")
+		child.Env = append(os.Environ(), "AGENTPLUGINS_PROCESS_SETSID_DESCENDANT=1")
+		child.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+		devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+		if err != nil {
+			os.Exit(81)
+		}
+		child.Stdin, child.Stdout, child.Stderr = devNull, devNull, devNull
+		if err := child.Start(); err != nil {
+			os.Exit(82)
+		}
+		if err := os.WriteFile(pidPath, []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil {
+			os.Exit(83)
+		}
+		// Exit immediately after the child is observable to model a sub-millisecond
+		// setsid escape. Atomic cgroup placement, not sampling, must contain it.
+		os.Exit(0)
+	}
+
+	pidPath := t.TempDir() + "/setsid-descendant.pid"
+	_, err := (OS{}).RunWithTreeExitGrace(context.Background(), ports.Command{
+		Argv: []string{os.Args[0], "-test.run=TestOSRunnerCleansTrackedDescendantThatCreatesNewSession"},
+		Env:  append(os.Environ(), "AGENTPLUGINS_PROCESS_SETSID_LEADER_PID_PATH="+pidPath),
+	}, time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "live descendants that required forced cleanup") {
+		t.Fatalf("clean leader exit with tracked setsid descendant error = %v, want forced-descendant causality", err)
+	}
+	body, err := os.ReadFile(pidPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid, err := strconv.Atoi(string(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for processStillRunning(pid) && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if processStillRunning(pid) {
+		t.Fatalf("tracked new-session descendant %d survived leader cleanup", pid)
+	}
+}
+
+func TestCgroupMemberInspectionFailurePreservesForcedCleanupCausality(t *testing.T) {
+	want := errors.New("cgroup.procs unreadable")
+	forced, err := cgroupForcedMemberCausality(1234, nil, want)
+	if !forced || !errors.Is(err, want) {
+		t.Fatalf("forced = %v error = %v, want uncertain forced cleanup causality", forced, err)
+	}
+}
+
+func TestFailedCgroupKillCannotClaimTreeShutdown(t *testing.T) {
+	originalRead, originalWrite := readCgroupProcs, writeCgroupKill
+	defer func() { readCgroupProcs, writeCgroupKill = originalRead, originalWrite }()
+	readCgroupProcs = func(string) ([]byte, error) { return []byte("1234\n5678\n"), nil }
+	killFailure := errors.New("cgroup.kill failed")
+	writeCgroupKill = func(string, []byte, os.FileMode) error { return killFailure }
+	containment := &commandContainment{
+		cmd:          &exec.Cmd{Process: &os.Process{Pid: 1234}},
+		cgroupPath:   "/deterministic-test-cgroup",
+		observeExit:  func() (bool, error) { return true, nil },
+		observeEmpty: func() (bool, error) { return false, nil },
+	}
+	result := containment.terminateCgroupWithin(time.Millisecond)
+	if !result.leaderStopped || !result.forcedMembers || !errors.Is(result.err, killFailure) || !strings.Contains(result.err.Error(), "did not empty") {
+		t.Fatalf("termination = %+v, want observed leader plus failed tree shutdown", result)
+	}
+}
+
+func TestSuccessfulLeaderKillRequestRequiresObservedShutdown(t *testing.T) {
+	result := stopLeaderAfterContainmentFailure(terminationResult{}, func() error { return nil }, func() (bool, error) { return false, errors.New("observation failed") })
+	if result.leaderStopped || result.err == nil || !strings.Contains(result.err.Error(), "confirm process leader stopped") {
+		t.Fatalf("termination = %+v, want unconfirmed leader shutdown failure", result)
+	}
+}
+
+func processStillRunning(pid int) bool {
+	stat, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if os.IsNotExist(err) {
+		return false
+	}
+	if err != nil {
+		return true
+	}
+	closing := strings.LastIndexByte(string(stat), ')')
+	return closing < 0 || len(stat) <= closing+2 || stat[closing+2] != 'Z'
+}

--- a/install/integrationctl/adapters/process/osrunner_tree_linux_test.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_linux_test.go
@@ -10,13 +10,14 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 	"syscall"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/ports"
+	"golang.org/x/sys/unix"
 )
 
 func TestOSRunnerPlannedDuplexShutdownContainsImmediateSetsidDescendant(t *testing.T) {
@@ -33,7 +34,7 @@ func TestOSRunnerPlannedDuplexShutdownContainsImmediateSetsidDescendant(t *testi
 		if err := child.Start(); err != nil {
 			os.Exit(81)
 		}
-		if err := os.WriteFile(pidPath, []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil {
+		if err := writeTestProcessIdentity(pidPath, child.Process.Pid); err != nil {
 			os.Exit(82)
 		}
 		fmt.Fprintln(os.Stdout, "ready")
@@ -59,12 +60,19 @@ func TestOSRunnerPlannedDuplexShutdownContainsImmediateSetsidDescendant(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	pid, err := strconv.Atoi(string(body))
+	pid, startTime, err := parseTestProcessIdentity(body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := syscall.Kill(pid, 0); err == nil || !errors.Is(err, syscall.ESRCH) {
-		t.Fatalf("immediate setsid descendant %d survived cgroup cleanup: %v", pid, err)
+	// cgroup.kill and populated=0 prove that no task remains in the scope. The
+	// namespace's PID 1 may retain the dead helper as a zombie briefly (or
+	// indefinitely), so kill(pid, 0) is not a liveness test here.
+	deadline := time.Now().Add(time.Second)
+	for processIdentityStillRunning(pid, startTime) && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if processIdentityStillRunning(pid, startTime) {
+		t.Fatalf("immediate setsid descendant %d survived cgroup cleanup", pid)
 	}
 }
 
@@ -82,7 +90,7 @@ func TestOSRunnerCancellationContainsImmediateSetsidDescendant(t *testing.T) {
 		if err := child.Start(); err != nil {
 			os.Exit(91)
 		}
-		if err := os.WriteFile(pidPath, []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil {
+		if err := writeTestProcessIdentity(pidPath, child.Process.Pid); err != nil {
 			os.Exit(92)
 		}
 		for {
@@ -118,11 +126,15 @@ func TestOSRunnerCancellationContainsImmediateSetsidDescendant(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	pid, err := strconv.Atoi(string(body))
+	pid, startTime, err := parseTestProcessIdentity(body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if processStillRunning(pid) {
+	deadline = time.Now().Add(time.Second)
+	for processIdentityStillRunning(pid, startTime) && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if processIdentityStillRunning(pid, startTime) {
 		t.Fatalf("setsid descendant %d survived Run cancellation", pid)
 	}
 }
@@ -131,6 +143,101 @@ func TestDuplexCapabilityRejectsNonCgroupDelegationBeforeStart(t *testing.T) {
 	_, _, err := createDelegatedCgroupAt(t.TempDir())
 	if err == nil || !strings.Contains(err.Error(), "cgroup") {
 		t.Fatalf("capability primitive error = %v, want honest pre-start unsupported result", err)
+	}
+}
+
+func TestOrdinaryCommandContainmentDoesNotRequireDelegatedCgroup(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "printf ordinary")
+	var before int
+	if err := unix.Prctl(unix.PR_GET_CHILD_SUBREAPER, uintptr(unsafe.Pointer(&before)), 0, 0, 0); err != nil {
+		t.Fatal(err)
+	}
+	containment, err := newOrdinaryCommandContainment(cmd, time.Second)
+	if err != nil {
+		t.Fatalf("ordinary containment unexpectedly required delegated cgroup: %v", err)
+	}
+	defer func() {
+		if err := containment.close(); err != nil {
+			t.Errorf("close ordinary containment: %v", err)
+		}
+	}()
+	if containment.cgroupPath != "" || containment.cgroupDir != nil {
+		t.Fatalf("ordinary containment allocated delegated cgroup: path=%q dir=%v", containment.cgroupPath, containment.cgroupDir)
+	}
+	if containment.descendants == nil || containment.stop == nil || containment.done == nil {
+		t.Fatal("ordinary pidfd descendant tracker fields were not initialized")
+	}
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setpgid || cmd.SysProcAttr.UseCgroupFD {
+		t.Fatalf("ordinary process attributes = %#v, want process group without cgroup requirement", cmd.SysProcAttr)
+	}
+	var after int
+	if err := unix.Prctl(unix.PR_GET_CHILD_SUBREAPER, uintptr(unsafe.Pointer(&after)), 0, 0, 0); err != nil {
+		t.Fatal(err)
+	}
+	if after != before {
+		t.Fatalf("ordinary containment changed process-wide subreaper state from %d to %d", before, after)
+	}
+	if len(cmd.ExtraFiles) != 3 {
+		t.Fatalf("ordinary supervisor descriptors = %d, want request/status boundary", len(cmd.ExtraFiles))
+	}
+}
+
+func TestOrdinaryRunWorksWhenDelegatedCgroupIsUnavailable(t *testing.T) {
+	root := t.TempDir()
+	if _, _, err := createDelegatedCgroupAt(root); err == nil {
+		t.Fatal("test fixture unexpectedly supplied a cgroup v2 delegation")
+	}
+
+	result, err := (OS{}).Run(context.Background(), ports.Command{Argv: []string{"/bin/sh", "-c", "printf ordinary-without-cgroup"}})
+	if err != nil {
+		t.Fatalf("ordinary Run failed without delegated cgroup: %v", err)
+	}
+	if result.ExitCode != 0 || string(result.Stdout) != "ordinary-without-cgroup" {
+		t.Fatalf("ordinary Run result = %#v", result)
+	}
+}
+
+func TestOSRunnerRapidSuccessfulCommandsPreserveNaturalExit(t *testing.T) {
+	// /bin/true commonly becomes waitable before the runner can acquire its
+	// post-Start pidfd. Exercise that attachment boundary enough times to prove
+	// rapid natural exits remain ordinary successful command results.
+	const attempts = 250
+	for attempt := 0; attempt < attempts; attempt++ {
+		result, err := (OS{}).Run(context.Background(), ports.Command{Argv: []string{"/bin/true"}})
+		if err != nil || result.ExitCode != 0 {
+			t.Fatalf("rapid command attempt %d result = %#v error = %v", attempt, result, err)
+		}
+	}
+}
+
+func TestOSRunnerRapidShellCommandsWithShortLivedChildrenPreserveNaturalExit(t *testing.T) {
+	root := t.TempDir()
+	script := root + "/client"
+	body := `#!/bin/sh
+set -eu
+mkdir -p "$(dirname "$TEST_STATE")" "$(dirname "$TEST_LOG")" "$(dirname "$TEST_MARKETPLACES")"
+touch "$TEST_STATE" "$TEST_LOG" "$TEST_MARKETPLACES"
+printf '%s\n' "$*" >> "$TEST_LOG"
+printf '[]\n'
+`
+	if err := os.WriteFile(script, []byte(body), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	environment := append(os.Environ(),
+		"TEST_STATE="+root+"/state/value",
+		"TEST_LOG="+root+"/log/value",
+		"TEST_MARKETPLACES="+root+"/marketplaces/value",
+	)
+	const attempts = 500
+	for attempt := 0; attempt < attempts; attempt++ {
+		result, err := (OS{}).Run(context.Background(), ports.Command{
+			Argv: []string{script, "plugin", "list", "--json"},
+			Env:  environment,
+			Dir:  root,
+		})
+		if err != nil || result.ExitCode != 0 || string(result.Stdout) != "[]\n" {
+			t.Fatalf("rapid shell attempt %d result = %#v error = %v", attempt, result, err)
+		}
 	}
 }
 
@@ -226,7 +333,7 @@ func TestOSRunnerCleansSameProcessGroupMemberAfterLeaderNaturalExit(t *testing.T
 		if err := child.Start(); err != nil {
 			os.Exit(62)
 		}
-		if err := os.WriteFile(pidPath, []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil {
+		if err := writeTestProcessIdentity(pidPath, child.Process.Pid); err != nil {
 			os.Exit(63)
 		}
 		os.Exit(0)
@@ -245,15 +352,15 @@ func TestOSRunnerCleansSameProcessGroupMemberAfterLeaderNaturalExit(t *testing.T
 	if readErr != nil {
 		t.Fatal(readErr)
 	}
-	pid, parseErr := strconv.Atoi(string(body))
+	pid, startTime, parseErr := parseTestProcessIdentity(body)
 	if parseErr != nil {
 		t.Fatal(parseErr)
 	}
 	deadline := time.Now().Add(time.Second)
-	for processStillRunning(pid) && time.Now().Before(deadline) {
+	for processIdentityStillRunning(pid, startTime) && time.Now().Before(deadline) {
 		time.Sleep(10 * time.Millisecond)
 	}
-	if processStillRunning(pid) {
+	if processIdentityStillRunning(pid, startTime) {
 		t.Fatalf("same-process-group member %d survived leader cleanup", pid)
 	}
 }
@@ -278,7 +385,7 @@ func TestOSRunnerPreservesDiagnosticAndStatusWhileCleaningNaturalExitGroup(t *te
 		if err := child.Start(); err != nil {
 			os.Exit(72)
 		}
-		if err := os.WriteFile(pidPath, []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil {
+		if err := writeTestProcessIdentity(pidPath, child.Process.Pid); err != nil {
 			os.Exit(73)
 		}
 		fmt.Fprint(os.Stderr, "fatal bounded-process diagnostic")
@@ -298,28 +405,27 @@ func TestOSRunnerPreservesDiagnosticAndStatusWhileCleaningNaturalExitGroup(t *te
 	if readErr != nil {
 		t.Fatal(readErr)
 	}
-	pid, parseErr := strconv.Atoi(string(body))
+	pid, startTime, parseErr := parseTestProcessIdentity(body)
 	if parseErr != nil {
 		t.Fatal(parseErr)
 	}
 	deadline := time.Now().Add(time.Second)
-	for processStillRunning(pid) && time.Now().Before(deadline) {
+	for processIdentityStillRunning(pid, startTime) && time.Now().Before(deadline) {
 		time.Sleep(10 * time.Millisecond)
 	}
-	if processStillRunning(pid) {
+	if processIdentityStillRunning(pid, startTime) {
 		t.Fatalf("same-process-group member %d survived diagnostic leader cleanup", pid)
 	}
 }
 
-func TestOSRunnerCleansTrackedDescendantThatCreatesNewSession(t *testing.T) {
-	requireDuplexCapability(t)
+func TestOSRunnerTreeGraceCleansImmediateDescendantThatCreatesNewSession(t *testing.T) {
 	if os.Getenv("AGENTPLUGINS_PROCESS_SETSID_DESCENDANT") == "1" {
 		for {
 			time.Sleep(time.Hour)
 		}
 	}
 	if pidPath := os.Getenv("AGENTPLUGINS_PROCESS_SETSID_LEADER_PID_PATH"); pidPath != "" {
-		child := exec.Command(os.Args[0], "-test.run=TestOSRunnerCleansTrackedDescendantThatCreatesNewSession")
+		child := exec.Command(os.Args[0], "-test.run=TestOSRunnerTreeGraceCleansImmediateDescendantThatCreatesNewSession")
 		child.Env = append(os.Environ(), "AGENTPLUGINS_PROCESS_SETSID_DESCENDANT=1")
 		child.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 		devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
@@ -330,17 +436,15 @@ func TestOSRunnerCleansTrackedDescendantThatCreatesNewSession(t *testing.T) {
 		if err := child.Start(); err != nil {
 			os.Exit(82)
 		}
-		if err := os.WriteFile(pidPath, []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil {
+		if err := writeTestProcessIdentity(pidPath, child.Process.Pid); err != nil {
 			os.Exit(83)
 		}
-		// Exit immediately after the child is observable to model a sub-millisecond
-		// setsid escape. Atomic cgroup placement, not sampling, must contain it.
 		os.Exit(0)
 	}
 
 	pidPath := t.TempDir() + "/setsid-descendant.pid"
 	_, err := (OS{}).RunWithTreeExitGrace(context.Background(), ports.Command{
-		Argv: []string{os.Args[0], "-test.run=TestOSRunnerCleansTrackedDescendantThatCreatesNewSession"},
+		Argv: []string{os.Args[0], "-test.run=TestOSRunnerTreeGraceCleansImmediateDescendantThatCreatesNewSession"},
 		Env:  append(os.Environ(), "AGENTPLUGINS_PROCESS_SETSID_LEADER_PID_PATH="+pidPath),
 	}, time.Millisecond)
 	if err == nil || !strings.Contains(err.Error(), "live descendants that required forced cleanup") {
@@ -350,15 +454,15 @@ func TestOSRunnerCleansTrackedDescendantThatCreatesNewSession(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	pid, err := strconv.Atoi(string(body))
+	pid, startTime, err := parseTestProcessIdentity(body)
 	if err != nil {
 		t.Fatal(err)
 	}
 	deadline := time.Now().Add(time.Second)
-	for processStillRunning(pid) && time.Now().Before(deadline) {
+	for processIdentityStillRunning(pid, startTime) && time.Now().Before(deadline) {
 		time.Sleep(10 * time.Millisecond)
 	}
-	if processStillRunning(pid) {
+	if processIdentityStillRunning(pid, startTime) {
 		t.Fatalf("tracked new-session descendant %d survived leader cleanup", pid)
 	}
 }
@@ -382,10 +486,59 @@ func TestFailedCgroupKillCannotClaimTreeShutdown(t *testing.T) {
 		cgroupPath:   "/deterministic-test-cgroup",
 		observeExit:  func() (bool, error) { return true, nil },
 		observeEmpty: func() (bool, error) { return false, nil },
+		inspectLive:  func(int) (bool, error) { return true, nil },
 	}
 	result := containment.terminateCgroupWithin(time.Millisecond)
-	if !result.leaderStopped || !result.forcedMembers || !errors.Is(result.err, killFailure) || !strings.Contains(result.err.Error(), "did not empty") {
+	if !result.leaderStopped || result.leaderTerminationInitiated || !result.forcedMembers || !errors.Is(result.err, killFailure) || !strings.Contains(result.err.Error(), "did not empty") {
 		t.Fatalf("termination = %+v, want observed leader plus failed tree shutdown", result)
+	}
+}
+
+func TestCgroupTerminationCausalityRequiresLiveLeaderAtSuccessfulKillBoundary(t *testing.T) {
+	originalRead, originalWrite := readCgroupProcs, writeCgroupKill
+	defer func() { readCgroupProcs, writeCgroupKill = originalRead, originalWrite }()
+	readCgroupProcs = func(string) ([]byte, error) { return []byte("1234\n"), nil }
+	writeCgroupKill = func(string, []byte, os.FileMode) error { return nil }
+
+	for _, test := range []struct {
+		name       string
+		leaderLive bool
+		initiated  bool
+	}{
+		{name: "live leader", leaderLive: true, initiated: true},
+		{name: "naturally stopped leader", leaderLive: false, initiated: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			containment := &commandContainment{
+				cmd:          &exec.Cmd{Process: &os.Process{Pid: 1234}},
+				cgroupPath:   "/deterministic-test-cgroup",
+				observeExit:  func() (bool, error) { return true, nil },
+				observeEmpty: func() (bool, error) { return true, nil },
+				inspectLive: func(pid int) (bool, error) {
+					return pid == 1234 && test.leaderLive, nil
+				},
+				prepareLeaderTermination: func(int, time.Duration) (bool, error) {
+					return test.leaderLive, nil
+				},
+			}
+			result := containment.terminateCgroupWithin(time.Millisecond)
+			if !result.leaderStopped || result.leaderTerminationInitiated != test.initiated || result.err != nil {
+				t.Fatalf("termination = %+v, want initiated = %v", result, test.initiated)
+			}
+		})
+	}
+}
+
+func TestCgroupCausalityExcludesNaturallyExitedZombieMember(t *testing.T) {
+	inspect := func(pid int) (bool, error) {
+		if pid == 5678 {
+			return false, nil
+		}
+		return true, nil
+	}
+	forced, err := cgroupForcedMemberCausalityWithInspect(1234, []byte("1234\n5678\n"), nil, inspect)
+	if err != nil || forced {
+		t.Fatalf("forced = %v error = %v, want naturally exited member excluded from cleanup causality", forced, err)
 	}
 }
 
@@ -393,6 +546,70 @@ func TestSuccessfulLeaderKillRequestRequiresObservedShutdown(t *testing.T) {
 	result := stopLeaderAfterContainmentFailure(terminationResult{}, func() error { return nil }, func() (bool, error) { return false, errors.New("observation failed") })
 	if result.leaderStopped || result.err == nil || !strings.Contains(result.err.Error(), "confirm process leader stopped") {
 		t.Fatalf("termination = %+v, want unconfirmed leader shutdown failure", result)
+	}
+}
+
+func TestLinuxTerminationDoesNotClassifyNaturalZombieDescendantAsForced(t *testing.T) {
+	child := exec.Command("/bin/sh", "-c", "exit 0")
+	if err := child.Start(); err != nil {
+		t.Fatal(err)
+	}
+	reaped := false
+	defer func() {
+		if !reaped {
+			_ = child.Wait()
+		}
+	}()
+	identity, err := readLinuxProcessIdentity(child.Process.Pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pidfd, err := unix.PidfdOpen(child.Process.Pid, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unix.Close(pidfd)
+	deadline := time.Now().Add(time.Second)
+	for {
+		current, readErr := readLinuxProcessIdentity(child.Process.Pid)
+		if readErr == nil && current.startTime == identity.startTime && current.zombie {
+			break
+		}
+		if readErr != nil {
+			t.Fatalf("observe unreaped child: %v", readErr)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("child did not become an observable zombie")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	containment := &commandContainment{
+		cmd:         &exec.Cmd{Process: &os.Process{Pid: 1 << 30}},
+		descendants: map[int]linuxTrackedProcess{child.Process.Pid: {startTime: identity.startTime, pidfd: pidfd}},
+		observeExit: func() (bool, error) { return true, nil },
+	}
+	result := containment.terminate()
+	if result.forcedMembers || result.err != nil || !result.leaderStopped {
+		t.Fatalf("termination = %+v, want naturally exited zombie excluded from forced cleanup", result)
+	}
+	if err := child.Wait(); err != nil && !errors.Is(err, syscall.ECHILD) {
+		t.Fatal(err)
+	}
+	reaped = true
+}
+
+func TestLinuxProcessGoneIncludesProcfsESRCHRace(t *testing.T) {
+	for _, err := range []error{
+		&os.PathError{Op: "read", Path: "/proc/123/stat", Err: syscall.ENOENT},
+		&os.PathError{Op: "read", Path: "/proc/123/stat", Err: syscall.ESRCH},
+	} {
+		if !linuxProcessGone(err) {
+			t.Fatalf("linuxProcessGone(%v) = false, want benign disappearance", err)
+		}
+	}
+	if linuxProcessGone(syscall.EACCES) {
+		t.Fatal("permission failure was misclassified as process disappearance")
 	}
 }
 
@@ -406,4 +623,30 @@ func processStillRunning(pid int) bool {
 	}
 	closing := strings.LastIndexByte(string(stat), ')')
 	return closing < 0 || len(stat) <= closing+2 || stat[closing+2] != 'Z'
+}
+
+func writeTestProcessIdentity(path string, pid int) error {
+	identity, err := readLinuxProcessIdentity(pid)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(fmt.Sprintf("%d %d", pid, identity.startTime)), 0o600)
+}
+
+func parseTestProcessIdentity(body []byte) (int, uint64, error) {
+	var pid int
+	var startTime uint64
+	_, err := fmt.Fscan(strings.NewReader(string(body)), &pid, &startTime)
+	return pid, startTime, err
+}
+
+func processIdentityStillRunning(pid int, startTime uint64) bool {
+	identity, err := readLinuxProcessIdentity(pid)
+	if linuxProcessGone(err) {
+		return false
+	}
+	if err != nil {
+		return true
+	}
+	return identity.startTime == startTime && !identity.zombie
 }

--- a/install/integrationctl/adapters/process/osrunner_tree_linux_test.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_linux_test.go
@@ -197,6 +197,57 @@ func TestOrdinaryRunWorksWhenDelegatedCgroupIsUnavailable(t *testing.T) {
 	}
 }
 
+func TestOrdinarySupervisorDescriptorsAreClosedBeforeCommandExec(t *testing.T) {
+	result, err := (OS{}).Run(context.Background(), ports.Command{
+		Argv: []string{"/bin/sh", "-c", `if printf '{"Forced":false}\n' 2>/dev/null >&5; then exit 97; fi; printf supervisor-fds-closed`},
+	})
+	if err != nil || result.ExitCode != 0 || string(result.Stdout) != "supervisor-fds-closed" {
+		t.Fatalf("supervised descriptor isolation result = %+v error = %v", result, err)
+	}
+}
+
+func TestSupervisorStatusRequiresOneAuthoritativeRecordAndEOF(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(writer, "{\"Forced\":false}\n{\"Forced\":true}\n"); err != nil {
+		t.Fatal(err)
+	}
+	_ = writer.Close()
+	containment := &commandContainment{supervisorStatus: reader}
+	if err := containment.readSupervisorResult(); err == nil || !strings.Contains(err.Error(), "trailing status data") {
+		t.Fatalf("forged multi-record supervisor status error = %v", err)
+	}
+}
+
+func TestExitedLeaderCannotAuthorizeNumericProcessGroupSignal(t *testing.T) {
+	called := false
+	err := signalOwnedLinuxProcessGroup(1234, true, func(int, syscall.Signal) error {
+		called = true
+		return nil
+	})
+	if err != nil || called {
+		t.Fatalf("signal after leader exit = (%v, called %v), want no numeric PGID signal", err, called)
+	}
+}
+
+func TestSupervisorEmptyBoundaryRequiresQuiescentErrorFreePasses(t *testing.T) {
+	boundary := linuxQuiescentBoundary{required: 3}
+	if boundary.observe(true, nil) || boundary.observe(true, nil) {
+		t.Fatal("non-atomic empty snapshots prematurely proved the boundary empty")
+	}
+	if boundary.observe(false, nil) {
+		t.Fatal("rapid adopted descendant was ignored")
+	}
+	if boundary.observe(true, nil) || boundary.observe(true, errors.New("proc scan uncertain")) {
+		t.Fatal("scan uncertainty did not reset the empty proof")
+	}
+	if boundary.observe(true, nil) || boundary.observe(true, nil) || !boundary.observe(true, nil) {
+		t.Fatal("three stable error-free snapshots did not prove quiescence")
+	}
+}
+
 func TestOSRunnerRapidSuccessfulCommandsPreserveNaturalExit(t *testing.T) {
 	// /bin/true commonly becomes waitable before the runner can acquire its
 	// post-Start pidfd. Exercise that attachment boundary enough times to prove

--- a/install/integrationctl/adapters/process/osrunner_tree_unix.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_unix.go
@@ -22,8 +22,14 @@ func duplexContainmentPreflight() error {
 
 func naturalExitNeedsContainmentCleanup() bool { return false }
 
+func plannedTerminationExitExpected(error) bool { return false }
+
 func newCommandContainment(cmd *exec.Cmd) (*commandContainment, error) {
 	return nil, fmt.Errorf("process execution is unsupported on %s", runtime.GOOS)
+}
+
+func newOrdinaryCommandContainment(cmd *exec.Cmd, _ time.Duration) (*commandContainment, error) {
+	return newCommandContainment(cmd)
 }
 
 func newDuplexCommandContainment(cmd *exec.Cmd) (*commandContainment, error) {

--- a/install/integrationctl/adapters/process/osrunner_tree_unix.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_unix.go
@@ -1,43 +1,45 @@
-//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+//go:build aix || dragonfly || freebsd || netbsd || openbsd || solaris
 
 package process
 
 import (
-	"errors"
-	"os"
+	"context"
+	"fmt"
 	"os/exec"
-	"syscall"
+	"runtime"
+	"time"
 )
 
-type commandTree struct {
+type commandContainment struct {
 	cmd *exec.Cmd
 }
 
-func newCommandTree(cmd *exec.Cmd) (*commandTree, error) {
-	tree := &commandTree{cmd: cmd}
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Cancel = tree.terminate
-	return tree, nil
+func explicitContainmentSupervision() bool { return true }
+
+func duplexContainmentPreflight() error {
+	return fmt.Errorf("safe duplex process containment unavailable on this platform; manual activation required")
 }
 
-func (*commandTree) attach(*exec.Cmd) error { return nil }
+func naturalExitNeedsContainmentCleanup() bool { return false }
 
-func (tree *commandTree) terminate() error {
-	if tree.cmd.Process == nil {
-		return os.ErrProcessDone
-	}
-	if err := syscall.Kill(-tree.cmd.Process.Pid, syscall.SIGKILL); err != nil {
-		if errors.Is(err, syscall.ESRCH) {
-			return os.ErrProcessDone
-		}
-		return err
-	}
-	return nil
+func newCommandContainment(cmd *exec.Cmd) (*commandContainment, error) {
+	return nil, fmt.Errorf("process execution is unsupported on %s", runtime.GOOS)
 }
 
-func (tree *commandTree) close() {
-	// Cancellation terminates the whole group while the command leader is a
-	// live, stable identity. After Wait reaps that leader, its PGID may be
-	// reused, so normal-exit descendants are deliberately not force-killed.
-	// Callers use this runner only for trusted, short-lived native commands.
+func newDuplexCommandContainment(cmd *exec.Cmd) (*commandContainment, error) {
+	return nil, duplexContainmentPreflight()
 }
+
+func (*commandContainment) attach(*exec.Cmd) error { return nil }
+
+func (*commandContainment) limitToProcessGroup() {}
+
+func (*commandContainment) terminate() terminationResult { return terminationResult{} }
+
+func (*commandContainment) exited() (bool, error) { return false, nil }
+
+func (*commandContainment) settleNaturalExit(context.Context, time.Duration) (bool, error) {
+	return false, nil
+}
+
+func (*commandContainment) close() error { return nil }

--- a/install/integrationctl/adapters/process/osrunner_tree_windows.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_windows.go
@@ -42,6 +42,11 @@ func duplexContainmentPreflight() error {
 
 func naturalExitNeedsContainmentCleanup() bool { return true }
 
+func plannedTerminationExitExpected(err error) bool {
+	exitErr, ok := err.(*exec.ExitError)
+	return ok && exitErr.ExitCode() == int(cleanupExitCode)
+}
+
 const cleanupExitCode uint32 = 0xc0de0001
 
 func newCommandContainment(cmd *exec.Cmd) (*commandContainment, error) {
@@ -59,6 +64,10 @@ func newCommandContainment(cmd *exec.Cmd) (*commandContainment, error) {
 	containment := &commandContainment{cmd: cmd, job: job}
 	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_SUSPENDED}
 	return containment, nil
+}
+
+func newOrdinaryCommandContainment(cmd *exec.Cmd, _ time.Duration) (*commandContainment, error) {
+	return newCommandContainment(cmd)
 }
 
 func newDuplexCommandContainment(cmd *exec.Cmd) (*commandContainment, error) {

--- a/install/integrationctl/adapters/process/osrunner_tree_windows.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_windows.go
@@ -3,26 +3,48 @@
 package process
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"sync"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
 
-type commandTree struct {
+type commandContainment struct {
 	cmd      *exec.Cmd
 	job      windows.Handle
+	process  windows.Handle
 	mu       sync.Mutex
 	attached bool
 	once     sync.Once
+	kill     func() error
+	confirm  func(time.Duration) (bool, error)
 }
 
-func newCommandTree(cmd *exec.Cmd) (*commandTree, error) {
+var terminateWindowsJob = windows.TerminateJobObject
+var closeWindowsHandle = windows.CloseHandle
+
+func explicitContainmentSupervision() bool { return true }
+
+func duplexContainmentPreflight() error {
+	// A Job can only be proven usable after a real child has been created,
+	// assigned, resumed, and terminated. Automatic Kiro activation also needs a
+	// race-free real-pipe settlement primitive, which is not implemented on
+	// Windows. Reject the automatic path before any package/native mutation.
+	return fmt.Errorf("safe duplex ACP containment and pipe settlement are unavailable on Windows; manual activation required")
+}
+
+func naturalExitNeedsContainmentCleanup() bool { return true }
+
+const cleanupExitCode uint32 = 0xc0de0001
+
+func newCommandContainment(cmd *exec.Cmd) (*commandContainment, error) {
 	job, err := windows.CreateJobObject(nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create process job: %w", err)
@@ -31,37 +53,43 @@ func newCommandTree(cmd *exec.Cmd) (*commandTree, error) {
 	limits.BasicLimitInformation.LimitFlags = windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
 	if _, err := windows.SetInformationJobObject(job, windows.JobObjectExtendedLimitInformation,
 		uintptr(unsafe.Pointer(&limits)), uint32(unsafe.Sizeof(limits))); err != nil {
-		windows.CloseHandle(job)
-		return nil, fmt.Errorf("configure process job: %w", err)
+		closeErr := closeWindowsHandle(job)
+		return nil, errors.Join(fmt.Errorf("configure process job: %w", err), closeErr)
 	}
-	tree := &commandTree{cmd: cmd, job: job}
+	containment := &commandContainment{cmd: cmd, job: job}
 	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_SUSPENDED}
-	cmd.Cancel = tree.terminate
-	return tree, nil
+	return containment, nil
 }
 
-func (tree *commandTree) attach(cmd *exec.Cmd) error {
-	process, err := windows.OpenProcess(windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE, false, uint32(cmd.Process.Pid))
+func newDuplexCommandContainment(cmd *exec.Cmd) (*commandContainment, error) {
+	return newCommandContainment(cmd)
+}
+
+func (containment *commandContainment) attach(cmd *exec.Cmd) (resultErr error) {
+	process, err := windows.OpenProcess(windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE|windows.SYNCHRONIZE, false, uint32(cmd.Process.Pid))
 	if err != nil {
 		return fmt.Errorf("open suspended process: %w", err)
 	}
-	defer windows.CloseHandle(process)
-	if err := windows.AssignProcessToJobObject(tree.job, process); err != nil {
-		return fmt.Errorf("assign process job: %w", err)
+	if err := windows.AssignProcessToJobObject(containment.job, process); err != nil {
+		closeErr := closeWindowsHandle(process)
+		return errors.Join(fmt.Errorf("assign process job: %w", err), closeErr)
 	}
-	tree.mu.Lock()
-	tree.attached = true
-	tree.mu.Unlock()
+	containment.mu.Lock()
+	containment.attached = true
+	containment.process = process
+	containment.mu.Unlock()
 	thread, err := suspendedProcessThread(uint32(cmd.Process.Pid))
 	if err != nil {
 		return err
 	}
-	defer windows.CloseHandle(thread)
+	defer func() { resultErr = errors.Join(resultErr, closeWindowsHandle(thread)) }()
 	if _, err := windows.ResumeThread(thread); err != nil {
 		return fmt.Errorf("resume process thread: %w", err)
 	}
 	return nil
 }
+
+func (*commandContainment) limitToProcessGroup() {}
 
 func suspendedProcessThread(pid uint32) (windows.Handle, error) {
 	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPTHREAD, 0)
@@ -86,24 +114,134 @@ func suspendedProcessThread(pid uint32) (windows.Handle, error) {
 	return 0, fmt.Errorf("enumerate suspended process threads: %w", err)
 }
 
-func (tree *commandTree) terminate() error {
-	tree.mu.Lock()
-	attached := tree.attached
-	tree.mu.Unlock()
+func (containment *commandContainment) terminate() terminationResult {
+	containment.mu.Lock()
+	attached := containment.attached
+	containment.mu.Unlock()
 	if attached {
-		if err := windows.TerminateJobObject(tree.job, 1); err == nil {
-			return nil
+		forcedMembers := containment.activeProcesses() > 0
+		if err := terminateWindowsJob(containment.job, cleanupExitCode); err == nil {
+			stopped, confirmErr := containment.confirmTermination(time.Second)
+			if !stopped && confirmErr == nil {
+				confirmErr = fmt.Errorf("process job remained active after cleanup deadline")
+			}
+			return terminationResult{leaderStopped: stopped, forcedMembers: forcedMembers, err: confirmErr}
+		} else {
+			killErr := containment.killLeader()
+			if errors.Is(killErr, os.ErrProcessDone) {
+				killErr = nil
+			}
+			stopped, confirmErr := containment.confirmTermination(time.Second)
+			if !stopped && confirmErr == nil {
+				confirmErr = fmt.Errorf("leader fallback kill was requested but job shutdown was not observed")
+			}
+			return terminationResult{leaderStopped: stopped, err: errors.Join(fmt.Errorf("terminate process job: %w", err), killErr, confirmErr)}
 		}
 	}
-	if tree.cmd.Process == nil {
+	killErr := containment.killLeader()
+	if errors.Is(killErr, os.ErrProcessDone) {
+		killErr = nil
+	}
+	return terminationResult{err: errors.Join(killErr, fmt.Errorf("unattached process shutdown could not be observed"))}
+}
+
+func (containment *commandContainment) activeProcesses() uint32 {
+	var accounting jobAccounting
+	if err := windows.QueryInformationJobObject(containment.job, windows.JobObjectBasicAccountingInformation,
+		uintptr(unsafe.Pointer(&accounting)), uint32(unsafe.Sizeof(accounting)), nil); err != nil {
+		return 1 // fail closed: containment could not prove the job was empty
+	}
+	return accounting.ActiveProcesses
+}
+
+type jobAccounting struct {
+	TotalUserTime             int64
+	TotalKernelTime           int64
+	ThisPeriodTotalUserTime   int64
+	ThisPeriodTotalKernelTime int64
+	TotalPageFaultCount       uint32
+	TotalProcesses            uint32
+	ActiveProcesses           uint32
+	TotalTerminatedProcesses  uint32
+}
+
+func (containment *commandContainment) confirmTermination(timeout time.Duration) (bool, error) {
+	if containment.confirm != nil {
+		return containment.confirm(timeout)
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		var accounting jobAccounting
+		if err := windows.QueryInformationJobObject(containment.job, windows.JobObjectBasicAccountingInformation,
+			uintptr(unsafe.Pointer(&accounting)), uint32(unsafe.Sizeof(accounting)), nil); err != nil {
+			return false, fmt.Errorf("confirm process job termination: %w", err)
+		}
+		leaderStopped, err := containment.exited()
+		if err != nil {
+			return false, fmt.Errorf("confirm process leader termination: %w", err)
+		}
+		if leaderStopped && accounting.ActiveProcesses == 0 {
+			return true, nil
+		}
+		if time.Now().After(deadline) {
+			return false, nil
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func (containment *commandContainment) killLeader() error {
+	if containment.kill != nil {
+		return containment.kill()
+	}
+	if containment.cmd.Process == nil {
 		return os.ErrProcessDone
 	}
-	if err := tree.cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+	if err := containment.cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
 		return err
 	}
 	return nil
 }
 
-func (tree *commandTree) close() {
-	tree.once.Do(func() { _ = windows.CloseHandle(tree.job) })
+func (containment *commandContainment) exited() (bool, error) {
+	containment.mu.Lock()
+	process := containment.process
+	containment.mu.Unlock()
+	if process == 0 {
+		return false, nil
+	}
+	event, err := windows.WaitForSingleObject(process, 0)
+	if err != nil {
+		return false, err
+	}
+	return event == windows.WAIT_OBJECT_0, nil
+}
+
+func (containment *commandContainment) settleNaturalExit(ctx context.Context, timeout time.Duration) (bool, error) {
+	deadline := time.Now().Add(timeout)
+	for containment.activeProcesses() > 0 {
+		if time.Now().After(deadline) {
+			return false, nil
+		}
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	return true, nil
+}
+
+func (containment *commandContainment) close() (resultErr error) {
+	containment.once.Do(func() {
+		containment.mu.Lock()
+		process := containment.process
+		containment.process = 0
+		containment.mu.Unlock()
+		if process != 0 {
+			resultErr = errors.Join(resultErr, closeWindowsHandle(process))
+		}
+		resultErr = errors.Join(resultErr, closeWindowsHandle(containment.job))
+	})
+	return resultErr
 }

--- a/install/integrationctl/adapters/process/osrunner_tree_windows_test.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_windows_test.go
@@ -18,7 +18,14 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func TestOSRunnerTerminatesWindowsGrandchildTree(t *testing.T) {
+func TestWindowsDuplexCapabilityFailsClosedBeforeACPStart(t *testing.T) {
+	err := (OS{}).DuplexCapability()
+	if err == nil || !strings.Contains(err.Error(), "manual activation required") {
+		t.Fatalf("Windows duplex capability = %v, want fail-closed manual activation", err)
+	}
+}
+
+func TestOSRunnerTerminatesWindowsJobMembers(t *testing.T) {
 	powershell, err := exec.LookPath("powershell.exe")
 	if err != nil {
 		t.Skip("powershell.exe is unavailable")
@@ -26,7 +33,7 @@ func TestOSRunnerTerminatesWindowsGrandchildTree(t *testing.T) {
 	root := t.TempDir()
 	childScript := filepath.Join(root, "child.ps1")
 	parentScript := filepath.Join(root, "parent.ps1")
-	pidPath := filepath.Join(root, "tree.pid")
+	pidPath := filepath.Join(root, "job.pid")
 	if err := os.WriteFile(childScript, []byte("Start-Sleep -Seconds 60\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +47,7 @@ func TestOSRunnerTerminatesWindowsGrandchildTree(t *testing.T) {
 	started := time.Now()
 	runResult := make(chan error, 1)
 	go func() {
-		_, runErr := (OS{}).Run(ctx, ports.Command{Argv: []string{powershell, "-NoProfile", "-File", parentScript}, Env: os.Environ()})
+		_, runErr := (OS{}).RunWithTreeExitGrace(ctx, ports.Command{Argv: []string{powershell, "-NoProfile", "-File", parentScript}, Env: os.Environ()}, time.Second)
 		runResult <- runErr
 	}()
 	var body []byte
@@ -54,16 +61,16 @@ func TestOSRunnerTerminatesWindowsGrandchildTree(t *testing.T) {
 	select {
 	case runErr = <-runResult:
 	case <-time.After(3 * time.Second):
-		t.Fatal("process tree termination exceeded bound")
+		t.Fatal("process job termination exceeded bound")
 	}
 	if !errors.Is(runErr, context.Canceled) {
 		t.Fatalf("run error = %v, want context canceled", runErr)
 	}
 	if elapsed := time.Since(started); elapsed > 13*time.Second {
-		t.Fatalf("process tree test took %s", elapsed)
+		t.Fatalf("process job test took %s", elapsed)
 	}
 	if len(strings.Fields(string(body))) != 2 {
-		t.Fatalf("process tree pids = %q", body)
+		t.Fatalf("process job pids = %q", body)
 	}
 	for _, field := range strings.Fields(string(body)) {
 		pid, err := strconv.Atoi(field)
@@ -92,4 +99,74 @@ func windowsProcessAlive(pid uint32) bool {
 		return true
 	}
 	return false
+}
+
+func TestWindowsContainmentTerminationPreservesJobFailureAfterLeaderKill(t *testing.T) {
+	want := errors.New("terminate job failed")
+	original := terminateWindowsJob
+	terminateWindowsJob = func(windows.Handle, uint32) error { return want }
+	t.Cleanup(func() { terminateWindowsJob = original })
+	containment := &commandContainment{attached: true, kill: func() error { return nil }, confirm: func(time.Duration) (bool, error) { return true, nil }}
+	result := containment.terminate()
+	if !result.leaderStopped || !errors.Is(result.err, want) {
+		t.Fatalf("termination result = %+v, want stopped leader and preserved job failure", result)
+	}
+}
+
+func TestWindowsContainmentTerminationReportsUnstoppedLeaderWhenBothStopsFail(t *testing.T) {
+	jobErr := errors.New("terminate job failed")
+	killErr := errors.New("terminate leader failed")
+	original := terminateWindowsJob
+	terminateWindowsJob = func(windows.Handle, uint32) error { return jobErr }
+	t.Cleanup(func() { terminateWindowsJob = original })
+	containment := &commandContainment{attached: true, kill: func() error { return killErr }}
+	result := containment.terminate()
+	if result.leaderStopped || !errors.Is(result.err, jobErr) || !errors.Is(result.err, killErr) {
+		t.Fatalf("termination result = %+v, want unstopped leader and both errors", result)
+	}
+}
+
+func TestWindowsAttachCleanupDoesNotKillLeaderAfterSuccessfulJobTermination(t *testing.T) {
+	original := terminateWindowsJob
+	terminateWindowsJob = func(windows.Handle, uint32) error { return nil }
+	t.Cleanup(func() { terminateWindowsJob = original })
+	killCalls := 0
+	waitCalls := 0
+	containment := &commandContainment{job: windows.Handle(1), attached: true, confirm: func(time.Duration) (bool, error) { return true, nil }, kill: func() error {
+		t.Fatal("job termination unexpectedly used the containment's leader fallback")
+		return nil
+	}}
+	attachErr := errors.New("attach failed")
+	err := cleanupAttachFailure(attachErr, containment.terminate, func() error {
+		killCalls++
+		return errors.New("redundant Process.Kill failed")
+	}, containment.exited, func() error { return nil }, func() error {
+		waitCalls++
+		return nil
+	})
+	if killCalls != 0 || waitCalls != 1 || !errors.Is(err, attachErr) {
+		t.Fatalf("kill calls = %d wait calls = %d error = %v, want successful job termination followed by one wait", killCalls, waitCalls, err)
+	}
+}
+
+func TestWindowsContainmentDoesNotTreatAcceptedJobKillAsCompletedCleanup(t *testing.T) {
+	original := terminateWindowsJob
+	terminateWindowsJob = func(windows.Handle, uint32) error { return nil }
+	t.Cleanup(func() { terminateWindowsJob = original })
+	containment := &commandContainment{attached: true, confirm: func(time.Duration) (bool, error) { return false, nil }}
+	result := containment.terminate()
+	if result.leaderStopped || result.err == nil || !strings.Contains(result.err.Error(), "remained active") {
+		t.Fatalf("termination result = %+v, want accepted kill to remain unconfirmed failure", result)
+	}
+}
+
+func TestWindowsContainmentCloseSurfacesHandleFailures(t *testing.T) {
+	want := errors.New("close handle failed")
+	original := closeWindowsHandle
+	closeWindowsHandle = func(windows.Handle) error { return want }
+	t.Cleanup(func() { closeWindowsHandle = original })
+	containment := &commandContainment{job: windows.Handle(1), process: windows.Handle(2)}
+	if err := containment.close(); !errors.Is(err, want) {
+		t.Fatalf("close error = %v, want surfaced handle failure", err)
+	}
 }

--- a/install/integrationctl/adapters/process/osrunner_unsupported_test.go
+++ b/install/integrationctl/adapters/process/osrunner_unsupported_test.go
@@ -1,0 +1,22 @@
+//go:build aix || dragonfly || freebsd || netbsd || openbsd || solaris
+
+package process
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/ports"
+)
+
+func TestOSRunnerFailsClosedOnUnsupportedPlatform(t *testing.T) {
+	command := ports.Command{Argv: []string{"unused"}}
+	if _, err := (OS{}).Run(context.Background(), command); err == nil || !strings.Contains(err.Error(), "process execution is unsupported") {
+		t.Fatalf("Run error = %v, want explicit unsupported-platform failure", err)
+	}
+	if err := (OS{}).RunDuplex(context.Background(), command, func(io.Writer, io.Reader) error { return nil }); err == nil || !strings.Contains(err.Error(), "manual activation required") {
+		t.Fatalf("RunDuplex error = %v, want explicit manual-activation containment failure", err)
+	}
+}

--- a/install/integrationctl/agentplugins/adapters/sourceacquisition/acquirer.go
+++ b/install/integrationctl/agentplugins/adapters/sourceacquisition/acquirer.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -15,8 +14,10 @@ import (
 	"time"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/pathpolicy"
+	processadapter "github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/process"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/packagedigest"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	legacyports "github.com/777genius/plugin-kit-ai/install/integrationctl/ports"
 )
 
 var (
@@ -37,13 +38,19 @@ type Runner interface {
 type OSRunner struct{}
 
 func (OSRunner) Run(ctx context.Context, command Command) ([]byte, error) {
-	process := exec.CommandContext(ctx, "git", command.Args...)
-	process.Dir = command.Dir
-	process.Stdin = bytes.NewReader(command.Stdin)
-	process.Env = isolatedGitEnvironment(os.Environ(), command.Dir)
-	output, err := process.CombinedOutput()
+	if len(command.Stdin) != 0 {
+		return nil, fmt.Errorf("git stdin is unsupported by the contained runner")
+	}
+	result, err := (processadapter.OS{}).RunWithTreeExitGrace(ctx, legacyports.Command{
+		Argv: append([]string{"git"}, command.Args...), Dir: command.Dir,
+		Env: isolatedGitEnvironment(os.Environ(), command.Dir),
+	}, 5*time.Second)
+	output := append(append([]byte(nil), result.Stdout...), result.Stderr...)
 	if err != nil {
 		return nil, fmt.Errorf("git %s failed: %w: %s", strings.Join(command.Args, " "), err, strings.TrimSpace(string(output)))
+	}
+	if result.ExitCode != 0 {
+		return nil, fmt.Errorf("git %s failed with exit code %d: %s", strings.Join(command.Args, " "), result.ExitCode, strings.TrimSpace(string(output)))
 	}
 	return output, nil
 }

--- a/install/integrationctl/agentplugins/adapters/sourceacquisition/acquirer_test.go
+++ b/install/integrationctl/agentplugins/adapters/sourceacquisition/acquirer_test.go
@@ -25,6 +25,7 @@ func TestAcquireGitHubExactSHASparselySnapshotsOnlyPluginRoot(t *testing.T) {
 	tempRoot := t.TempDir()
 	acquirer := Acquirer{
 		TempRoot:   tempRoot,
+		Runner:     localGitTestRunner{},
 		Digester:   packagedigest.Builder{TempRoot: tempRoot, Limits: domain.PackageLimits{MaxTreeBytes: 1024}},
 		URLForRepo: func(string) string { return repository },
 	}
@@ -51,7 +52,7 @@ func TestAcquireGitHubRepositoryRootExcludesGitMetadata(t *testing.T) {
 	repository := newRepository(t)
 	writeRepo(t, repository, "plugin.json", `{"$schema":"https://agent-plugins.org/schemas/1.0.0/plugin.schema.json","name":"root"}`, 0o644)
 	revision := commit(t, repository)
-	acquirer := Acquirer{TempRoot: t.TempDir(), URLForRepo: func(string) string { return repository }}
+	acquirer := Acquirer{TempRoot: t.TempDir(), Runner: localGitTestRunner{}, URLForRepo: func(string) string { return repository }}
 	snapshot, err := acquirer.AcquireGitHub(context.Background(), "example/root-plugin", revision, "")
 	if err != nil {
 		t.Fatal(err)
@@ -85,7 +86,7 @@ func TestAcquireGitHubRejectsSubmoduleInsidePluginRoot(t *testing.T) {
 	writeRepo(t, repository, "plugin/plugin.json", `{"$schema":"https://agent-plugins.org/schemas/1.0.0/plugin.schema.json","name":"submodule"}`, 0o644)
 	runGit(t, "-c", "protocol.file.allow=always", "-C", repository, "submodule", "add", "--quiet", submodule, "plugin/vendor")
 	revision := commit(t, repository)
-	acquirer := Acquirer{TempRoot: t.TempDir(), URLForRepo: func(string) string { return repository }}
+	acquirer := Acquirer{TempRoot: t.TempDir(), Runner: localGitTestRunner{}, URLForRepo: func(string) string { return repository }}
 	if _, err := acquirer.AcquireGitHub(context.Background(), "example/plugin", revision, "plugin"); err == nil || !strings.Contains(err.Error(), "submodule") {
 		t.Fatalf("submodule error = %v", err)
 	}
@@ -183,6 +184,18 @@ type panicRunner struct{}
 
 func (panicRunner) Run(context.Context, Command) ([]byte, error) {
 	panic("git must not run for invalid source")
+}
+
+// localGitTestRunner keeps repository-fixture tests independent of host kernel
+// cgroup delegation. Production's default OSRunner remains fail-closed and is
+// covered by the process containment regressions.
+type localGitTestRunner struct{}
+
+func (localGitTestRunner) Run(ctx context.Context, command Command) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", command.Args...)
+	cmd.Dir = command.Dir
+	cmd.Env = isolatedGitEnvironment(os.Environ(), command.Dir)
+	return cmd.CombinedOutput()
 }
 
 func newRepository(t *testing.T) string {

--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"unicode"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/pathpolicy"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
@@ -28,7 +29,26 @@ type Activator struct {
 // CLI for this exact request. Runtime preflight consumes this same predicate so
 // it cannot drift from the provider's activation paths.
 func (activator Activator) AutomaticallyActivates(request domain.ActivationRequest) bool {
-	return activationObservable(request, activator.Runner != nil)
+	if request.Client.ClientID == domain.ClientKiro {
+		return strings.TrimSpace(request.BackendExecutable) != "" && mcpOnly(request.Plan.Components) && isKiroCLI(request.BackendExecutable)
+	}
+	return activationObservable(request, activator.Runner)
+}
+
+// PreflightActivation rejects lifecycle configurations that would otherwise
+// discover a missing required capability only after native client mutation.
+func (activator Activator) PreflightActivation(request domain.ActivationRequest) error {
+	if !activator.AutomaticallyActivates(request) || request.Client.ClientID != domain.ClientKiro {
+		return nil
+	}
+	runner, ok := activator.Runner.(duplexCapabilityRunner)
+	if !ok {
+		return fmt.Errorf("manual_activation_required: automatic native Kiro MCP lifecycle requires an ACP duplex process runner with capability preflight")
+	}
+	if err := runner.DuplexCapability(); err != nil {
+		return fmt.Errorf("manual_activation_required: automatic native Kiro MCP lifecycle containment preflight failed: %w", err)
+	}
+	return nil
 }
 
 func (activator Activator) Deactivate(ctx context.Context, request domain.DeactivationRequest) (domain.DeactivationOutcome, error) {
@@ -98,6 +118,9 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 	}
 	if strings.TrimSpace(request.DeclaredName) == "" {
 		return domain.ActivationOutcome{}, fmt.Errorf("activation plugin name is required")
+	}
+	if err := activator.PreflightActivation(request); err != nil {
+		return domain.ActivationOutcome{}, err
 	}
 	if err := pathpolicy.RequireContainedChild(request.Delivery.OwnedBase, request.Delivery.ActivePath); err != nil {
 		return domain.ActivationOutcome{}, fmt.Errorf("unsafe activation artifact: %w", err)
@@ -178,26 +201,26 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 		}
 		if request.VerifyOnly {
 			if err := activator.verifyKiroMCP(ctx, request); err != nil {
-				if errors.Is(err, errKiroStatusContractUnknown) {
+				if errors.Is(err, errKiroACPContractUnknown) {
 					return manualKiroVerification(outcome, request), nil
 				}
-				return failedActivation(outcome, fmt.Sprintf("verify each server with `%s mcp status --name <server>`", request.BackendExecutable), err)
+				return failedActivation(outcome, fmt.Sprintf("rerun structured Kiro ACP verification with `%s acp --agent-engine v3 --auth-method cli`", request.BackendExecutable), err)
 			}
 			outcome.Activation = domain.ActivationActive
 			outcome.Verification = domain.VerificationInstalled
 			return outcome, nil
 		}
-		if !isKiroCLI(request.BackendExecutable) || activator.Runner == nil {
+		if !activator.AutomaticallyActivates(request) {
 			outcome.Activation = domain.ActivationManual
 			outcome.UserActions = append(outcome.UserActions, "install kiro-cli and rerun add to import and verify the prepared MCP configuration")
-			outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf("install kiro-cli, rerun add for %s, then verify each MCP server with `kiro-cli mcp status --name <server>`", request.Delivery.ActivePath))
+			outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf("install a complete Kiro CLI distribution (including kiro-cli-chat), then rerun add for %s to import and verify the native MCP configuration", request.Delivery.ActivePath))
 			return outcome, nil
 		}
 		if err := activator.activateKiroMCP(ctx, request); err != nil {
-			if errors.Is(err, errKiroStatusContractUnknown) {
+			if errors.Is(err, errKiroACPContractUnknown) {
 				return manualKiroVerification(outcome, request), nil
 			}
-			return failedActivation(outcome, fmt.Sprintf("rerun the MCP import from %s, then verify each server with `%s mcp status --name <server>`", filepath.Join(request.Delivery.ActivePath, "mcp.json"), request.BackendExecutable), err)
+			return failedActivation(outcome, fmt.Sprintf("rerun the MCP import from %s, then retry structured verification with `%s acp --agent-engine v3 --auth-method cli`", filepath.Join(request.Delivery.ActivePath, "mcp.json"), request.BackendExecutable), err)
 		}
 		outcome.Activation = domain.ActivationActive
 		outcome.Verification = domain.VerificationInstalled
@@ -333,43 +356,17 @@ func (activator Activator) activateKiroMCP(ctx context.Context, request domain.A
 }
 
 func (activator Activator) verifyKiroMCP(ctx context.Context, request domain.ActivationRequest) error {
-	var firstCommandErr error
-	var firstUnknown string
-	var firstUnhealthy string
+	runner, ok := activator.Runner.(duplexCommandRunner)
+	if !ok {
+		return fmt.Errorf("%w: the process runner does not support an ACP duplex exchange", errKiroACPContractUnknown)
+	}
+	var servers []string
 	for _, component := range request.Plan.Components {
-		if component.Kind != domain.ComponentMCPServer {
-			continue
-		}
-		status, err := activator.runClientResult(ctx, "Kiro CLI", request.BackendExecutable, "mcp", "status", "--name", component.Name)
-		if err != nil {
-			if firstCommandErr == nil {
-				firstCommandErr = fmt.Errorf("verify Kiro MCP server %s: %w", component.Name, err)
-			}
-			continue
-		}
-		switch kiroMCPStatus(status.Stdout, component.Name) {
-		case kiroStatusHealthy:
-			continue
-		case kiroStatusUnhealthy:
-			if firstUnhealthy == "" {
-				firstUnhealthy = component.Name
-			}
-		default:
-			if firstUnknown == "" {
-				firstUnknown = component.Name
-			}
+		if component.Kind == domain.ComponentMCPServer && component.Support != domain.SupportUnsupported {
+			servers = append(servers, component.Name)
 		}
 	}
-	if firstUnhealthy != "" {
-		return fmt.Errorf("%w: verify Kiro MCP server %s: server is not connected", errRecognizedNegativeEvidence, firstUnhealthy)
-	}
-	if firstCommandErr != nil {
-		return firstCommandErr
-	}
-	if firstUnknown != "" {
-		return fmt.Errorf("%w for server %s", errKiroStatusContractUnknown, firstUnknown)
-	}
-	return nil
+	return verifyKiroACP(ctx, runner, request.BackendExecutable, request.Delivery.ActivePath, servers)
 }
 
 func (activator Activator) deactivateCopilot(ctx context.Context, request domain.DeactivationRequest) error {
@@ -527,12 +524,17 @@ func decodeUniqueJSONValue(decoder *json.Decoder) (any, error) {
 	}
 	delimiter, isDelimiter := token.(json.Delim)
 	if !isDelimiter {
+		if number, ok := token.(json.Number); ok {
+			if err := validateACPNumber(number); err != nil {
+				return nil, err
+			}
+		}
 		return token, nil
 	}
 	switch delimiter {
 	case '{':
 		object := make(map[string]any)
-		var keys []string
+		foldedKeys := make(map[string]struct{})
 		for decoder.More() {
 			keyToken, keyErr := decoder.Token()
 			if keyErr != nil {
@@ -542,12 +544,11 @@ func decodeUniqueJSONValue(decoder *json.Decoder) (any, error) {
 			if !ok {
 				return nil, fmt.Errorf("JSON object key is not a string")
 			}
-			for _, prior := range keys {
-				if strings.EqualFold(prior, key) {
-					return nil, fmt.Errorf("duplicate or case-ambiguous JSON object key %q", key)
-				}
+			folded := foldJSONKey(key)
+			if _, duplicate := foldedKeys[folded]; duplicate {
+				return nil, fmt.Errorf("duplicate or case-ambiguous JSON object key %q", key)
 			}
-			keys = append(keys, key)
+			foldedKeys[folded] = struct{}{}
 			value, valueErr := decodeUniqueJSONValue(decoder)
 			if valueErr != nil {
 				return nil, valueErr
@@ -576,6 +577,23 @@ func decodeUniqueJSONValue(decoder *json.Decoder) (any, error) {
 	default:
 		return nil, fmt.Errorf("unexpected JSON delimiter %q", delimiter)
 	}
+}
+
+// foldJSONKey produces a stable representative for each unicode.SimpleFold
+// equivalence class, matching strings.EqualFold without pairwise comparisons.
+func foldJSONKey(key string) string {
+	var folded strings.Builder
+	folded.Grow(len(key))
+	for _, current := range key {
+		representative := current
+		for next := unicode.SimpleFold(current); next != current; next = unicode.SimpleFold(next) {
+			if next < representative {
+				representative = next
+			}
+		}
+		folded.WriteRune(representative)
+	}
+	return folded.String()
 }
 
 var copilotInstalledEntry = regexp.MustCompile(`^[ \t]+•[ \t]+([A-Za-z0-9][A-Za-z0-9._-]*@[A-Za-z0-9][A-Za-z0-9._-]*)[ \t]+\(v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?\)[ \t]*$`)
@@ -650,52 +668,19 @@ func copilotPluginStatus(stdout []byte, expected string) copilotStatus {
 	return copilotStatusUnknown
 }
 
-func activationObservable(request domain.ActivationRequest, runnerAvailable bool) bool {
-	if !runnerAvailable || strings.TrimSpace(request.BackendExecutable) == "" {
+func activationObservable(request domain.ActivationRequest, runner CommandRunner) bool {
+	if runner == nil || strings.TrimSpace(request.BackendExecutable) == "" {
 		return false
 	}
 	switch request.Client.ClientID {
 	case domain.ClientCodex, domain.ClientCopilot, domain.ClientVSCode:
 		return true
 	case domain.ClientKiro:
-		return mcpOnly(request.Plan.Components) && isKiroCLI(request.BackendExecutable)
+		_, duplexAvailable := runner.(duplexCommandRunner)
+		return duplexAvailable && mcpOnly(request.Plan.Components) && isKiroCLI(request.BackendExecutable)
 	default:
 		return false
 	}
-}
-
-type kiroStatus int
-
-const (
-	kiroStatusUnknown kiroStatus = iota
-	kiroStatusHealthy
-	kiroStatusUnhealthy
-)
-
-var errKiroStatusContractUnknown = errors.New("Kiro MCP status output is not recognized")
-
-func kiroMCPStatus(stdout []byte, expected string) kiroStatus {
-	contract := strings.ReplaceAll(string(stdout), "\r\n", "\n")
-	contract = strings.TrimSuffix(contract, "\n")
-	status := ""
-	if prefix := expected + ": "; strings.HasPrefix(contract, prefix) && !strings.Contains(contract, "\n") {
-		status = strings.TrimPrefix(contract, prefix)
-	} else {
-		lines := strings.Split(contract, "\n")
-		if len(lines) != 2 || lines[0] != "Name: "+expected || !strings.HasPrefix(lines[1], "Status: ") {
-			return kiroStatusUnknown
-		}
-		status = strings.TrimPrefix(lines[1], "Status: ")
-	}
-	if status == "connected" {
-		return kiroStatusHealthy
-	}
-	for _, negative := range []string{"pending", "disconnected", "disabled", "auth-required", "auth required", "authentication required", "error", "failed", "failure"} {
-		if status == negative {
-			return kiroStatusUnhealthy
-		}
-	}
-	return kiroStatusUnknown
 }
 
 func attestedUnknownVerification(outcome domain.ActivationOutcome, request domain.ActivationRequest) (domain.ActivationOutcome, bool) {
@@ -724,7 +709,7 @@ func manualKiroVerification(outcome domain.ActivationOutcome, request domain.Act
 	}
 	outcome.Activation = domain.ActivationManual
 	outcome.UserActions = []string{"confirm each imported MCP server is connected in Kiro"}
-	outcome.LocalActions = []string{fmt.Sprintf("Kiro's documented `%s mcp status --name <server>` output contract was not recognized; inspect each server manually", request.BackendExecutable)}
+	outcome.LocalActions = []string{fmt.Sprintf("Kiro structured ACP verification via `%s acp --agent-engine v3 --auth-method cli` was unavailable or unrecognized; ensure the companion kiro-cli-chat is installed, then inspect each imported server manually", request.BackendExecutable)}
 	return outcome
 }
 

--- a/install/integrationctl/agentplugins/providers/activator_test.go
+++ b/install/integrationctl/agentplugins/providers/activator_test.go
@@ -3,7 +3,9 @@ package providers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -15,9 +17,64 @@ import (
 )
 
 type recordingRunner struct {
-	commands []legacyports.Command
-	run      func(legacyports.Command) legacyports.CommandResult
+	commands      []legacyports.Command
+	run           func(legacyports.Command) legacyports.CommandResult
+	duplexOutput  string
+	duplexErr     error
+	duplexPostErr error
+	duplexLive    bool
+	capabilityErr error
 }
+
+type runOnlyRecordingRunner struct {
+	commands []legacyports.Command
+}
+
+func (runner *runOnlyRecordingRunner) Run(_ context.Context, command legacyports.Command) (legacyports.CommandResult, error) {
+	runner.commands = append(runner.commands, command)
+	return legacyports.CommandResult{}, nil
+}
+
+func (runner *recordingRunner) RunDuplexWithPlannedShutdown(_ context.Context, command legacyports.Command, exchange func(io.Writer, io.Reader) error) error {
+	runner.commands = append(runner.commands, command)
+	if runner.duplexErr != nil {
+		return runner.duplexErr
+	}
+	output := io.Reader(strings.NewReader(runner.duplexOutput))
+	var liveWriter *os.File
+	var outputWritten chan struct{}
+	if runner.duplexLive {
+		liveReader, writer, err := os.Pipe()
+		if err != nil {
+			return err
+		}
+		defer liveReader.Close()
+		liveWriter = writer
+		output = liveReader
+		outputWritten = make(chan struct{})
+		go func() {
+			_, _ = io.WriteString(writer, runner.duplexOutput)
+			close(outputWritten)
+		}()
+	}
+	stdin := &fixtureACPStdin{close: func() error {
+		if liveWriter != nil {
+			<-outputWritten
+		}
+		return nil
+	}}
+	exchangeErr := exchange(stdin, output)
+	_ = stdin.Close()
+	if liveWriter != nil {
+		_ = liveWriter.Close()
+	}
+	if runner.duplexPostErr != nil {
+		return errors.Join(exchangeErr, runner.duplexPostErr)
+	}
+	return exchangeErr
+}
+
+func (runner *recordingRunner) DuplexCapability() error { return runner.capabilityErr }
 
 func (runner *recordingRunner) Run(_ context.Context, command legacyports.Command) (legacyports.CommandResult, error) {
 	runner.commands = append(runner.commands, command)
@@ -197,13 +254,7 @@ func TestKiroVerificationScansUnknownBeforeRecognizedNegative(t *testing.T) {
 				{Kind: domain.ComponentMCPServer, Name: "unknown-first", Support: domain.SupportNative},
 				{Kind: domain.ComponentMCPServer, Name: "negative-later", Support: domain.SupportNative},
 			}
-			runner := &recordingRunner{run: func(command legacyports.Command) legacyports.CommandResult {
-				name := command.Argv[len(command.Argv)-1]
-				if name == "negative-later" {
-					return legacyports.CommandResult{Stdout: []byte(name + ": disconnected")}
-				}
-				return legacyports.CommandResult{Stdout: []byte(name + ": enabled")}
-			}}
+			runner := &recordingRunner{duplexOutput: acpResponse(0, `{"protocolVersion":1}`) + acpResponse(1, `{"sessionId":"s"}`) + acpStatus("s", "negative-later", "disconnected", "")}
 			outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
 			if err == nil || outcome.Activation != domain.ActivationFailed || !outcome.AuthoritativeObservation {
 				t.Fatalf("outcome=%+v err=%v", outcome, err)
@@ -211,14 +262,14 @@ func TestKiroVerificationScansUnknownBeforeRecognizedNegative(t *testing.T) {
 			if outcome.ActivationAttested {
 				t.Fatalf("recognized negative evidence was bypassed by attestation: %+v", outcome)
 			}
-			if len(runner.commands) != 2 {
-				t.Fatalf("verifier calls = %d, want every MCP server", len(runner.commands))
+			if len(runner.commands) != 1 {
+				t.Fatalf("verifier calls = %d, want one ACP session", len(runner.commands))
 			}
 		})
 	}
 }
 
-func TestKiroVerificationReturnsUnknownOnlyAfterScanningEveryServer(t *testing.T) {
+func TestKiroVerificationFailsWhenAnyPlannedServerIsMissing(t *testing.T) {
 	t.Parallel()
 	request := activationRequest(t, domain.ClientKiro)
 	request.BackendExecutable = "/test/bin/kiro-cli"
@@ -227,19 +278,68 @@ func TestKiroVerificationReturnsUnknownOnlyAfterScanningEveryServer(t *testing.T
 		{Kind: domain.ComponentMCPServer, Name: "unknown-first", Support: domain.SupportNative},
 		{Kind: domain.ComponentMCPServer, Name: "healthy-later", Support: domain.SupportNative},
 	}
-	runner := &recordingRunner{run: func(command legacyports.Command) legacyports.CommandResult {
-		name := command.Argv[len(command.Argv)-1]
-		if name == "healthy-later" {
-			return legacyports.CommandResult{Stdout: []byte(name + ": connected")}
-		}
-		return legacyports.CommandResult{Stdout: []byte(name + ": enabled")}
-	}}
+	runner := &recordingRunner{duplexOutput: acpResponse(0, `{"protocolVersion":1}`) + acpResponse(1, `{"sessionId":"s"}`) + acpStatus("s", "healthy-later", "connected", `[{"name":"search","disabled":false}]`)}
 	outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
-	if err != nil || outcome.Activation != domain.ActivationManual || outcome.AuthoritativeObservation {
+	if err == nil || outcome.Activation != domain.ActivationFailed || !outcome.AuthoritativeObservation {
 		t.Fatalf("outcome=%+v err=%v", outcome, err)
 	}
-	if len(runner.commands) != 2 {
-		t.Fatalf("verifier calls = %d, want every MCP server", len(runner.commands))
+	if len(runner.commands) != 1 {
+		t.Fatalf("verifier calls = %d, want one ACP session", len(runner.commands))
+	}
+}
+
+func TestKiroMultiServerTimeoutCannotFallBackToActivationAttestation(t *testing.T) {
+	t.Parallel()
+	request := activationRequest(t, domain.ClientKiro)
+	request.BackendExecutable = "/test/bin/kiro-cli"
+	request.VerifyOnly = true
+	request.ActivationComplete = true
+	request.Plan.Components = []domain.ComponentDecision{
+		{Kind: domain.ComponentMCPServer, Name: "alpha", Support: domain.SupportNative},
+		{Kind: domain.ComponentMCPServer, Name: "beta", Support: domain.SupportNative},
+	}
+	runner := &recordingRunner{
+		duplexOutput: acpResponse(0, `{"protocolVersion":1}`) + acpResponse(1, `{"sessionId":"s"}`) +
+			acpStatus("s", "alpha", "connected", `[{"name":"search","disabled":false}]`),
+		duplexPostErr: context.DeadlineExceeded,
+	}
+	outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
+	if err == nil || outcome.Activation != domain.ActivationFailed || !outcome.AuthoritativeObservation {
+		t.Fatalf("outcome=%+v err=%v, want authoritative incomplete verification failure", outcome, err)
+	}
+	if outcome.ActivationAttested || errors.Is(err, errKiroACPContractUnknown) {
+		t.Fatalf("timeout downgraded negative evidence to attestation/manual fallback: outcome=%+v err=%v", outcome, err)
+	}
+}
+
+func TestKiroEOFDuringSettlementFailsClosed(t *testing.T) {
+	t.Parallel()
+	request := activationRequest(t, domain.ClientKiro)
+	request.BackendExecutable = "/test/bin/kiro-cli"
+	request.VerifyOnly = true
+	request.ActivationComplete = true
+	request.Plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "alpha", Support: domain.SupportNative}}
+	runner := &recordingRunner{duplexOutput: connectedACP("alpha")}
+	outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
+	if err == nil || outcome.Activation != domain.ActivationFailed {
+		t.Fatalf("outcome=%+v err=%v, want settlement EOF failure", outcome, err)
+	}
+	if outcome.ActivationAttested {
+		t.Fatalf("settlement EOF was converted to attested active: %+v", outcome)
+	}
+}
+
+func TestKiroPartialRecordAfterCompletionCannotBeAttestedActive(t *testing.T) {
+	t.Parallel()
+	request := activationRequest(t, domain.ClientKiro)
+	request.BackendExecutable = "/test/bin/kiro-cli"
+	request.VerifyOnly = true
+	request.ActivationComplete = true
+	request.Plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "alpha", Support: domain.SupportNative}}
+	runner := &recordingRunner{duplexOutput: connectedACP("alpha") + `{"jsonrpc":"2.0"`}
+	outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
+	if err == nil || !errors.Is(err, errKiroACPPartialExit) || !errors.Is(err, errRecognizedNegativeEvidence) || outcome.ActivationAttested {
+		t.Fatalf("partial EOF outcome=%+v err=%v, want non-attestable negative evidence", outcome, err)
 	}
 }
 
@@ -361,6 +461,7 @@ func TestActivationAttestationCannotBypassObservableVerifier(t *testing.T) {
 			if client == domain.ClientKiro {
 				request.BackendExecutable = "/test/bin/kiro-cli"
 				request.Plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "demo", Support: domain.SupportNative}}
+				runner.duplexOutput = acpResponse(0, `{"protocolVersion":1}`) + acpResponse(1, `{"sessionId":"s"}`) + acpStatus("s", "demo", "disconnected", "")
 			}
 			outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
 			if err == nil || outcome.Activation != domain.ActivationFailed || outcome.Verification != domain.VerificationFailed || !outcome.AuthoritativeObservation {
@@ -376,25 +477,21 @@ func TestActivationAttestationCannotBypassObservableVerifier(t *testing.T) {
 	}
 }
 
-func TestKiroVerificationUsesExactHealthyStdoutIdentity(t *testing.T) {
+func TestKiroHumanStatusOutputNeverProvesActivation(t *testing.T) {
 	t.Parallel()
 	request := activationRequest(t, domain.ClientKiro)
 	request.BackendExecutable = "/test/bin/kiro-cli"
 	request.VerifyOnly = true
 	request.Plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "demo-server", Support: domain.SupportNative}}
 	for name, listed := range map[string]legacyports.CommandResult{
-		"pending":       {Stdout: []byte("demo-server: pending")},
-		"disconnected":  {Stdout: []byte("demo-server: disconnected")},
-		"disabled":      {Stdout: []byte("demo-server: disabled")},
-		"auth required": {Stdout: []byte("demo-server: auth-required")},
-		"error":         {Stdout: []byte("demo-server: error")},
-		"failed":        {Stdout: []byte("demo-server: failed")},
+		"legacy connected": {Stdout: []byte("demo-server: connected")},
+		"current table":    {Stdout: []byte("Name         Scope  Agent  Command  Timeout  Disabled  Env Vars\ndemo-server global -      http     60       false     -")},
 	} {
 		t.Run(name, func(t *testing.T) {
-			runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult { return listed }}
+			runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult { return listed }, duplexErr: errors.New("ACP unsupported")}
 			outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
-			if err == nil || outcome.Activation != domain.ActivationFailed {
-				t.Fatalf("untrusted Kiro status was accepted: outcome=%+v err=%v", outcome, err)
+			if err != nil || outcome.Activation != domain.ActivationManual || len(runner.commands) != 1 || runner.commands[0].Argv[1] != "acp" {
+				t.Fatalf("human Kiro status influenced activation: outcome=%+v err=%v commands=%v", outcome, err, runner.commands)
 			}
 		})
 	}
@@ -415,35 +512,13 @@ func TestKiroUnknownStatusContractRemainsManual(t *testing.T) {
 		"unknown":                  {Stdout: []byte("demo-server: enabled")},
 	} {
 		t.Run(name, func(t *testing.T) {
-			runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult { return listed }}
+			runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult { return listed }, duplexErr: errors.New("ACP output contract unknown")}
 			outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
 			if err != nil || outcome.Activation != domain.ActivationManual || outcome.Verification != domain.VerificationPackageValid {
 				t.Fatalf("outcome=%+v err=%v", outcome, err)
 			}
 			if outcome.ActivationAttested || len(runner.commands) != 1 || len(outcome.LocalActions) == 0 {
 				t.Fatalf("unknown output path is not actionable: outcome=%+v commands=%+v", outcome, runner.commands)
-			}
-		})
-	}
-}
-
-func TestKiroStatusParserAcceptsOnlyExactRequestedIdentityShapes(t *testing.T) {
-	t.Parallel()
-	for name, test := range map[string]struct {
-		body string
-		want kiroStatus
-	}{
-		"one line healthy":  {"demo: connected\n", kiroStatusHealthy},
-		"two line healthy":  {"Name: demo\nStatus: connected\n", kiroStatusHealthy},
-		"one line negative": {"demo: disabled\n", kiroStatusUnhealthy},
-		"two line negative": {"Name: demo\nStatus: auth required\n", kiroStatusUnhealthy},
-		"other negative":    {"other: disconnected\n", kiroStatusUnknown},
-		"extra warning":     {"warning\ndemo: disconnected\n", kiroStatusUnknown},
-		"extra suffix":      {"demo: disconnected now\n", kiroStatusUnknown},
-	} {
-		t.Run(name, func(t *testing.T) {
-			if got := kiroMCPStatus([]byte(test.body), "demo"); got != test.want {
-				t.Fatalf("status = %v, want %v", got, test.want)
 			}
 		})
 	}
@@ -465,6 +540,9 @@ func TestUnknownObservableVerificationRequiresAndRecordsExplicitAttestation(t *t
 				request.Plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "demo", Support: domain.SupportNative}}
 			}
 			runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult { return legacyports.CommandResult{} }}
+			if client == domain.ClientKiro {
+				runner.duplexErr = errors.New("ACP unsupported")
+			}
 			outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
 			if err != nil || outcome.Activation != domain.ActivationActive || outcome.Verification != domain.VerificationInstalled || !outcome.ActivationAttested {
 				t.Fatalf("outcome=%+v err=%v", outcome, err)
@@ -506,13 +584,11 @@ func TestVerifyOnlyRunsOnlyReadOnlyClientCommands(t *testing.T) {
 					{Kind: domain.ComponentMCPServer, Name: "alpha", Support: domain.SupportNative},
 					{Kind: domain.ComponentMCPServer, Name: "beta", Support: domain.SupportNative},
 				}
-				runner.run = func(command legacyports.Command) legacyports.CommandResult {
-					name := command.Argv[len(command.Argv)-1]
-					return legacyports.CommandResult{Stdout: []byte(name + ": connected")}
-				}
+				runner.duplexOutput = acpResponse(0, `{"protocolVersion":1}`) + acpResponse(1, `{"sessionId":"s"}`) +
+					acpStatus("s", "alpha", "connected", `[{"name":"a","disabled":false}]`) + acpStatus("s", "beta", "connected", `[{"name":"b","disabled":false}]`)
+				runner.duplexLive = true
 				want = [][]string{
-					{"/test/bin/kiro-cli", "mcp", "status", "--name", "alpha"},
-					{"/test/bin/kiro-cli", "mcp", "status", "--name", "beta"},
+					{"/test/bin/kiro-cli", "acp", "--agent-engine", "v3", "--auth-method", "cli"},
 				}
 			}
 
@@ -540,14 +616,9 @@ func TestClientListingDoesNotConvertUnknownAuthentication(t *testing.T) {
 	}
 }
 
-func TestActivatorImportsMCPOnlyPackageThroughKiroCLIAndVerifiesEachStatus(t *testing.T) {
+func TestActivatorPinsDetectedKiroExecutableForImportAndACPVerification(t *testing.T) {
 	t.Parallel()
-	runner := &recordingRunner{run: func(command legacyports.Command) legacyports.CommandResult {
-		if strings.Contains(strings.Join(command.Argv, " "), "mcp status --name demo-server") {
-			return legacyports.CommandResult{Stdout: []byte("Name: demo-server\nStatus: connected")}
-		}
-		return legacyports.CommandResult{}
-	}}
+	runner := &recordingRunner{duplexOutput: connectedACP("demo-server"), duplexLive: true}
 	request := activationRequest(t, domain.ClientKiro)
 	request.BackendExecutable = "/test/bin/kiro-cli"
 	request.Plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "demo-server", Support: domain.SupportNative}}
@@ -560,10 +631,43 @@ func TestActivatorImportsMCPOnlyPackageThroughKiroCLIAndVerifiesEachStatus(t *te
 	}
 	want := [][]string{
 		{"/test/bin/kiro-cli", "mcp", "import", "--file", filepath.Join(request.Delivery.ActivePath, "mcp.json"), "global", "--force"},
-		{"/test/bin/kiro-cli", "mcp", "status", "--name", "demo-server"},
+		{"/test/bin/kiro-cli", "acp", "--agent-engine", "v3", "--auth-method", "cli"},
 	}
 	if got := commandArgv(runner.commands); !reflect.DeepEqual(got, want) {
 		t.Fatalf("commands = %#v, want %#v", got, want)
+	}
+	request.VerifyOnly = true
+	retry, err := (Activator{Runner: runner}).Activate(context.Background(), request)
+	if err != nil || retry.Activation != domain.ActivationActive || retry.Verification != domain.VerificationInstalled {
+		t.Fatalf("verify-only retry = %+v, %v", retry, err)
+	}
+	want = append(want, []string{"/test/bin/kiro-cli", "acp", "--agent-engine", "v3", "--auth-method", "cli"})
+	if got := commandArgv(runner.commands); !reflect.DeepEqual(got, want) {
+		t.Fatalf("idempotent commands = %#v, want %#v", got, want)
+	}
+}
+
+func TestActivatorRunOnlyRunnerCannotMutateKiro(t *testing.T) {
+	t.Parallel()
+	runner := &runOnlyRecordingRunner{}
+	request := activationRequest(t, domain.ClientKiro)
+	request.BackendExecutable = "/test/bin/kiro-cli"
+	request.Plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "demo-server", Support: domain.SupportNative}}
+	outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
+	if err == nil || !strings.Contains(err.Error(), "requires an ACP duplex process runner") || len(runner.commands) != 0 {
+		t.Fatalf("run-only Kiro activation mutated before duplex preflight: outcome=%+v commands=%+v", outcome, runner.commands)
+	}
+}
+
+func TestActivatorContainmentPreflightFailureCannotMutateKiro(t *testing.T) {
+	t.Parallel()
+	runner := &recordingRunner{capabilityErr: errors.New("delegated cgroup unavailable")}
+	request := activationRequest(t, domain.ClientKiro)
+	request.BackendExecutable = "/test/bin/kiro-cli"
+	request.Plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "demo-server", Support: domain.SupportNative}}
+	outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
+	if err == nil || !strings.Contains(err.Error(), "manual_activation_required") || len(runner.commands) != 0 {
+		t.Fatalf("failed containment preflight mutated Kiro: outcome=%+v error=%v commands=%+v", outcome, err, runner.commands)
 	}
 }
 

--- a/install/integrationctl/agentplugins/providers/kiro_acp.go
+++ b/install/integrationctl/agentplugins/providers/kiro_acp.go
@@ -1,0 +1,669 @@
+package providers
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+	"unicode/utf8"
+
+	legacyports "github.com/777genius/plugin-kit-ai/install/integrationctl/ports"
+)
+
+const (
+	kiroACPTimeout    = 40 * time.Second
+	kiroACPMaxBytes   = 1024 * 1024
+	kiroACPMaxLine    = 256 * 1024
+	kiroACPMaxRecords = 256
+	kiroACPSettlement = 150 * time.Millisecond
+)
+
+var (
+	errKiroACPContractUnknown = errors.New("Kiro structured ACP verification is unavailable or unrecognized")
+	errKiroACPEarlyExit       = errors.New("Kiro ACP process exited before verification completed")
+	errKiroACPPartialExit     = fmt.Errorf("%w: Kiro ACP process exited with a partial trailing record", errRecognizedNegativeEvidence)
+)
+
+type duplexCommandRunner interface {
+	RunDuplexWithPlannedShutdown(context.Context, legacyports.Command, func(io.Writer, io.Reader) error) error
+}
+
+type duplexCapabilityRunner interface {
+	duplexCommandRunner
+	DuplexCapability() error
+}
+
+type kiroACPServerState struct {
+	connecting       bool
+	connected        bool
+	sessionID        string
+	connectingRecord string
+	connectedRecord  string
+}
+
+// verifyKiroACP performs only ACP initialization and session creation. The
+// empty mcpServers list is intentional: Kiro must discover the native config
+// installed by the preceding import rather than receive package definitions
+// through the verification channel.
+func verifyKiroACP(ctx context.Context, runner duplexCommandRunner, executable, cwd string, servers []string) error {
+	return verifyKiroACPWithTimeout(ctx, runner, executable, cwd, servers, kiroACPTimeout)
+}
+
+func verifyKiroACPWithTimeout(ctx context.Context, runner duplexCommandRunner, executable, cwd string, servers []string, startupTimeout time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if runner == nil {
+		return fmt.Errorf("%w: interactive process runner is unavailable", errKiroACPContractUnknown)
+	}
+	absoluteCWD, err := filepath.Abs(cwd)
+	if err != nil || !filepath.IsAbs(absoluteCWD) {
+		return fmt.Errorf("%w: resolve prepared verification directory", errKiroACPContractUnknown)
+	}
+	expected := make(map[string]*kiroACPServerState, len(servers))
+	for _, rawName := range servers {
+		name := strings.TrimSpace(rawName)
+		if name == "" {
+			return fmt.Errorf("%w: planned MCP server name is empty", errKiroACPContractUnknown)
+		}
+		if _, duplicate := expected[name]; duplicate {
+			return fmt.Errorf("%w: duplicate planned MCP server identity %q", errKiroACPContractUnknown, name)
+		}
+		expected[name] = &kiroACPServerState{}
+	}
+	if len(expected) == 0 {
+		return fmt.Errorf("%w: no planned MCP servers", errKiroACPContractUnknown)
+	}
+
+	if startupTimeout <= 0 {
+		return fmt.Errorf("%w: ACP startup timeout must be positive", errKiroACPContractUnknown)
+	}
+	bounded, cancel := context.WithTimeout(ctx, startupTimeout)
+	defer cancel()
+	command := legacyports.Command{
+		Argv: []string{executable, "acp", "--agent-engine", "v3", "--auth-method", "cli"},
+		Dir:  absoluteCWD,
+	}
+	var exchangeEntered atomic.Bool
+	err = runner.RunDuplexWithPlannedShutdown(bounded, command, func(stdin io.Writer, stdout io.Reader) error {
+		exchangeEntered.Store(true)
+		exchangeErr := exchangeKiroACP(stdin, stdout, absoluteCWD, expected)
+		if exchangeErr == nil {
+			return nil
+		}
+		// Once the client has entered the ACP exchange, malformed records,
+		// partial output, protocol violations, and stream/process interruption
+		// are authoritative verification failures rather than fallback signals.
+		return errors.Join(errRecognizedNegativeEvidence, exchangeErr)
+	})
+	if err == nil {
+		if ctxErr := bounded.Err(); ctxErr != nil {
+			return errors.Join(errRecognizedNegativeEvidence, ctxErr)
+		}
+		return nil
+	}
+	if exchangeEntered.Load() {
+		if !errors.Is(err, errRecognizedNegativeEvidence) {
+			err = errors.Join(errRecognizedNegativeEvidence, err)
+		}
+		// The phase-specific deadline belongs to the ACP exchange even when pipe
+		// closure is observed first. Preserve that cause instead of degrading a
+		// no-data timeout into an indistinguishable early EOF.
+		if boundedErr := bounded.Err(); boundedErr != nil && !errors.Is(err, boundedErr) {
+			err = errors.Join(err, boundedErr)
+		}
+	}
+	if errors.Is(err, errRecognizedNegativeEvidence) {
+		if ctxErr := ctx.Err(); ctxErr != nil && !errors.Is(err, ctxErr) {
+			return errors.Join(err, ctxErr)
+		}
+		return err
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	return fmt.Errorf("%w: %v", errKiroACPContractUnknown, err)
+}
+
+func exchangeKiroACP(stdin io.Writer, stdout io.Reader, cwd string, expected map[string]*kiroACPServerState) error {
+	_, ok := stdin.(io.Closer)
+	if !ok {
+		return fmt.Errorf("ACP stdin does not support close")
+	}
+	initialize := map[string]any{
+		"jsonrpc": "2.0", "id": 0, "method": "initialize",
+		"params": map[string]any{
+			"protocolVersion":    1,
+			"clientCapabilities": map[string]any{},
+			"clientInfo":         map[string]any{"name": "agentplugins", "version": "1"},
+		},
+	}
+	if err := writeACPRecord(stdin, initialize); err != nil {
+		return fmt.Errorf("write initialize request: %w", err)
+	}
+
+	reader := bufio.NewReaderSize(stdout, kiroACPMaxLine+1)
+	initialized := false
+	sessionCreated := false
+	sessionID := ""
+	var negativeErr error
+	settling := false
+	totalBytes := 0
+	for record := 0; ; record++ {
+		line, err := readBoundedACPLine(reader, &totalBytes)
+		if err != nil {
+			if negativeErr != nil {
+				return negativeErr
+			}
+			if settling && errors.Is(err, os.ErrDeadlineExceeded) {
+				queued, eof, probeErr := queuedACPRealPipeEvidence(stdout)
+				if probeErr != nil {
+					return fmt.Errorf("inspect ACP pipe at settlement boundary: %w", probeErr)
+				}
+				if eof {
+					return fmt.Errorf("%w: ACP output reached EOF at the post-success settlement boundary", errRecognizedNegativeEvidence)
+				}
+				if !queued {
+					return nil
+				}
+				deadlineWriter := stdout.(interface{ SetReadDeadline(time.Time) error })
+				if err := deadlineWriter.SetReadDeadline(time.Now().Add(kiroACPSettlement)); err != nil {
+					return fmt.Errorf("rearm ACP queued-evidence drain deadline: %w", err)
+				}
+				continue
+			}
+			if settling && errors.Is(err, errKiroACPEarlyExit) {
+				return fmt.Errorf("%w: ACP output reached EOF during post-success settlement", errRecognizedNegativeEvidence)
+			}
+			if sessionCreated && !allKiroServersConnected(expected, sessionID) && errors.Is(err, errKiroACPEarlyExit) {
+				return fmt.Errorf("%w: not every planned MCP server reported connected", errRecognizedNegativeEvidence)
+			}
+			return err
+		}
+		if record >= kiroACPMaxRecords {
+			return fmt.Errorf("ACP output exceeded its record bound")
+		}
+		message, err := decodeACPMessage(line)
+		if err != nil {
+			if negativeErr != nil {
+				return negativeErr
+			}
+			return err
+		}
+		if !initialized {
+			if err := validateInitializeResponse(message); err != nil {
+				return err
+			}
+			initialized = true
+			sessionRequest := map[string]any{
+				"jsonrpc": "2.0", "id": 1, "method": "session/new",
+				"params": map[string]any{"cwd": cwd, "mcpServers": []any{}},
+			}
+			if err := writeACPRecord(stdin, sessionRequest); err != nil {
+				return fmt.Errorf("write session/new request: %w", err)
+			}
+			continue
+		}
+
+		if _, hasID := message.document["id"]; hasID {
+			if sessionCreated || !acpIDEquals(message.document["id"], 1) {
+				if negativeErr != nil {
+					return negativeErr
+				}
+				return fmt.Errorf("ACP response has an unexpected or duplicate id")
+			}
+			result, ok := message.document["result"].(map[string]any)
+			_, hasError := message.document["error"]
+			if !ok || hasError {
+				if negativeErr != nil {
+					return negativeErr
+				}
+				return fmt.Errorf("session/new did not return a valid result")
+			}
+			var okSession bool
+			sessionID, okSession = result["sessionId"].(string)
+			if !okSession || strings.TrimSpace(sessionID) == "" {
+				if negativeErr != nil {
+					return negativeErr
+				}
+				return fmt.Errorf("session/new response is missing its session identity")
+			}
+			sessionCreated = true
+			for _, state := range expected {
+				if state.sessionID != "" && state.sessionID != sessionID {
+					return fmt.Errorf("%w: MCP status belongs to a different ACP session", errRecognizedNegativeEvidence)
+				}
+			}
+		} else {
+			method, ok := message.document["method"].(string)
+			if !ok || strings.TrimSpace(method) == "" {
+				if negativeErr != nil {
+					return negativeErr
+				}
+				return fmt.Errorf("ACP notification is missing its method")
+			}
+			if method == "_kiro/mcp/status" {
+				if err := consumeKiroMCPStatus(message.document, expected); err != nil {
+					if errors.Is(err, errRecognizedNegativeEvidence) {
+						if negativeErr == nil {
+							negativeErr = err
+						}
+					} else {
+						if negativeErr != nil {
+							return negativeErr
+						}
+						return err
+					}
+				}
+			}
+		}
+
+		if sessionCreated && negativeErr != nil {
+			return negativeErr
+		}
+		if sessionCreated && allKiroServersConnected(expected, sessionID) {
+			// Kiro ACP is intentionally long-lived. Keep stdin open while draining
+			// the bounded settlement window: closing it would manufacture EOF and
+			// can let the leader exit while a KAS descendant survives. A nil return
+			// after settlement causally requests the runner's planned tree shutdown.
+			if !settling {
+				deadlineWriter, ok := stdout.(interface{ SetReadDeadline(time.Time) error })
+				if !ok {
+					// Finite readers used by callers/tests still provide EOF as the
+					// completion boundary. Real process pipes always support deadlines.
+					continue
+				}
+				if err := deadlineWriter.SetReadDeadline(time.Now().Add(kiroACPSettlement)); err != nil {
+					return fmt.Errorf("arm ACP post-success settlement deadline: %w", err)
+				}
+				settling = true
+			}
+		}
+	}
+}
+
+type acpMessage struct {
+	document map[string]any
+}
+
+func consumeKiroMCPStatus(document map[string]any, expected map[string]*kiroACPServerState) error {
+	params, ok := document["params"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("Kiro MCP status params are malformed")
+	}
+	rawServers, hasServers := params["servers"]
+	_, hasServerName := params["serverName"]
+	if hasServers && hasServerName {
+		return fmt.Errorf("Kiro MCP status mixes array and legacy server shapes")
+	}
+	if _, hasAlias := params["name"]; hasAlias {
+		return fmt.Errorf("Kiro MCP status contains an unknown or conflicting server identity")
+	}
+	sessionID, ok := params["sessionId"].(string)
+	if !ok || strings.TrimSpace(sessionID) == "" {
+		return fmt.Errorf("Kiro MCP status is missing its session identity")
+	}
+	if hasServers {
+		servers, ok := rawServers.([]any)
+		if !ok || len(servers) == 0 {
+			return fmt.Errorf("Kiro MCP status servers are malformed or empty")
+		}
+		seen := make(map[string]struct{}, len(servers))
+		for _, rawServer := range servers {
+			server, ok := rawServer.(map[string]any)
+			if !ok {
+				return fmt.Errorf("Kiro MCP status contains a malformed server record")
+			}
+			if _, conflicting := server["serverName"]; conflicting {
+				return fmt.Errorf("Kiro MCP status array record contains a conflicting identity field")
+			}
+			name, ok := server["name"].(string)
+			if !ok || strings.TrimSpace(name) == "" {
+				return fmt.Errorf("Kiro MCP status server has no unambiguous identity")
+			}
+			if _, duplicate := seen[name]; duplicate {
+				return fmt.Errorf("Kiro MCP status contains duplicate server identity %q", name)
+			}
+			seen[name] = struct{}{}
+			if err := consumeKiroMCPServer(name, sessionID, server, expected); err != nil {
+				return err
+			}
+		}
+		// The array form is a complete native-registry snapshot, not a delta.
+		// Once a planned server has appeared, its omission from a later full
+		// snapshot revokes the sticky state accumulated from older snapshots.
+		// Failing immediately also prevents a previously complete snapshot from
+		// surviving the settlement window after Kiro removes a server.
+		for name, state := range expected {
+			if _, present := seen[name]; !present && (state.connecting || state.connected) {
+				return fmt.Errorf("%w: full Kiro MCP status snapshot omitted planned server %s", errRecognizedNegativeEvidence, name)
+			}
+		}
+		return nil
+	}
+	if !hasServerName {
+		return fmt.Errorf("Kiro MCP status has no recognized server shape")
+	}
+	name, ok := params["serverName"].(string)
+	if !ok || strings.TrimSpace(name) == "" {
+		return fmt.Errorf("Kiro MCP status has no unambiguous server identity")
+	}
+	return consumeKiroMCPServer(name, sessionID, params, expected)
+}
+
+func consumeKiroMCPServer(name, sessionID string, server map[string]any, expected map[string]*kiroACPServerState) error {
+	if authType, present := server["authType"]; present {
+		value, valid := authType.(string)
+		if !valid || strings.TrimSpace(value) == "" {
+			return fmt.Errorf("Kiro MCP server %s has malformed auth type", name)
+		}
+	}
+	if disabled, present := server["disabled"]; present {
+		if _, valid := disabled.(bool); !valid {
+			return fmt.Errorf("Kiro MCP server %s has malformed disabled state", name)
+		}
+	}
+	if status, valid := server["status"].(string); !valid || strings.TrimSpace(status) == "" {
+		return fmt.Errorf("Kiro MCP server %s has malformed status", name)
+	}
+	if rawTools, present := server["tools"]; present && rawTools != nil {
+		tools, valid := rawTools.([]any)
+		if !valid {
+			return fmt.Errorf("Kiro MCP server %s has malformed tools", name)
+		}
+		seenToolNames := make(map[string]struct{}, len(tools))
+		for _, rawTool := range tools {
+			tool, valid := rawTool.(map[string]any)
+			if !valid {
+				return fmt.Errorf("Kiro MCP server %s has a malformed tool record", name)
+			}
+			toolName, valid := tool["name"].(string)
+			if !valid || strings.TrimSpace(toolName) == "" {
+				return fmt.Errorf("Kiro MCP server %s has an unnamed tool", name)
+			}
+			if _, duplicate := seenToolNames[toolName]; duplicate {
+				return fmt.Errorf("Kiro MCP server %s has duplicate tool identity %s", name, toolName)
+			}
+			seenToolNames[toolName] = struct{}{}
+			if disabled, valid := tool["disabled"].(bool); !valid {
+				return fmt.Errorf("Kiro MCP server %s has a tool with malformed disabled state", name)
+			} else if disabled {
+				// Disabled tools are authoritative only for planned servers. An
+				// unrelated native-registry entry must not veto this package.
+				if _, planned := expected[name]; planned {
+					return fmt.Errorf("%w: Kiro MCP server %s has a disabled tool", errRecognizedNegativeEvidence, name)
+				}
+			}
+		}
+	}
+	state, planned := expected[name]
+	if !planned {
+		// Kiro loads the complete native registry. Other well-formed server
+		// notifications are unrelated to the package being verified.
+		return nil
+	}
+	if state.sessionID != "" && state.sessionID != sessionID {
+		return fmt.Errorf("%w: Kiro MCP server %s has conflicting session identities", errRecognizedNegativeEvidence, name)
+	}
+	state.sessionID = sessionID
+	if disabled, present := server["disabled"]; present {
+		value, valid := disabled.(bool)
+		if !valid {
+			return fmt.Errorf("Kiro MCP server %s has malformed disabled state", name)
+		}
+		if value {
+			return fmt.Errorf("%w: Kiro MCP server %s is disabled", errRecognizedNegativeEvidence, name)
+		}
+	}
+	status, ok := server["status"].(string)
+	if !ok {
+		return fmt.Errorf("Kiro MCP server %s has malformed status", name)
+	}
+	switch status {
+	case "connecting":
+		fingerprint, err := json.Marshal(server)
+		if err != nil {
+			return fmt.Errorf("encode Kiro MCP connecting state: %w", err)
+		}
+		// Once connected has been observed, every connecting record is a
+		// regression. In particular, do not accept an exact duplicate of the
+		// earlier connecting record when it was queued before settlement.
+		if state.connected {
+			return fmt.Errorf("%w: Kiro MCP server %s has regressive connecting status after connected", errRecognizedNegativeEvidence, name)
+		}
+		if state.connecting && state.connectingRecord == string(fingerprint) {
+			return nil
+		}
+		if state.connecting {
+			return fmt.Errorf("%w: Kiro MCP server %s has duplicate or regressive status", errRecognizedNegativeEvidence, name)
+		}
+		state.connecting = true
+		state.connectingRecord = string(fingerprint)
+		return nil
+	case "connected":
+		fingerprint, err := json.Marshal(server)
+		if err != nil {
+			return fmt.Errorf("encode Kiro MCP connected state: %w", err)
+		}
+		if state.connected {
+			// The servers-array notification is a full registry snapshot. While
+			// another server advances, Kiro repeats already-connected entries in
+			// later snapshots. An identical repeat is idempotent evidence; a
+			// changed connected record remains contradictory and fails closed.
+			if state.connectedRecord == string(fingerprint) {
+				return nil
+			}
+			return fmt.Errorf("%w: Kiro MCP server %s has duplicate connected identities", errRecognizedNegativeEvidence, name)
+		}
+		tools, present := server["tools"].([]any)
+		if !present || len(tools) == 0 {
+			return fmt.Errorf("%w: Kiro MCP server %s has no usable tools", errRecognizedNegativeEvidence, name)
+		}
+		seenTools := make(map[string]struct{}, len(tools))
+		for _, rawTool := range tools {
+			tool, valid := rawTool.(map[string]any)
+			if !valid {
+				return fmt.Errorf("Kiro MCP server %s has a malformed tool record", name)
+			}
+			toolName, valid := tool["name"].(string)
+			if !valid || strings.TrimSpace(toolName) == "" {
+				return fmt.Errorf("Kiro MCP server %s has an unnamed tool", name)
+			}
+			if _, duplicate := seenTools[toolName]; duplicate {
+				return fmt.Errorf("Kiro MCP server %s has duplicate tool identity %s", name, toolName)
+			}
+			seenTools[toolName] = struct{}{}
+			disabled, valid := tool["disabled"].(bool)
+			if !valid {
+				return fmt.Errorf("Kiro MCP server %s tool %s has malformed disabled state", name, toolName)
+			}
+			if disabled {
+				return fmt.Errorf("%w: Kiro MCP server %s tool %s is disabled", errRecognizedNegativeEvidence, name, toolName)
+			}
+		}
+		state.connected = true
+		state.connectedRecord = string(fingerprint)
+		return nil
+	case "pending", "disconnected", "disabled", "auth-required", "auth required", "authentication required", "error", "failed", "failure", "unhealthy":
+		return fmt.Errorf("%w: Kiro MCP server %s reported %s", errRecognizedNegativeEvidence, name, status)
+	default:
+		return fmt.Errorf("Kiro MCP server %s reported an unknown status %q", name, status)
+	}
+}
+
+func allKiroServersConnected(expected map[string]*kiroACPServerState, sessionID string) bool {
+	for _, state := range expected {
+		if !state.connected || state.sessionID != sessionID {
+			return false
+		}
+	}
+	return true
+}
+
+func writeACPRecord(writer io.Writer, value any) error {
+	body, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	body = append(body, '\n')
+	written, err := writer.Write(body)
+	if err == nil && written != len(body) {
+		return io.ErrShortWrite
+	}
+	return err
+}
+
+func readBoundedACPLine(reader *bufio.Reader, total *int) ([]byte, error) {
+	line, err := reader.ReadSlice('\n')
+	*total += len(line)
+	if errors.Is(err, bufio.ErrBufferFull) || len(line) > kiroACPMaxLine || *total > kiroACPMaxBytes {
+		return nil, fmt.Errorf("ACP output exceeded its byte bound")
+	}
+	if err != nil {
+		// ReadSlice may return both bytes and a terminal/deadline error. Those
+		// Bytes accompanying EOF or another terminal read error are queued
+		// protocol evidence. Preserve them as a partial-record failure.
+		if len(line) > 0 {
+			return nil, fmt.Errorf("%w: ACP output ended with a non-delimited %d-byte record", errKiroACPPartialExit, len(line))
+		}
+		if errors.Is(err, io.EOF) {
+			return nil, errKiroACPEarlyExit
+		}
+		return nil, fmt.Errorf("read ACP output: %w", err)
+	}
+	if len(line) == 1 {
+		return nil, fmt.Errorf("ACP output contained an empty record")
+	}
+	return line[:len(line)-1], nil
+}
+
+func decodeACPMessage(line []byte) (acpMessage, error) {
+	// encoding/json accepts invalid UTF-8 by replacing it with U+FFFD. ACP
+	// evidence must remain byte-exact: replacement could turn a malformed
+	// status, identity, object key, or extension value into trusted evidence.
+	if !utf8.Valid(line) {
+		return acpMessage{}, fmt.Errorf("malformed ACP JSON: record is not valid UTF-8")
+	}
+	if err := validateJSONSurrogateEscapes(line); err != nil {
+		return acpMessage{}, fmt.Errorf("malformed ACP JSON: %w", err)
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(line)))
+	decoder.UseNumber()
+	value, err := decodeUniqueJSONValue(decoder)
+	if err != nil {
+		return acpMessage{}, fmt.Errorf("malformed ACP JSON: %w", err)
+	}
+	if _, err := decoder.Token(); err == nil || !errors.Is(err, io.EOF) {
+		return acpMessage{}, fmt.Errorf("ACP record contains multiple JSON values")
+	}
+	document, ok := value.(map[string]any)
+	if !ok || document["jsonrpc"] != "2.0" {
+		return acpMessage{}, fmt.Errorf("ACP record has an invalid JSON-RPC envelope")
+	}
+	_, hasMethod := document["method"]
+	_, hasID := document["id"]
+	_, hasResult := document["result"]
+	_, hasParams := document["params"]
+	errorValue, hasError := document["error"]
+	if hasMethod {
+		if hasID || hasResult || hasError {
+			return acpMessage{}, fmt.Errorf("ACP record mixes JSON-RPC request and response members")
+		}
+	} else if !hasID || hasParams || hasResult == hasError || hasError && errorValue == nil {
+		return acpMessage{}, fmt.Errorf("ACP response does not have an exclusive result or error member")
+	}
+	return acpMessage{document: document}, nil
+}
+
+func validateJSONSurrogateEscapes(document []byte) error {
+	inString := false
+	for index := 0; index < len(document); index++ {
+		switch document[index] {
+		case '"':
+			inString = !inString
+		case '\\':
+			if !inString || index+1 >= len(document) {
+				continue
+			}
+			index++
+			if document[index] != 'u' || index+4 >= len(document) {
+				continue
+			}
+			value, ok := parseJSONHexQuad(document[index+1 : index+5])
+			if !ok {
+				continue // encoding/json reports the malformed escape itself
+			}
+			index += 4
+			switch {
+			case value >= 0xd800 && value <= 0xdbff:
+				if index+6 >= len(document) || document[index+1] != '\\' || document[index+2] != 'u' {
+					return fmt.Errorf("unpaired high UTF-16 surrogate escape")
+				}
+				low, valid := parseJSONHexQuad(document[index+3 : index+7])
+				if !valid || low < 0xdc00 || low > 0xdfff {
+					return fmt.Errorf("unpaired high UTF-16 surrogate escape")
+				}
+				index += 6
+			case value >= 0xdc00 && value <= 0xdfff:
+				return fmt.Errorf("unpaired low UTF-16 surrogate escape")
+			}
+		}
+	}
+	return nil
+}
+
+func parseJSONHexQuad(value []byte) (uint16, bool) {
+	if len(value) != 4 {
+		return 0, false
+	}
+	var result uint16
+	for _, digit := range value {
+		result <<= 4
+		switch {
+		case digit >= '0' && digit <= '9':
+			result |= uint16(digit - '0')
+		case digit >= 'a' && digit <= 'f':
+			result |= uint16(digit-'a') + 10
+		case digit >= 'A' && digit <= 'F':
+			result |= uint16(digit-'A') + 10
+		default:
+			return 0, false
+		}
+	}
+	return result, true
+}
+
+func validateACPNumber(number json.Number) error {
+	// ACP/JSON-RPC numeric values must be representable as finite IEEE-754
+	// values. This gives every numeric token, including unused extension
+	// members, a deterministic finite/range policy before it can be trusted.
+	if _, err := strconv.ParseFloat(number.String(), 64); err != nil {
+		return fmt.Errorf("JSON number %q is outside the finite numeric range", number)
+	}
+	return nil
+}
+
+func validateInitializeResponse(message acpMessage) error {
+	if !acpIDEquals(message.document["id"], 0) {
+		return fmt.Errorf("initialize response has the wrong id")
+	}
+	result, ok := message.document["result"].(map[string]any)
+	_, hasError := message.document["error"]
+	if !ok || hasError || !acpIDEquals(result["protocolVersion"], 1) {
+		return fmt.Errorf("initialize response did not select ACP protocol v1")
+	}
+	return nil
+}
+
+func acpIDEquals(value any, expected int) bool {
+	number, ok := value.(json.Number)
+	return ok && number.String() == fmt.Sprintf("%d", expected)
+}

--- a/install/integrationctl/agentplugins/providers/kiro_acp_test.go
+++ b/install/integrationctl/agentplugins/providers/kiro_acp_test.go
@@ -1,0 +1,877 @@
+package providers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	legacyports "github.com/777genius/plugin-kit-ai/install/integrationctl/ports"
+)
+
+type fixtureDuplexRunner struct {
+	recordingRunner
+	output          string
+	reader          io.Reader
+	duplexErr       error
+	postError       error
+	command         legacyports.Command
+	written         []byte
+	exchangeErr     error
+	hasDeadline     bool
+	keepAlive       bool
+	closeAfterWrite bool
+	closeOnContext  bool
+	writeDelay      time.Duration
+	stdinCloses     int
+}
+
+type fixtureACPStdin struct {
+	bytes.Buffer
+	close func() error
+}
+
+func (stdin *fixtureACPStdin) Close() error {
+	if stdin.close == nil {
+		return nil
+	}
+	return stdin.close()
+}
+
+func (runner *fixtureDuplexRunner) RunDuplexWithPlannedShutdown(ctx context.Context, command legacyports.Command, exchange func(io.Writer, io.Reader) error) error {
+	runner.command = command
+	_, runner.hasDeadline = ctx.Deadline()
+	if runner.duplexErr != nil {
+		return runner.duplexErr
+	}
+	reader := runner.reader
+	var liveWriter *os.File
+	var outputWritten chan struct{}
+	var closeOutput func()
+	if reader == nil && runner.keepAlive {
+		liveReader, writer, err := os.Pipe()
+		if err != nil {
+			return err
+		}
+		defer liveReader.Close()
+		liveWriter = writer
+		reader = liveReader
+		outputWritten = make(chan struct{})
+		var closeOnce sync.Once
+		closeOutput = func() { closeOnce.Do(func() { _ = writer.Close() }) }
+		go func() {
+			if runner.writeDelay > 0 {
+				time.Sleep(runner.writeDelay)
+			}
+			_, _ = io.WriteString(writer, runner.output)
+			close(outputWritten)
+			if runner.closeAfterWrite {
+				closeOutput()
+			}
+		}()
+		if runner.closeOnContext {
+			go func() {
+				<-ctx.Done()
+				closeOutput()
+			}()
+		}
+	} else if reader == nil {
+		reader = strings.NewReader(runner.output)
+	}
+	stdin := &fixtureACPStdin{close: func() error {
+		runner.stdinCloses++
+		return nil
+	}}
+	runner.exchangeErr = exchange(stdin, reader)
+	_ = stdin.Close()
+	if liveWriter != nil {
+		closeOutput()
+	}
+	runner.written = append([]byte(nil), stdin.Bytes()...)
+	if runner.postError != nil {
+		return errors.Join(runner.exchangeErr, runner.postError)
+	}
+	return runner.exchangeErr
+}
+
+type terminalErrorReader struct {
+	err error
+}
+
+type delayedReader struct {
+	delay  time.Duration
+	reader io.Reader
+	once   bool
+}
+
+func (reader *delayedReader) Read(value []byte) (int, error) {
+	if !reader.once {
+		reader.once = true
+		time.Sleep(reader.delay)
+	}
+	return reader.reader.Read(value)
+}
+
+type contextBlockingReader struct {
+	context.Context
+	prefix *bytes.Reader
+}
+
+func (reader *contextBlockingReader) Read(buffer []byte) (int, error) {
+	if reader.prefix.Len() > 0 {
+		return reader.prefix.Read(buffer)
+	}
+	<-reader.Done()
+	return 0, reader.Err()
+}
+
+func (reader terminalErrorReader) Read([]byte) (int, error) {
+	return 0, reader.err
+}
+
+func acpResponse(id int, result string) string {
+	return fmt.Sprintf("{\"jsonrpc\":\"2.0\",\"id\":%d,\"result\":%s}\n", id, result)
+}
+
+func acpStatus(sessionID, name, status string, tools string) string {
+	if tools == "" {
+		tools = "null"
+	}
+	return fmt.Sprintf("{\"jsonrpc\":\"2.0\",\"method\":\"_kiro/mcp/status\",\"params\":{\"sessionId\":%q,\"serverName\":%q,\"status\":%q,\"tools\":%s}}\n", sessionID, name, status, tools)
+}
+
+func acpArrayStatus(sessionID, servers string) string {
+	return fmt.Sprintf("{\"jsonrpc\":\"2.0\",\"method\":\"_kiro/mcp/status\",\"params\":{\"sessionId\":%q,\"servers\":%s}}\n", sessionID, servers)
+}
+
+func acpArrayServer(name, status, tools string) string {
+	if tools == "" {
+		return fmt.Sprintf(`{"name":%q,"authType":"oauth","status":%q}`, name, status)
+	}
+	return fmt.Sprintf(`{"name":%q,"authType":"oauth","status":%q,"tools":%s}`, name, status, tools)
+}
+
+func connectedACP(name string) string {
+	return acpResponse(0, `{"protocolVersion":1}`) +
+		acpResponse(1, `{"sessionId":"session-1"}`) +
+		acpStatus("session-1", name, "connected", `[{"name":"search","disabled":false}]`)
+}
+
+func TestKiroACPVerifiesOneAndMultipleNativeServersWithoutPrompt(t *testing.T) {
+	t.Parallel()
+	for _, servers := range [][]string{{"alpha"}, {"alpha", "beta"}} {
+		servers := servers
+		t.Run(strings.Join(servers, "+"), func(t *testing.T) {
+			t.Parallel()
+			output := acpResponse(0, `{"protocolVersion":1}`)
+			for _, name := range servers {
+				output += acpStatus("session-1", name, "connected", `[{"name":"tool-`+name+`","disabled":false}]`)
+			}
+			output += acpResponse(1, `{"sessionId":"session-1"}`)
+			runner := &fixtureDuplexRunner{output: output, keepAlive: true}
+			cwd := t.TempDir()
+			if err := verifyKiroACP(context.Background(), runner, filepath.Join("test", "kiro-cli"), cwd, servers); err != nil {
+				t.Fatal(err)
+			}
+			wantArgv := []string{filepath.Join("test", "kiro-cli"), "acp", "--agent-engine", "v3", "--auth-method", "cli"}
+			if !reflect.DeepEqual(runner.command.Argv, wantArgv) || runner.command.Dir != cwd || !filepath.IsAbs(runner.command.Dir) {
+				t.Fatalf("command = %+v, want argv=%v cwd=%s", runner.command, wantArgv, cwd)
+			}
+			if !runner.hasDeadline {
+				t.Fatal("ACP process context has no time bound")
+			}
+			requests := strings.Split(strings.TrimSpace(string(runner.written)), "\n")
+			if len(requests) != 2 || strings.Contains(string(runner.written), "session/prompt") {
+				t.Fatalf("ACP requests = %q", runner.written)
+			}
+			var initialize, session map[string]any
+			if json.Unmarshal([]byte(requests[0]), &initialize) != nil || json.Unmarshal([]byte(requests[1]), &session) != nil {
+				t.Fatalf("requests are not JSON: %q", requests)
+			}
+			if initialize["method"] != "initialize" || initialize["id"] != float64(0) || session["method"] != "session/new" || session["id"] != float64(1) {
+				t.Fatalf("requests = %#v %#v", initialize, session)
+			}
+			initializeParams := initialize["params"].(map[string]any)
+			clientInfo := initializeParams["clientInfo"].(map[string]any)
+			if initializeParams["protocolVersion"] != float64(1) || len(initializeParams["clientCapabilities"].(map[string]any)) != 0 ||
+				clientInfo["name"] != "agentplugins" || clientInfo["version"] != "1" {
+				t.Fatalf("initialize params = %#v", initializeParams)
+			}
+			params := session["params"].(map[string]any)
+			if params["cwd"] != cwd || len(params["mcpServers"].([]any)) != 0 {
+				t.Fatalf("session params = %#v", params)
+			}
+		})
+	}
+}
+
+func TestKiroACPAllowsConnectingThenConnected(t *testing.T) {
+	t.Parallel()
+	runner := &fixtureDuplexRunner{output: acpResponse(0, `{"protocolVersion":1}`) +
+		acpStatus("s", "alpha", "connecting", "") + acpResponse(1, `{"sessionId":"s"}`) +
+		acpStatus("s", "alpha", "connected", `[{"name":"search","disabled":false}]`), keepAlive: true}
+	if err := verifyKiroACP(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha"}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestKiroACPActualServersArrayOrderingAndDuplicateConnecting(t *testing.T) {
+	t.Parallel()
+	connecting := acpArrayStatus("s", "["+acpArrayServer("alpha", "connecting", "")+"]")
+	connected := acpArrayStatus("s", "["+acpArrayServer("alpha", "connected", `[{"name":"search","disabled":false}]`)+"]")
+	runner := &fixtureDuplexRunner{output: acpResponse(0, `{"protocolVersion":1}`) + connecting + connecting +
+		acpResponse(1, `{"sessionId":"s"}`) + connected, keepAlive: true}
+	if err := verifyKiroACP(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha"}); err != nil {
+		t.Fatalf("captured Kiro ordering failed: %v", err)
+	}
+}
+
+func TestKiroACPCapturedDuplicateConnectingSnapshotsThenConnectedSnapshot(t *testing.T) {
+	t.Parallel()
+	connecting := acpArrayStatus("s", "["+acpArrayServer("alpha", "connecting", "")+","+acpArrayServer("beta", "connecting", "")+"]")
+	connected := acpArrayStatus("s", "["+
+		acpArrayServer("alpha", "connected", `[{"name":"search","disabled":false}]`)+","+
+		acpArrayServer("beta", "connected", `[{"name":"fetch","disabled":false}]`)+"]")
+	runner := &fixtureDuplexRunner{
+		output:    acpResponse(0, `{"protocolVersion":1}`) + connecting + connecting + acpResponse(1, `{"sessionId":"s"}`) + connected,
+		keepAlive: true,
+	}
+	if err := verifyKiroACP(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha", "beta"}); err != nil {
+		t.Fatalf("captured Kiro 2.19.1/KAS 0.48.0 sequence failed: %v", err)
+	}
+}
+
+func TestKiroACPServersArraySupportsPlannedAndUnrelatedServers(t *testing.T) {
+	t.Parallel()
+	servers := "[" + acpArrayServer("unrelated", "connecting", "") + "," +
+		acpArrayServer("alpha", "connected", `[{"name":"a","disabled":false}]`) + "," +
+		acpArrayServer("beta", "connected", `[{"name":"b","disabled":false}]`) + "]"
+	runner := &fixtureDuplexRunner{output: acpResponse(0, `{"protocolVersion":1}`) +
+		acpArrayStatus("s", servers) + acpResponse(1, `{"sessionId":"s"}`), keepAlive: true}
+	if err := verifyKiroACP(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha", "beta"}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestKiroACPServersArrayRepeatedConnectedSnapshotDuringPeerTransition(t *testing.T) {
+	t.Parallel()
+	alphaConnecting := acpArrayServer("alpha", "connecting", "")
+	betaConnecting := acpArrayServer("beta", "connecting", "")
+	alphaConnected := acpArrayServer("alpha", "connected", `[{"name":"a","disabled":false}]`)
+	betaConnected := acpArrayServer("beta", "connected", `[{"name":"b","disabled":false}]`)
+	runner := &fixtureDuplexRunner{output: acpResponse(0, `{"protocolVersion":1}`) +
+		acpArrayStatus("s", "["+alphaConnecting+","+betaConnecting+"]") +
+		acpResponse(1, `{"sessionId":"s"}`) +
+		acpArrayStatus("s", "["+alphaConnected+","+betaConnecting+"]") +
+		acpArrayStatus("s", "["+alphaConnected+","+betaConnected+"]"), keepAlive: true}
+	if err := verifyKiroACP(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha", "beta"}); err != nil {
+		t.Fatalf("repeated connected entry in a later registry snapshot failed: %v", err)
+	}
+}
+
+func TestKiroACPFullSnapshotOmissionRevokesConnectedState(t *testing.T) {
+	t.Parallel()
+	alphaConnected := acpArrayServer("alpha", "connected", `[{"name":"a","disabled":false}]`)
+	betaConnected := acpArrayServer("beta", "connected", `[{"name":"b","disabled":false}]`)
+	runner := &fixtureDuplexRunner{output: acpResponse(0, `{"protocolVersion":1}`) +
+		acpResponse(1, `{"sessionId":"s"}`) +
+		acpArrayStatus("s", "["+alphaConnected+","+betaConnected+"]") +
+		acpArrayStatus("s", "["+alphaConnected+"]"), keepAlive: true}
+	err := verifyKiroACP(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha", "beta"})
+	if !errors.Is(err, errRecognizedNegativeEvidence) || !strings.Contains(err.Error(), "omitted planned server beta") {
+		t.Fatalf("connected -> omitted full snapshot error = %v", err)
+	}
+}
+
+func TestKiroACPRejectsMalformedOrAmbiguousServersArrays(t *testing.T) {
+	t.Parallel()
+	valid := acpArrayServer("alpha", "connected", `[{"name":"search","disabled":false}]`)
+	tests := map[string]string{
+		"both shapes":                 `{"sessionId":"s","serverName":"alpha","servers":[` + valid + `]}`,
+		"duplicate names":             `{"sessionId":"s","servers":[` + valid + `,` + valid + `]}`,
+		"malformed array":             `{"sessionId":"s","servers":{}}`,
+		"malformed record":            `{"sessionId":"s","servers":["alpha"]}`,
+		"missing name":                `{"sessionId":"s","servers":[{"status":"connected","tools":[]}]}`,
+		"malformed auth":              `{"sessionId":"s","servers":[{"name":"alpha","authType":7,"status":"connected","tools":[]}]}`,
+		"unrelated malformed status":  `{"sessionId":"s","servers":[{"name":"unrelated","status":7},` + valid + `]}`,
+		"unrelated malformed tools":   `{"sessionId":"s","servers":[{"name":"unrelated","status":"connected","tools":{}},` + valid + `]}`,
+		"conflicting record identity": `{"sessionId":"s","servers":[{"name":"alpha","serverName":"beta","status":"connected","tools":[{"name":"search","disabled":false}]}]}`,
+		"conflicting duplicate connecting": `{"sessionId":"s","servers":[` + acpArrayServer("alpha", "connecting", "") + `]}` + "\n" +
+			`{"jsonrpc":"2.0","method":"_kiro/mcp/status","params":{"sessionId":"s","servers":[{"name":"alpha","authType":"iam","status":"connecting"}]}}`,
+	}
+	for name, params := range tests {
+		params := params
+		t.Run(name, func(t *testing.T) {
+			status := `{"jsonrpc":"2.0","method":"_kiro/mcp/status","params":` + params + "}\n"
+			if name == "conflicting duplicate connecting" {
+				parts := strings.SplitN(params, "\n", 2)
+				status = `{"jsonrpc":"2.0","method":"_kiro/mcp/status","params":` + parts[0] + "}\n" + parts[1] + "\n"
+			}
+			runner := &fixtureDuplexRunner{output: acpResponse(0, `{"protocolVersion":1}`) + status + acpResponse(1, `{"sessionId":"s"}`)}
+			if err := verifyKiroACP(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha"}); err == nil {
+				t.Fatal("ambiguous/malformed servers array unexpectedly succeeded")
+			}
+		})
+	}
+}
+
+func TestKiroACPStartupTimeoutAllowsDelayedValidColdStart(t *testing.T) {
+	runner := &fixtureDuplexRunner{output: connectedACP("alpha"), keepAlive: true, writeDelay: 25 * time.Millisecond}
+	if err := verifyKiroACPWithTimeout(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha"}, 250*time.Millisecond); err != nil {
+		t.Fatalf("delayed valid ACP startup failed: %v", err)
+	}
+}
+
+func TestKiroACPRealPipeDeadlineBoundary(t *testing.T) {
+	complete := connectedACP("alpha")
+	for name, test := range map[string]struct {
+		output  string
+		wantErr bool
+	}{
+		"complete record then EOF": {output: complete, wantErr: true},
+		"early EOF":                {output: acpResponse(0, `{"protocolVersion":1}`), wantErr: true},
+		"partial record then EOF":  {output: complete + `{"jsonrpc":"2.0"`, wantErr: true},
+		"complete contradiction":   {output: complete + acpStatus("session-1", "alpha", "disconnected", ""), wantErr: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			runner := &fixtureDuplexRunner{output: test.output, keepAlive: true, closeAfterWrite: true}
+			err := verifyKiroACPWithTimeout(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha"}, 250*time.Millisecond)
+			if test.wantErr && !errors.Is(err, errRecognizedNegativeEvidence) {
+				t.Fatalf("real-pipe error = %v, want negative evidence", err)
+			}
+			if !test.wantErr && err != nil {
+				t.Fatalf("real-pipe completion failed: %v", err)
+			}
+		})
+	}
+
+	t.Run("no data timeout", func(t *testing.T) {
+		runner := &fixtureDuplexRunner{keepAlive: true, closeOnContext: true}
+		err := verifyKiroACPWithTimeout(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha"}, 25*time.Millisecond)
+		if !errors.Is(err, context.DeadlineExceeded) || !errors.Is(err, errRecognizedNegativeEvidence) {
+			t.Fatalf("real-pipe no-data error = %v, want bounded negative deadline evidence", err)
+		}
+	})
+}
+
+func TestKiroACPRealPipePostSuccessSettlement(t *testing.T) {
+	for name, trailing := range map[string]string{
+		"complete contradiction": acpArrayStatus("s", "["+acpArrayServer("alpha", "disconnected", "")+"]"),
+		"partial record":         `{"jsonrpc":"2.0"`,
+	} {
+		trailing := trailing
+		t.Run(name, func(t *testing.T) {
+			stdout, peer, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer stdout.Close()
+			defer peer.Close()
+			stdinPeer, stdin, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer stdinPeer.Close()
+			defer stdin.Close()
+			go func() {
+				_, _ = io.WriteString(peer, acpResponse(0, `{"protocolVersion":1}`)+acpResponse(1, `{"sessionId":"s"}`)+
+					acpArrayStatus("s", "["+acpArrayServer("alpha", "connected", `[{"name":"search","disabled":false}]`)+"]"))
+				time.Sleep(kiroACPSettlement / 3)
+				_, _ = io.WriteString(peer, trailing)
+			}()
+			err = exchangeKiroACP(stdin, stdout, t.TempDir(), map[string]*kiroACPServerState{"alpha": {}})
+			if !errors.Is(err, errRecognizedNegativeEvidence) && !errors.Is(err, errKiroACPPartialExit) {
+				t.Fatalf("settlement error = %v, want trailing negative evidence", err)
+			}
+		})
+	}
+
+	t.Run("quiet long-lived peer", func(t *testing.T) {
+		stdout, peer, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer stdout.Close()
+		defer peer.Close()
+		stdinPeer, stdin, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer stdinPeer.Close()
+		defer stdin.Close()
+		go func() {
+			_, _ = io.WriteString(peer, acpResponse(0, `{"protocolVersion":1}`)+acpResponse(1, `{"sessionId":"s"}`)+
+				acpArrayStatus("s", "["+acpArrayServer("alpha", "connected", `[{"name":"search","disabled":false}]`)+"]"))
+		}()
+		started := time.Now()
+		if err := exchangeKiroACP(stdin, stdout, t.TempDir(), map[string]*kiroACPServerState{"alpha": {}}); err != nil {
+			t.Fatal(err)
+		}
+		if elapsed := time.Since(started); elapsed < kiroACPSettlement/2 || elapsed > time.Second {
+			t.Fatalf("settlement duration = %s, want bounded quiet drain", elapsed)
+		}
+	})
+}
+
+func TestKiroACPSettlementBoundaryObservesAlreadyQueuedPipeEvidence(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skip("kernel pipe settlement probe is implemented on Linux and Darwin")
+	}
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	if _, err := io.WriteString(writer, "queued-before-boundary"); err != nil {
+		t.Fatal(err)
+	}
+	queued, eof, err := queuedACPRealPipeEvidence(reader)
+	if err != nil || !queued || eof {
+		t.Fatalf("queued boundary evidence = queued:%v eof:%v error:%v", queued, eof, err)
+	}
+	buffer := make([]byte, len("queued-before-boundary"))
+	if _, err := io.ReadFull(reader, buffer); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	queued, eof, err = queuedACPRealPipeEvidence(reader)
+	if err != nil || queued || !eof {
+		t.Fatalf("EOF boundary evidence = queued:%v eof:%v error:%v", queued, eof, err)
+	}
+}
+
+func TestKiroACPConsumesQueuedStatusesUntilCleanEOFAfterCompletion(t *testing.T) {
+	t.Parallel()
+	connected := acpStatus("s", "alpha", "connected", `[{"name":"search","disabled":false}]`)
+	for name, queued := range map[string]string{
+		"disconnect":            acpStatus("s", "alpha", "disconnected", ""),
+		"conflicting duplicate": acpStatus("s", "alpha", "connected", `[{"name":"different","disabled":false}]`),
+		"regression":            acpStatus("s", "alpha", "connecting", ""),
+	} {
+		queued := queued
+		t.Run(name, func(t *testing.T) {
+			runner := &fixtureDuplexRunner{output: acpResponse(0, `{"protocolVersion":1}`) + acpResponse(1, `{"sessionId":"s"}`) + connected + queued, keepAlive: true}
+			err := verifyKiroACP(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha"})
+			if !errors.Is(err, errRecognizedNegativeEvidence) {
+				t.Fatalf("error = %v, want queued contradictory status to be recognized negative evidence", err)
+			}
+			if runner.stdinCloses != 1 {
+				t.Fatalf("stdin closes = %d, want exactly one", runner.stdinCloses)
+			}
+			if strings.Contains(string(runner.written), "session/prompt") {
+				t.Fatalf("ACP requests unexpectedly prompted: %q", runner.written)
+			}
+		})
+	}
+}
+
+func TestKiroACPRejectsQueuedDuplicateConnectingAfterConnected(t *testing.T) {
+	t.Parallel()
+	connecting := acpStatus("s", "alpha", "connecting", "")
+	connected := acpStatus("s", "alpha", "connected", `[{"name":"search","disabled":false}]`)
+	runner := &fixtureDuplexRunner{
+		output: acpResponse(0, `{"protocolVersion":1}`) + connecting +
+			acpResponse(1, `{"sessionId":"s"}`) + connected + connecting,
+		keepAlive: true,
+	}
+	err := verifyKiroACP(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha"})
+	if !errors.Is(err, errRecognizedNegativeEvidence) || !strings.Contains(err.Error(), "regressive connecting status after connected") {
+		t.Fatalf("queued connected -> connecting error = %v, want recognized regressive evidence", err)
+	}
+	if runner.stdinCloses != 1 {
+		t.Fatalf("stdin closes = %d, want exactly one after failed settlement", runner.stdinCloses)
+	}
+}
+
+func TestKiroACPCleanEOFAfterCompletionSucceedsAndClosesStdinOnce(t *testing.T) {
+	t.Parallel()
+	runner := &fixtureDuplexRunner{output: connectedACP("alpha"), keepAlive: true}
+	if err := verifyKiroACP(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha"}); err != nil {
+		t.Fatal(err)
+	}
+	if runner.stdinCloses != 1 {
+		t.Fatalf("stdin closes = %d, want exactly one", runner.stdinCloses)
+	}
+}
+
+func TestKiroACPRequiresClosableStdinBeforeWritingRequests(t *testing.T) {
+	t.Parallel()
+	var stdin bytes.Buffer
+	err := exchangeKiroACP(&stdin, strings.NewReader(connectedACP("alpha")), t.TempDir(), map[string]*kiroACPServerState{"alpha": {}})
+	if err == nil || !strings.Contains(err.Error(), "stdin does not support close") {
+		t.Fatalf("error = %v, want closable-stdin contract failure", err)
+	}
+	if stdin.Len() != 0 {
+		t.Fatalf("non-closable stdin received %d request bytes", stdin.Len())
+	}
+}
+
+func TestKiroACPRejectsPartialRecordAfterCompletion(t *testing.T) {
+	t.Parallel()
+	runner := &fixtureDuplexRunner{output: connectedACP("alpha") + `{"jsonrpc":"2.0"`, keepAlive: true}
+	err := verifyKiroACP(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha"})
+	if !errors.Is(err, errKiroACPPartialExit) || !errors.Is(err, errRecognizedNegativeEvidence) {
+		t.Fatalf("error = %v, want partial trailing record failure", err)
+	}
+	if runner.stdinCloses != 1 {
+		t.Fatalf("stdin closes = %d, want exactly one", runner.stdinCloses)
+	}
+}
+
+func TestKiroACPNonClosingOutputFailsAtContextBound(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	runner := &fixtureDuplexRunner{reader: &contextBlockingReader{Context: ctx, prefix: bytes.NewReader([]byte(connectedACP("alpha")))}}
+	started := time.Now()
+	err := verifyKiroACP(ctx, runner, "kiro-cli", t.TempDir(), []string{"alpha"})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want context deadline failure", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("non-closing output exceeded bounded failure time: %s", elapsed)
+	}
+	if runner.stdinCloses != 1 {
+		t.Fatalf("stdin closes = %d, want exactly one", runner.stdinCloses)
+	}
+}
+
+func TestKiroACPProcessFailureAfterCleanCompletionFailsClosed(t *testing.T) {
+	t.Parallel()
+	processErr := errors.New("ACP process exited unsuccessfully")
+	runner := &fixtureDuplexRunner{output: connectedACP("alpha"), postError: processErr}
+	err := verifyKiroACP(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha"})
+	if !errors.Is(err, processErr) || !errors.Is(err, errRecognizedNegativeEvidence) || errors.Is(err, errKiroACPContractUnknown) {
+		t.Fatalf("error = %v, want fail-closed post-exchange process failure", err)
+	}
+}
+
+func TestKiroACPRejectsEveryOutOfRangeNumberToken(t *testing.T) {
+	t.Parallel()
+	initialize := acpResponse(0, `{"protocolVersion":1}`)
+	session := acpResponse(1, `{"sessionId":"s"}`)
+	status := acpStatus("s", "alpha", "connected", `[{"name":"search","disabled":false}]`)
+	for name, output := range map[string]string{
+		"initialize unused member": acpResponse(0, `{"protocolVersion":1,"unused":{"value":1e1000000}}`),
+		"session unused member":    initialize + acpResponse(1, `{"sessionId":"s","unused":[1e1000000]}`),
+		"notification unused member": initialize + session + strings.Replace(status, `"status":"connected"`,
+			`"status":"connected","unused":{"value":1e1000000}`, 1),
+	} {
+		output := output
+		t.Run(name, func(t *testing.T) {
+			runner := &fixtureDuplexRunner{output: output, keepAlive: true}
+			err := verifyKiroACP(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha"})
+			if !errors.Is(err, errRecognizedNegativeEvidence) || errors.Is(err, errKiroACPContractUnknown) {
+				t.Fatalf("error = %v, want out-of-range JSON number rejected as a protocol failure", err)
+			}
+		})
+	}
+}
+
+func TestKiroACPRejectsInvalidUTF8WithoutReplacement(t *testing.T) {
+	t.Parallel()
+	initialize := []byte(acpResponse(0, `{"protocolVersion":1}`))
+	session := []byte(acpResponse(1, `{"sessionId":"s"}`))
+	connected := []byte(acpStatus("s", "alpha", "connected", `[{"name":"search","disabled":false}]`))
+	invalid := byte(0xff)
+	join := func(parts ...[]byte) []byte {
+		var result []byte
+		for _, part := range parts {
+			result = append(result, part...)
+		}
+		return result
+	}
+	tests := map[string][]byte{
+		"status field": join(initialize, session,
+			[]byte(`{"jsonrpc":"2.0","method":"_kiro/mcp/status","params":{"sessionId":"s","serverName":"alpha","status":"`),
+			[]byte{invalid}, []byte(`","tools":[{"name":"search","disabled":false}]}}`+"\n")),
+		"extension value": join(initialize,
+			[]byte(`{"jsonrpc":"2.0","id":1,"result":{"sessionId":"s","extension":"`),
+			[]byte{invalid}, []byte(`"}}`+"\n")),
+		"object key": join(initialize, session,
+			[]byte(`{"jsonrpc":"2.0","method":"_kiro/mcp/status","params":{"sessionId":"s","serverName":"alpha","status":"connected","tools":[{"name":"search","disabled":false}],"`),
+			[]byte{invalid}, []byte(`":true}}`+"\n")),
+		"partial multibyte boundary": join(initialize, session, connected,
+			[]byte{'{', '"', 'x', '"', ':', '"', 0xe2, 0x82}),
+		"queued settlement record": join(initialize, session, connected,
+			[]byte(`{"jsonrpc":"2.0","method":"progress","params":{"extension":"`),
+			[]byte{invalid}, []byte(`"}}`+"\n")),
+	}
+	for name, output := range tests {
+		output := output
+		t.Run(name, func(t *testing.T) {
+			runner := &fixtureDuplexRunner{output: string(output), keepAlive: true, closeAfterWrite: true}
+			err := verifyKiroACP(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha"})
+			if !errors.Is(err, errRecognizedNegativeEvidence) {
+				t.Fatalf("error = %v, want invalid UTF-8 to prevent connected success", err)
+			}
+			if err == nil {
+				t.Fatal("invalid UTF-8 record reached connected success")
+			}
+		})
+	}
+}
+
+func TestKiroACPRejectsUnpairedUTF16EscapesWithoutReplacement(t *testing.T) {
+	t.Parallel()
+	initialize := acpResponse(0, `{"protocolVersion":1}`)
+	session := acpResponse(1, `{"sessionId":"s"}`)
+	connected := acpStatus("s", "alpha", "connected", `[{"name":"search","disabled":false}]`)
+	tests := map[string]string{
+		"tool name": initialize + session + acpStatus("s", "alpha", "connected", `[{"name":"\ud800","disabled":false}]`),
+		"server name": initialize + session + `{"jsonrpc":"2.0","method":"_kiro/mcp/status","params":{"sessionId":"s","serverName":"\ud800","status":"connected","tools":[{"name":"search","disabled":false}]}}` + "\n",
+		"object key": initialize + session + `{"jsonrpc":"2.0","method":"_kiro/mcp/status","params":{"sessionId":"s","serverName":"alpha","status":"connected","tools":[{"name":"search","disabled":false}],"\ud800":true}}` + "\n",
+		"extension value": initialize + `{"jsonrpc":"2.0","id":1,"result":{"sessionId":"s","extension":"\ud800"}}` + "\n",
+		"queued settlement": initialize + session + connected + `{"jsonrpc":"2.0","method":"progress","params":{"extension":"\ud800"}}` + "\n",
+		"standalone low": initialize + `{"jsonrpc":"2.0","id":1,"result":{"sessionId":"\udfff"}}` + "\n",
+	}
+	for name, output := range tests {
+		output := output
+		t.Run(name, func(t *testing.T) {
+			runner := &fixtureDuplexRunner{output: output, keepAlive: true, closeAfterWrite: true}
+			err := verifyKiroACP(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha"})
+			if !errors.Is(err, errRecognizedNegativeEvidence) || !strings.Contains(err.Error(), "surrogate") {
+				t.Fatalf("error = %v, want unpaired UTF-16 escape rejected before evidence acceptance", err)
+			}
+		})
+	}
+}
+
+func TestKiroACPAcceptsValidUTF16SurrogatePairs(t *testing.T) {
+	t.Parallel()
+	message, err := decodeACPMessage([]byte(`{"jsonrpc":"2.0","method":"progress","params":{"tool":"\ud83d\ude80","\ud83d\ude80":true}}`))
+	if err != nil {
+		t.Fatalf("valid surrogate pair rejected: %v", err)
+	}
+	params := message.document["params"].(map[string]any)
+	if params["tool"] != "🚀" || params["🚀"] != true {
+		t.Fatalf("decoded surrogate-pair strings = %#v", params)
+	}
+}
+
+func TestKiroACPRealPipeRejectsInvalidUTF8QueuedDuringSettlement(t *testing.T) {
+	stdout, peer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stdout.Close()
+	defer peer.Close()
+	stdinPeer, stdin, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stdinPeer.Close()
+	defer stdin.Close()
+	go func() {
+		_, _ = io.WriteString(peer, connectedACP("alpha"))
+		time.Sleep(kiroACPSettlement / 3)
+		_, _ = peer.Write(append([]byte(`{"jsonrpc":"2.0","method":"progress","params":{"extension":"`),
+			append([]byte{0xff}, []byte(`"}}`+"\n")...)...))
+	}()
+	err = exchangeKiroACP(stdin, stdout, t.TempDir(), map[string]*kiroACPServerState{"alpha": {}})
+	if err == nil || !strings.Contains(err.Error(), "valid UTF-8") {
+		t.Fatalf("settlement error = %v, want queued invalid UTF-8 rejected", err)
+	}
+}
+
+func TestDecodeACPMessageWideObjectRemainsResourceBounded(t *testing.T) {
+	t.Parallel()
+	var record strings.Builder
+	record.WriteString(`{"jsonrpc":"2.0","method":"progress","params":{"wide":{`)
+	for index := 0; index < 12000; index++ {
+		if index != 0 {
+			record.WriteByte(',')
+		}
+		record.WriteString(strconv.Quote(fmt.Sprintf("k%05d", index)))
+		record.WriteString(":0")
+	}
+	record.WriteString(`}}}`)
+	if record.Len() >= kiroACPMaxLine {
+		t.Fatalf("wide-object fixture exceeds legal ACP line width: %d", record.Len())
+	}
+	started := time.Now()
+	if _, err := decodeACPMessage([]byte(record.String())); err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(started); elapsed > 3*time.Second {
+		t.Fatalf("legal-width object decoding was not linearly resource-bounded: %s", elapsed)
+	}
+}
+
+func TestKiroACPPreservesPreSessionNegativeEvidenceAcrossLaterFailures(t *testing.T) {
+	t.Parallel()
+	prefix := acpResponse(0, `{"protocolVersion":1}`) + acpStatus("s", "alpha", "disconnected", "")
+	readFailure := errors.New("deterministic ACP read failure")
+	tests := map[string]io.Reader{
+		"malformed": strings.NewReader(prefix + "not-json\n"),
+		"unknown":   strings.NewReader(prefix + acpStatus("s", "alpha", "future-state", "")),
+		"byte cap":  strings.NewReader(prefix + strings.Repeat("x", kiroACPMaxLine+1) + "\n"),
+		"EOF":       strings.NewReader(prefix),
+		"read":      io.MultiReader(strings.NewReader(prefix), terminalErrorReader{err: readFailure}),
+	}
+	for name, output := range tests {
+		output := output
+		t.Run(name, func(t *testing.T) {
+			runner := &fixtureDuplexRunner{reader: output}
+			err := verifyKiroACP(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha"})
+			if !errors.Is(err, errRecognizedNegativeEvidence) || errors.Is(err, errKiroACPContractUnknown) {
+				t.Fatalf("error = %v, want sticky recognized negative evidence", err)
+			}
+		})
+	}
+}
+
+func TestKiroACPMultiServerTimeoutPreservesIncompleteNegativeEvidence(t *testing.T) {
+	t.Parallel()
+	runner := &fixtureDuplexRunner{
+		output: acpResponse(0, `{"protocolVersion":1}`) + acpResponse(1, `{"sessionId":"s"}`) +
+			acpStatus("s", "alpha", "connected", `[{"name":"search","disabled":false}]`),
+		postError: context.DeadlineExceeded,
+	}
+	err := verifyKiroACP(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha", "beta"})
+	if !errors.Is(err, errRecognizedNegativeEvidence) || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want incomplete evidence and deadline identities", err)
+	}
+}
+
+func TestKiroACPPropagatesCallerCancellation(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	runner := &fixtureDuplexRunner{}
+	err := verifyKiroACP(ctx, runner, "kiro-cli", t.TempDir(), []string{"alpha"})
+	if !errors.Is(err, context.Canceled) || errors.Is(err, errKiroACPContractUnknown) {
+		t.Fatalf("error = %v, want caller cancellation without manual fallback", err)
+	}
+	if len(runner.command.Argv) != 0 {
+		t.Fatalf("canceled verification unexpectedly launched %+v", runner.command)
+	}
+}
+
+func TestKiroACPRejectsNonExclusiveJSONRPCEnvelopes(t *testing.T) {
+	t.Parallel()
+	validInitialize := acpResponse(0, `{"protocolVersion":1}`)
+	tests := map[string]string{
+		"initialize method and id":     `{"jsonrpc":"2.0","id":0,"method":"initialize","result":{"protocolVersion":1}}` + "\n",
+		"initialize result and error":  `{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":1},"error":{"code":-1}}` + "\n",
+		"initialize null error":        `{"jsonrpc":"2.0","id":0,"error":null}` + "\n",
+		"initialize result and params": `{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":1},"params":{}}` + "\n",
+		"session method and id":        validInitialize + `{"jsonrpc":"2.0","id":1,"method":"session/new","result":{"sessionId":"s"}}` + "\n",
+		"session result and error":     validInitialize + `{"jsonrpc":"2.0","id":1,"result":{"sessionId":"s"},"error":{"code":-1}}` + "\n",
+		"session null error":           validInitialize + `{"jsonrpc":"2.0","id":1,"error":null}` + "\n",
+		"session result and params":    validInitialize + `{"jsonrpc":"2.0","id":1,"result":{"sessionId":"s"},"params":{}}` + "\n",
+	}
+	for name, output := range tests {
+		output := output
+		t.Run(name, func(t *testing.T) {
+			runner := &fixtureDuplexRunner{output: output}
+			err := verifyKiroACP(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha"})
+			if !errors.Is(err, errRecognizedNegativeEvidence) || errors.Is(err, errKiroACPContractUnknown) {
+				t.Fatalf("error = %v, want rejected JSON-RPC protocol failure", err)
+			}
+		})
+	}
+}
+
+func TestKiroACPRejectsStructuredNegativeEvidence(t *testing.T) {
+	t.Parallel()
+	tests := map[string]string{
+		"disconnected":  acpStatus("s", "alpha", "disconnected", ""),
+		"disabled":      `{"jsonrpc":"2.0","method":"_kiro/mcp/status","params":{"sessionId":"s","serverName":"alpha","status":"connected","disabled":true,"tools":[{"name":"search","disabled":false}]}}` + "\n",
+		"error":         acpStatus("s", "alpha", "error", ""),
+		"auth required": acpStatus("s", "alpha", "auth-required", ""),
+		"empty tools":   acpStatus("s", "alpha", "connected", `[]`),
+		"missing tools": `{"jsonrpc":"2.0","method":"_kiro/mcp/status","params":{"sessionId":"s","serverName":"alpha","status":"connected"}}` + "\n",
+		"disabled tool": acpStatus("s", "alpha", "connected", `[{"name":"search","disabled":true}]`),
+	}
+	for name, status := range tests {
+		status := status
+		t.Run(name, func(t *testing.T) {
+			runner := &fixtureDuplexRunner{output: acpResponse(0, `{"protocolVersion":1}`) + acpResponse(1, `{"sessionId":"s"}`) + status}
+			err := verifyKiroACP(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha"})
+			if !errors.Is(err, errRecognizedNegativeEvidence) {
+				t.Fatalf("error = %v, want recognized negative evidence", err)
+			}
+		})
+	}
+}
+
+func TestKiroACPRejectsAmbiguousDuplicateAndWrongIdentity(t *testing.T) {
+	t.Parallel()
+	connected := acpStatus("s", "alpha", "connected", `[{"name":"search","disabled":false}]`)
+	tests := map[string]string{
+		"conflicting identity": acpResponse(0, `{"protocolVersion":1}`) + `{"jsonrpc":"2.0","method":"_kiro/mcp/status","params":{"sessionId":"s","serverName":"alpha","name":"beta","status":"connected","tools":[{"name":"search","disabled":false}]}}` + "\n",
+		"duplicate identity":   acpResponse(0, `{"protocolVersion":1}`) + `{"jsonrpc":"2.0","method":"_kiro/mcp/status","params":{"sessionId":"s","serverName":"alpha","name":"alpha","status":"connected","tools":[{"name":"search","disabled":false}]}}` + "\n",
+		"missing identity":     acpResponse(0, `{"protocolVersion":1}`) + `{"jsonrpc":"2.0","method":"_kiro/mcp/status","params":{"sessionId":"s","status":"connected","tools":[{"name":"search","disabled":false}]}}` + "\n",
+		"conflicting duplicate connected": acpResponse(0, `{"protocolVersion":1}`) + connected +
+			acpStatus("s", "alpha", "connected", `[{"name":"different","disabled":false}]`) + acpResponse(1, `{"sessionId":"s"}`),
+		"wrong server":   acpResponse(0, `{"protocolVersion":1}`) + acpResponse(1, `{"sessionId":"s"}`) + acpStatus("s", "beta", "connected", `[{"name":"search","disabled":false}]`),
+		"missing server": acpResponse(0, `{"protocolVersion":1}`) + acpResponse(1, `{"sessionId":"s"}`),
+		"wrong session":  acpResponse(0, `{"protocolVersion":1}`) + acpResponse(1, `{"sessionId":"s"}`) + acpStatus("other", "alpha", "connected", `[{"name":"search","disabled":false}]`),
+	}
+	for name, output := range tests {
+		output := output
+		t.Run(name, func(t *testing.T) {
+			runner := &fixtureDuplexRunner{output: output}
+			err := verifyKiroACP(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha"})
+			if err == nil {
+				t.Fatal("ambiguous ACP evidence unexpectedly succeeded")
+			}
+			if name == "wrong server" || name == "missing server" || name == "wrong session" || name == "conflicting duplicate connected" {
+				if !errors.Is(err, errRecognizedNegativeEvidence) {
+					t.Fatalf("error = %v, want recognized negative evidence", err)
+				}
+			}
+		})
+	}
+}
+
+func TestKiroACPProtocolFailuresFailClosedAndLaunchFailuresFallBack(t *testing.T) {
+	t.Parallel()
+	progress := `{"jsonrpc":"2.0","method":"progress","params":{}}` + "\n"
+	paddedProgress := `{"jsonrpc":"2.0","method":"progress","params":{"padding":"` + strings.Repeat("x", 200*1024) + `"}}` + "\n"
+	tests := map[string]struct {
+		output string
+		err    error
+	}{
+		"malformed JSON":           {output: "not-json\n"},
+		"wrong protocol":           {output: acpResponse(0, `{"protocolVersion":2}`)},
+		"wrong initialize id":      {output: acpResponse(9, `{"protocolVersion":1}`)},
+		"wrong session id":         {output: acpResponse(0, `{"protocolVersion":1}`) + acpResponse(2, `{"sessionId":"s"}`)},
+		"missing session identity": {output: acpResponse(0, `{"protocolVersion":1}`) + acpResponse(1, `{}`)},
+		"oversized output":         {output: strings.Repeat("x", kiroACPMaxLine+1) + "\n"},
+		"total byte overflow":      {output: acpResponse(0, `{"protocolVersion":1}`) + strings.Repeat(paddedProgress, 6)},
+		"record overflow":          {output: acpResponse(0, `{"protocolVersion":1}`) + strings.Repeat(progress, kiroACPMaxRecords)},
+		"early exit":               {output: acpResponse(0, `{"protocolVersion":1}`)},
+		"missing companion":        {err: errors.New("fork/exec kiro-cli-chat: executable file not found")},
+		"ACP unsupported":          {err: errors.New("unknown command acp")},
+		"timeout":                  {err: context.DeadlineExceeded},
+	}
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			runner := &fixtureDuplexRunner{output: test.output, duplexErr: test.err}
+			err := verifyKiroACP(context.Background(), runner, "kiro-cli", t.TempDir(), []string{"alpha"})
+			if test.err == nil {
+				if !errors.Is(err, errRecognizedNegativeEvidence) || errors.Is(err, errKiroACPContractUnknown) {
+					t.Fatalf("error = %v, want fail-closed protocol evidence", err)
+				}
+			} else if !errors.Is(err, errKiroACPContractUnknown) || errors.Is(err, errRecognizedNegativeEvidence) {
+				t.Fatalf("error = %v, want safe pre-exchange fallback", err)
+			}
+		})
+	}
+}

--- a/install/integrationctl/agentplugins/providers/kiro_acp_test.go
+++ b/install/integrationctl/agentplugins/providers/kiro_acp_test.go
@@ -631,12 +631,12 @@ func TestKiroACPRejectsUnpairedUTF16EscapesWithoutReplacement(t *testing.T) {
 	session := acpResponse(1, `{"sessionId":"s"}`)
 	connected := acpStatus("s", "alpha", "connected", `[{"name":"search","disabled":false}]`)
 	tests := map[string]string{
-		"tool name": initialize + session + acpStatus("s", "alpha", "connected", `[{"name":"\ud800","disabled":false}]`),
-		"server name": initialize + session + `{"jsonrpc":"2.0","method":"_kiro/mcp/status","params":{"sessionId":"s","serverName":"\ud800","status":"connected","tools":[{"name":"search","disabled":false}]}}` + "\n",
-		"object key": initialize + session + `{"jsonrpc":"2.0","method":"_kiro/mcp/status","params":{"sessionId":"s","serverName":"alpha","status":"connected","tools":[{"name":"search","disabled":false}],"\ud800":true}}` + "\n",
-		"extension value": initialize + `{"jsonrpc":"2.0","id":1,"result":{"sessionId":"s","extension":"\ud800"}}` + "\n",
+		"tool name":         initialize + session + acpStatus("s", "alpha", "connected", `[{"name":"\ud800","disabled":false}]`),
+		"server name":       initialize + session + `{"jsonrpc":"2.0","method":"_kiro/mcp/status","params":{"sessionId":"s","serverName":"\ud800","status":"connected","tools":[{"name":"search","disabled":false}]}}` + "\n",
+		"object key":        initialize + session + `{"jsonrpc":"2.0","method":"_kiro/mcp/status","params":{"sessionId":"s","serverName":"alpha","status":"connected","tools":[{"name":"search","disabled":false}],"\ud800":true}}` + "\n",
+		"extension value":   initialize + `{"jsonrpc":"2.0","id":1,"result":{"sessionId":"s","extension":"\ud800"}}` + "\n",
 		"queued settlement": initialize + session + connected + `{"jsonrpc":"2.0","method":"progress","params":{"extension":"\ud800"}}` + "\n",
-		"standalone low": initialize + `{"jsonrpc":"2.0","id":1,"result":{"sessionId":"\udfff"}}` + "\n",
+		"standalone low":    initialize + `{"jsonrpc":"2.0","id":1,"result":{"sessionId":"\udfff"}}` + "\n",
 	}
 	for name, output := range tests {
 		output := output

--- a/install/integrationctl/agentplugins/providers/kiro_pipe_fallback.go
+++ b/install/integrationctl/agentplugins/providers/kiro_pipe_fallback.go
@@ -1,0 +1,12 @@
+//go:build !darwin && !linux && !windows
+
+package providers
+
+import (
+	"fmt"
+	"io"
+)
+
+func queuedACPRealPipeEvidence(io.Reader) (queued, eof bool, err error) {
+	return false, false, fmt.Errorf("safe ACP pipe settlement inspection is unavailable on this platform")
+}

--- a/install/integrationctl/agentplugins/providers/kiro_pipe_unix.go
+++ b/install/integrationctl/agentplugins/providers/kiro_pipe_unix.go
@@ -1,0 +1,49 @@
+//go:build darwin || linux
+
+package providers
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// queuedACPRealPipeEvidence establishes the settlement boundary in the kernel:
+// poll reports every byte and EOF ordered before this call, independent of when
+// the goroutine next gets scheduled to issue Read.
+func queuedACPRealPipeEvidence(reader io.Reader) (queued, eof bool, resultErr error) {
+	file, ok := reader.(*os.File)
+	if !ok {
+		return false, false, nil
+	}
+	raw, err := file.SyscallConn()
+	if err != nil {
+		return false, false, err
+	}
+	err = raw.Control(func(fd uintptr) {
+		poll := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN | unix.POLLHUP}}
+		for attempt := 0; attempt < 3; attempt++ {
+			_, pollErr := unix.Poll(poll, 0)
+			if errors.Is(pollErr, unix.EINTR) {
+				resultErr = pollErr
+				continue
+			}
+			resultErr = pollErr
+			break
+		}
+		if resultErr != nil {
+			return
+		}
+		events := poll[0].Revents
+		if events&unix.POLLNVAL != 0 {
+			resultErr = fmt.Errorf("ACP pipe descriptor is invalid")
+			return
+		}
+		queued = events&unix.POLLIN != 0
+		eof = events&unix.POLLHUP != 0 && !queued
+	})
+	return queued, eof, errors.Join(resultErr, err)
+}

--- a/install/integrationctl/agentplugins/providers/kiro_pipe_windows.go
+++ b/install/integrationctl/agentplugins/providers/kiro_pipe_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package providers
+
+import (
+	"fmt"
+	"io"
+)
+
+func queuedACPRealPipeEvidence(io.Reader) (queued, eof bool, err error) {
+	// Automatic Kiro ACP activation is rejected by the Windows containment
+	// capability preflight. Keep this lower-level boundary fail-closed as well:
+	// Windows pipe handles need PeekNamedPipe/overlapped status semantics before
+	// an expired deadline can ever be accepted as a quiet settlement window.
+	return false, false, fmt.Errorf("safe ACP pipe settlement inspection is unavailable on Windows")
+}

--- a/install/integrationctl/agentplugins/providers/native_identity.go
+++ b/install/integrationctl/agentplugins/providers/native_identity.go
@@ -25,14 +25,19 @@ type packageVerifier interface {
 // registry. A manager-owned path is not proof that the logical identity is
 // free: another prepared marketplace, local plugin, installed CLI entry, or
 // native config entry can already claim the same manifest identity.
-// Native registry discovery executes trusted, short-lived list commands. On
-// Unix, cancellation kills their live process group, but descendants surviving
-// a normal leader exit are not force-killed after Wait because the PGID can be
-// reused; stronger normal-exit containment is deferred to an OS-native slice.
+// Native registry discovery executes trusted, short-lived list commands. A
+// tree-aware runner is used when available so Linux requires atomic cgroup
+// containment and Windows uses a Job Object. Plain runners remain supported as
+// injected test/provider implementations, but OS execution never claims cleanup
+// based on descendant sampling.
 type NativeIdentityObserver struct {
 	Stager           packageVerifier
 	Runner           CommandRunner
 	DiscoveryTimeout time.Duration
+}
+
+type treeCommandRunner interface {
+	RunWithTreeExitGrace(context.Context, legacyports.Command, time.Duration) (legacyports.CommandResult, error)
 }
 
 const defaultNativeDiscoveryTimeout = 15 * time.Second
@@ -182,7 +187,7 @@ func (observer NativeIdentityObserver) inspectCodexCLI(ctx context.Context, plan
 	if observer.Runner == nil {
 		return registryIndeterminate, nil
 	}
-	result, err := observer.Runner.Run(ctx, legacyports.Command{Argv: []string{plan.NativeRegistryExecutable, "plugin", "list", "--json"}})
+	result, err := observer.runNativeRegistry(ctx, legacyports.Command{Argv: []string{plan.NativeRegistryExecutable, "plugin", "list", "--json"}})
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return registryIndeterminate, ctxErr
@@ -248,7 +253,7 @@ func (observer NativeIdentityObserver) inspectCopilotCLI(ctx context.Context, pl
 	if observer.Runner == nil {
 		return registryIndeterminate, nil
 	}
-	result, err := observer.Runner.Run(ctx, legacyports.Command{Argv: []string{plan.NativeRegistryExecutable, "plugin", "list"}})
+	result, err := observer.runNativeRegistry(ctx, legacyports.Command{Argv: []string{plan.NativeRegistryExecutable, "plugin", "list"}})
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return registryIndeterminate, ctxErr
@@ -259,6 +264,13 @@ func (observer NativeIdentityObserver) inspectCopilotCLI(ctx context.Context, pl
 		return registryIndeterminate, fmt.Errorf("Copilot plugin registry command failed with exit code %d", result.ExitCode)
 	}
 	return copilotRegistryFinding(result.Stdout, plan.DeclaredName, managedMarketplaceName(plan.PhysicalArtifactID), managed != nil), nil
+}
+
+func (observer NativeIdentityObserver) runNativeRegistry(ctx context.Context, command legacyports.Command) (legacyports.CommandResult, error) {
+	if runner, ok := observer.Runner.(treeCommandRunner); ok {
+		return runner.RunWithTreeExitGrace(ctx, command, time.Second)
+	}
+	return observer.Runner.Run(ctx, command)
 }
 
 func copilotRegistryFinding(stdout []byte, name, expectedMarketplace string, owned bool) registryFinding {

--- a/install/integrationctl/agentplugins/providers/native_identity_timeout_unix_test.go
+++ b/install/integrationctl/agentplugins/providers/native_identity_timeout_unix_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestNativeIdentityTimeoutReapsAuthoritativeDiscoveryChild(t *testing.T) {
+	requireNativeIdentityTreeCapability(t)
 	root := t.TempDir()
 	pidPath := filepath.Join(root, "child.pid")
 	executable := filepath.Join(root, "copilot")
@@ -42,12 +43,12 @@ func TestNativeIdentityTimeoutReapsAuthoritativeDiscoveryChild(t *testing.T) {
 	}
 	pidFields := strings.Fields(string(body))
 	if len(pidFields) != 2 {
-		t.Fatalf("process tree pids = %q", body)
+		t.Fatalf("process-group pids = %q", body)
 	}
 	for _, field := range pidFields {
 		pid, parseErr := strconv.Atoi(field)
 		if parseErr != nil {
-			t.Fatalf("parse process tree pid %q: %v", field, parseErr)
+			t.Fatalf("parse process-group pid %q: %v", field, parseErr)
 		}
 		if err := waitProcessGone(pid, 2*time.Second); err != nil {
 			_ = syscall.Kill(pid, syscall.SIGKILL)
@@ -56,7 +57,8 @@ func TestNativeIdentityTimeoutReapsAuthoritativeDiscoveryChild(t *testing.T) {
 	}
 }
 
-func TestNativeIdentityNormalExitDoesNotKillByReapedLeaderPGID(t *testing.T) {
+func TestNativeIdentityNormalExitCleansSameGroupMemberBeforeReapingLeader(t *testing.T) {
+	requireNativeIdentityTreeCapability(t)
 	root := t.TempDir()
 	pidPath := filepath.Join(root, "grandchild.pid")
 	executable := filepath.Join(root, "copilot")
@@ -71,8 +73,8 @@ func TestNativeIdentityNormalExitDoesNotKillByReapedLeaderPGID(t *testing.T) {
 	observation, err := (NativeIdentityObserver{
 		Runner: processadapter.OS{}, DiscoveryTimeout: 5 * time.Second,
 	}).ObserveNativeIdentity(context.Background(), domain.DetectedClient{ClientID: domain.ClientCopilot}, plan, nil)
-	if err == nil || observation.State != domain.NativeIdentityIndeterminate {
-		t.Fatalf("observation = %+v, err = %v", observation, err)
+	if err == nil || !strings.Contains(err.Error(), "live descendants that required forced cleanup") || observation.State != domain.NativeIdentityIndeterminate {
+		t.Fatalf("observation = %+v, err = %v, want forced-descendant uncertainty", observation, err)
 	}
 	if elapsed := time.Since(started); elapsed > 2*time.Second {
 		t.Fatalf("normal-exit background cleanup took %s", elapsed)
@@ -85,11 +87,19 @@ func TestNativeIdentityNormalExitDoesNotKillByReapedLeaderPGID(t *testing.T) {
 	if parseErr != nil {
 		t.Fatalf("parse grandchild pid: %v", parseErr)
 	}
-	if signalErr := syscall.Kill(pid, 0); signalErr != nil {
-		t.Fatalf("normal-exit descendant was unexpectedly killed: %v", signalErr)
+	if err := waitProcessGone(pid, 2*time.Second); err != nil {
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+		t.Fatalf("normal-exit process-group member was not cleaned before leader reap: %v", err)
 	}
-	if killErr := syscall.Kill(pid, syscall.SIGKILL); killErr != nil && !errors.Is(killErr, syscall.ESRCH) {
-		t.Fatalf("clean up normal-exit descendant: %v", killErr)
+}
+
+func requireNativeIdentityTreeCapability(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "linux" {
+		return
+	}
+	if err := (processadapter.OS{}).DuplexCapability(); err != nil {
+		t.Skipf("atomic Linux process-tree containment unavailable: %v", err)
 	}
 }
 

--- a/install/integrationctl/agentplugins/usecase/group.go
+++ b/install/integrationctl/agentplugins/usecase/group.go
@@ -250,6 +250,9 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 		if plan.Status == domain.PlanUnsupported {
 			return result, fmt.Errorf("target %s is unsupported; group preflight caused no mutation", target.Client.ClientID)
 		}
+		if err := service.preflightActivation(target, plan); err != nil {
+			return result, err
+		}
 		if err := preflightRuntime(target.Envelope, plan, service.automaticallyActivates(target, plan)); err != nil {
 			return result, err
 		}
@@ -328,6 +331,9 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 			}
 			if plan.Status == domain.PlanUnsupported {
 				return result, fmt.Errorf("update candidate is incompatible with installed binding %s", check.Client.ClientID)
+			}
+			if err := service.preflightActivation(check, plan); err != nil {
+				return result, err
 			}
 			if err := preflightRuntime(check.Envelope, plan, service.automaticallyActivates(check, plan)); err != nil {
 				return result, err

--- a/install/integrationctl/agentplugins/usecase/service.go
+++ b/install/integrationctl/agentplugins/usecase/service.go
@@ -213,6 +213,9 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 		}
 		return result, fmt.Errorf("delivery plan for %s is unsupported", plan.ClientID)
 	}
+	if err := service.preflightActivation(input, plan); err != nil {
+		return result, err
+	}
 	if err := preflightRuntime(input.Envelope, plan, service.automaticallyActivates(input, plan)); err != nil {
 		return result, err
 	}
@@ -1117,6 +1120,21 @@ func packageNeedsPluginData(envelope domain.PackageEnvelope) bool {
 
 type automaticActivationClassifier interface {
 	AutomaticallyActivates(domain.ActivationRequest) bool
+}
+
+type activationPreflighter interface {
+	PreflightActivation(domain.ActivationRequest) error
+}
+
+func (service Service) preflightActivation(input AddInput, plan domain.DeliveryPlan) error {
+	preflighter, ok := service.Activator.(activationPreflighter)
+	if !ok {
+		return nil
+	}
+	return preflighter.PreflightActivation(domain.ActivationRequest{
+		Client: input.Client, Plan: plan, BackendExecutable: input.BackendExecutable,
+		VerifyOnly: input.DryRun,
+	})
 }
 
 func (service Service) automaticallyActivates(input AddInput, plan domain.DeliveryPlan) bool {

--- a/install/integrationctl/agentplugins/usecase/service_test.go
+++ b/install/integrationctl/agentplugins/usecase/service_test.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -776,6 +777,35 @@ func TestRepairAbortsWhenNativeObjectChangesBetweenPreflightAndCommit(t *testing
 	}
 	if len(onlyBinding(after.Installations[0]).Receipts) != len(onlyBinding(before.Installations[0]).Receipts) {
 		t.Fatalf("repair race committed a receipt: %+v", onlyBinding(after.Installations[0]).Receipts)
+	}
+}
+
+func TestKiroCapabilityPreflightFailureChangesNoStateOrNativeConfiguration(t *testing.T) {
+	service, store, _ := serviceFixture(t)
+	activator := &observedActivator{preflightErr: errors.New("manual_activation_required: delegated cgroup unavailable")}
+	service.Activator = activator
+	kiro := domain.DetectedClient{ClientID: domain.ClientKiro, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".kiro")}
+	input := addInput(t, kiro, "./kiro-capability-preflight")
+	input.BackendExecutable = "/test/bin/kiro-cli"
+	input.Confirmed = true
+	result, err := service.Add(context.Background(), input)
+	if err == nil || !strings.Contains(err.Error(), "manual_activation_required") {
+		t.Fatalf("capability preflight error = %v", err)
+	}
+	if activator.calls != 0 {
+		t.Fatalf("activation ran %d time(s) after failed capability preflight", activator.calls)
+	}
+	state, loadErr := store.Load()
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if len(state.Installations) != 0 {
+		t.Fatalf("failed capability preflight changed state: %+v", state.Installations)
+	}
+	if result.Plan.ActivePath != "" {
+		if _, statErr := os.Lstat(result.Plan.ActivePath); !os.IsNotExist(statErr) {
+			t.Fatalf("failed capability preflight materialized native path: %v", statErr)
+		}
 	}
 }
 
@@ -1815,9 +1845,14 @@ func (stager *changingRepairStager) Verify(ctx context.Context, root, expected s
 }
 
 type observedActivator struct {
-	outcome domain.ActivationOutcome
-	err     error
-	calls   int
+	outcome      domain.ActivationOutcome
+	err          error
+	preflightErr error
+	calls        int
+}
+
+func (activator *observedActivator) PreflightActivation(domain.ActivationRequest) error {
+	return activator.preflightErr
 }
 
 type fixedUsecaseRunner struct {

--- a/npm/agentplugins/README.md
+++ b/npm/agentplugins/README.md
@@ -100,3 +100,22 @@ user-controlled. Cancelling keeps the package and reports authentication as
 pending or cancelled rather than runtime success. Directory badges and status
 describe only the exact schema, materialization, discovery, runtime, or OAuth
 evidence collected—not every plugin/client/environment combination.
+
+For native MCP-only Kiro packages, a complete supported Kiro CLI distribution
+is verified automatically after import with a bounded structured ACP v1
+initialize/session handshake. The handshake supplies no MCP definitions and
+sends no prompt, model turn, tool call, or permission response: Kiro must load
+the installed native configuration and report each planned server connected
+with enabled tools. The verifier keeps ACP stdin open while it drains a bounded
+quiet settlement window, and rejects EOF, partial, contradictory, or malformed
+protocol evidence before supervised containment stops and reaps the long-lived
+child. Automatic Kiro ACP verification is Linux-only and requires delegated
+cgroup v2 creation, atomic CLONE_INTO_CGROUP placement, and cgroup.kill to be
+proved before native mutation. Windows, macOS, and other unsupported hosts give
+explicit manual activation guidance. This proves session loading, not runtime
+tool end-to-end behavior. Failure to start the ACP executable itself leaves
+activation manual with recovery guidance. Once ACP starts, companion-launch
+failure (including a missing `kiro-cli-chat`), EOF, timeout, authentication
+failure, malformed or partial output, contradiction, and non-clean exit are
+authoritative activation failures; managed state stays committed for explicit
+repair and is never reported active.

--- a/npm/agentplugins/README.md
+++ b/npm/agentplugins/README.md
@@ -109,12 +109,15 @@ the installed native configuration and report each planned server connected
 with enabled tools. The verifier keeps ACP stdin open while it drains a bounded
 quiet settlement window, and rejects EOF, partial, contradictory, or malformed
 protocol evidence before supervised containment stops and reaps the long-lived
-child. Automatic Kiro ACP verification is Linux-only and requires delegated
-cgroup v2 creation, atomic CLONE_INTO_CGROUP placement, and cgroup.kill to be
-proved before native mutation. Windows, macOS, and other unsupported hosts give
-explicit manual activation guidance. This proves session loading, not runtime
-tool end-to-end behavior. Failure to start the ACP executable itself leaves
-activation manual with recovery guidance. Once ACP starts, companion-launch
+child. Automatic Kiro ACP verification is available only on Linux after
+capability preflight proves delegated cgroup v2 creation, atomic
+CLONE_INTO_CGROUP placement, and cgroup.kill. macOS, Windows, and Linux hosts
+without every required proof fail preflight before any native mutation. On
+those hosts, install or import the package manually in Kiro, activate it in
+Kiro's UI, and verify its servers there; that workflow is outside this
+automatic CLI path. Failure to start ACP after a supported preflight may still
+leave a manual verification action. This proves session loading, not runtime
+tool end-to-end behavior. Once ACP starts, companion-launch
 failure (including a missing `kiro-cli-chat`), EOF, timeout, authentication
 failure, malformed or partial output, contradiction, and non-clean exit are
 authoritative activation failures; managed state stays committed for explicit


### PR DESCRIPTION
## Summary

- install Agent Plugins into Kiro through its native ACP/MCP lifecycle
- verify activation fail-closed with bounded process cleanup on Linux, macOS, and Windows
- make multi-target add, repair, remove, and rollback preserve per-client results
- document the automatic Kiro activation flow in the CLI quick start

## Verification

- pinned Go 1.25.13 full tests and vet
- process stress tests (`-count=10`) and provider/use-case tests (`-count=5`)
- Windows and macOS cross-compilation
- fresh isolated Kiro lifecycle E2E: add, repair, update guard, native removal, manager removal, purge
- final independent xhigh review: `CODE GATE PASS`

No real user project or profile was used for testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic Kiro MCP package verification through a bounded ACP handshake.
  * Verification confirms server connectivity and enabled tools without prompts or tool calls.
  * Added platform-aware process containment and cleanup for reliable command execution.

* **Bug Fixes**
  * Repair operations now stop within a defined timeout and respond to cancellation.
  * Activation failures no longer report packages as active or apply partial changes.
  * Improved cleanup of descendant processes and preservation of diagnostic errors.

* **Documentation**
  * Documented Linux verification requirements, unsupported-platform manual fallback, and failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->