### PR TITLE
feat(agentplugins): add signed discovery and lifecycle commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,12 @@ community bridge is not mistaken for its upstream project. Direct local paths
 and exact GitHub revisions work without Directory submission.
 
 ```bash
+npx universal-agent-plugins search docs
+npx universal-agent-plugins validate ./my-plugin
 npx universal-agent-plugins add context7 --dry-run --target cursor
 npx universal-agent-plugins add context7 --target codex,cursor,kiro
+npx universal-agent-plugins outdated --all
+npx universal-agent-plugins update --all
 npx universal-agent-plugins update context7 --target codex,cursor,kiro
 npx universal-agent-plugins repair context7 --target codex,cursor,kiro
 npx universal-agent-plugins remove context7 --target codex,cursor,kiro
@@ -45,6 +49,15 @@ reviewed; branches, tags, and abbreviated SHAs are rejected. `add`, `update`,
 `repair`, and `remove` accept comma-separated targets. `repair` reapplies the
 recorded revision; `update` selects a newer eligible release. `switch` moves the
 whole installation to a qualified Directory distribution or exact source.
+
+`search` combines the reviewed Directory with a separately signed Discovery
+Index. Unreviewed results use publisher-qualified `discovery:owner/repo//path`
+selectors and show their exact indexed commit before install. The CLI
+reacquires and validates those package bytes before mutation; the index
+signature authenticates metadata but is not a package or runtime endorsement.
+`outdated` is read-only, while `update --all` keeps every installation's
+recorded source and targets and fails the batch preflight before mutation if any
+planned update is unsafe.
 
 For Agent Plugins 1.0, the root `plugin.json` is the install authority. A
 `plugin.yaml` file is legacy `plugin-kit-ai` authoring input only: it is not

--- a/cli/plugin-kit-ai/cmd/agentplugins/directory_configuration_test.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins/directory_configuration_test.go
@@ -95,6 +95,29 @@ func TestOrdinaryDirectoryOriginPreservesProductionTrustAndBootstrap(t *testing.
 	}
 }
 
+func TestProductionDiscoveryUsesIndependentOriginAndCacheWithPinnedTrust(t *testing.T) {
+	clearDirectoryEnvironment(t)
+	root := t.TempDir()
+	client, err := newDiscoveryClient(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.Origin != defaultDiscoveryOrigin || client.Cache.Path != filepath.Join(root, "discovery-v1-cache.json") ||
+		len(client.Trust.Keys) != 1 || client.Trust.Keys[0].ID != defaultDiscoveryKeyID {
+		t.Fatalf("production Discovery configuration = %+v", client)
+	}
+	t.Setenv("AGENTPLUGINS_DISCOVERY_ORIGIN", "https://mirror.example/discovery/")
+	client, err = newDiscoveryClient(root)
+	if err != nil || client.Origin != "https://mirror.example/discovery/" {
+		t.Fatalf("custom Discovery origin = %q err=%v", client.Origin, err)
+	}
+	for _, value := range []string{"http://mirror.example/discovery/", "https://mirror.example/discovery", "https://mirror.example/discovery/../trust/"} {
+		if _, err := productionFeedOrigin(value, defaultDiscoveryOrigin, "AGENTPLUGINS_DISCOVERY_ORIGIN"); err == nil {
+			t.Fatalf("unsafe Discovery origin accepted: %q", value)
+		}
+	}
+}
+
 func TestMalformedDirectoryEnvironmentCausesZeroMutation(t *testing.T) {
 	clearDirectoryEnvironment(t)
 	t.Setenv("HOME", t.TempDir())
@@ -136,7 +159,7 @@ func TestProductionDirectoryOriginValidation(t *testing.T) {
 
 func clearDirectoryEnvironment(t *testing.T) {
 	t.Helper()
-	for _, name := range append(append([]string{}, forbiddenProductionDirectoryVariables...), "AGENTPLUGINS_DIRECTORY_ORIGIN") {
+	for _, name := range append(append([]string{}, forbiddenProductionDirectoryVariables...), "AGENTPLUGINS_DIRECTORY_ORIGIN", "AGENTPLUGINS_DISCOVERY_ORIGIN") {
 		value, existed := os.LookupEnv(name)
 		if err := os.Unsetenv(name); err != nil {
 			t.Fatal(err)

--- a/cli/plugin-kit-ai/cmd/agentplugins/main.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins/main.go
@@ -21,6 +21,7 @@ import (
 	processadapter "github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/process"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/clientdetect"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/directoryv1"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/discoveryv1"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/loader"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/processlock"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/sourceacquisition"
@@ -40,7 +41,11 @@ var (
 	defaultDirectoryOrigin    = "https://777genius.github.io/universal-agent-plugins/registry/schemas/1/"
 	defaultDirectoryKeyID     = "uap-directory-2026-01"
 	defaultDirectoryPublicKey = "HalXARjat+v3ylTPLMAnvuavRo4ZfrF+DbWwsjlp2bI="
+	defaultDiscoveryOrigin    = "https://777genius.github.io/universal-agent-plugins/discovery/"
+	defaultDiscoveryKeyID     = "uap-discovery-2026-01"
+	defaultDiscoveryPublicKey = "IxWvGuscXR9crlCrGyBQZNqroYNVPbBA1B3pnjSffhc="
 	directoryClientFactory    = newDirectoryClient
+	discoveryClientFactory    = newDiscoveryClient
 )
 
 func main() {
@@ -60,6 +65,10 @@ func run() error {
 		return err
 	}
 	directoryClient, err := directoryClientFactory(dataRoot)
+	if err != nil {
+		return err
+	}
+	discoveryClient, err := discoveryClientFactory(dataRoot)
 	if err != nil {
 		return err
 	}
@@ -97,6 +106,7 @@ func run() error {
 		LegacyStateLock:     locks.FileLock{BaseDir: filepath.Join(home, ".plugin-kit-ai", "locks")},
 		Detector:            clientdetect.NewOS(home),
 		DirectoryClient:     directoryClient,
+		DiscoveryClient:     discoveryClient,
 		SourceAcquirer:      lazySourceAcquirer{dataRoot: dataRoot, acquirer: sourceacquisition.Acquirer{TempRoot: dataRoot}},
 		PackageLoader:       packageLoader,
 		NativePackageLoader: loader.OpenAILoader{Loader: packageLoader},
@@ -109,6 +119,22 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	return agentpluginscli.NewRoot(app).ExecuteContext(ctx)
+}
+
+func newDiscoveryClient(dataRoot string) (*discoveryv1.Client, error) {
+	publicKey, err := base64.StdEncoding.Strict().DecodeString(defaultDiscoveryPublicKey)
+	if err != nil || len(publicKey) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("decode Discovery public key")
+	}
+	origin, err := productionFeedOrigin(os.Getenv("AGENTPLUGINS_DISCOVERY_ORIGIN"), defaultDiscoveryOrigin, "AGENTPLUGINS_DISCOVERY_ORIGIN")
+	if err != nil {
+		return nil, err
+	}
+	return &discoveryv1.Client{
+		Origin: origin, HTTPClient: hardenedHTTPClient(),
+		Trust: discoveryv1.TrustStore{Keys: []discoveryv1.TrustedKey{{ID: defaultDiscoveryKeyID, PublicKey: ed25519.PublicKey(publicKey), State: discoveryv1.KeyCurrent}}},
+		Cache: discoveryv1.Cache{Path: filepath.Join(dataRoot, "discovery-v1-cache.json")},
+	}, nil
 }
 
 // lazySourceAcquirer creates the private temporary root only once a validated
@@ -173,16 +199,20 @@ func newDirectoryClient(dataRoot string) (*directoryv1.Client, error) {
 }
 
 func productionDirectoryOrigin(environmentValue string) (string, error) {
+	return productionFeedOrigin(environmentValue, defaultDirectoryOrigin, "AGENTPLUGINS_DIRECTORY_ORIGIN")
+}
+
+func productionFeedOrigin(environmentValue, fallback, variable string) (string, error) {
 	origin := strings.TrimSpace(environmentValue)
 	if origin == "" {
-		origin = defaultDirectoryOrigin
+		origin = fallback
 	}
 	parsed, err := url.Parse(origin)
 	if err != nil || parsed.Scheme != "https" || parsed.Opaque != "" || parsed.Host == "" || parsed.Hostname() == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
-		return "", fmt.Errorf("AGENTPLUGINS_DIRECTORY_ORIGIN must be an absolute credential-free HTTPS URL without query or fragment")
+		return "", fmt.Errorf("%s must be an absolute credential-free HTTPS URL without query or fragment", variable)
 	}
 	if !strings.HasSuffix(parsed.Path, "/") || parsed.RawPath != "" || strings.Contains(parsed.Path, "\\") || path.Clean(parsed.Path) != strings.TrimSuffix(parsed.Path, "/") {
-		return "", fmt.Errorf("AGENTPLUGINS_DIRECTORY_ORIGIN must have a clean, unescaped directory path ending in /")
+		return "", fmt.Errorf("%s must have a clean, unescaped directory path ending in /", variable)
 	}
 	return parsed.String(), nil
 }

--- a/cli/plugin-kit-ai/cmd/agentplugins/main.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins/main.go
@@ -131,7 +131,7 @@ func newDiscoveryClient(dataRoot string) (*discoveryv1.Client, error) {
 		return nil, err
 	}
 	return &discoveryv1.Client{
-		Origin: origin, HTTPClient: hardenedHTTPClient(),
+		Origin: origin, HTTPClient: hardenedHTTPClient("Discovery"),
 		Trust: discoveryv1.TrustStore{Keys: []discoveryv1.TrustedKey{{ID: defaultDiscoveryKeyID, PublicKey: ed25519.PublicKey(publicKey), State: discoveryv1.KeyCurrent}}},
 		Cache: discoveryv1.Cache{Path: filepath.Join(dataRoot, "discovery-v1-cache.json")},
 	}, nil
@@ -188,7 +188,7 @@ func newDirectoryClient(dataRoot string) (*directoryv1.Client, error) {
 		return nil, err
 	}
 	return &directoryv1.Client{
-		Origin: origin, HTTPClient: hardenedHTTPClient(),
+		Origin: origin, HTTPClient: hardenedHTTPClient("Directory"),
 		Trust: trust,
 		// The production bootstrap is intentionally absent until the first
 		// post-merge Directory publication. Short-name resolution fails closed
@@ -232,17 +232,17 @@ func agentpluginsHome() (string, error) {
 	return filepath.Join(root, "agentplugins"), nil
 }
 
-func hardenedHTTPClient() *http.Client {
+func hardenedHTTPClient(feed string) *http.Client {
 	return &http.Client{
 		Timeout: 20 * time.Second,
 		CheckRedirect: func(request *http.Request, via []*http.Request) error {
 			if len(via) > 2 {
-				return fmt.Errorf("too many Directory redirects")
+				return fmt.Errorf("too many %s redirects", feed)
 			}
 			if request.URL.Scheme != "https" || len(via) == 0 ||
 				!strings.EqualFold(request.URL.Scheme, via[0].URL.Scheme) ||
 				!strings.EqualFold(request.URL.Host, via[0].URL.Host) {
-				return fmt.Errorf("Directory redirect must remain on the original HTTPS origin")
+				return fmt.Errorf("%s redirect must remain on the original HTTPS origin", feed)
 			}
 			request.Header.Del("Authorization")
 			request.Header.Del("Cookie")

--- a/cli/plugin-kit-ai/cmd/agentplugins/main_test.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins/main_test.go
@@ -56,7 +56,7 @@ func TestMainUsesProductionDirectoryTrustAndReleaseBootstrap(t *testing.T) {
 }
 
 func TestHardenedHTTPClientRedirectPolicy(t *testing.T) {
-	check := hardenedHTTPClient().CheckRedirect
+	check := hardenedHTTPClient("Directory").CheckRedirect
 	original, _ := http.NewRequest(http.MethodGet, "https://directory.example/registry/latest.json", nil)
 	first, _ := http.NewRequest(http.MethodGet, "https://directory.example/registry/one.json", nil)
 	first.Header.Set("Authorization", "secret")
@@ -83,6 +83,10 @@ func TestHardenedHTTPClientRedirectPolicy(t *testing.T) {
 	downgrade, _ := http.NewRequest(http.MethodGet, "http://directory.example/registry/latest.json", nil)
 	if err := check(downgrade, []*http.Request{original}); err == nil {
 		t.Fatal("HTTPS downgrade redirect was accepted")
+	}
+	discoveryCheck := hardenedHTTPClient("Discovery").CheckRedirect
+	if err := discoveryCheck(crossOrigin, []*http.Request{original}); err == nil || !strings.Contains(err.Error(), "Discovery redirect") {
+		t.Fatalf("Discovery redirect diagnostic = %v", err)
 	}
 }
 

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -16,9 +16,10 @@ import (
 func newAddCommand(app App, opts *options) *cobra.Command {
 	var activationComplete, authComplete bool
 	command := &cobra.Command{
-		Use:   "add <name-or-source>",
-		Short: "Plan and install one Agent Plugins 1.0 package for one or more clients",
-		Args:  cobra.ExactArgs(1),
+		Use:     "add <name-or-source>",
+		Aliases: []string{"install"},
+		Short:   "Plan and install one Agent Plugins 1.0 package for one or more clients",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateCommonOptions(opts); err != nil {
 				return err

--- a/cli/plugin-kit-ai/internal/agentpluginscli/app.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/app.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/directoryv1"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/discoveryv1"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/statemigration"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/ports"
@@ -16,6 +17,10 @@ import (
 
 type DirectoryClient interface {
 	Load(context.Context, uint64) (directoryv1.VerifiedBundle, error)
+}
+
+type DiscoveryClient interface {
+	Load(context.Context, uint64) (discoveryv1.VerifiedBundle, error)
 }
 
 type SourceAcquirer interface {
@@ -31,6 +36,7 @@ type App struct {
 	StateStore          transaction.StateStore
 	Detector            ports.ClientDetector
 	DirectoryClient     DirectoryClient
+	DiscoveryClient     DiscoveryClient
 	SourceAcquirer      SourceAcquirer
 	PackageLoader       ports.PackageLoader
 	NativePackageLoader ports.PackageLoader

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -125,6 +125,36 @@ func TestOperationalAndReadCommandsProduceVersionedJSON(t *testing.T) {
 	}
 }
 
+func TestValidateLoadsPackageWithoutDetectionOrStateMutation(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, nil)
+	plugin := writeCLIPlugin(t)
+	stdout, _, err := fixture.execute(false, "validate", plugin, "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertVersionedJSON(t, stdout, "validate")
+	var envelope struct {
+		Data validationResult `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if !envelope.Data.Conformant || envelope.Data.Name != "demo" || envelope.Data.SchemaURI != domain.PluginSchemaV1 {
+		t.Fatalf("validation result = %+v", envelope.Data)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Installations) != 0 {
+		t.Fatalf("validate mutated state: %+v", state)
+	}
+	if _, _, err := fixture.execute(false, "validate", "demo"); err == nil || !strings.Contains(err.Error(), "local path or exact") {
+		t.Fatalf("short-name validation error = %v", err)
+	}
+}
+
 func TestLifecycleOutputKeepsPrivatePathsOutOfPublicJSON(t *testing.T) {
 	t.Parallel()
 	privatePath := "/home/private-user/.codex/plugins/demo"
@@ -215,6 +245,98 @@ func TestAutomatedAddRequiresExplicitTargetButNotYes(t *testing.T) {
 	}
 	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor"); err != nil {
 		t.Fatalf("explicit-target add without --yes failed: %v", err)
+	}
+}
+
+func TestInstallAliasProducesTheSamePlanAndStateAsAdd(t *testing.T) {
+	t.Parallel()
+	plugin := writeCLIPlugin(t)
+	addFixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	installFixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+
+	addOutput, _, err := addFixture.execute(false, "add", plugin, "--target", "cursor", "--dry-run", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	installOutput, _, err := installFixture.execute(false, "install", plugin, "--target", "cursor", "--dry-run", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	normalize := func(encoded string) map[string]any {
+		var value map[string]any
+		if err := json.Unmarshal([]byte(encoded), &value); err != nil {
+			t.Fatal(err)
+		}
+		var strip func(any)
+		strip = func(current any) {
+			switch item := current.(type) {
+			case map[string]any:
+				for _, key := range []string{"operation_id", "installation_id", "physical_artifact_id"} {
+					delete(item, key)
+				}
+				for _, child := range item {
+					strip(child)
+				}
+			case []any:
+				for _, child := range item {
+					strip(child)
+				}
+			}
+		}
+		strip(value)
+		return value
+	}
+	if addPlan, installPlan := normalize(addOutput), normalize(installOutput); !reflect.DeepEqual(addPlan, installPlan) {
+		t.Fatalf("install alias plan differs from add:\nadd=%s\ninstall=%s", addOutput, installOutput)
+	}
+	for name, fixture := range map[string]cliFixture{"add": addFixture, "install": installFixture} {
+		state, err := fixture.store.Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(state.Installations) != 0 {
+			t.Fatalf("%s dry-run mutated state: %+v", name, state)
+		}
+	}
+	if _, _, err := addFixture.execute(false, "add", plugin, "--target", "cursor"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := installFixture.execute(false, "install", plugin, "--target", "cursor"); err != nil {
+		t.Fatal(err)
+	}
+	addState, err := addFixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	installState, err := installFixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(addState.Installations) != 1 || len(installState.Installations) != 1 {
+		t.Fatalf("alias installation counts differ: add=%d install=%d", len(addState.Installations), len(installState.Installations))
+	}
+	addInstallation, installInstallation := addState.Installations[0], installState.Installations[0]
+	if addInstallation.DeclaredName != installInstallation.DeclaredName || addInstallation.OriginMode != installInstallation.OriginMode ||
+		addInstallation.Source.RequestedSource != installInstallation.Source.RequestedSource ||
+		addInstallation.Source.CanonicalSource != installInstallation.Source.CanonicalSource ||
+		addInstallation.Source.ResolvedRevision != installInstallation.Source.ResolvedRevision ||
+		addInstallation.Source.TreeDigest != installInstallation.Source.TreeDigest ||
+		!reflect.DeepEqual(addInstallation.Package, installInstallation.Package) {
+		t.Fatalf("install alias persisted different package state:\nadd=%+v\ninstall=%+v", addInstallation, installInstallation)
+	}
+	if len(addInstallation.Clients) != 1 || len(installInstallation.Clients) != 1 {
+		t.Fatalf("alias client counts differ: add=%d install=%d", len(addInstallation.Clients), len(installInstallation.Clients))
+	}
+	var addClient, installClient domain.ClientBinding
+	for _, addClient = range addInstallation.Clients {
+	}
+	for _, installClient = range installInstallation.Clients {
+	}
+	if addClient.ClientID != installClient.ClientID || addClient.Scope != installClient.Scope ||
+		addClient.Materialization != installClient.Materialization || addClient.Activation != installClient.Activation ||
+		addClient.Authentication != installClient.Authentication || addClient.Policy != installClient.Policy ||
+		addClient.Verification != installClient.Verification || !reflect.DeepEqual(addClient.PackageRevision, installClient.PackageRevision) {
+		t.Fatalf("install alias persisted different client state:\nadd=%+v\ninstall=%+v", addClient, installClient)
 	}
 }
 

--- a/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
@@ -17,13 +17,26 @@ import (
 )
 
 func newUpdateCommand(app App, opts *options) *cobra.Command {
-	return &cobra.Command{
-		Use:   "update <name-or-installation-id>",
+	var all bool
+	command := &cobra.Command{
+		Use:   "update <name-or-installation-id> | update --all",
 		Short: "Safely update a tracked Agent Plugin across selected or installed clients",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateCommonOptions(opts); err != nil {
 				return err
+			}
+			if all {
+				if len(args) > 0 {
+					return fmt.Errorf("choose either one installation or --all")
+				}
+				if strings.TrimSpace(opts.target) != "" {
+					return fmt.Errorf("--target cannot be combined with --all; every installation keeps its recorded targets")
+				}
+				return runUpdateAll(cmd.Context(), cmd, app, opts)
+			}
+			if len(args) != 1 {
+				return fmt.Errorf("provide one installation or use --all")
 			}
 			if strings.TrimSpace(opts.target) == "" {
 				targets, err := defaultBoundTargets(app, args[0], opts.scope, false)
@@ -40,6 +53,8 @@ func newUpdateCommand(app App, opts *options) *cobra.Command {
 			return runUpdateMany(cmd.Context(), cmd, app, opts, args[0], targets)
 		},
 	}
+	command.Flags().BoolVar(&all, "all", false, "update every eligible tracked installation after one complete preflight")
+	return command
 }
 
 func newRepairCommand(app App, opts *options) *cobra.Command {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/outdated.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/outdated.go
@@ -276,7 +276,7 @@ func inspectOutdatedInstallation(bundle directoryv1.VerifiedBundle, bundleOK boo
 			TreeDigest: selection.TreeDigest, ManifestDigest: selection.ManifestDigest}
 		return item
 	}
-	if errors.Is(err, domain.ErrDirectoryIneligible) && isNoSafeDirectoryUpdate(err) {
+	if errors.Is(err, domain.ErrDirectoryIneligible) && errors.Is(err, domain.ErrDirectoryNoSafeUpdate) {
 		if len(item.Warnings) > 0 {
 			item.Status, item.Reason = "blocked", "installed release is unsafe and no later eligible release is available"
 		} else {
@@ -286,10 +286,6 @@ func inspectOutdatedInstallation(bundle directoryv1.VerifiedBundle, bundleOK boo
 	}
 	item.Status, item.Reason = "blocked", err.Error()
 	return item
-}
-
-func isNoSafeDirectoryUpdate(err error) bool {
-	return strings.Contains(err.Error(), "no later eligible non-revoked release exists in the recorded distribution")
 }
 
 // staticDetectedClientSource is used only to reuse the exact client-surface

--- a/cli/plugin-kit-ai/internal/agentpluginscli/outdated.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/outdated.go
@@ -1,0 +1,331 @@
+package agentpluginscli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/directoryv1"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/discoveryv1"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/spf13/cobra"
+)
+
+type outdatedReleaseIdentity struct {
+	DistributionID  string `json:"distribution_id"`
+	ReleaseSequence uint64 `json:"release_sequence"`
+	PackageVersion  string `json:"package_version,omitempty"`
+	Revision        string `json:"revision,omitempty"`
+	TreeDigest      string `json:"tree_digest,omitempty"`
+	ManifestDigest  string `json:"manifest_digest,omitempty"`
+}
+
+type outdatedInstallation struct {
+	InstallationID string                   `json:"installation_id"`
+	Name           string                   `json:"name"`
+	Status         string                   `json:"status"`
+	Reason         string                   `json:"reason"`
+	Targets        []domain.ClientID        `json:"targets,omitempty"`
+	Installed      *outdatedReleaseIdentity `json:"installed,omitempty"`
+	Available      *outdatedReleaseIdentity `json:"available,omitempty"`
+	Warnings       []publicSafetyWarning    `json:"warnings,omitempty"`
+}
+
+type outdatedResult struct {
+	ReadOnly              bool                   `json:"read_only"`
+	Snapshot              uint64                 `json:"snapshot_sequence,omitempty"`
+	SnapshotHash          string                 `json:"snapshot_digest,omitempty"`
+	DiscoverySnapshot     uint64                 `json:"discovery_snapshot_sequence,omitempty"`
+	DiscoverySnapshotHash string                 `json:"discovery_snapshot_digest,omitempty"`
+	Outdated              int                    `json:"outdated"`
+	Current               int                    `json:"current"`
+	Blocked               int                    `json:"blocked"`
+	Unknown               int                    `json:"unknown"`
+	Unmanaged             int                    `json:"unmanaged"`
+	Installations         []outdatedInstallation `json:"installations"`
+}
+
+func newOutdatedCommand(app App, opts *options) *cobra.Command {
+	var all bool
+	command := &cobra.Command{
+		Use:   "outdated [name-or-installation-id]",
+		Short: "Check immutable release identities without changing installations",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateCommonOptions(opts); err != nil {
+				return err
+			}
+			if all && len(args) > 0 {
+				return fmt.Errorf("choose either one installation or --all")
+			}
+			selector := ""
+			if len(args) == 1 {
+				selector = args[0]
+			}
+			return runOutdated(cmd.Context(), cmd, app, opts, selector)
+		},
+	}
+	command.Flags().BoolVar(&all, "all", false, "check every tracked installation")
+	return command
+}
+
+func runOutdated(ctx context.Context, cmd *cobra.Command, app App, opts *options, selector string) error {
+	state, err := app.StateStore.Load()
+	if err != nil {
+		return err
+	}
+	installations := append([]domain.Installation(nil), state.Installations...)
+	if strings.TrimSpace(selector) != "" {
+		installation, err := selectInstallation(state, selector)
+		if err != nil {
+			return err
+		}
+		installations = []domain.Installation{installation}
+	}
+	sort.Slice(installations, func(i, j int) bool {
+		left, right := strings.ToLower(installations[i].DeclaredName), strings.ToLower(installations[j].DeclaredName)
+		if left != right {
+			return left < right
+		}
+		return installations[i].InstallationID < installations[j].InstallationID
+	})
+
+	result := outdatedResult{ReadOnly: true, Installations: make([]outdatedInstallation, 0, len(installations))}
+	needsDirectory := false
+	for _, installation := range installations {
+		if installation.OriginMode == domain.OriginModeDirectory && installation.Directory != nil {
+			needsDirectory = true
+			break
+		}
+	}
+	var bundle directoryv1.VerifiedBundle
+	bundleOK := false
+	if needsDirectory {
+		bundle, bundleOK, err = directoryBundleForRead(ctx, app, state, true)
+		if err != nil {
+			return fmt.Errorf("load signed Directory: %w", err)
+		}
+		if bundleOK {
+			result.Snapshot, result.SnapshotHash = bundle.Snapshot.Sequence, bundle.Digest
+		}
+	}
+	needsDiscovery := false
+	for _, installation := range installations {
+		if strings.HasPrefix(strings.TrimSpace(installation.Source.RequestedSource), "discovery:") {
+			needsDiscovery = true
+			break
+		}
+	}
+	var discovery discoveryv1.VerifiedBundle
+	var discoveryErr error
+	if needsDiscovery {
+		if app.DiscoveryClient == nil {
+			discoveryErr = errors.New("signed Discovery Index dependencies are unavailable")
+		} else {
+			discovery, discoveryErr = app.DiscoveryClient.Load(ctx, 0)
+			if discoveryErr == nil {
+				result.DiscoverySnapshot, result.DiscoverySnapshotHash = discovery.Snapshot.Sequence, discovery.Digest
+			}
+		}
+	}
+
+	var detected map[domain.ClientID]domain.DetectedClient
+	var detectionErr error
+	if needsDirectory && bundleOK {
+		clients, err := detectClientsForLifecycleResolution(ctx, app.Detector, false)
+		if err != nil {
+			detectionErr = fmt.Errorf("detect AI clients: %w", err)
+		} else {
+			detected = make(map[domain.ClientID]domain.DetectedClient, len(clients)+1)
+			for _, client := range clients {
+				detected[client.ClientID] = client
+			}
+		}
+	}
+
+	for _, installation := range installations {
+		var item outdatedInstallation
+		if strings.HasPrefix(strings.TrimSpace(installation.Source.RequestedSource), "discovery:") {
+			item = inspectDiscoveryOutdated(discovery, discoveryErr, installation, opts.scope)
+		} else {
+			item = inspectOutdatedInstallation(bundle, bundleOK, detected, detectionErr, app.Version, installation, opts.scope)
+		}
+		result.Installations = append(result.Installations, item)
+		switch item.Status {
+		case "outdated":
+			result.Outdated++
+		case "current":
+			result.Current++
+		case "blocked":
+			result.Blocked++
+		case "unknown":
+			result.Unknown++
+		default:
+			result.Unmanaged++
+		}
+	}
+	if opts.format == "json" {
+		return writeJSONOutput(cmd.OutOrStdout(), "outdated", result)
+	}
+	return renderOutdated(cmd.OutOrStdout(), result)
+}
+
+func inspectDiscoveryOutdated(bundle discoveryv1.VerifiedBundle, bundleErr error, installation domain.Installation, scope string) outdatedInstallation {
+	item := outdatedInstallation{InstallationID: installation.InstallationID, Name: installation.DeclaredName, Targets: installationTargets(installation, scope)}
+	selector := strings.TrimSpace(installation.Source.RequestedSource)
+	item.Installed = &outdatedReleaseIdentity{DistributionID: selector, PackageVersion: installation.Package.Version,
+		Revision: installation.Source.ResolvedRevision, TreeDigest: installation.Source.TreeDigest, ManifestDigest: installation.Package.ManifestDigest}
+	if installation.NeedsRebind {
+		item.Status, item.Reason = "blocked", "installation requires explicit rebind before update"
+		return item
+	}
+	if bundleErr != nil {
+		item.Status, item.Reason = "unknown", "no authenticated Discovery snapshot is available: "+bundleErr.Error()
+		return item
+	}
+	var matches []discoveryv1.Record
+	for _, record := range bundle.Search.Records {
+		if record.Slug == selector {
+			matches = append(matches, record)
+		}
+	}
+	if len(matches) != 1 {
+		item.Status, item.Reason = "blocked", "recorded Discovery selector is absent or ambiguous"
+		return item
+	}
+	record := matches[0]
+	item.Available = &outdatedReleaseIdentity{DistributionID: record.Slug, Revision: record.Revision, TreeDigest: record.TreeDigest, ManifestDigest: record.ManifestDigest}
+	if record.Version != nil {
+		item.Available.PackageVersion = *record.Version
+	}
+	if record.Availability != "available" {
+		item.Status, item.Reason = "blocked", "Discovery source is unavailable"
+		return item
+	}
+	if record.Repository != installation.Source.Repository || record.PackagePath != installation.Source.PackageSubpath {
+		item.Status, item.Reason = "blocked", "Discovery selector changed repository or package path; explicit switch required"
+		return item
+	}
+	if record.Revision == installation.Source.ResolvedRevision && record.TreeDigest == installation.Source.TreeDigest && record.ManifestDigest == installation.Package.ManifestDigest {
+		item.Status, item.Reason = "current", "the signed Discovery record matches the installed immutable package"
+		item.Available = nil
+		return item
+	}
+	item.Status, item.Reason = "outdated", "the same Discovery source has a newer immutable package identity"
+	return item
+}
+
+func inspectOutdatedInstallation(bundle directoryv1.VerifiedBundle, bundleOK bool, detected map[domain.ClientID]domain.DetectedClient, detectionErr error, installerVersion string, installation domain.Installation, scope string) outdatedInstallation {
+	item := outdatedInstallation{InstallationID: installation.InstallationID, Name: installation.DeclaredName}
+	if installation.NeedsRebind {
+		item.Status, item.Reason = "blocked", "installation requires explicit rebind before update"
+		return item
+	}
+	if installation.Package.LoaderKind != domain.LoaderKindAgentPlugins {
+		item.Status, item.Reason = "unmanaged", "legacy plugin.yaml installation has no Agent Plugins release identity"
+		return item
+	}
+	if installation.OriginMode != domain.OriginModeDirectory || installation.Directory == nil {
+		item.Status, item.Reason = "unmanaged", "direct source has no signed update channel; use an explicit source switch"
+		return item
+	}
+	origin := installation.Directory
+	item.Targets = installationTargets(installation, scope)
+	item.Installed = &outdatedReleaseIdentity{DistributionID: origin.DistributionID, ReleaseSequence: origin.DesiredReleaseSequence,
+		PackageVersion: installation.Package.Version, Revision: installation.Source.ResolvedRevision,
+		TreeDigest: installation.Source.TreeDigest, ManifestDigest: installation.Package.ManifestDigest}
+	if !bundleOK {
+		item.Status, item.Reason = "unknown", "no authenticated Directory snapshot is available"
+		return item
+	}
+	item.Warnings = installedDirectoryWarnings(bundle.Snapshot, installation)
+	if detectionErr != nil {
+		item.Status, item.Reason = "unknown", detectionErr.Error()
+		return item
+	}
+	if len(item.Targets) == 0 {
+		item.Status, item.Reason = "blocked", "installation has no materialized target in the selected scope"
+		return item
+	}
+	if selectedTargetsNeedDesiredRelease(installation, item.Targets, scope) {
+		item.Status, item.Reason = "outdated", "one or more installed clients have not converged to the recorded desired release"
+		item.Available = cloneOutdatedIdentity(item.Installed)
+		return item
+	}
+	_, clientMap, err := preflightSelectedTargets(context.Background(), App{Detector: staticDetectedClientSource(detected)}, item.Targets, detectedClientValues(detected), false)
+	if err != nil {
+		item.Status, item.Reason = "blocked", err.Error()
+		return item
+	}
+	environment := directoryEnvironment(clientMap)
+	environment.InstallerVersion = installerVersion
+	selection, err := domain.ResolveDirectory(bundle.Snapshot, domain.DirectoryResolveRequest{
+		Selector: origin.ProductID, Targets: expandAffectedSurfaceTargets(item.Targets), Scope: domain.ScopeUser,
+		InstallerVersion: installerVersion, ClientVersions: environment.ClientVersions, OS: environment.OS,
+		Architecture: environment.Architecture, DependencyIdentity: environment.DependencyIdentity,
+		SchemaVersion: "1.0.0", Operation: domain.DirectoryUpdate,
+		Recorded: recordedDirectoryRelease(installation, origin.DesiredReleaseSequence, installation.Source.ResolvedRevision),
+	})
+	if err == nil {
+		item.Status, item.Reason = "outdated", "a later eligible immutable release is available"
+		item.Available = &outdatedReleaseIdentity{DistributionID: selection.DistributionID, ReleaseSequence: selection.ReleaseSequence,
+			PackageVersion: selection.PackageVersion, Revision: selection.Source.Revision,
+			TreeDigest: selection.TreeDigest, ManifestDigest: selection.ManifestDigest}
+		return item
+	}
+	if errors.Is(err, domain.ErrDirectoryIneligible) && isNoSafeDirectoryUpdate(err) {
+		if len(item.Warnings) > 0 {
+			item.Status, item.Reason = "blocked", "installed release is unsafe and no later eligible release is available"
+		} else {
+			item.Status, item.Reason = "current", "no later eligible immutable release exists"
+		}
+		return item
+	}
+	item.Status, item.Reason = "blocked", err.Error()
+	return item
+}
+
+func isNoSafeDirectoryUpdate(err error) bool {
+	return strings.Contains(err.Error(), "no later eligible non-revoked release exists in the recorded distribution")
+}
+
+// staticDetectedClientSource is used only to reuse the exact client-surface
+// preflight rules for a previously detected, read-only snapshot.
+type staticDetectedClientSource map[domain.ClientID]domain.DetectedClient
+
+func (source staticDetectedClientSource) Detect(context.Context) ([]domain.DetectedClient, error) {
+	return detectedClientValues(source), nil
+}
+
+func cloneOutdatedIdentity(identity *outdatedReleaseIdentity) *outdatedReleaseIdentity {
+	if identity == nil {
+		return nil
+	}
+	clone := *identity
+	return &clone
+}
+
+func renderOutdated(writer io.Writer, result outdatedResult) error {
+	if len(result.Installations) == 0 {
+		_, err := fmt.Fprintln(writer, "No tracked Agent Plugins installations.")
+		return err
+	}
+	for _, installation := range result.Installations {
+		if _, err := fmt.Fprintf(writer, "%s: %s - %s\n", installation.Name, installation.Status, installation.Reason); err != nil {
+			return err
+		}
+		if installation.Available != nil {
+			label := fmt.Sprintf("%s release %d", installation.Available.DistributionID, installation.Available.ReleaseSequence)
+			if installation.Available.ReleaseSequence == 0 {
+				label = installation.Available.DistributionID
+			}
+			if _, err := fmt.Fprintf(writer, "  Available: %s (%s)\n", label, installation.Available.Revision); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/outdated_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/outdated_test.go
@@ -1,0 +1,245 @@
+package agentpluginscli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/discoveryv1"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+func TestOutdatedComparesDirectoryReleaseIdentityWithoutAcquisitionOrMutation(t *testing.T) {
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	plugin := writeCLIPlugin(t)
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor"); err != nil {
+		t.Fatal(err)
+	}
+	bundle := readModelBundle()
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bindDirectoryRelease(&state.Installations[0], bundle.Snapshot, "owner/demo", 1)
+	if err := fixture.store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+	before, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	acquirer := &countingSourceAcquirer{delegate: fixture.app.SourceAcquirer}
+	fixture.app.SourceAcquirer = acquirer
+	fixture.app.DirectoryClient = &fixedDirectoryClient{bundle: bundle}
+
+	stdout, _, err := fixture.execute(false, "outdated", "demo", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`"read_only":true`, `"outdated":1`, `"status":"outdated"`,
+		`"release_sequence":1`, `"release_sequence":2`,
+		`"revision":"` + strings.Repeat("2", 40) + `"`,
+		`"code":"directory_release_revoked"`,
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("outdated result omitted %q:\n%s", want, stdout)
+		}
+	}
+	if acquirer.calls != 0 {
+		t.Fatalf("outdated acquired package bytes %d times", acquirer.calls)
+	}
+	after, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeJSON, _ := json.Marshal(before)
+	afterJSON, _ := json.Marshal(after)
+	if string(beforeJSON) != string(afterJSON) {
+		t.Fatalf("outdated mutated installation state\nbefore=%s\nafter=%s", beforeJSON, afterJSON)
+	}
+}
+
+func TestOutdatedDistinguishesCurrentUnsafeAndDirectInstallations(t *testing.T) {
+	tests := []struct {
+		name      string
+		sequence  uint64
+		configure func(*domain.DirectorySnapshot)
+		want      string
+		reason    string
+	}{
+		{name: "current", sequence: 2, want: `"status":"current"`, reason: "no later eligible immutable release exists"},
+		{name: "unsafe without successor", sequence: 1, configure: func(snapshot *domain.DirectorySnapshot) {
+			distribution := &snapshot.Distributions[0]
+			distribution.Releases = distribution.Releases[:1]
+			distribution.ReleasePolicies = distribution.ReleasePolicies[:1]
+		}, want: `"status":"blocked"`, reason: "installed release is unsafe and no later eligible release is available"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+			if _, _, err := fixture.execute(false, "add", writeCLIPlugin(t), "--target", "cursor"); err != nil {
+				t.Fatal(err)
+			}
+			bundle := readModelBundle()
+			if test.configure != nil {
+				test.configure(&bundle.Snapshot)
+			}
+			state, err := fixture.store.Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			bindDirectoryRelease(&state.Installations[0], bundle.Snapshot, "owner/demo", test.sequence)
+			if err := fixture.store.Save(state); err != nil {
+				t.Fatal(err)
+			}
+			fixture.app.DirectoryClient = &fixedDirectoryClient{bundle: bundle}
+			stdout, _, err := fixture.execute(false, "outdated", "demo", "--format", "json")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(stdout, test.want) || !strings.Contains(stdout, test.reason) {
+				t.Fatalf("result did not distinguish %s:\n%s", test.name, stdout)
+			}
+		})
+	}
+
+	direct := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	if _, _, err := direct.execute(false, "add", writeCLIPlugin(t), "--target", "cursor"); err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, err := direct.execute(false, "outdated", "--all", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, `"unmanaged":1`) || !strings.Contains(stdout, "direct source has no signed update channel") {
+		t.Fatalf("direct installation was not explicitly unmanaged:\n%s", stdout)
+	}
+}
+
+func TestOutdatedAllIsDeterministicForMixedReleaseStates(t *testing.T) {
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	if _, _, err := fixture.execute(false, "add", writeCLIPlugin(t), "--target", "cursor"); err != nil {
+		t.Fatal(err)
+	}
+	bundle := readModelBundle()
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := cloneDirectoryInstallation(state.Installations[0], bundle.Snapshot, "alpha", "installation-alpha", "source-alpha", 1)
+	current := cloneDirectoryInstallation(state.Installations[0], bundle.Snapshot, "zulu", "installation-zulu", "source-zulu", 2)
+	state.Installations = []domain.Installation{current, old}
+	state.TransactionReceipts = nil
+	if err := fixture.store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+	fixture.app.DirectoryClient = &fixedDirectoryClient{bundle: bundle}
+	first, _, err := fixture.execute(false, "outdated", "--all", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, _, err := fixture.execute(false, "outdated", "--all", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second || strings.Index(first, `"name":"alpha"`) > strings.Index(first, `"name":"zulu"`) {
+		t.Fatalf("outdated --all output is not deterministic:\n%s\n%s", first, second)
+	}
+	if !strings.Contains(first, `"outdated":1`) || !strings.Contains(first, `"current":1`) || !strings.Contains(first, `"code":"directory_release_revoked"`) {
+		t.Fatalf("mixed release states were not preserved:\n%s", first)
+	}
+}
+
+func TestOutdatedComparesSignedDiscoveryIdentityWithoutAcquisition(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	if _, _, err := fixture.execute(false, "add", writeCLIPlugin(t), "--target", "cursor"); err != nil {
+		t.Fatal(err)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	selector := "discovery:owner/demo//plugin"
+	installation := &state.Installations[0]
+	installation.Source.RequestedSource = selector
+	installation.Source.Repository = "owner/demo"
+	installation.Source.PackageSubpath = "plugin"
+	installation.Source.ResolvedRevision = strings.Repeat("a", 40)
+	if err := fixture.store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+	record := discoveryv1.Record{
+		Slug: selector, Repository: "owner/demo", PackagePath: "plugin", Revision: strings.Repeat("b", 40),
+		TreeDigest: installation.Source.TreeDigest, ManifestDigest: installation.Package.ManifestDigest, Availability: "available",
+	}
+	fixture.app.DiscoveryClient = &fixedDiscoveryClient{bundle: discoveryv1.VerifiedBundle{
+		Snapshot: discoveryv1.Snapshot{Sequence: 11}, Search: discoveryv1.Search{Records: []discoveryv1.Record{record}},
+		Digest: "sha256:" + strings.Repeat("4", 64),
+	}}
+	acquirer := &countingSourceAcquirer{delegate: fixture.app.SourceAcquirer}
+	fixture.app.SourceAcquirer = acquirer
+	stdout, _, err := fixture.execute(false, "outdated", "demo", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, `"outdated":1`) || !strings.Contains(stdout, `"discovery_snapshot_sequence":11`) ||
+		!strings.Contains(stdout, record.Revision) || acquirer.calls != 0 {
+		t.Fatalf("Discovery outdated result=%s acquisitions=%d", stdout, acquirer.calls)
+	}
+}
+
+func bindDirectoryRelease(installation *domain.Installation, snapshot domain.DirectorySnapshot, distributionID string, sequence uint64) {
+	distribution := snapshotDistribution(snapshot, distributionID)
+	if distribution == nil {
+		panic("test Directory distribution is missing")
+	}
+	var release *domain.DirectoryRelease
+	for index := range distribution.Releases {
+		if distribution.Releases[index].Sequence == sequence {
+			release = &distribution.Releases[index]
+			break
+		}
+	}
+	if release == nil {
+		panic("test Directory release is missing")
+	}
+	installation.OriginMode = domain.OriginModeDirectory
+	installation.Directory = &domain.DirectoryOrigin{ProductID: distribution.ProductID, DistributionID: distribution.ID,
+		DistributionKind: distribution.Kind, DesiredReleaseSequence: sequence, SnapshotSchema: 1,
+		SnapshotSequence: snapshot.Sequence, SnapshotDigest: "sha256:" + strings.Repeat("a", 64)}
+	installation.Source.RequestedSource = distribution.ProductID
+	installation.Source.CanonicalSource = "github:" + release.PackageSource.Repository + "@" + release.PackageSource.Revision + "//" + release.PackageSource.Path
+	installation.Source.Repository = release.PackageSource.Repository
+	installation.Source.PackageSubpath = release.PackageSource.Path
+	installation.Source.ResolvedRevision = release.PackageSource.Revision
+	installation.Source.TreeDigest = release.TreeDigest
+	installation.Source.SourceBindingID = domain.ComputeSourceBindingID(domain.SourceIdentity{CanonicalSource: installation.Source.CanonicalSource,
+		Repository: installation.Source.Repository, PackageSubpath: installation.Source.PackageSubpath})
+	installation.Package.Version = release.PackageVersion
+	installation.Package.ManifestDigest = release.ManifestDigest
+	for key, binding := range installation.Clients {
+		binding.PackageRevision = &domain.ClientPackageRevision{Version: release.PackageVersion, ResolvedRevision: release.PackageSource.Revision,
+			TreeDigest: release.TreeDigest, ManifestDigest: release.ManifestDigest, DistributionID: distribution.ID, ReleaseSequence: sequence}
+		installation.Clients[key] = binding
+	}
+}
+
+func cloneDirectoryInstallation(base domain.Installation, snapshot domain.DirectorySnapshot, name, installationID, sourceID string, sequence uint64) domain.Installation {
+	clone := base
+	clone.InstallationID, clone.DeclaredName = installationID, name
+	clone.Source.SourceBindingID = sourceID
+	clone.Package.DeclaredName = name
+	clone.Clients = map[string]domain.ClientBinding{}
+	for _, binding := range base.Clients {
+		binding.ClientBindingID = domain.ComputeClientBindingID(installationID, binding.ClientID, binding.Scope, binding.TargetLocator)
+		binding.PhysicalArtifact = domain.ComputePhysicalArtifactID(name, installationID)
+		binding.Receipts = nil
+		clone.Clients[binding.ClientBindingID] = binding
+	}
+	clone.DataReceipts, clone.DataRetained, clone.OperationGroupID = nil, false, ""
+	bindDirectoryRelease(&clone, snapshot, "owner/demo", sequence)
+	clone.Source.SourceBindingID = sourceID
+	return clone
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/root.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/root.go
@@ -34,6 +34,9 @@ func NewRoot(app App) *cobra.Command {
 	root.AddCommand(newRebindCommand(app, opts))
 	root.AddCommand(newListCommand(app, opts))
 	root.AddCommand(newInfoCommand(app, opts))
+	root.AddCommand(newSearchCommand(app, opts))
+	root.AddCommand(newValidateCommand(app, opts))
+	root.AddCommand(newOutdatedCommand(app, opts))
 	root.AddCommand(newDoctorCommand(app, opts))
 	root.AddCommand(newVersionCommand(app, opts))
 	return root

--- a/cli/plugin-kit-ai/internal/agentpluginscli/search.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/search.go
@@ -1,0 +1,459 @@
+package agentpluginscli
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/discoveryv1"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/spf13/cobra"
+)
+
+type searchCompatibility struct {
+	Client         domain.ClientID                  `json:"client"`
+	Authentication domain.AuthenticationRequirement `json:"authentication"`
+	Delivery       string                           `json:"delivery"`
+}
+
+type searchResult struct {
+	TrustState       string                  `json:"trust_state"`
+	InstallSelector  string                  `json:"install_selector"`
+	ProductID        string                  `json:"product_id"`
+	DisplayName      string                  `json:"display_name"`
+	Description      string                  `json:"description"`
+	ManifestName     string                  `json:"manifest_name"`
+	DistributionID   string                  `json:"distribution_id"`
+	DistributionKind domain.DistributionKind `json:"distribution_kind"`
+	Status           string                  `json:"status"`
+	PackageVersion   string                  `json:"package_version"`
+	Repository       string                  `json:"repository"`
+	Revision         string                  `json:"revision"`
+	PackagePath      string                  `json:"package_path"`
+	SchemaURI        string                  `json:"schema_uri"`
+	Components       []string                `json:"components"`
+	Compatibility    []searchCompatibility   `json:"compatibility"`
+	RuntimeReviewed  bool                    `json:"runtime_reviewed"`
+	Stars            int                     `json:"stars"`
+	matchScore       int
+}
+
+type searchResponse struct {
+	Query                     string         `json:"query"`
+	TrustFilter               string         `json:"trust_filter"`
+	SnapshotSequence          uint64         `json:"snapshot_sequence"`
+	SnapshotDigest            string         `json:"snapshot_digest"`
+	DiscoveryStatus           string         `json:"discovery_status"`
+	DiscoverySnapshotSequence uint64         `json:"discovery_snapshot_sequence,omitempty"`
+	DiscoverySnapshotDigest   string         `json:"discovery_snapshot_digest,omitempty"`
+	Results                   []searchResult `json:"results"`
+}
+
+type searchOptions struct {
+	trust     string
+	component string
+	client    string
+	auth      string
+	owner     string
+}
+
+func newSearchCommand(app App, opts *options) *cobra.Command {
+	search := &searchOptions{}
+	command := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Search signed Agent Plugin discovery metadata without downloading packages",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateCommonOptions(opts); err != nil {
+				return err
+			}
+			response, err := searchReviewedDirectory(cmd.Context(), app, strings.TrimSpace(args[0]), *search)
+			if err != nil {
+				return err
+			}
+			if opts.format == "json" {
+				return writeJSONOutput(cmd.OutOrStdout(), "search", response)
+			}
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%d results for %q\n", len(response.Results), response.Query); err != nil {
+				return err
+			}
+			installTarget := "YOUR_AGENT"
+			if strings.TrimSpace(search.client) != "" {
+				installTarget = strings.ToLower(strings.TrimSpace(search.client))
+			}
+			for _, result := range response.Results {
+				source := result.Repository + "@" + result.Revision
+				if result.PackagePath != "" {
+					source += "//" + result.PackagePath
+				}
+				runtime := "not reviewed"
+				if result.RuntimeReviewed {
+					runtime = "reviewed"
+				}
+				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  %s - %s [%s, %s]\n    source: %s\n    schema: Agent Plugins 1.0; runtime: %s\n",
+					result.DisplayName, result.Description, result.TrustState, result.Status, source, runtime); err != nil {
+					return err
+				}
+				if result.Status != "available" {
+					if _, err := fmt.Fprintln(cmd.OutOrStdout(), "    install: unavailable at indexed source"); err != nil {
+						return err
+					}
+					continue
+				}
+				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "    npx universal-agent-plugins install %s --target %s\n", result.InstallSelector, installTarget); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+	flags := command.Flags()
+	flags.StringVar(&search.trust, "trust", "all", "trust state: all, reviewed, or unreviewed")
+	flags.StringVar(&search.component, "component", "", "required component(s), comma-separated")
+	flags.StringVar(&search.client, "client", "", "compatible client")
+	flags.StringVar(&search.auth, "auth", "all", "authentication: all, required, not_required, or unknown")
+	flags.StringVar(&search.owner, "owner", "", "source repository owner")
+	return command
+}
+
+func searchReviewedDirectory(ctx context.Context, app App, query string, options searchOptions) (searchResponse, error) {
+	if query == "" {
+		return searchResponse{}, fmt.Errorf("search query is required")
+	}
+	trust := strings.ToLower(strings.TrimSpace(options.trust))
+	if trust != "all" && trust != "reviewed" && trust != "unreviewed" {
+		return searchResponse{}, fmt.Errorf("--trust must be all, reviewed, or unreviewed")
+	}
+	auth := strings.ToLower(strings.TrimSpace(options.auth))
+	if auth != "all" && auth != string(domain.AuthenticationRequirementRequired) && auth != string(domain.AuthenticationRequirementNotRequired) && auth != string(domain.AuthenticationRequirementUnknown) {
+		return searchResponse{}, fmt.Errorf("--auth must be all, required, not_required, or unknown")
+	}
+	components, err := parseSearchValues(options.component)
+	if err != nil {
+		return searchResponse{}, fmt.Errorf("--component: %w", err)
+	}
+	var selectedClient domain.ClientID
+	if strings.TrimSpace(options.client) != "" {
+		parsed, err := parseTargetOption(options.client)
+		if err != nil || len(parsed) != 1 {
+			return searchResponse{}, fmt.Errorf("--client must name exactly one supported client")
+		}
+		selectedClient = parsed[0]
+	}
+	state, err := app.StateStore.Load()
+	if err != nil {
+		return searchResponse{}, err
+	}
+	response := searchResponse{Query: query, TrustFilter: trust, DiscoveryStatus: "not_requested", Results: []searchResult{}}
+	products := map[string]domain.DirectoryProduct{}
+	if trust != "unreviewed" {
+		if app.DirectoryClient == nil {
+			return searchResponse{}, fmt.Errorf("signed Directory dependencies are unavailable")
+		}
+		bundle, err := app.DirectoryClient.Load(ctx, installedDirectoryFloor(state))
+		if err != nil {
+			return searchResponse{}, fmt.Errorf("load signed Directory: %w", err)
+		}
+		response.SnapshotSequence, response.SnapshotDigest = bundle.Snapshot.Sequence, bundle.Digest
+		products = make(map[string]domain.DirectoryProduct, len(bundle.Snapshot.Products))
+		for _, product := range bundle.Snapshot.Products {
+			products[product.ID] = product
+		}
+		for _, distribution := range bundle.Snapshot.Distributions {
+			product, ok := products[distribution.ProductID]
+			if !ok || !containsDirectoryValue(product.Distributions, distribution.ID) {
+				continue
+			}
+			release, policy := currentSearchRelease(bundle.Snapshot, distribution)
+			if release == nil || policy == nil {
+				continue
+			}
+			result, ok := directorySearchResult(bundle.Snapshot, product, distribution, *release, *policy, query, options.owner, components, selectedClient, auth)
+			if ok {
+				result.matchScore = reviewedSearchRank(result.matchScore)
+				response.Results = append(response.Results, result)
+			}
+		}
+	}
+	if trust != "reviewed" {
+		response.DiscoveryStatus = "unavailable"
+		if app.DiscoveryClient == nil {
+			if trust == "unreviewed" {
+				return searchResponse{}, fmt.Errorf("signed Discovery Index dependencies are unavailable")
+			}
+			_, _ = fmt.Fprintln(app.errorOutput(), "WARNING [discovery_unavailable]: signed unreviewed search is unavailable; reviewed results remain usable")
+		} else {
+			discovery, err := app.DiscoveryClient.Load(ctx, 0)
+			if err != nil {
+				if trust == "unreviewed" {
+					return searchResponse{}, fmt.Errorf("load signed Discovery Index: %w", err)
+				}
+				_, _ = fmt.Fprintf(app.errorOutput(), "WARNING [discovery_unavailable]: %v; reviewed results remain usable\n", err)
+			} else {
+				response.DiscoveryStatus = "available"
+				response.DiscoverySnapshotSequence = discovery.Snapshot.Sequence
+				response.DiscoverySnapshotDigest = discovery.Digest
+				for _, record := range discovery.Search.Records {
+					if result, ok := discoverySearchResult(record, query, options.owner, components, selectedClient, auth); ok {
+						response.Results = append(response.Results, result)
+					}
+				}
+			}
+		}
+	}
+	sort.SliceStable(response.Results, func(i, j int) bool {
+		left, right := response.Results[i], response.Results[j]
+		if left.matchScore != right.matchScore {
+			return left.matchScore < right.matchScore
+		}
+		if left.TrustState != right.TrustState {
+			return left.TrustState == "reviewed"
+		}
+		leftDefault := left.TrustState == "reviewed" && left.DistributionID == products[left.ProductID].DefaultDistribution
+		rightDefault := right.TrustState == "reviewed" && right.DistributionID == products[right.ProductID].DefaultDistribution
+		if leftDefault != rightDefault {
+			return leftDefault
+		}
+		if left.Stars != right.Stars {
+			return left.Stars > right.Stars
+		}
+		if left.Repository != right.Repository {
+			return left.Repository < right.Repository
+		}
+		if left.PackagePath != right.PackagePath {
+			return left.PackagePath < right.PackagePath
+		}
+		return left.InstallSelector < right.InstallSelector
+	})
+	for index := range response.Results {
+		response.Results[index].matchScore = 0
+	}
+	return response, nil
+}
+
+func reviewedSearchRank(score int) int {
+	if score <= 1 {
+		return score
+	}
+	return score + 2
+}
+
+func discoverySearchResult(record discoveryv1.Record, query, owner string, components map[string]struct{}, client domain.ClientID, auth string) (searchResult, bool) {
+	score, matched := discoveryMatchScore(query, record)
+	if !matched || (strings.TrimSpace(owner) != "" && strings.ToLower(strings.TrimSpace(owner)) != record.Owner) {
+		return searchResult{}, false
+	}
+	availableComponents := []string{}
+	if record.Components.Extensions > 0 {
+		availableComponents = append(availableComponents, "extensions")
+	}
+	if record.Components.MCP > 0 {
+		availableComponents = append(availableComponents, "mcp")
+	}
+	if record.Components.Skills > 0 {
+		availableComponents = append(availableComponents, "skills")
+	}
+	if !searchComponentsMatch(components, availableComponents) || (auth != "all" && auth != record.Authentication) {
+		return searchResult{}, false
+	}
+	compatibility := make([]searchCompatibility, 0, len(record.CompatibleClients))
+	for _, compatible := range record.CompatibleClients {
+		clientID := domain.ClientID(compatible)
+		if client != "" && clientID != client {
+			continue
+		}
+		compatibility = append(compatibility, searchCompatibility{Client: clientID, Authentication: domain.AuthenticationRequirement(record.Authentication), Delivery: "portable-package"})
+	}
+	if client != "" && len(compatibility) == 0 {
+		return searchResult{}, false
+	}
+	sort.Slice(compatibility, func(i, j int) bool { return compatibility[i].Client < compatibility[j].Client })
+	version := ""
+	if record.Version != nil {
+		version = *record.Version
+	}
+	return searchResult{
+		TrustState: "unreviewed", InstallSelector: record.Slug, ProductID: record.Name, DisplayName: record.Name,
+		Description: record.Description, ManifestName: record.Name, Status: record.Availability, PackageVersion: version,
+		Repository: record.Repository, Revision: record.Revision, PackagePath: record.PackagePath,
+		SchemaURI: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json", Components: availableComponents,
+		Compatibility: compatibility, RuntimeReviewed: false, Stars: record.Stars, matchScore: score,
+	}, true
+}
+
+func discoveryMatchScore(query string, record discoveryv1.Record) (int, bool) {
+	needle := strings.ToLower(strings.TrimSpace(query))
+	identities := []string{record.Slug, record.Name, record.Repository}
+	if record.PackagePath != "" {
+		identities = append(identities, record.Repository+"//"+record.PackagePath)
+	}
+	for _, identity := range identities {
+		if strings.ToLower(identity) == needle {
+			return 2, true
+		}
+	}
+	for _, identity := range identities {
+		if strings.HasPrefix(strings.ToLower(identity), needle) {
+			return 3, true
+		}
+	}
+	for _, identity := range identities {
+		if strings.Contains(strings.ToLower(identity), needle) {
+			return 4, true
+		}
+	}
+	if strings.Contains(strings.ToLower(record.Description), needle) {
+		return 5, true
+	}
+	return 0, false
+}
+
+func currentSearchRelease(snapshot domain.DirectorySnapshot, distribution domain.DirectoryDistribution) (*domain.DirectoryRelease, *domain.DirectoryReleasePolicy) {
+	policies := make(map[uint64]domain.DirectoryReleasePolicy, len(distribution.ReleasePolicies))
+	for _, policy := range distribution.ReleasePolicies {
+		policies[policy.ReleaseSequence] = policy
+	}
+	releases := append([]domain.DirectoryRelease(nil), distribution.Releases...)
+	sort.SliceStable(releases, func(i, j int) bool { return releases[i].Sequence > releases[j].Sequence })
+	for index := range releases {
+		policy, ok := policies[releases[index].Sequence]
+		if !ok || policy.Status == domain.ReleaseRevoked || releaseSearchRevoked(snapshot, distribution.ID, releases[index].Sequence) {
+			continue
+		}
+		return &releases[index], &policy
+	}
+	return nil, nil
+}
+
+func directorySearchResult(snapshot domain.DirectorySnapshot, product domain.DirectoryProduct, distribution domain.DirectoryDistribution, release domain.DirectoryRelease, policy domain.DirectoryReleasePolicy, query, owner string, components map[string]struct{}, client domain.ClientID, auth string) (searchResult, bool) {
+	score, matched := searchMatchScore(query, product, distribution, release)
+	if !matched || !searchOwnerMatches(owner, distribution, release) || !searchComponentsMatch(components, release.Components) {
+		return searchResult{}, false
+	}
+	compatibility := make([]searchCompatibility, 0, len(policy.Targets))
+	for _, target := range policy.Targets {
+		if client != "" && target.Client != client {
+			continue
+		}
+		if auth != "all" && string(target.Authentication) != auth {
+			continue
+		}
+		compatibility = append(compatibility, searchCompatibility{Client: target.Client, Authentication: target.Authentication, Delivery: target.Delivery})
+	}
+	if (client != "" || auth != "all") && len(compatibility) == 0 {
+		return searchResult{}, false
+	}
+	sort.Slice(compatibility, func(i, j int) bool { return compatibility[i].Client < compatibility[j].Client })
+	selector := distribution.ID
+	if distribution.ID == product.DefaultDistribution && distribution.Status == domain.DistributionActive {
+		selector = product.ID
+	}
+	status := "available"
+	if distribution.Status != domain.DistributionActive || policy.Status != domain.ReleaseActive {
+		status = "unavailable"
+	}
+	return searchResult{
+		TrustState: "reviewed", InstallSelector: selector, ProductID: product.ID, DisplayName: product.DisplayName,
+		Description: product.Description, ManifestName: product.ManifestName, DistributionID: distribution.ID,
+		DistributionKind: distribution.Kind, Status: status, PackageVersion: release.PackageVersion,
+		Repository: release.PackageSource.Repository, Revision: release.PackageSource.Revision, PackagePath: release.PackageSource.Path,
+		SchemaURI: release.AgentPluginsSchema, Components: append([]string(nil), release.Components...), Compatibility: compatibility,
+		RuntimeReviewed: searchHasRuntimeEvidence(snapshot, distribution.ID, release.Sequence, policy, client), matchScore: score,
+	}, true
+}
+
+func searchMatchScore(query string, product domain.DirectoryProduct, distribution domain.DirectoryDistribution, release domain.DirectoryRelease) (int, bool) {
+	needle := strings.ToLower(strings.TrimSpace(query))
+	identities := []string{product.ID, product.ManifestName, distribution.ID, release.ManifestName}
+	identities = append(identities, product.Aliases...)
+	for _, identity := range identities {
+		if strings.ToLower(identity) == needle {
+			return 0, true
+		}
+	}
+	for _, identity := range identities {
+		if strings.HasPrefix(strings.ToLower(identity), needle) {
+			return 1, true
+		}
+	}
+	for _, identity := range identities {
+		if strings.Contains(strings.ToLower(identity), needle) {
+			return 2, true
+		}
+	}
+	if strings.Contains(strings.ToLower(product.DisplayName+" "+product.Description), needle) {
+		return 3, true
+	}
+	return 0, false
+}
+
+func searchOwnerMatches(owner string, distribution domain.DirectoryDistribution, release domain.DirectoryRelease) bool {
+	owner = strings.ToLower(strings.TrimSpace(owner))
+	if owner == "" {
+		return true
+	}
+	for _, value := range []string{distribution.ID, release.PackageSource.Repository} {
+		parts := strings.SplitN(strings.ToLower(value), "/", 2)
+		if len(parts) == 2 && parts[0] == owner {
+			return true
+		}
+	}
+	return false
+}
+
+func searchComponentsMatch(required map[string]struct{}, available []string) bool {
+	if len(required) == 0 {
+		return true
+	}
+	seen := map[string]struct{}{}
+	for _, value := range available {
+		seen[strings.ToLower(strings.TrimSpace(value))] = struct{}{}
+	}
+	for value := range required {
+		if _, ok := seen[value]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func parseSearchValues(value string) (map[string]struct{}, error) {
+	result := map[string]struct{}{}
+	if strings.TrimSpace(value) == "" {
+		return result, nil
+	}
+	for _, item := range strings.Split(value, ",") {
+		item = strings.ToLower(strings.TrimSpace(item))
+		if item == "" {
+			return nil, fmt.Errorf("empty value")
+		}
+		result[item] = struct{}{}
+	}
+	return result, nil
+}
+
+func releaseSearchRevoked(snapshot domain.DirectorySnapshot, distribution string, sequence uint64) bool {
+	for _, revocation := range snapshot.Revocations {
+		if revocation.DistributionID == distribution && revocation.ReleaseSequence == sequence {
+			return true
+		}
+	}
+	return false
+}
+
+func searchHasRuntimeEvidence(snapshot domain.DirectorySnapshot, distribution string, sequence uint64, policy domain.DirectoryReleasePolicy, client domain.ClientID) bool {
+	current := make(map[string]struct{}, len(policy.CurrentEvidence))
+	for _, id := range policy.CurrentEvidence {
+		current[id] = struct{}{}
+	}
+	for _, evidence := range snapshot.Evidence {
+		_, active := current[evidence.ID]
+		if active && evidence.DistributionID == distribution && evidence.ReleaseSequence == sequence &&
+			(client == "" || evidence.Client == client) &&
+			evidence.Level == "runtime" && evidence.Outcome == "passed" && evidence.HasTrustedEligibilityProvenance() {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/search_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/search_test.go
@@ -1,0 +1,214 @@
+package agentpluginscli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/discoveryv1"
+)
+
+type fixedDiscoveryClient struct {
+	bundle discoveryv1.VerifiedBundle
+	err    error
+	calls  int
+}
+
+func (client *fixedDiscoveryClient) Load(context.Context, uint64) (discoveryv1.VerifiedBundle, error) {
+	client.calls++
+	return client.bundle, client.err
+}
+
+func discoverySearchBundle() discoveryv1.VerifiedBundle {
+	version := "1.0.0"
+	record := discoveryv1.Record{
+		Slug: "discovery:upstream/demo//plugin", Name: "demo", Description: "unreviewed demo", Owner: "upstream",
+		Repository: "upstream/demo", PackagePath: "plugin", Revision: strings.Repeat("a", 40), Version: &version,
+		SchemaVersion: "1.0.0", Components: discoveryv1.Components{MCP: 1}, MCPTransports: []string{"streamable-http"},
+		CompatibleClients: []string{"codex", "cursor"}, Authentication: "unknown", Status: "conformant_unreviewed",
+		TreeDigest: "sha256:" + strings.Repeat("1", 64), ManifestDigest: "sha256:" + strings.Repeat("2", 64),
+		RepositoryUpdatedAt: "2026-08-27T00:00:00Z", Availability: "available",
+	}
+	return discoveryv1.VerifiedBundle{
+		Snapshot: discoveryv1.Snapshot{Sequence: 7}, Search: discoveryv1.Search{Sequence: 7, Records: []discoveryv1.Record{record}},
+		Digest: "sha256:" + strings.Repeat("3", 64),
+	}
+}
+
+func TestSearchReviewedDirectoryIsDeterministicReadOnlyAndFiltered(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, nil)
+	fixture.app.DirectoryClient = &fixedDirectoryClient{bundle: readModelBundle()}
+	fixture.app.DiscoveryClient = &fixedDiscoveryClient{bundle: discoveryv1.VerifiedBundle{Snapshot: discoveryv1.Snapshot{Sequence: 1}, Search: discoveryv1.Search{Records: []discoveryv1.Record{}}, Digest: "sha256:" + strings.Repeat("3", 64)}}
+
+	stdout, _, err := fixture.execute(false, "search", "demo", "--client", "cursor", "--owner", "owner", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertVersionedJSON(t, stdout, "search")
+	var envelope struct {
+		Data searchResponse `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if len(envelope.Data.Results) == 0 || envelope.Data.Results[0].TrustState != "reviewed" || envelope.Data.Results[0].InstallSelector != "demo" {
+		t.Fatalf("search results = %+v", envelope.Data.Results)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Installations) != 0 {
+		t.Fatalf("search mutated state: %+v", state)
+	}
+
+	repeat, _, err := fixture.execute(false, "search", "demo", "--client", "cursor", "--owner", "owner", "--format", "json")
+	if err != nil || stdout != repeat {
+		t.Fatalf("search is not deterministic: err=%v\nfirst=%s\nsecond=%s", err, stdout, repeat)
+	}
+	empty, _, err := fixture.execute(false, "search", "demo", "--trust", "unreviewed", "--format", "json")
+	if err != nil || !strings.Contains(empty, `"results":[]`) {
+		t.Fatalf("unreviewed filter = %q err=%v", empty, err)
+	}
+}
+
+func TestSearchMergesReviewedAndSignedUnreviewedWithTrustRanking(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, nil)
+	fixture.app.DirectoryClient = &fixedDirectoryClient{bundle: readModelBundle()}
+	fixture.app.DiscoveryClient = &fixedDiscoveryClient{bundle: discoverySearchBundle()}
+	stdout, _, err := fixture.execute(false, "search", "demo", "--client", "cursor", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var envelope struct {
+		Data searchResponse `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if envelope.Data.DiscoveryStatus != "available" || envelope.Data.DiscoverySnapshotSequence != 7 || len(envelope.Data.Results) < 2 {
+		t.Fatalf("search response = %+v", envelope.Data)
+	}
+	unreviewedIndex := -1
+	for index, result := range envelope.Data.Results {
+		if result.TrustState == "unreviewed" {
+			unreviewedIndex = index
+			break
+		}
+	}
+	if unreviewedIndex < 1 || envelope.Data.Results[0].TrustState != "reviewed" ||
+		envelope.Data.Results[unreviewedIndex].InstallSelector != "discovery:upstream/demo//plugin" {
+		t.Fatalf("ranked results = %+v", envelope.Data.Results)
+	}
+	unreviewed, _, err := fixture.execute(false, "search", "demo", "--trust", "unreviewed", "--owner", "upstream", "--component", "mcp", "--auth", "unknown", "--format", "json")
+	if err != nil || !strings.Contains(unreviewed, `"trust_state":"unreviewed"`) || strings.Contains(unreviewed, `"trust_state":"reviewed"`) {
+		t.Fatalf("unreviewed search = %q err=%v", unreviewed, err)
+	}
+}
+
+func TestHumanSearchShowsExactProvenanceTrustAndRunnableInstallCommand(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, nil)
+	fixture.app.DirectoryClient = &fixedDirectoryClient{bundle: readModelBundle()}
+	fixture.app.DiscoveryClient = &fixedDiscoveryClient{bundle: discoverySearchBundle()}
+	stdout, _, err := fixture.execute(false, "search", "upstream/demo", "--trust", "unreviewed", "--client", "cursor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"[unreviewed, available]",
+		"source: upstream/demo@" + strings.Repeat("a", 40) + "//plugin",
+		"schema: Agent Plugins 1.0; runtime: not reviewed",
+		"npx universal-agent-plugins install discovery:upstream/demo//plugin --target cursor",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("human search omitted %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestHumanSearchUsesShellSafeTargetPlaceholderWithoutClient(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, nil)
+	fixture.app.DirectoryClient = &fixedDirectoryClient{bundle: readModelBundle()}
+	fixture.app.DiscoveryClient = &fixedDiscoveryClient{bundle: discoverySearchBundle()}
+	stdout, _, err := fixture.execute(false, "search", "upstream/demo", "--trust", "unreviewed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "npx universal-agent-plugins install discovery:upstream/demo//plugin --target YOUR_AGENT"
+	if !strings.Contains(stdout, want) || strings.Contains(stdout, "--target <agent>") {
+		t.Fatalf("human search target placeholder is not shell-safe:\n%s", stdout)
+	}
+}
+
+func TestHumanSearchDoesNotOfferInstallForUnavailablePackage(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, nil)
+	fixture.app.DirectoryClient = &fixedDirectoryClient{bundle: readModelBundle()}
+	bundle := discoverySearchBundle()
+	bundle.Search.Records[0].Availability = "unavailable"
+	fixture.app.DiscoveryClient = &fixedDiscoveryClient{bundle: bundle}
+	stdout, _, err := fixture.execute(false, "search", "upstream/demo", "--trust", "unreviewed", "--client", "cursor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "install: unavailable at indexed source") || strings.Contains(stdout, "npx universal-agent-plugins install") {
+		t.Fatalf("human search offered installation for an unavailable package:\n%s", stdout)
+	}
+}
+
+func TestSearchKeepsReviewedResultsWhenDiscoveryIsUnavailable(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, nil)
+	fixture.app.DirectoryClient = &fixedDirectoryClient{bundle: readModelBundle()}
+	fixture.app.DiscoveryClient = &fixedDiscoveryClient{err: errors.New("offline")}
+	stdout, stderr, err := fixture.execute(false, "search", "demo", "--format", "json")
+	if err != nil || !strings.Contains(stdout, `"discovery_status":"unavailable"`) || !strings.Contains(stdout, `"trust_state":"reviewed"`) ||
+		!strings.Contains(stderr, "discovery_unavailable") {
+		t.Fatalf("graceful search = stdout:%q stderr:%q err:%v", stdout, stderr, err)
+	}
+}
+
+func TestSearchUsesStarsOnlyAfterTrustAndTextRelevance(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, nil)
+	fixture.app.DirectoryClient = &fixedDirectoryClient{bundle: readModelBundle()}
+	bundle := discoverySearchBundle()
+	popular := bundle.Search.Records[0]
+	popular.Slug = "discovery:zeta/popular//plugin"
+	popular.Repository = "zeta/popular"
+	popular.Owner = "zeta"
+	popular.Stars = 100
+	quiet := popular
+	quiet.Slug = "discovery:alpha/quiet//plugin"
+	quiet.Repository = "alpha/quiet"
+	quiet.Owner = "alpha"
+	quiet.Stars = 1
+	bundle.Search.Records = []discoveryv1.Record{quiet, popular}
+	fixture.app.DiscoveryClient = &fixedDiscoveryClient{bundle: bundle}
+
+	stdout, _, err := fixture.execute(false, "search", "demo", "--trust", "unreviewed", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Index(stdout, popular.Slug) > strings.Index(stdout, quiet.Slug) || !strings.Contains(stdout, `"stars":100`) {
+		t.Fatalf("stars were not the final deterministic tie-breaker:\n%s", stdout)
+	}
+}
+
+func TestSearchRuntimeReviewIsScopedToSelectedClient(t *testing.T) {
+	t.Parallel()
+	bundle := readModelBundle()
+	distribution := bundle.Snapshot.Distributions[0]
+	policy := distribution.ReleasePolicies[1]
+	if !searchHasRuntimeEvidence(bundle.Snapshot, distribution.ID, 2, policy, "") ||
+		!searchHasRuntimeEvidence(bundle.Snapshot, distribution.ID, 2, policy, "cursor") ||
+		searchHasRuntimeEvidence(bundle.Snapshot, distribution.ID, 2, policy, "kiro") {
+		t.Fatal("runtime review leaked across client identities")
+	}
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/source.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/source.go
@@ -276,13 +276,13 @@ func (app App) acquireDiscovery(ctx context.Context, selector string, request pa
 	}
 	if len(matches) != 1 {
 		if len(matches) == 0 {
-			return loadedPackage{}, fmt.Errorf("Discovery package %q was not found", selector)
+			return loadedPackage{}, fmt.Errorf("discovery package %q was not found", selector)
 		}
-		return loadedPackage{}, fmt.Errorf("Discovery package %q is ambiguous", selector)
+		return loadedPackage{}, fmt.Errorf("discovery package %q is ambiguous", selector)
 	}
 	record := matches[0]
 	if record.Availability != "available" {
-		return loadedPackage{}, fmt.Errorf("Discovery package %q is unavailable and cannot be newly acquired", selector)
+		return loadedPackage{}, fmt.Errorf("discovery package %q is unavailable and cannot be newly acquired", selector)
 	}
 	for _, target := range request.Targets {
 		compatible := false
@@ -293,11 +293,11 @@ func (app App) acquireDiscovery(ctx context.Context, selector string, request pa
 			}
 		}
 		if !compatible {
-			return loadedPackage{}, fmt.Errorf("Discovery package %q does not declare portable components for %s", selector, target)
+			return loadedPackage{}, fmt.Errorf("discovery package %q does not declare portable components for %s", selector, target)
 		}
 	}
 	if request.DirectBinding != nil && (request.DirectBinding.Repository != record.Repository || request.DirectBinding.PackageSubpath != record.PackagePath) {
-		return loadedPackage{}, fmt.Errorf("Discovery selector %q changed repository or package path; use agentplugins switch explicitly", selector)
+		return loadedPackage{}, fmt.Errorf("discovery selector %q changed repository or package path; use agentplugins switch explicitly", selector)
 	}
 	loaded, err := app.acquireGitHub(ctx, selector, record.Repository, record.Revision, record.PackagePath, record.TreeDigest)
 	if err != nil {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/source.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/source.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/catalog"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/directoryv1"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/discoveryv1"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/packagedigest"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 	clientplanner "github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/planner"
@@ -20,7 +21,7 @@ import (
 
 var (
 	shortNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]{0,63}$`)
-	exactGitPattern  = regexp.MustCompile(`^(?:github:)?([A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9][A-Za-z0-9._-]*)@([0-9a-f]{40})//(.+)$`)
+	exactGitPattern  = regexp.MustCompile(`^(?:github:)?([A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9][A-Za-z0-9._-]*)@([0-9a-f]{40})(?://(.+))?$`)
 )
 
 type loadedPackage struct {
@@ -42,6 +43,7 @@ type packageResolutionRequest struct {
 	RetainRecorded    bool
 	Selector          string
 	RequestedSelector string
+	DirectBinding     *domain.SourceBinding
 }
 
 func (app App) addResolutionRequest(selector string, targets []domain.ClientID) packageResolutionRequest {
@@ -50,7 +52,8 @@ func (app App) addResolutionRequest(selector string, targets []domain.ClientID) 
 
 func (app App) loadInstalledPackage(ctx context.Context, installation domain.Installation, targets []domain.ClientID, operation domain.DirectoryOperation, releaseSequence uint64, resolvedRevision string, clients map[domain.ClientID]domain.DetectedClient) (loadedPackage, error) {
 	if installation.OriginMode != domain.OriginModeDirectory || installation.Directory == nil {
-		return app.loadPackageFor(ctx, updateSource(installation), packageResolutionRequest{Targets: targets, Operation: operation, Clients: clients})
+		binding := installation.Source
+		return app.loadPackageFor(ctx, updateSource(installation), packageResolutionRequest{Targets: targets, Operation: operation, Clients: clients, DirectBinding: &binding})
 	}
 	sequence := releaseSequence
 	if sequence == 0 {
@@ -248,10 +251,70 @@ func (app App) loadPackageFor(ctx context.Context, raw string, request packageRe
 	if match := exactGitPattern.FindStringSubmatch(requested); match != nil {
 		return app.acquireGitHub(ctx, requested, match[1], match[2], match[3], "")
 	}
+	if strings.HasPrefix(requested, "discovery:") {
+		return app.acquireDiscovery(ctx, requested, request)
+	}
 	if !isDirectorySelector(requested) {
-		return loadedPackage{}, fmt.Errorf("source must be a local path, an exact owner/repo@FULL_SHA//path source, or a Directory selector")
+		return loadedPackage{}, fmt.Errorf("source must be a local path, an exact owner/repo@FULL_SHA[//path] source, a discovery: slug, or a Directory selector")
 	}
 	return app.acquireDirectory(ctx, requested, request)
+}
+
+func (app App) acquireDiscovery(ctx context.Context, selector string, request packageResolutionRequest) (loadedPackage, error) {
+	if app.DiscoveryClient == nil || app.SourceAcquirer == nil {
+		return loadedPackage{}, fmt.Errorf("signed Discovery Index dependencies are unavailable; use owner/repository@FULL_SHA[//path]")
+	}
+	bundle, err := app.DiscoveryClient.Load(ctx, 0)
+	if err != nil {
+		return loadedPackage{}, fmt.Errorf("load signed Discovery Index: %w", err)
+	}
+	var matches []discoveryv1.Record
+	for _, record := range bundle.Search.Records {
+		if record.Slug == selector {
+			matches = append(matches, record)
+		}
+	}
+	if len(matches) != 1 {
+		if len(matches) == 0 {
+			return loadedPackage{}, fmt.Errorf("Discovery package %q was not found", selector)
+		}
+		return loadedPackage{}, fmt.Errorf("Discovery package %q is ambiguous", selector)
+	}
+	record := matches[0]
+	if record.Availability != "available" {
+		return loadedPackage{}, fmt.Errorf("Discovery package %q is unavailable and cannot be newly acquired", selector)
+	}
+	for _, target := range request.Targets {
+		compatible := false
+		for _, client := range record.CompatibleClients {
+			if string(target) == client {
+				compatible = true
+				break
+			}
+		}
+		if !compatible {
+			return loadedPackage{}, fmt.Errorf("Discovery package %q does not declare portable components for %s", selector, target)
+		}
+	}
+	if request.DirectBinding != nil && (request.DirectBinding.Repository != record.Repository || request.DirectBinding.PackageSubpath != record.PackagePath) {
+		return loadedPackage{}, fmt.Errorf("Discovery selector %q changed repository or package path; use agentplugins switch explicitly", selector)
+	}
+	loaded, err := app.acquireGitHub(ctx, selector, record.Repository, record.Revision, record.PackagePath, record.TreeDigest)
+	if err != nil {
+		return loadedPackage{}, err
+	}
+	if loaded.envelope.ManifestDigest != record.ManifestDigest || loaded.envelope.Manifest.Name != record.Name {
+		_ = loaded.cleanup()
+		return loadedPackage{}, fmt.Errorf("signed Discovery metadata does not match acquired package manifest")
+	}
+	// Discovery is the stable update channel; the exact commit and digests remain
+	// separately bound in ResolvedRevision, TreeDigest, and ManifestDigest. If the
+	// SHA URL became the canonical source, every legitimate index advance would
+	// look like an unauthorized publisher/source switch.
+	loaded.envelope.Source.CanonicalSource = record.Slug
+	loaded.envelope.Source.SourceBindingHint = "discovery-v1"
+	_, _ = fmt.Fprintf(app.errorOutput(), "WARNING [conformant_unreviewed]: %s passed static Agent Plugins 1.0 checks but has no runtime review\n", selector)
+	return loaded, nil
 }
 
 func (app App) acquireLocal(ctx context.Context, requested string) (loadedPackage, error) {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/source_directory_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/source_directory_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/directoryv1"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/discoveryv1"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/sourceacquisition"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 )
@@ -839,6 +840,130 @@ func TestDirectLocalAndFullSHASourcesBypassDirectory(t *testing.T) {
 	}
 }
 
+func TestSignedDiscoverySelectorAcquiresExactDigestAsUnreviewedDirectSource(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	plugin := writeCLIPlugin(t)
+	local, err := fixture.app.acquireLocal(context.Background(), plugin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	treeDigest, manifestDigest := local.envelope.TreeDigest, local.envelope.ManifestDigest
+	if err := local.cleanup(); err != nil {
+		t.Fatal(err)
+	}
+	selector := "discovery:owner/demo//plugin"
+	revision := strings.Repeat("a", 40)
+	record := discoveryv1.Record{
+		Slug: selector, Name: "demo", Repository: "owner/demo", PackagePath: "plugin", Revision: revision,
+		TreeDigest: treeDigest, ManifestDigest: manifestDigest, Availability: "available", CompatibleClients: []string{"cursor"},
+	}
+	discovery := &fixedDiscoveryClient{bundle: discoveryv1.VerifiedBundle{
+		Snapshot: discoveryv1.Snapshot{Sequence: 9}, Search: discoveryv1.Search{Records: []discoveryv1.Record{record}},
+		Digest: "sha256:" + strings.Repeat("9", 64),
+	}}
+	acquirer := &localBackedSourceAcquirer{delegate: fixture.app.SourceAcquirer, root: plugin}
+	fixture.app.DiscoveryClient, fixture.app.SourceAcquirer = discovery, acquirer
+	_, stderr, err := fixture.execute(false, "install", selector, "--target", "cursor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if discovery.calls != 1 || acquirer.verifiedCalls != 1 || acquirer.directGitCalls != 0 || len(state.Installations) != 1 {
+		t.Fatalf("Discovery boundary calls/state = discovery:%d verified:%d direct:%d state:%+v", discovery.calls, acquirer.verifiedCalls, acquirer.directGitCalls, state)
+	}
+	installation := state.Installations[0]
+	if installation.OriginMode != domain.OriginModeDirect || installation.Directory != nil || installation.Source.RequestedSource != selector ||
+		installation.Source.CanonicalSource != selector || installation.Source.Repository != "owner/demo" || installation.Source.ResolvedRevision != revision ||
+		installation.Source.SourceBindingID != domain.ComputeSourceBindingID(domain.SourceIdentity{RequestedSource: selector, CanonicalSource: selector, Repository: "owner/demo", PackageSubpath: "plugin"}) ||
+		!strings.Contains(stderr, "conformant_unreviewed") {
+		t.Fatalf("Discovery install provenance = installation:%+v stderr:%q", installation, stderr)
+	}
+}
+
+func TestSignedDiscoverySelectorUpdatesSameRepositoryPathWithoutSourceSwitch(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	firstRoot := writeCLIPlugin(t)
+	secondRoot := writeCLIPlugin(t)
+	manifestPath := filepath.Join(secondRoot, "plugin.json")
+	body, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(manifestPath, []byte(strings.Replace(string(body), `"version": "1.0.0"`, `"version": "2.0.0"`, 1)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	identity := func(root string) (string, string) {
+		t.Helper()
+		loaded, loadErr := fixture.app.acquireLocal(context.Background(), root)
+		if loadErr != nil {
+			t.Fatal(loadErr)
+		}
+		defer loaded.cleanup()
+		return loaded.envelope.TreeDigest, loaded.envelope.ManifestDigest
+	}
+	firstTree, firstManifest := identity(firstRoot)
+	secondTree, secondManifest := identity(secondRoot)
+	selector := "discovery:owner/demo//plugin"
+	firstRevision, secondRevision := strings.Repeat("a", 40), strings.Repeat("b", 40)
+	version := "1.0.0"
+	record := discoveryv1.Record{Slug: selector, Name: "demo", Version: &version, Repository: "owner/demo", PackagePath: "plugin",
+		Revision: firstRevision, TreeDigest: firstTree, ManifestDigest: firstManifest, Availability: "available", CompatibleClients: []string{"cursor"}}
+	discovery := &fixedDiscoveryClient{bundle: discoveryv1.VerifiedBundle{Snapshot: discoveryv1.Snapshot{Sequence: 1}, Search: discoveryv1.Search{Records: []discoveryv1.Record{record}}}}
+	fixture.app.DiscoveryClient = discovery
+	fixture.app.SourceAcquirer = &localBackedSourceAcquirer{delegate: fixture.app.SourceAcquirer, root: firstRoot,
+		revisionRoots: map[string]string{firstRevision: firstRoot, secondRevision: secondRoot}}
+
+	if _, _, err := fixture.execute(false, "install", selector, "--target", "cursor"); err != nil {
+		t.Fatal(err)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	initialBindingID := state.Installations[0].Source.SourceBindingID
+
+	version = "2.0.0"
+	record.Version, record.Revision, record.TreeDigest, record.ManifestDigest = &version, secondRevision, secondTree, secondManifest
+	discovery.bundle.Snapshot.Sequence = 2
+	discovery.bundle.Search.Records = []discoveryv1.Record{record}
+	if _, _, err := fixture.execute(false, "update", "demo", "--target", "cursor"); err != nil {
+		t.Fatal(err)
+	}
+	state, err = fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated := state.Installations[0]
+	if updated.Source.SourceBindingID != initialBindingID || updated.Source.CanonicalSource != selector ||
+		updated.Source.ResolvedRevision != secondRevision || updated.Source.TreeDigest != secondTree ||
+		updated.Package.Version != version || updated.Package.ManifestDigest != secondManifest {
+		t.Fatalf("Discovery update lost channel or immutable identity: %+v", updated)
+	}
+}
+
+func TestDiscoveryUpdateRejectsRepositoryOrPathRebindingBeforeAcquisition(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, nil)
+	selector := "discovery:owner/demo//plugin"
+	fixture.app.DiscoveryClient = &fixedDiscoveryClient{bundle: discoveryv1.VerifiedBundle{
+		Search: discoveryv1.Search{Records: []discoveryv1.Record{{
+			Slug: selector, Name: "demo", Repository: "attacker/demo", PackagePath: "plugin", Revision: strings.Repeat("b", 40),
+			TreeDigest: "sha256:" + strings.Repeat("1", 64), ManifestDigest: "sha256:" + strings.Repeat("2", 64), Availability: "available",
+		}}},
+	}}
+	counter := &countingSourceAcquirer{delegate: fixture.app.SourceAcquirer}
+	fixture.app.SourceAcquirer = counter
+	_, err := fixture.app.acquireDiscovery(context.Background(), selector, packageResolutionRequest{DirectBinding: &domain.SourceBinding{Repository: "owner/demo", PackageSubpath: "plugin"}})
+	if err == nil || !strings.Contains(err.Error(), "use agentplugins switch explicitly") || counter.calls != 0 {
+		t.Fatalf("Discovery rebind error=%v acquisitions=%d", err, counter.calls)
+	}
+}
+
 func TestProductionGitHubAcquirerOutputResolvesAsDirectExactSource(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git is unavailable")
@@ -929,6 +1054,24 @@ func TestExplicitLocalPathRecognizesOnlyPortableExplicitAndAbsoluteWindowsForms(
 	for _, value := range []string{"plugin", "existing-plugin", `C:plugin`, `owner\\plugin`, `\\server`} {
 		if explicitLocalPath(value) {
 			t.Errorf("explicitLocalPath(%q) = true", value)
+		}
+	}
+}
+
+func TestExactGitSourceAcceptsRootAndSubpathPackages(t *testing.T) {
+	revision := strings.Repeat("a", 40)
+	for source, path := range map[string]string{
+		"owner/repo@" + revision:              "",
+		"owner/repo@" + revision + "//plugin": "plugin",
+	} {
+		match := exactGitPattern.FindStringSubmatch(source)
+		if match == nil || match[1] != "owner/repo" || match[2] != revision || match[3] != path {
+			t.Fatalf("exact source %q match = %v", source, match)
+		}
+	}
+	for _, source := range []string{"owner/repo@" + revision + "//", "owner/repo@main", "owner/repo"} {
+		if exactGitPattern.MatchString(source) {
+			t.Fatalf("invalid exact source accepted: %q", source)
 		}
 	}
 }

--- a/cli/plugin-kit-ai/internal/agentpluginscli/update_all.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/update_all.go
@@ -1,0 +1,205 @@
+package agentpluginscli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/directoryv1"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/spf13/cobra"
+)
+
+type updateAllInstallation struct {
+	InstallationID string             `json:"installation_id"`
+	Name           string             `json:"name"`
+	Status         string             `json:"status"`
+	Reason         string             `json:"reason,omitempty"`
+	Plan           *updateMultiResult `json:"plan,omitempty"`
+}
+
+type updateAllResult struct {
+	Batch         bool                    `json:"batch"`
+	Status        string                  `json:"status"`
+	DryRun        bool                    `json:"dry_run"`
+	Planned       int                     `json:"planned"`
+	Updated       int                     `json:"updated"`
+	Skipped       int                     `json:"skipped"`
+	Failed        int                     `json:"failed"`
+	Installations []updateAllInstallation `json:"installations"`
+}
+
+type preparedUpdateAllItem struct {
+	installation domain.Installation
+	prepared     *preparedUpdateMany
+	resultIndex  int
+}
+
+func runUpdateAll(ctx context.Context, cmd *cobra.Command, app App, opts *options) error {
+	state, err := app.StateStore.Load()
+	if err != nil {
+		return err
+	}
+	installations := append([]domain.Installation(nil), state.Installations...)
+	sort.Slice(installations, func(i, j int) bool {
+		left, right := strings.ToLower(installations[i].DeclaredName), strings.ToLower(installations[j].DeclaredName)
+		if left != right {
+			return left < right
+		}
+		return installations[i].InstallationID < installations[j].InstallationID
+	})
+	result := updateAllResult{Batch: true, Status: "planned", DryRun: opts.dryRun,
+		Installations: make([]updateAllInstallation, 0, len(installations))}
+	if len(installations) == 0 {
+		result.Status = "no_installations"
+		return renderUpdateAll(cmd, opts, result)
+	}
+
+	bundle, bundleOK, detected, detectionErr, err := updateAllDirectoryContext(ctx, app, state, installations)
+	if err != nil {
+		return err
+	}
+	preparedItems := make([]preparedUpdateAllItem, 0, len(installations))
+	defer func() {
+		for index := range preparedItems {
+			preparedItems[index].prepared.cleanup()
+		}
+	}()
+
+	preflightFailed := false
+	for _, installation := range installations {
+		item := updateAllInstallation{InstallationID: installation.InstallationID, Name: installation.DeclaredName}
+		if installation.OriginMode == domain.OriginModeDirectory && installation.Directory != nil {
+			status := inspectOutdatedInstallation(bundle, bundleOK, detected, detectionErr, app.Version, installation, opts.scope)
+			switch status.Status {
+			case "current":
+				item.Status, item.Reason = "skipped", status.Reason
+				result.Skipped++
+				result.Installations = append(result.Installations, item)
+				continue
+			case "blocked", "unknown":
+				item.Status, item.Reason = "preflight_failed", status.Reason
+				result.Failed++
+				preflightFailed = true
+				result.Installations = append(result.Installations, item)
+				continue
+			}
+		}
+		targets := installationTargets(installation, opts.scope)
+		prepared, prepareErr := prepareUpdateMany(ctx, app, opts, installation, targets, !opts.dryRun)
+		if prepareErr != nil {
+			item.Status, item.Reason = "preflight_failed", prepareErr.Error()
+			if prepared != nil {
+				plan := prepared.result
+				item.Plan = &plan
+				prepared.cleanup()
+			}
+			result.Failed++
+			preflightFailed = true
+			result.Installations = append(result.Installations, item)
+			continue
+		}
+		if prepared.noChange {
+			item.Status, item.Reason = "skipped", "installed package and every selected target are current"
+			plan := prepared.result
+			item.Plan = &plan
+			prepared.cleanup()
+			result.Skipped++
+			result.Installations = append(result.Installations, item)
+			continue
+		}
+		item.Status = "planned"
+		plan := prepared.result
+		item.Plan = &plan
+		resultIndex := len(result.Installations)
+		result.Installations = append(result.Installations, item)
+		preparedItems = append(preparedItems, preparedUpdateAllItem{installation: installation, prepared: prepared, resultIndex: resultIndex})
+		result.Planned++
+	}
+	if preflightFailed {
+		result.Status = "preflight_failed"
+		_ = renderUpdateAll(cmd, opts, result)
+		return fmt.Errorf("update --all preflight failed; no installation was changed")
+	}
+	if opts.dryRun {
+		return renderUpdateAll(cmd, opts, result)
+	}
+	result.Status = "completed"
+	for index := range preparedItems {
+		item := &preparedItems[index]
+		applied, applyErr := applyPreparedUpdate(ctx, item.prepared)
+		view := &result.Installations[item.resultIndex]
+		view.Plan = &applied
+		if applyErr != nil {
+			view.Status, view.Reason = "apply_failed", applyErr.Error()
+			result.Failed++
+			result.Status = "partial_failure"
+			_ = renderUpdateAll(cmd, opts, result)
+			return applyErr
+		}
+		view.Status = "updated"
+		result.Updated++
+	}
+	return renderUpdateAll(cmd, opts, result)
+}
+
+func updateAllDirectoryContext(ctx context.Context, app App, state domain.StateFileV2, installations []domain.Installation) (directoryv1.VerifiedBundle, bool, map[domain.ClientID]domain.DetectedClient, error, error) {
+	needsDirectory := false
+	for _, installation := range installations {
+		if installation.OriginMode == domain.OriginModeDirectory && installation.Directory != nil {
+			needsDirectory = true
+			break
+		}
+	}
+	if !needsDirectory {
+		return directoryv1.VerifiedBundle{}, false, nil, nil, nil
+	}
+	bundle, ok, err := directoryBundleForRead(ctx, app, state, true)
+	if err != nil {
+		return directoryv1.VerifiedBundle{}, false, nil, nil, fmt.Errorf("load signed Directory: %w", err)
+	}
+	if !ok {
+		return directoryv1.VerifiedBundle{}, false, nil, nil, nil
+	}
+	clients, err := detectClientsForLifecycleResolution(ctx, app.Detector, false)
+	if err != nil {
+		return bundle, true, nil, fmt.Errorf("detect AI clients: %w", err), nil
+	}
+	detected := make(map[domain.ClientID]domain.DetectedClient, len(clients))
+	for _, client := range clients {
+		detected[client.ClientID] = client
+	}
+	return bundle, true, detected, nil, nil
+}
+
+func renderUpdateAll(cmd *cobra.Command, opts *options, result updateAllResult) error {
+	if opts.format == "json" {
+		overall := "success"
+		if result.Failed > 0 {
+			overall = "failure"
+		}
+		return writeJSONResult(cmd.OutOrStdout(), "update", overall, result)
+	}
+	return renderUpdateAllHuman(cmd.OutOrStdout(), result)
+}
+
+func renderUpdateAllHuman(writer io.Writer, result updateAllResult) error {
+	for _, installation := range result.Installations {
+		if _, err := fmt.Fprintf(writer, "%s: %s", installation.Name, installation.Status); err != nil {
+			return err
+		}
+		if installation.Reason != "" {
+			if _, err := fmt.Fprintf(writer, " - %s", installation.Reason); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintln(writer); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprintf(writer, "Update all: %s (planned=%d updated=%d skipped=%d failed=%d)\n",
+		result.Status, result.Planned, result.Updated, result.Skipped, result.Failed)
+	return err
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/update_all.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/update_all.go
@@ -136,6 +136,7 @@ func runUpdateAll(ctx context.Context, cmd *cobra.Command, app App, opts *option
 			view.Status, view.Reason = "apply_failed", applyErr.Error()
 			result.Failed++
 			result.Status = "partial_failure"
+			markUnattemptedUpdateAll(&result, preparedItems, index+1)
 			_ = renderUpdateAll(cmd, opts, result)
 			return applyErr
 		}
@@ -143,6 +144,14 @@ func runUpdateAll(ctx context.Context, cmd *cobra.Command, app App, opts *option
 		result.Updated++
 	}
 	return renderUpdateAll(cmd, opts, result)
+}
+
+func markUnattemptedUpdateAll(result *updateAllResult, prepared []preparedUpdateAllItem, start int) {
+	for index := start; index < len(prepared); index++ {
+		view := &result.Installations[prepared[index].resultIndex]
+		view.Status = "not_attempted"
+		view.Reason = "batch stopped after an earlier apply failure"
+	}
 }
 
 func updateAllDirectoryContext(ctx context.Context, app App, state domain.StateFileV2, installations []domain.Installation) (directoryv1.VerifiedBundle, bool, map[domain.ClientID]domain.DetectedClient, error, error) {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/update_all_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/update_all_test.go
@@ -1,0 +1,124 @@
+package agentpluginscli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+func TestUpdateAllAppliesOnlyAfterCompletePreflight(t *testing.T) {
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	alpha := writeNamedCLIPlugin(t, "alpha", "1.0.0")
+	if _, _, err := fixture.execute(false, "add", alpha, "--target", "cursor"); err != nil {
+		t.Fatal(err)
+	}
+	writeNamedCLIPluginVersion(t, alpha, "alpha", "2.0.0")
+
+	stdout, _, err := fixture.execute(false, "update", "--all", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"batch":true`, `"status":"completed"`, `"planned":1`, `"updated":1`, `"name":"alpha"`, `"status":"updated"`} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("update --all omitted %q:\n%s", want, stdout)
+		}
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Installations) != 1 || state.Installations[0].Package.Version != "2.0.0" {
+		t.Fatalf("update --all did not apply prepared package: %+v", state.Installations)
+	}
+}
+
+func TestUpdateAllPreflightFailureProducesZeroMutation(t *testing.T) {
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	alpha := writeNamedCLIPlugin(t, "alpha", "1.0.0")
+	beta := writeNamedCLIPlugin(t, "beta", "1.0.0")
+	if _, _, err := fixture.execute(false, "add", alpha, "--target", "cursor"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := fixture.execute(false, "add", beta, "--target", "cursor"); err != nil {
+		t.Fatal(err)
+	}
+	writeNamedCLIPluginVersion(t, alpha, "alpha", "2.0.0")
+	if err := os.RemoveAll(beta); err != nil {
+		t.Fatal(err)
+	}
+	before, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, _, err := fixture.execute(false, "update", "--all", "--format", "json")
+	if err == nil || !strings.Contains(err.Error(), "preflight failed; no installation was changed") {
+		t.Fatalf("update --all error = %v, output=%s", err, stdout)
+	}
+	for _, want := range []string{`"status":"preflight_failed"`, `"planned":1`, `"updated":0`, `"failed":1`, `"name":"alpha"`, `"name":"beta"`} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("failed update --all omitted %q:\n%s", want, stdout)
+		}
+	}
+	after, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeJSON, _ := json.Marshal(before)
+	afterJSON, _ := json.Marshal(after)
+	if string(beforeJSON) != string(afterJSON) {
+		t.Fatalf("failed batch mutated state\nbefore=%s\nafter=%s", beforeJSON, afterJSON)
+	}
+	for _, installation := range after.Installations {
+		if installation.Package.Version != "1.0.0" {
+			t.Fatalf("failed batch updated %s before all preflights passed", installation.DeclaredName)
+		}
+	}
+}
+
+func TestUpdateAllDryRunAndTargetGuardRemainNonInteractive(t *testing.T) {
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+	plugin := writeNamedCLIPlugin(t, "alpha", "1.0.0")
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "cursor"); err != nil {
+		t.Fatal(err)
+	}
+	writeNamedCLIPluginVersion(t, plugin, "alpha", "2.0.0")
+	stdout, _, err := fixture.execute(false, "update", "--all", "--dry-run", "--format", "json")
+	if err != nil || !strings.Contains(stdout, `"dry_run":true`) || !strings.Contains(stdout, `"status":"planned"`) {
+		t.Fatalf("update --all dry run err=%v output=%s", err, stdout)
+	}
+	state, err := fixture.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Installations[0].Package.Version != "1.0.0" {
+		t.Fatalf("dry run mutated installation: %+v", state.Installations[0])
+	}
+	if _, _, err := fixture.execute(false, "update", "--all", "--target", "cursor"); err == nil || !strings.Contains(err.Error(), "keeps its recorded targets") {
+		t.Fatalf("update --all accepted an overriding target: %v", err)
+	}
+}
+
+func writeNamedCLIPlugin(t *testing.T, name, version string) string {
+	t.Helper()
+	root := t.TempDir()
+	writeNamedCLIPluginVersion(t, root, name, version)
+	return root
+}
+
+func writeNamedCLIPluginVersion(t *testing.T, root, name, version string) {
+	t.Helper()
+	body := `{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "` + name + `",
+  "version": "` + version + `",
+  "description": "Batch update fixture"
+}`
+	if err := os.WriteFile(filepath.Join(root, "plugin.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/update_all_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/update_all_test.go
@@ -103,6 +103,21 @@ func TestUpdateAllDryRunAndTargetGuardRemainNonInteractive(t *testing.T) {
 	}
 }
 
+func TestUpdateAllMarksRemainingPreparedItemsNotAttempted(t *testing.T) {
+	result := updateAllResult{Installations: []updateAllInstallation{
+		{Name: "alpha", Status: "apply_failed"},
+		{Name: "beta", Status: "planned"},
+		{Name: "gamma", Status: "planned"},
+	}}
+	prepared := []preparedUpdateAllItem{{resultIndex: 0}, {resultIndex: 1}, {resultIndex: 2}}
+	markUnattemptedUpdateAll(&result, prepared, 1)
+	for _, index := range []int{1, 2} {
+		if result.Installations[index].Status != "not_attempted" || result.Installations[index].Reason == "" {
+			t.Fatalf("remaining installation %d = %+v", index, result.Installations[index])
+		}
+	}
+}
+
 func writeNamedCLIPlugin(t *testing.T, name, version string) string {
 	t.Helper()
 	root := t.TempDir()

--- a/cli/plugin-kit-ai/internal/agentpluginscli/update_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/update_multi.go
@@ -33,6 +33,16 @@ type updateMultiResult struct {
 	Targets     []updateTargetResult `json:"targets"`
 }
 
+type preparedUpdateMany struct {
+	loaded        loadedPackage
+	service       usecase.Service
+	inputs        []usecase.AddInput
+	compatibility []usecase.AddInput
+	selected      []domain.ClientID
+	result        updateMultiResult
+	noChange      bool
+}
+
 func runUpdateMany(ctx context.Context, cmd *cobra.Command, app App, opts *options, selector string, targets []domain.ClientID) error {
 	state, err := app.StateStore.Load()
 	if err != nil {
@@ -42,22 +52,44 @@ func runUpdateMany(ctx context.Context, cmd *cobra.Command, app App, opts *optio
 	if err != nil {
 		return err
 	}
+	prepared, err := prepareUpdateMany(ctx, app, opts, installation, targets, !opts.dryRun)
+	if prepared != nil {
+		defer prepared.cleanup()
+	}
+	if err != nil {
+		if prepared != nil {
+			_ = renderUpdateMultiResult(cmd, opts, prepared.result)
+			return fmt.Errorf("group update preflight failed; no target was changed: %w%s", err, groupNextAction(prepared.result.Targets))
+		}
+		return err
+	}
+	if opts.dryRun {
+		return renderUpdateMultiResult(cmd, opts, prepared.result)
+	}
+	result, applyErr := applyPreparedUpdate(ctx, prepared)
+	if renderErr := renderUpdateMultiResult(cmd, opts, result); renderErr != nil && applyErr == nil {
+		applyErr = renderErr
+	}
+	return applyErr
+}
+
+func prepareUpdateMany(ctx context.Context, app App, opts *options, installation domain.Installation, targets []domain.ClientID, probeVersion bool) (*preparedUpdateMany, error) {
 	if installation.NeedsRebind || installation.Package.LoaderKind != domain.LoaderKindAgentPlugins {
-		return fmt.Errorf("update requires a bound Agent Plugins installation")
+		return nil, fmt.Errorf("update requires a bound Agent Plugins installation")
 	}
 	for _, target := range targets {
 		if !installationHasTarget(installation, target, opts.scope) {
-			return fmt.Errorf("plugin is not installed for target %q in %s scope; no target was changed", target, opts.scope)
+			return nil, fmt.Errorf("plugin is not installed for target %q in %s scope; no target was changed", target, opts.scope)
 		}
 	}
 	allTargets := installationTargets(installation, opts.scope)
-	_, detected, err := preflightSelectedTargets(ctx, app, targets, nil, !opts.dryRun && installation.OriginMode == domain.OriginModeDirectory)
+	_, detected, err := preflightSelectedTargets(ctx, app, targets, nil, probeVersion && installation.OriginMode == domain.OriginModeDirectory)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	installedClients, err := preflightInstalledBindings(installedBindingTargets(installation, opts.scope), detected)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	writeProgress(app, opts.format, "Resolving and validating one updated Agent Plugin package for every selected target...")
 	operation := domain.DirectoryUpdate
@@ -69,13 +101,15 @@ func runUpdateMany(ctx context.Context, cmd *cobra.Command, app App, opts *optio
 	}
 	loaded, err := app.loadInstalledPackage(ctx, installation, allTargets, operation, 0, installation.Source.ResolvedRevision, detected)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	if loaded.cleanup != nil {
-		defer loaded.cleanup()
+	prepared := &preparedUpdateMany{loaded: loaded}
+	fail := func(err error) (*preparedUpdateMany, error) {
+		prepared.cleanup()
+		return nil, err
 	}
 	if installation.OriginMode != domain.OriginModeDirectory && domain.ComputeSourceBindingID(loaded.envelope.Source) != installation.Source.SourceBindingID {
-		return fmt.Errorf("resolved source identity changed; use agentplugins switch after reviewing provenance")
+		return fail(fmt.Errorf("resolved source identity changed; use agentplugins switch after reviewing provenance"))
 	}
 	service := lifecycleService(app, detected)
 	inputs := make([]usecase.AddInput, 0, len(targets))
@@ -91,7 +125,7 @@ func runUpdateMany(ctx context.Context, cmd *cobra.Command, app App, opts *optio
 		target := client.ClientID
 		clientPackage := cloneLoadedPackage(loaded)
 		if err := prepareLoadedPackageForClient(&clientPackage, target); err != nil {
-			return fmt.Errorf("preflight target %s: %w; no target was changed", target, err)
+			return fail(fmt.Errorf("preflight target %s: %w; no target was changed", target, err))
 		}
 		input := usecase.AddInput{
 			Envelope: clientPackage.envelope, Client: client, Scope: domain.ScopeUser,
@@ -105,7 +139,7 @@ func runUpdateMany(ctx context.Context, cmd *cobra.Command, app App, opts *optio
 		client := detected[target]
 		clientPackage := cloneLoadedPackage(loaded)
 		if err := prepareLoadedPackageForClient(&clientPackage, target); err != nil {
-			return fmt.Errorf("preflight target %s: %w; no target was changed", target, err)
+			return fail(fmt.Errorf("preflight target %s: %w; no target was changed", target, err))
 		}
 		inputs = append(inputs, usecase.AddInput{
 			Envelope: clientPackage.envelope, Client: client, Scope: domain.ScopeUser,
@@ -117,7 +151,7 @@ func runUpdateMany(ctx context.Context, cmd *cobra.Command, app App, opts *optio
 	}
 	operationID, err := newOperationGroupID()
 	if err != nil {
-		return err
+		return fail(err)
 	}
 	result.OperationID = operationID
 	planned, err := service.UpdateGroup(ctx, usecase.GroupInput{Targets: inputs, CompatibilityChecks: compatibility, OperationGroupID: operationID, DryRun: true})
@@ -127,30 +161,48 @@ func runUpdateMany(ctx context.Context, cmd *cobra.Command, app App, opts *optio
 		result.Targets = append(result.Targets, updateTargetResult{Target: string(selected[index]), Selected: true, Status: groupTargetStatus(targetResult), Output: output, NextAction: nextLifecycleAction(targetResult)})
 	}
 	result.Succeeded = len(planned.Targets)
+	prepared.service, prepared.inputs, prepared.compatibility = service, inputs, compatibility
+	prepared.selected, prepared.result = selected, result
+	prepared.noChange = len(planned.Targets) > 0
+	for _, targetResult := range planned.Targets {
+		if !targetResult.NoChange {
+			prepared.noChange = false
+			break
+		}
+	}
 	if err != nil {
 		result.Status, result.Failed, result.Succeeded = "preflight_failed", len(inputs), 0
-		_ = renderUpdateMultiResult(cmd, opts, result)
-		return fmt.Errorf("group update preflight failed; no target was changed: %w%s", err, groupNextAction(result.Targets))
+		prepared.result = result
+		return prepared, err
 	}
-	if opts.dryRun {
-		return renderUpdateMultiResult(cmd, opts, result)
-	}
-	applied, groupErr := service.UpdateGroup(ctx, usecase.GroupInput{Targets: inputs, CompatibilityChecks: compatibility, OperationGroupID: operationID, Confirmed: true})
+	return prepared, nil
+}
+
+func applyPreparedUpdate(ctx context.Context, prepared *preparedUpdateMany) (updateMultiResult, error) {
+	result := prepared.result
+	applied, groupErr := prepared.service.UpdateGroup(ctx, usecase.GroupInput{Targets: prepared.inputs, CompatibilityChecks: prepared.compatibility, OperationGroupID: result.OperationID, Confirmed: true})
 	result.Status, result.Targets, result.Succeeded = string(applied.Phase), result.Targets[:0], 0
 	for index, targetResult := range applied.Targets {
-		output := newAddResultData(inputs[index].Envelope, targetResult, false)
-		output.OperationID = operationID
-		result.Targets = append(result.Targets, updateTargetResult{Target: string(selected[index]), Selected: true, Status: groupTargetStatus(targetResult), Output: output, NextAction: nextLifecycleAction(targetResult)})
+		output := newAddResultData(prepared.inputs[index].Envelope, targetResult, false)
+		output.OperationID = result.OperationID
+		result.Targets = append(result.Targets, updateTargetResult{Target: string(prepared.selected[index]), Selected: true, Status: groupTargetStatus(targetResult), Output: output, NextAction: nextLifecycleAction(targetResult)})
 		if targetResult.GroupPhase == usecase.GroupTargetExternalCompleted {
 			result.Succeeded++
 		}
 	}
 	if groupErr != nil {
-		result.Status, result.Failed = groupFailureStatus(applied.Phase), len(inputs)-result.Succeeded
-		_ = renderUpdateMultiResult(cmd, opts, result)
-		return groupErr
+		result.Status, result.Failed = groupFailureStatus(applied.Phase), len(prepared.inputs)-result.Succeeded
+		return result, groupErr
 	}
-	return renderUpdateMultiResult(cmd, opts, result)
+	return result, nil
+}
+
+func (prepared *preparedUpdateMany) cleanup() {
+	if prepared == nil || prepared.loaded.cleanup == nil {
+		return
+	}
+	_ = prepared.loaded.cleanup()
+	prepared.loaded.cleanup = nil
 }
 
 func installationHasTarget(installation domain.Installation, target domain.ClientID, scope string) bool {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/validate.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/validate.go
@@ -1,0 +1,99 @@
+package agentpluginscli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/spf13/cobra"
+)
+
+type validationComponents struct {
+	Skills        int      `json:"skills"`
+	MCPServers    int      `json:"mcp_servers"`
+	AppBindings   int      `json:"app_bindings"`
+	Extensions    int      `json:"extensions"`
+	MCPTransports []string `json:"mcp_transports,omitempty"`
+}
+
+type validationSource struct {
+	Repository string `json:"repository,omitempty"`
+	Revision   string `json:"revision,omitempty"`
+	Path       string `json:"path,omitempty"`
+}
+
+type validationResult struct {
+	Conformant     bool                 `json:"conformant"`
+	Name           string               `json:"name"`
+	Version        string               `json:"version,omitempty"`
+	FormatID       string               `json:"format_id"`
+	SchemaURI      string               `json:"schema_uri"`
+	SchemaVersion  string               `json:"schema_version"`
+	Source         validationSource     `json:"source"`
+	TreeDigest     string               `json:"tree_digest"`
+	ManifestDigest string               `json:"manifest_digest"`
+	Components     validationComponents `json:"components"`
+	Diagnostics    []domain.Diagnostic  `json:"diagnostics,omitempty"`
+}
+
+func newValidateCommand(app App, opts *options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "validate <local-or-full-sha-source>",
+		Short: "Validate one Agent Plugins package without installing it",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateCommonOptions(opts); err != nil {
+				return err
+			}
+			source := strings.TrimSpace(args[0])
+			if !explicitLocalPath(source) && exactGitPattern.FindStringSubmatch(source) == nil {
+				return fmt.Errorf("validate requires a local path or exact owner/repo@FULL_SHA[//path] source")
+			}
+			loaded, err := app.loadPackage(cmd.Context(), source)
+			if err != nil {
+				return err
+			}
+			if loaded.cleanup != nil {
+				defer loaded.cleanup()
+			}
+			result := newValidationResult(loaded.envelope)
+			if opts.format == "json" {
+				return writeJSONOutput(cmd.OutOrStdout(), "validate", result)
+			}
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Valid Agent Plugin: %s %s\nSchema: %s\nSource: %s\nComponents: %d skills, %d MCP servers, %d app bindings\n",
+				result.Name, result.Version, result.SchemaURI, publicPackageSource(loaded.envelope.Source),
+				result.Components.Skills, result.Components.MCPServers, result.Components.AppBindings)
+			return err
+		},
+	}
+}
+
+func newValidationResult(envelope domain.PackageEnvelope) validationResult {
+	transports := make([]string, 0, len(envelope.MCP.Servers))
+	seen := map[string]struct{}{}
+	for _, server := range envelope.MCP.Servers {
+		transport := strings.TrimSpace(server.Type)
+		if transport == "" {
+			continue
+		}
+		if _, duplicate := seen[transport]; duplicate {
+			continue
+		}
+		seen[transport] = struct{}{}
+		transports = append(transports, transport)
+	}
+	sort.Strings(transports)
+	return validationResult{
+		Conformant: true, Name: envelope.Manifest.Name, Version: envelope.Manifest.Version,
+		FormatID: envelope.FormatID, SchemaURI: envelope.SchemaURI, SchemaVersion: envelope.SchemaVersion,
+		Source:     validationSource{Repository: envelope.Source.Repository, Revision: envelope.Source.ResolvedRevision, Path: envelope.Source.PackageSubpath},
+		TreeDigest: envelope.TreeDigest, ManifestDigest: envelope.ManifestDigest,
+		Components: validationComponents{
+			Skills: len(envelope.Inventory.Skills), MCPServers: len(envelope.Inventory.MCPServers),
+			AppBindings: len(envelope.Inventory.AppBindings), Extensions: len(envelope.Inventory.Extensions),
+			MCPTransports: transports,
+		},
+		Diagnostics: append([]domain.Diagnostic(nil), envelope.Diagnostics...),
+	}
+}

--- a/install/integrationctl/adapters/process/osrunner_test.go
+++ b/install/integrationctl/adapters/process/osrunner_test.go
@@ -42,7 +42,6 @@ func (*naturalExitBoundaryContainment) exited() (bool, error) { return false, ni
 func (*naturalExitBoundaryContainment) close() error          { return nil }
 
 func TestOSRunnerPreservesCommandOutputAndExitCode(t *testing.T) {
-	requireDuplexCapability(t)
 	if os.Getenv("AGENTPLUGINS_PROCESS_OUTPUT_HELPER") == "1" {
 		fmt.Fprint(os.Stdout, "expected stdout")
 		fmt.Fprint(os.Stderr, "expected stderr")
@@ -62,7 +61,6 @@ func TestOSRunnerPreservesCommandOutputAndExitCode(t *testing.T) {
 }
 
 func TestOSRunnerCleanExitWithoutOtherGroupMembersRemainsSuccess(t *testing.T) {
-	requireDuplexCapability(t)
 	if os.Getenv("AGENTPLUGINS_PROCESS_CLEAN_EXIT_HELPER") == "1" {
 		fmt.Fprint(os.Stdout, "clean")
 		os.Exit(0)

--- a/install/integrationctl/adapters/process/osrunner_tree_darwin.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_darwin.go
@@ -84,13 +84,17 @@ func (containment *commandContainment) terminate() terminationResult {
 		return terminationResult{err: os.ErrProcessDone}
 	}
 	members, inspectErr := containment.groupMembers(containment.cmd.Process.Pid)
+	stopped, observeErr := containment.exited()
+	if inspectErr == nil && observeErr == nil && stopped && members == 0 {
+		return terminationResult{leaderStopped: true}
+	}
 	killErr := containment.signalGroup(-containment.cmd.Process.Pid, syscall.SIGKILL)
 	if errors.Is(killErr, syscall.ESRCH) {
 		killErr = nil
 	}
 	deadline := time.Now().Add(time.Second)
 	for {
-		stopped, observeErr := containment.exited()
+		stopped, observeErr = containment.exited()
 		remaining, groupErr := containment.groupMembers(containment.cmd.Process.Pid)
 		if stopped && remaining == 0 {
 			return terminationResult{leaderStopped: true, forcedMembers: members > 0, err: errors.Join(inspectErr, killErr, observeErr, groupErr)}

--- a/install/integrationctl/agentplugins/adapters/discoveryv1/cache.go
+++ b/install/integrationctl/agentplugins/adapters/discoveryv1/cache.go
@@ -1,0 +1,202 @@
+package discoveryv1
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+type Cache struct {
+	Path         string
+	BeforeRename func(string) error
+}
+
+type cacheRecord struct {
+	SchemaVersion int    `json:"schema_version"`
+	Sequence      uint64 `json:"sequence"`
+	Pointer       string `json:"pointer"`
+	Snapshot      string `json:"snapshot"`
+	Envelope      string `json:"envelope"`
+	Search        string `json:"search"`
+}
+
+var ErrCacheRollback = errors.New("Discovery cache would roll back last-known-good sequence")
+
+func (cache Cache) Load(trust TrustStore) (VerifiedBundle, error) {
+	if cache.Path == "" {
+		return VerifiedBundle{}, os.ErrNotExist
+	}
+	info, err := os.Lstat(cache.Path)
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || (runtime.GOOS != "windows" && info.Mode().Perm()&0077 != 0) {
+		return VerifiedBundle{}, errors.New("Discovery cache must be a restrictive regular file")
+	}
+	file, err := os.Open(cache.Path)
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	defer file.Close()
+	maximum := base64.StdEncoding.EncodedLen(MaxLatestBytes+MaxSnapshotBytes+MaxEnvelopeBytes+MaxSearchBytes) + 4096
+	body, err := io.ReadAll(io.LimitReader(file, int64(maximum)+1))
+	if err != nil || len(body) > maximum {
+		return VerifiedBundle{}, errors.New("invalid Discovery cache: oversized or unreadable")
+	}
+	var record cacheRecord
+	if err := strictDecode(body, &record, maximum); err != nil {
+		return VerifiedBundle{}, fmt.Errorf("invalid Discovery cache: %w", err)
+	}
+	if err := exactObject(body, []string{"schema_version", "sequence", "pointer", "snapshot", "envelope", "search"}); err != nil || record.SchemaVersion != 1 || record.Sequence < 1 {
+		return VerifiedBundle{}, errors.New("invalid Discovery cache identity")
+	}
+	decode := func(label, value string) ([]byte, error) {
+		decoded, err := base64.StdEncoding.Strict().DecodeString(value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid cached %s encoding: %w", label, err)
+		}
+		return decoded, nil
+	}
+	pointer, err := decode("pointer", record.Pointer)
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	snapshot, err := decode("snapshot", record.Snapshot)
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	envelope, err := decode("envelope", record.Envelope)
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	search, err := decode("search", record.Search)
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	bundle, err := VerifyBundle(pointer, snapshot, envelope, search, trust)
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	if bundle.Snapshot.Sequence != record.Sequence {
+		return VerifiedBundle{}, ErrSequenceMismatch
+	}
+	bundle.Source = BundleSourceCache
+	return bundle, nil
+}
+
+func (cache Cache) Store(candidate VerifiedBundle, trust TrustStore) error {
+	verified, err := VerifyBundle(candidate.PointerBytes, candidate.SnapshotBytes, candidate.EnvelopeBytes, candidate.SearchBytes, trust)
+	if err != nil {
+		return err
+	}
+	authoritative, err := cache.reconcile(verified, trust, true)
+	if err == nil && authoritative.Snapshot.Sequence > verified.Snapshot.Sequence {
+		return ErrCacheRollback
+	}
+	return err
+}
+
+func (cache Cache) Reconcile(candidate VerifiedBundle, trust TrustStore) (VerifiedBundle, error) {
+	verified, err := VerifyBundle(candidate.PointerBytes, candidate.SnapshotBytes, candidate.EnvelopeBytes, candidate.SearchBytes, trust)
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	return cache.reconcile(verified, trust, true)
+}
+
+func (cache Cache) Observe(candidate VerifiedBundle, trust TrustStore) (VerifiedBundle, error) {
+	verified, err := VerifyBundle(candidate.PointerBytes, candidate.SnapshotBytes, candidate.EnvelopeBytes, candidate.SearchBytes, trust)
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	verified.Source = candidate.Source
+	return cache.reconcile(verified, trust, false)
+}
+
+func (cache Cache) reconcile(verified VerifiedBundle, trust TrustStore, persist bool) (VerifiedBundle, error) {
+	if cache.Path == "" {
+		return VerifiedBundle{}, errors.New("Discovery cache path is empty")
+	}
+	directory := filepath.Dir(cache.Path)
+	if err := os.MkdirAll(directory, 0700); err != nil {
+		return VerifiedBundle{}, err
+	}
+	if err := os.Chmod(directory, 0700); err != nil {
+		return VerifiedBundle{}, err
+	}
+	unlock, err := lockCache(cache.Path + ".lock")
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	defer unlock()
+	if current, loadErr := cache.Load(trust); loadErr == nil && current.Snapshot.Sequence >= verified.Snapshot.Sequence {
+		if current.Snapshot.Sequence == verified.Snapshot.Sequence && current.Digest != verified.Digest {
+			return VerifiedBundle{}, fmt.Errorf("%w: sequence %d", ErrSequenceConflict, verified.Snapshot.Sequence)
+		}
+		return current, nil
+	}
+	if !persist {
+		return verified, nil
+	}
+	record := cacheRecord{
+		SchemaVersion: 1, Sequence: verified.Snapshot.Sequence,
+		Pointer: base64.StdEncoding.EncodeToString(verified.PointerBytes), Snapshot: base64.StdEncoding.EncodeToString(verified.SnapshotBytes),
+		Envelope: base64.StdEncoding.EncodeToString(verified.EnvelopeBytes), Search: base64.StdEncoding.EncodeToString(verified.SearchBytes),
+	}
+	body, err := json.Marshal(record)
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	body = append(body, '\n')
+	var nonce [8]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		return VerifiedBundle{}, err
+	}
+	temporary := filepath.Join(directory, "."+filepath.Base(cache.Path)+"."+hex.EncodeToString(nonce[:])+".tmp")
+	file, err := os.OpenFile(temporary, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	ok := false
+	defer func() {
+		_ = file.Close()
+		if !ok {
+			_ = os.Remove(temporary)
+		}
+	}()
+	if _, err = file.Write(body); err != nil {
+		return VerifiedBundle{}, err
+	}
+	if err = file.Sync(); err != nil {
+		return VerifiedBundle{}, err
+	}
+	if err = file.Close(); err != nil {
+		return VerifiedBundle{}, err
+	}
+	if cache.BeforeRename != nil {
+		if err := cache.BeforeRename(temporary); err != nil {
+			return VerifiedBundle{}, err
+		}
+	}
+	if err = os.Rename(temporary, cache.Path); err != nil {
+		return VerifiedBundle{}, err
+	}
+	ok = true
+	dir, err := os.Open(directory)
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	defer dir.Close()
+	if err := dir.Sync(); err != nil {
+		return VerifiedBundle{}, err
+	}
+	verified.Source = BundleSourceCache
+	return verified, nil
+}

--- a/install/integrationctl/agentplugins/adapters/discoveryv1/cache_lock_unix.go
+++ b/install/integrationctl/agentplugins/adapters/discoveryv1/cache_lock_unix.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package discoveryv1
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockCache(path string) (func(), error) {
+	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("Discovery cache lock must not be a symlink")
+	} else if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(path, 0600); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return func() {
+		_ = unix.Flock(int(file.Fd()), unix.LOCK_UN)
+		_ = file.Close()
+	}, nil
+}

--- a/install/integrationctl/agentplugins/adapters/discoveryv1/cache_lock_windows.go
+++ b/install/integrationctl/agentplugins/adapters/discoveryv1/cache_lock_windows.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package discoveryv1
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockCache(path string) (func(), error) {
+	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("Discovery cache lock must not be a symlink")
+	} else if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, err
+	}
+	overlapped := new(windows.Overlapped)
+	if err := windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, overlapped); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return func() {
+		_ = windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, overlapped)
+		_ = file.Close()
+	}, nil
+}

--- a/install/integrationctl/agentplugins/adapters/discoveryv1/client.go
+++ b/install/integrationctl/agentplugins/adapters/discoveryv1/client.go
@@ -61,21 +61,17 @@ func (client Client) Load(ctx context.Context, installedFloor uint64) (VerifiedB
 		}
 	}
 	if cacheErr == nil && cached.Snapshot.Sequence >= floor {
-		if err := ValidityError(cached.Snapshot, now); err == nil {
-			authoritative, err := client.Cache.Observe(cached, client.Trust)
-			if err != nil {
-				return VerifiedBundle{}, err
-			}
-			if authoritative.Snapshot.Sequence < floor {
-				return VerifiedBundle{}, fmt.Errorf("%w: got %d, floor %d", ErrRollback, authoritative.Snapshot.Sequence, floor)
-			}
-			return authoritative, ValidityError(authoritative.Snapshot, now)
-		}
-	}
-	if cacheErr == nil && cached.Snapshot.Sequence >= floor {
 		if err := ValidityError(cached.Snapshot, now); err != nil {
 			return VerifiedBundle{}, err
 		}
+		authoritative, err := client.Cache.Observe(cached, client.Trust)
+		if err != nil {
+			return VerifiedBundle{}, err
+		}
+		if authoritative.Snapshot.Sequence < floor {
+			return VerifiedBundle{}, fmt.Errorf("%w: got %d, floor %d", ErrRollback, authoritative.Snapshot.Sequence, floor)
+		}
+		return authoritative, ValidityError(authoritative.Snapshot, now)
 	}
 	if remoteErr != nil {
 		return VerifiedBundle{}, remoteErr
@@ -145,7 +141,7 @@ func (client Client) originURL() (*url.URL, error) {
 	if err != nil || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
 		return nil, ErrUnsafeOrigin
 	}
-	if parsed.Scheme != "https" && !(client.AllowHTTPForTests && parsed.Scheme == "http") {
+	if parsed.Scheme != "https" && (!client.AllowHTTPForTests || parsed.Scheme != "http") {
 		return nil, ErrUnsafeOrigin
 	}
 	if !strings.HasSuffix(parsed.Path, "/") {

--- a/install/integrationctl/agentplugins/adapters/discoveryv1/client.go
+++ b/install/integrationctl/agentplugins/adapters/discoveryv1/client.go
@@ -1,0 +1,239 @@
+package discoveryv1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	pathpkg "path"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	Origin     string
+	HTTPClient *http.Client
+	Trust      TrustStore
+	Cache      Cache
+	Now        func() time.Time
+	// AllowHTTPForTests is never populated by production wiring.
+	AllowHTTPForTests bool
+}
+
+func (client Client) Load(ctx context.Context, installedFloor uint64) (VerifiedBundle, error) {
+	if len(client.Trust.Keys) == 0 {
+		return VerifiedBundle{}, ErrNoTrustedKeys
+	}
+	now := time.Now().UTC()
+	if client.Now != nil {
+		now = client.Now().UTC()
+	}
+	cached, cacheErr := client.Cache.Load(client.Trust)
+	floor := installedFloor
+	if cacheErr == nil && cached.Snapshot.Sequence > floor {
+		floor = cached.Snapshot.Sequence
+	}
+	remote, remoteErr := client.fetch(ctx)
+	if remoteErr == nil {
+		if remote.Snapshot.Sequence < floor {
+			remoteErr = fmt.Errorf("%w: got %d, floor %d", ErrRollback, remote.Snapshot.Sequence, floor)
+		} else if cacheErr == nil && sameSequenceDifferentDigest(remote, cached) {
+			return VerifiedBundle{}, fmt.Errorf("%w: sequence %d", ErrSequenceConflict, remote.Snapshot.Sequence)
+		} else if err := ValidityError(remote.Snapshot, now); err == nil {
+			authoritative, err := client.Cache.Reconcile(remote, client.Trust)
+			if err != nil {
+				return VerifiedBundle{}, fmt.Errorf("persist verified Discovery snapshot: %w", err)
+			}
+			if authoritative.Snapshot.Sequence < floor {
+				return VerifiedBundle{}, fmt.Errorf("%w: got %d, floor %d", ErrRollback, authoritative.Snapshot.Sequence, floor)
+			}
+			if err := ValidityError(authoritative.Snapshot, now); err != nil {
+				return VerifiedBundle{}, err
+			}
+			if authoritative.Snapshot.Sequence == remote.Snapshot.Sequence && authoritative.Digest == remote.Digest {
+				authoritative.Source = BundleSourceRemote
+			}
+			return authoritative, nil
+		} else {
+			remoteErr = ValidityError(remote.Snapshot, now)
+		}
+	}
+	if cacheErr == nil && cached.Snapshot.Sequence >= floor {
+		if err := ValidityError(cached.Snapshot, now); err == nil {
+			authoritative, err := client.Cache.Observe(cached, client.Trust)
+			if err != nil {
+				return VerifiedBundle{}, err
+			}
+			if authoritative.Snapshot.Sequence < floor {
+				return VerifiedBundle{}, fmt.Errorf("%w: got %d, floor %d", ErrRollback, authoritative.Snapshot.Sequence, floor)
+			}
+			return authoritative, ValidityError(authoritative.Snapshot, now)
+		}
+	}
+	if cacheErr == nil && cached.Snapshot.Sequence >= floor {
+		if err := ValidityError(cached.Snapshot, now); err != nil {
+			return VerifiedBundle{}, err
+		}
+	}
+	if remoteErr != nil {
+		return VerifiedBundle{}, remoteErr
+	}
+	return VerifiedBundle{}, fmt.Errorf("%w: cache=%v", ErrUnavailable, cacheErr)
+}
+
+func (client Client) LoadLocal(installedFloor uint64) (VerifiedBundle, error) {
+	bundle, err := client.Cache.Load(client.Trust)
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	if bundle.Snapshot.Sequence < installedFloor {
+		return VerifiedBundle{}, fmt.Errorf("%w: got %d, floor %d", ErrRollback, bundle.Snapshot.Sequence, installedFloor)
+	}
+	return bundle, nil
+}
+
+func (client Client) fetch(ctx context.Context) (VerifiedBundle, error) {
+	origin, err := client.originURL()
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	httpClient := client.safeHTTPClient(origin, 0)
+	pointerBytes, err := fetchBounded(ctx, httpClient, origin.ResolveReference(&url.URL{Path: "latest.json"}).String(), MaxLatestBytes, 3)
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	pointer, err := ParsePointer(pointerBytes)
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	if len(pointerBytes) > pointer.FetchContract.LatestMaxBytes {
+		return VerifiedBundle{}, fmt.Errorf("%w: latest", ErrResponseTooLarge)
+	}
+	httpClient = client.safeHTTPClient(origin, pointer.FetchContract.MaxRedirects)
+	fetch := func(relative string, maximum int) ([]byte, error) {
+		return fetchBounded(ctx, httpClient, origin.ResolveReference(&url.URL{Path: relative}).String(), maximum, pointer.FetchContract.RetryAttempts)
+	}
+	snapshot, err := fetch(pointer.SnapshotPath, pointer.FetchContract.SnapshotMaxBytes)
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	envelope, err := fetch(pointer.EnvelopePath, pointer.FetchContract.EnvelopeMaxBytes)
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	search, err := fetch(pointer.SearchPath, pointer.FetchContract.SearchMaxBytes)
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	bundle, err := VerifyBundle(pointerBytes, snapshot, envelope, search, client.Trust)
+	if err == nil {
+		bundle.Source = BundleSourceRemote
+	}
+	return bundle, err
+}
+
+var (
+	ErrUnsafeOrigin     = errors.New("unsafe Discovery origin")
+	ErrUnsafeRedirect   = errors.New("unsafe Discovery redirect")
+	ErrResponseTooLarge = errors.New("Discovery response exceeds declared limit")
+)
+
+func (client Client) originURL() (*url.URL, error) {
+	parsed, err := url.Parse(client.Origin)
+	if err != nil || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, ErrUnsafeOrigin
+	}
+	if parsed.Scheme != "https" && !(client.AllowHTTPForTests && parsed.Scheme == "http") {
+		return nil, ErrUnsafeOrigin
+	}
+	if !strings.HasSuffix(parsed.Path, "/") {
+		parsed.Path += "/"
+	}
+	escaped := strings.ToLower(parsed.EscapedPath())
+	clean := strings.TrimSuffix(parsed.Path, "/")
+	if clean == "" {
+		clean = "/"
+	}
+	if strings.Contains(escaped, "%2f") || strings.Contains(escaped, "%5c") || strings.Contains(escaped, "%2e") || pathpkg.Clean(parsed.Path) != clean {
+		return nil, ErrUnsafeOrigin
+	}
+	return parsed, nil
+}
+
+func (client Client) safeHTTPClient(origin *url.URL, maxRedirects int) *http.Client {
+	result := http.Client{Timeout: 20 * time.Second}
+	if client.HTTPClient != nil {
+		result = *client.HTTPClient
+		if result.Timeout == 0 {
+			result.Timeout = 20 * time.Second
+		}
+	}
+	result.Jar = nil
+	prior := result.CheckRedirect
+	result.CheckRedirect = func(request *http.Request, via []*http.Request) error {
+		if len(via) > maxRedirects {
+			return ErrUnsafeRedirect
+		}
+		escaped := strings.ToLower(request.URL.EscapedPath())
+		unsafePath := strings.Contains(escaped, "%2f") || strings.Contains(escaped, "%5c") || strings.Contains(escaped, "%2e") || pathpkg.Clean(request.URL.Path) != request.URL.Path
+		if request.URL.User != nil || request.URL.Scheme != origin.Scheme || !strings.EqualFold(request.URL.Host, origin.Host) || !strings.HasPrefix(request.URL.Path, origin.Path) || unsafePath {
+			return ErrUnsafeRedirect
+		}
+		if prior != nil {
+			if err := prior(request, via); err != nil {
+				return err
+			}
+		}
+		request.Header.Del("Authorization")
+		request.Header.Del("Proxy-Authorization")
+		request.Header.Del("Cookie")
+		return nil
+	}
+	return &result
+}
+
+func fetchBounded(ctx context.Context, client *http.Client, target string, maximum, attempts int) ([]byte, error) {
+	var last error
+	for attempt := 0; attempt < attempts; attempt++ {
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+		if err != nil {
+			return nil, err
+		}
+		request.Header.Set("Accept", "application/json")
+		request.Header.Set("User-Agent", "agentplugins-discovery/1")
+		response, err := client.Do(request)
+		if err == nil {
+			body, readErr := io.ReadAll(io.LimitReader(response.Body, int64(maximum)+1))
+			closeErr := response.Body.Close()
+			if readErr == nil && closeErr == nil && response.StatusCode == http.StatusOK && len(body) <= maximum {
+				return body, nil
+			}
+			if len(body) > maximum {
+				return nil, ErrResponseTooLarge
+			}
+			if readErr != nil {
+				last = readErr
+			} else if closeErr != nil {
+				last = closeErr
+			} else {
+				last = fmt.Errorf("Discovery origin returned HTTP %d", response.StatusCode)
+			}
+		} else {
+			last = err
+		}
+		if attempt+1 < attempts {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(time.Duration(attempt+1) * 100 * time.Millisecond):
+			}
+		}
+	}
+	return nil, last
+}
+
+func sameSequenceDifferentDigest(left, right VerifiedBundle) bool {
+	return left.Snapshot.Sequence > 0 && left.Snapshot.Sequence == right.Snapshot.Sequence && left.Digest != right.Digest
+}

--- a/install/integrationctl/agentplugins/adapters/discoveryv1/discoveryv1_test.go
+++ b/install/integrationctl/agentplugins/adapters/discoveryv1/discoveryv1_test.go
@@ -1,0 +1,293 @@
+package discoveryv1
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fixtureArtifacts struct {
+	pointer  []byte
+	snapshot []byte
+	envelope []byte
+	search   []byte
+	trust    TrustStore
+}
+
+func stringPointer(value string) *string { return &value }
+
+func discoveryFixture(t *testing.T, sequence uint64, generated time.Time) fixtureArtifacts {
+	t.Helper()
+	private := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{7}, ed25519.SeedSize))
+	public := private.Public().(ed25519.PublicKey)
+	stem := strings.Repeat("0", 20-len(string(rune('0'+sequence)))) + string(rune('0'+sequence))
+	// Tests use single-digit sequences. Production validation independently
+	// requires the exact twenty-digit sequence framing.
+	if sequence > 9 {
+		t.Fatal("fixture sequence must be one digit")
+	}
+	record := Record{
+		Slug: "discovery:owner/repo//plugins/demo", Name: "demo", Description: "fixture", Owner: "owner",
+		Repository: "owner/repo", PackagePath: "plugins/demo", Revision: strings.Repeat("a", 40),
+		Version: stringPointer("1.0.0"), License: stringPointer("Apache-2.0"), SchemaVersion: "1.0.0",
+		Components: Components{MCP: 1}, MCPTransports: []string{"streamable-http"},
+		CompatibleClients: []string{"codex", "cursor", "copilot", "vscode", "kiro"},
+		Authentication:    "unknown", Status: "conformant_unreviewed", RuntimeReviewed: false,
+		TreeDigest: "sha256:" + strings.Repeat("1", 64), ManifestDigest: "sha256:" + strings.Repeat("2", 64),
+		Stars: 42, RepositoryUpdatedAt: generated.Format(time.RFC3339), Availability: "available",
+		Author: &Author{Name: "Fixture"}, FirstSeen: generated.Format(time.RFC3339), LastSeen: generated.Format(time.RFC3339),
+	}
+	compact := record
+	compact.Author, compact.FirstSeen, compact.LastSeen = nil, "", ""
+	search := Search{SearchSchemaVersion: 1, Sequence: sequence, GeneratedAt: generated.Format(time.RFC3339), Records: []Record{compact}}
+	searchBytes, err := json.Marshal(search)
+	if err != nil {
+		t.Fatal(err)
+	}
+	searchDigest := sha256.Sum256(searchBytes)
+	snapshot := Snapshot{
+		DiscoverySchemaVersion: 1, Sequence: sequence, PublicationID: "fixture", SourceCommit: strings.Repeat("b", 40),
+		GeneratedAt: generated.Format(time.RFC3339), ExpiresAt: generated.Add(72 * time.Hour).Format(time.RFC3339), Complete: true,
+		QueryManifestDigest: "sha256:" + strings.Repeat("3", 64), Partitions: []Partition{},
+		SearchProjection: SearchProjection{Path: "search/" + stem + ".json", Digest: "sha256:" + hex.EncodeToString(searchDigest[:]), RecordCount: 1},
+		Records:          []Record{record},
+	}
+	snapshotBytes, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshotDigest := sha256.Sum256(snapshotBytes)
+	envelope := Envelope{
+		EnvelopeSchemaVersion: 1, SnapshotSchemaVersion: 1, Sequence: sequence, KeyID: "fixture",
+		Algorithm: "Ed25519", SignatureDomain: SignatureDomain, SnapshotDigest: "sha256:" + hex.EncodeToString(snapshotDigest[:]),
+		Signature: base64.StdEncoding.EncodeToString(ed25519.Sign(private, SignatureMessage(snapshotBytes))),
+	}
+	envelopeBytes, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pointer := Pointer{
+		PointerSchemaVersion: 1, SnapshotSchemaVersion: 1, Sequence: sequence,
+		SnapshotPath: "snapshots/" + stem + ".json", EnvelopePath: "snapshots/" + stem + ".envelope.json", SearchPath: "search/" + stem + ".json",
+		FetchContract: FetchContract{MaxRedirects: 0, LatestMaxBytes: MaxLatestBytes, SnapshotMaxBytes: MaxSnapshotBytes,
+			EnvelopeMaxBytes: MaxEnvelopeBytes, SearchMaxBytes: MaxSearchBytes, RetryAttempts: 1},
+	}
+	pointerBytes, err := json.Marshal(pointer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fixtureArtifacts{pointer: pointerBytes, snapshot: snapshotBytes, envelope: envelopeBytes, search: searchBytes,
+		trust: TrustStore{Keys: []TrustedKey{{ID: "fixture", PublicKey: public, State: KeyCurrent}}}}
+}
+
+func TestVerifyBundleRejectsTamperingAndWrongDomain(t *testing.T) {
+	t.Parallel()
+	fixture := discoveryFixture(t, 1, time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC))
+	if _, err := VerifyBundle(fixture.pointer, fixture.snapshot, fixture.envelope, fixture.search, fixture.trust); err != nil {
+		t.Fatal(err)
+	}
+	tampered := append([]byte(nil), fixture.search...)
+	tampered[len(tampered)-2] ^= 1
+	if _, err := VerifyBundle(fixture.pointer, fixture.snapshot, fixture.envelope, tampered, fixture.trust); err == nil {
+		t.Fatal("tampered search projection was accepted")
+	}
+	var envelope Envelope
+	if err := json.Unmarshal(fixture.envelope, &envelope); err != nil {
+		t.Fatal(err)
+	}
+	envelope.SignatureDomain = "UAP-DIRECTORY-SNAPSHOT-ED25519-V1"
+	wrongDomain, _ := json.Marshal(envelope)
+	if _, err := VerifyBundle(fixture.pointer, fixture.snapshot, wrongDomain, fixture.search, fixture.trust); !errors.Is(err, ErrStrictJSON) {
+		t.Fatalf("wrong signature domain error = %v", err)
+	}
+}
+
+func TestDiscoveryTrustRotationAndEverySignedArtifactFailClosed(t *testing.T) {
+	t.Parallel()
+	fixture := discoveryFixture(t, 1, time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC))
+	trusted := fixture.trust.Keys[0]
+
+	next := TrustStore{Keys: append([]TrustedKey(nil), fixture.trust.Keys...)}
+	next.Keys[0].State = KeyNext
+	if _, err := VerifyBundle(fixture.pointer, fixture.snapshot, fixture.envelope, fixture.search, next); err != nil {
+		t.Fatalf("next rotation key was not accepted: %v", err)
+	}
+	retired := TrustStore{Keys: append([]TrustedKey(nil), fixture.trust.Keys...)}
+	retired.Keys[0].State = KeyRetired
+	if _, err := VerifyBundle(fixture.pointer, fixture.snapshot, fixture.envelope, fixture.search, retired); !errors.Is(err, ErrRetiredKey) {
+		t.Fatalf("retired key error = %v", err)
+	}
+	unknown := TrustStore{Keys: []TrustedKey{{ID: "other", PublicKey: trusted.PublicKey, State: KeyCurrent}}}
+	if _, err := VerifyBundle(fixture.pointer, fixture.snapshot, fixture.envelope, fixture.search, unknown); !errors.Is(err, ErrUnknownKey) {
+		t.Fatalf("unknown key error = %v", err)
+	}
+
+	mutate := func(body []byte) []byte {
+		result := append([]byte(nil), body...)
+		result[len(result)/2] ^= 1
+		return result
+	}
+	for name, artifacts := range map[string]struct {
+		pointer, snapshot, envelope, search []byte
+	}{
+		"pointer":  {mutate(fixture.pointer), fixture.snapshot, fixture.envelope, fixture.search},
+		"snapshot": {fixture.pointer, mutate(fixture.snapshot), fixture.envelope, fixture.search},
+		"envelope": {fixture.pointer, fixture.snapshot, mutate(fixture.envelope), fixture.search},
+		"search":   {fixture.pointer, fixture.snapshot, fixture.envelope, mutate(fixture.search)},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := VerifyBundle(artifacts.pointer, artifacts.snapshot, artifacts.envelope, artifacts.search, fixture.trust); err == nil {
+				t.Fatalf("tampered %s was accepted", name)
+			}
+		})
+	}
+}
+
+func TestUnreviewedDiscoveryRejectsUnprovedChatGPTCompatibility(t *testing.T) {
+	generated := time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC)
+	record := Record{
+		Slug: "discovery:owner/repo", Name: "demo", Owner: "owner", Repository: "owner/repo",
+		Revision: strings.Repeat("a", 40), SchemaVersion: "1.0.0", Components: Components{MCP: 1},
+		MCPTransports: []string{"streamable-http"}, CompatibleClients: []string{"codex", "chatgpt"}, Authentication: "unknown",
+		Status: "conformant_unreviewed", TreeDigest: "sha256:" + strings.Repeat("1", 64),
+		ManifestDigest: "sha256:" + strings.Repeat("2", 64), RepositoryUpdatedAt: generated.Format(time.RFC3339),
+		Availability: "available", FirstSeen: generated.Format(time.RFC3339), LastSeen: generated.Format(time.RFC3339),
+	}
+	if err := validateRecords([]Record{record}, generated, true); !errors.Is(err, ErrStrictJSON) {
+		t.Fatalf("unproved ChatGPT compatibility error = %v", err)
+	}
+}
+
+func TestClientColdCachedOfflineTamperedExpiredAndRollback(t *testing.T) {
+	now := time.Date(2026, 8, 27, 1, 0, 0, 0, time.UTC)
+	first := discoveryFixture(t, 1, now.Add(-time.Hour))
+	current := first
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		var body []byte
+		switch request.URL.Path {
+		case "/latest.json":
+			body = current.pointer
+		default:
+			pointer, _ := ParsePointer(current.pointer)
+			switch request.URL.Path {
+			case "/" + pointer.SnapshotPath:
+				body = current.snapshot
+			case "/" + pointer.EnvelopePath:
+				body = current.envelope
+			case "/" + pointer.SearchPath:
+				body = current.search
+			default:
+				http.NotFound(writer, request)
+				return
+			}
+		}
+		_, _ = writer.Write(body)
+	}))
+	cachePath := filepath.Join(t.TempDir(), "discovery.json")
+	client := Client{Origin: server.URL + "/", AllowHTTPForTests: true, Trust: first.trust, Cache: Cache{Path: cachePath}, Now: func() time.Time { return now }}
+	cold, err := client.Load(context.Background(), 0)
+	if err != nil || cold.Source != BundleSourceRemote || cold.Snapshot.Sequence != 1 {
+		t.Fatalf("cold load = %+v, %v", cold, err)
+	}
+	server.Close()
+	offline, err := client.Load(context.Background(), 0)
+	if err != nil || offline.Snapshot.Sequence != 1 {
+		t.Fatalf("offline load = %+v, %v", offline, err)
+	}
+
+	second := discoveryFixture(t, 2, now.Add(-30*time.Minute))
+	secondBundle, err := VerifyBundle(second.pointer, second.snapshot, second.envelope, second.search, second.trust)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Cache.Store(secondBundle, second.trust); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.LoadLocal(3); !errors.Is(err, ErrRollback) {
+		t.Fatalf("cache floor error = %v", err)
+	}
+	rollbackServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		pointer, _ := ParsePointer(first.pointer)
+		body := first.pointer
+		switch request.URL.Path {
+		case "/" + pointer.SnapshotPath:
+			body = first.snapshot
+		case "/" + pointer.EnvelopePath:
+			body = first.envelope
+		case "/" + pointer.SearchPath:
+			body = first.search
+		}
+		_, _ = writer.Write(body)
+	}))
+	client.Origin = rollbackServer.URL + "/"
+	rolledBack, err := client.Load(context.Background(), 0)
+	rollbackServer.Close()
+	if err != nil || rolledBack.Snapshot.Sequence != 2 {
+		t.Fatalf("rollback did not retain LKG: sequence=%d err=%v", rolledBack.Snapshot.Sequence, err)
+	}
+
+	expired := discoveryFixture(t, 3, now.Add(-96*time.Hour))
+	expiredServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		pointer, _ := ParsePointer(expired.pointer)
+		body := expired.pointer
+		switch request.URL.Path {
+		case "/" + pointer.SnapshotPath:
+			body = expired.snapshot
+		case "/" + pointer.EnvelopePath:
+			body = expired.envelope
+		case "/" + pointer.SearchPath:
+			body = expired.search
+		}
+		_, _ = writer.Write(body)
+	}))
+	defer expiredServer.Close()
+	expiredClient := Client{Origin: expiredServer.URL + "/", AllowHTTPForTests: true, Trust: expired.trust,
+		Cache: Cache{Path: filepath.Join(t.TempDir(), "expired.json")}, Now: func() time.Time { return now }}
+	if _, err := expiredClient.Load(context.Background(), 0); !errors.Is(err, ErrExpired) {
+		t.Fatalf("expired error = %v", err)
+	}
+}
+
+func TestInterruptedCacheReplacementRetainsLKG(t *testing.T) {
+	t.Parallel()
+	generated := time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC)
+	first := discoveryFixture(t, 1, generated)
+	path := filepath.Join(t.TempDir(), "cache.json")
+	cache := Cache{Path: path}
+	bundle, err := VerifyBundle(first.pointer, first.snapshot, first.envelope, first.search, first.trust)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.Store(bundle, first.trust); err != nil {
+		t.Fatal(err)
+	}
+	original, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache.BeforeRename = func(string) error { return errors.New("injected") }
+	second := discoveryFixture(t, 2, generated.Add(time.Hour))
+	secondBundle, err := VerifyBundle(second.pointer, second.snapshot, second.envelope, second.search, second.trust)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.Store(secondBundle, second.trust); err == nil || err.Error() != "injected" {
+		t.Fatalf("interrupted replacement error = %v", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil || string(after) != string(original) {
+		t.Fatalf("cache changed after interrupted reconciliation: %v", err)
+	}
+}

--- a/install/integrationctl/agentplugins/adapters/discoveryv1/models.go
+++ b/install/integrationctl/agentplugins/adapters/discoveryv1/models.go
@@ -1,0 +1,645 @@
+// Package discoveryv1 authenticates and validates the static unreviewed Agent
+// Plugins Discovery Index. It never acquires or executes package content.
+package discoveryv1
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"path"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	SchemaVersion    = 1
+	SignatureDomain  = "UAP-DISCOVERY-INDEX-ED25519-V1"
+	MaxLatestBytes   = 16 << 10
+	MaxEnvelopeBytes = 16 << 10
+	MaxSnapshotBytes = 16 << 20
+	MaxSearchBytes   = 10 << 20
+)
+
+type Pointer struct {
+	PointerSchemaVersion  int           `json:"pointer_schema_version"`
+	SnapshotSchemaVersion int           `json:"snapshot_schema_version"`
+	Sequence              uint64        `json:"sequence"`
+	SnapshotPath          string        `json:"snapshot_path"`
+	EnvelopePath          string        `json:"envelope_path"`
+	SearchPath            string        `json:"search_path"`
+	FetchContract         FetchContract `json:"fetch_contract"`
+}
+
+type FetchContract struct {
+	MaxRedirects     int `json:"max_redirects"`
+	LatestMaxBytes   int `json:"latest_max_bytes"`
+	SnapshotMaxBytes int `json:"snapshot_max_bytes"`
+	EnvelopeMaxBytes int `json:"envelope_max_bytes"`
+	SearchMaxBytes   int `json:"search_max_bytes"`
+	RetryAttempts    int `json:"retry_attempts"`
+}
+
+type Envelope struct {
+	EnvelopeSchemaVersion int    `json:"envelope_schema_version"`
+	SnapshotSchemaVersion int    `json:"snapshot_schema_version"`
+	Sequence              uint64 `json:"sequence"`
+	KeyID                 string `json:"key_id"`
+	Algorithm             string `json:"algorithm"`
+	SignatureDomain       string `json:"signature_domain"`
+	SnapshotDigest        string `json:"snapshot_digest"`
+	Signature             string `json:"signature"`
+}
+
+type Partition struct {
+	Query      string `json:"query"`
+	SizeMin    int    `json:"size_min"`
+	SizeMax    int    `json:"size_max"`
+	TotalCount int    `json:"total_count"`
+}
+
+type SearchProjection struct {
+	Path        string `json:"path"`
+	Digest      string `json:"digest"`
+	RecordCount int    `json:"record_count"`
+}
+
+type Components struct {
+	Extensions int `json:"extensions"`
+	MCP        int `json:"mcp"`
+	Skills     int `json:"skills"`
+}
+
+type Author struct {
+	Name  string `json:"name"`
+	Email string `json:"email,omitempty"`
+	URL   string `json:"url,omitempty"`
+}
+
+type Record struct {
+	Slug                   string     `json:"slug"`
+	Name                   string     `json:"name"`
+	Description            string     `json:"description"`
+	Owner                  string     `json:"owner"`
+	Repository             string     `json:"repository"`
+	PackagePath            string     `json:"package_path"`
+	Revision               string     `json:"revision"`
+	Version                *string    `json:"version"`
+	License                *string    `json:"license"`
+	SchemaVersion          string     `json:"schema_version"`
+	Components             Components `json:"components"`
+	MCPTransports          []string   `json:"mcp_transports"`
+	CompatibleClients      []string   `json:"compatible_clients"`
+	Authentication         string     `json:"authentication"`
+	Status                 string     `json:"status"`
+	RuntimeReviewed        bool       `json:"runtime_reviewed"`
+	TreeDigest             string     `json:"tree_digest"`
+	ManifestDigest         string     `json:"manifest_digest"`
+	Stars                  int        `json:"stars"`
+	RepositoryUpdatedAt    string     `json:"repository_updated_at"`
+	ReviewedDistributionID *string    `json:"reviewed_distribution_id"`
+	Availability           string     `json:"availability"`
+	Author                 *Author    `json:"author,omitempty"`
+	FirstSeen              string     `json:"first_seen,omitempty"`
+	LastSeen               string     `json:"last_seen,omitempty"`
+}
+
+type Snapshot struct {
+	DiscoverySchemaVersion int              `json:"discovery_schema_version"`
+	Sequence               uint64           `json:"sequence"`
+	PublicationID          string           `json:"publication_id"`
+	SourceCommit           string           `json:"source_commit"`
+	GeneratedAt            string           `json:"generated_at"`
+	ExpiresAt              string           `json:"expires_at"`
+	Complete               bool             `json:"complete"`
+	QueryManifestDigest    string           `json:"query_manifest_digest"`
+	Partitions             []Partition      `json:"partitions"`
+	SearchProjection       SearchProjection `json:"search_projection"`
+	Records                []Record         `json:"records"`
+}
+
+type Search struct {
+	SearchSchemaVersion int      `json:"search_schema_version"`
+	Sequence            uint64   `json:"sequence"`
+	GeneratedAt         string   `json:"generated_at"`
+	Records             []Record `json:"records"`
+}
+
+type KeyState string
+
+const (
+	KeyCurrent KeyState = "current"
+	KeyNext    KeyState = "next"
+	KeyRetired KeyState = "retired"
+)
+
+type TrustedKey struct {
+	ID        string
+	PublicKey ed25519.PublicKey
+	State     KeyState
+}
+
+type TrustStore struct{ Keys []TrustedKey }
+
+type BundleSource string
+
+const (
+	BundleSourceVerified BundleSource = "verified"
+	BundleSourceRemote   BundleSource = "remote"
+	BundleSourceCache    BundleSource = "cache"
+)
+
+type VerifiedBundle struct {
+	PointerBytes  []byte
+	SnapshotBytes []byte
+	EnvelopeBytes []byte
+	SearchBytes   []byte
+	Pointer       Pointer
+	Snapshot      Snapshot
+	Envelope      Envelope
+	Search        Search
+	Digest        string
+	Source        BundleSource
+}
+
+var (
+	ErrStrictJSON       = errors.New("Discovery JSON is not strict schema 1")
+	ErrUnknownKey       = errors.New("unknown Discovery signing key")
+	ErrRetiredKey       = errors.New("retired Discovery signing key")
+	ErrNoTrustedKeys    = errors.New("no trusted Discovery signing keys configured")
+	ErrDigestMismatch   = errors.New("Discovery artifact digest mismatch")
+	ErrInvalidSignature = errors.New("invalid Discovery snapshot signature")
+	ErrSequenceMismatch = errors.New("Discovery schema or sequence mismatch")
+	ErrExpired          = errors.New("Discovery snapshot is expired")
+	ErrClockSkew        = errors.New("local clock is before Discovery generation time")
+	ErrRollback         = errors.New("Discovery snapshot sequence is below local floor")
+	ErrSequenceConflict = errors.New("Discovery sequence has conflicting authenticated bytes")
+	ErrUnavailable      = errors.New("no valid Discovery snapshot is available")
+)
+
+var (
+	keyIDPattern       = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$`)
+	publicationPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
+	repositoryPattern  = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*/[a-z0-9][a-z0-9._-]*$`)
+	packagePathPattern = regexp.MustCompile(`^(?:|[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*)$`)
+	shaPattern         = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	digestPattern      = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	timestampPattern   = regexp.MustCompile(`^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$`)
+)
+
+var signaturePrefix = []byte(SignatureDomain + "\x00")
+
+func ParsePointer(body []byte) (Pointer, error) {
+	var value Pointer
+	if err := strictDecode(body, &value, MaxLatestBytes); err != nil {
+		return value, strictError("pointer: %v", err)
+	}
+	if err := exactObject(body, []string{"pointer_schema_version", "snapshot_schema_version", "sequence", "snapshot_path", "envelope_path", "search_path", "fetch_contract"}); err != nil {
+		return value, strictError("pointer: %v", err)
+	}
+	var root map[string]json.RawMessage
+	_ = json.Unmarshal(body, &root)
+	if err := exactObject(root["fetch_contract"], []string{"max_redirects", "latest_max_bytes", "snapshot_max_bytes", "envelope_max_bytes", "search_max_bytes", "retry_attempts"}); err != nil {
+		return value, strictError("fetch contract: %v", err)
+	}
+	stem := fmt.Sprintf("%020d", value.Sequence)
+	if value.PointerSchemaVersion != 1 || value.SnapshotSchemaVersion != 1 || value.Sequence < 1 ||
+		exactPath(value.SnapshotPath, "snapshots/"+stem+".json") != nil ||
+		exactPath(value.EnvelopePath, "snapshots/"+stem+".envelope.json") != nil ||
+		exactPath(value.SearchPath, "search/"+stem+".json") != nil {
+		return value, strictError("invalid pointer identity")
+	}
+	c := value.FetchContract
+	if c.MaxRedirects != 0 || c.RetryAttempts < 1 || c.RetryAttempts > 3 || c.LatestMaxBytes < 1 || c.LatestMaxBytes > MaxLatestBytes ||
+		c.SnapshotMaxBytes < 1 || c.SnapshotMaxBytes > MaxSnapshotBytes || c.EnvelopeMaxBytes < 1 || c.EnvelopeMaxBytes > MaxEnvelopeBytes ||
+		c.SearchMaxBytes < 1 || c.SearchMaxBytes > MaxSearchBytes {
+		return value, strictError("unsafe fetch contract")
+	}
+	return value, nil
+}
+
+func VerifyBundle(pointerBytes, snapshotBytes, envelopeBytes, searchBytes []byte, trust TrustStore) (VerifiedBundle, error) {
+	if len(trust.Keys) == 0 {
+		return VerifiedBundle{}, ErrNoTrustedKeys
+	}
+	pointer, err := ParsePointer(pointerBytes)
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	var envelope Envelope
+	if err := strictDecode(envelopeBytes, &envelope, MaxEnvelopeBytes); err != nil {
+		return VerifiedBundle{}, strictError("envelope: %v", err)
+	}
+	if err := exactObject(envelopeBytes, []string{"envelope_schema_version", "snapshot_schema_version", "sequence", "key_id", "algorithm", "signature_domain", "snapshot_digest", "signature"}); err != nil {
+		return VerifiedBundle{}, strictError("envelope: %v", err)
+	}
+	if envelope.EnvelopeSchemaVersion != 1 || envelope.SnapshotSchemaVersion != 1 || envelope.Sequence < 1 || !keyIDPattern.MatchString(envelope.KeyID) ||
+		envelope.Algorithm != "Ed25519" || envelope.SignatureDomain != SignatureDomain || !digestPattern.MatchString(envelope.SnapshotDigest) {
+		return VerifiedBundle{}, strictError("invalid envelope")
+	}
+	sum := sha256.Sum256(snapshotBytes)
+	digest := "sha256:" + hex.EncodeToString(sum[:])
+	if digest != envelope.SnapshotDigest {
+		return VerifiedBundle{}, ErrDigestMismatch
+	}
+	key, err := trustedKey(trust, envelope.KeyID)
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	signature, err := base64.StdEncoding.Strict().DecodeString(envelope.Signature)
+	if err != nil || len(signature) != ed25519.SignatureSize || !ed25519.Verify(key.PublicKey, SignatureMessage(snapshotBytes), signature) {
+		return VerifiedBundle{}, ErrInvalidSignature
+	}
+	snapshot, err := parseSnapshot(snapshotBytes)
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	search, err := parseSearch(searchBytes)
+	if err != nil {
+		return VerifiedBundle{}, err
+	}
+	if pointer.Sequence != snapshot.Sequence || envelope.Sequence != snapshot.Sequence || search.Sequence != snapshot.Sequence ||
+		pointer.SnapshotSchemaVersion != snapshot.DiscoverySchemaVersion || envelope.SnapshotSchemaVersion != snapshot.DiscoverySchemaVersion ||
+		pointer.SearchPath != snapshot.SearchProjection.Path || search.GeneratedAt != snapshot.GeneratedAt || len(search.Records) != snapshot.SearchProjection.RecordCount {
+		return VerifiedBundle{}, ErrSequenceMismatch
+	}
+	searchSum := sha256.Sum256(searchBytes)
+	if "sha256:"+hex.EncodeToString(searchSum[:]) != snapshot.SearchProjection.Digest {
+		return VerifiedBundle{}, ErrDigestMismatch
+	}
+	for index := range snapshot.Records {
+		expected := snapshot.Records[index]
+		expected.Author, expected.FirstSeen, expected.LastSeen = nil, "", ""
+		if !reflect.DeepEqual(expected, search.Records[index]) {
+			return VerifiedBundle{}, strictError("search projection does not match signed records")
+		}
+	}
+	return VerifiedBundle{
+		PointerBytes: append([]byte(nil), pointerBytes...), SnapshotBytes: append([]byte(nil), snapshotBytes...),
+		EnvelopeBytes: append([]byte(nil), envelopeBytes...), SearchBytes: append([]byte(nil), searchBytes...),
+		Pointer: pointer, Snapshot: snapshot, Envelope: envelope, Search: search, Digest: digest, Source: BundleSourceVerified,
+	}, nil
+}
+
+func SignatureMessage(snapshot []byte) []byte {
+	message := make([]byte, 0, len(signaturePrefix)+8+len(snapshot))
+	message = append(message, signaturePrefix...)
+	message = binary.BigEndian.AppendUint64(message, uint64(len(snapshot)))
+	return append(message, snapshot...)
+}
+
+func parseSnapshot(body []byte) (Snapshot, error) {
+	var value Snapshot
+	if err := strictDecode(body, &value, MaxSnapshotBytes); err != nil {
+		return value, strictError("snapshot: %v", err)
+	}
+	rootFields := []string{"discovery_schema_version", "sequence", "publication_id", "source_commit", "generated_at", "expires_at", "complete", "query_manifest_digest", "partitions", "search_projection", "records"}
+	if err := exactObject(body, rootFields); err != nil {
+		return value, strictError("snapshot: %v", err)
+	}
+	var root map[string]json.RawMessage
+	_ = json.Unmarshal(body, &root)
+	if err := validateNested(root, true); err != nil {
+		return value, err
+	}
+	if value.DiscoverySchemaVersion != 1 || value.Sequence < 1 || !publicationPattern.MatchString(value.PublicationID) || !shaPattern.MatchString(value.SourceCommit) ||
+		!value.Complete || !digestPattern.MatchString(value.QueryManifestDigest) || value.Partitions == nil || value.Records == nil || len(value.Records) > 10_000 {
+		return value, strictError("invalid snapshot identity")
+	}
+	generated, err := parseTimestamp(value.GeneratedAt)
+	if err != nil {
+		return value, strictError("generated_at: %v", err)
+	}
+	expires, err := parseTimestamp(value.ExpiresAt)
+	if err != nil || !expires.After(generated) || expires.Sub(generated) > 7*24*time.Hour {
+		return value, strictError("invalid snapshot lifetime")
+	}
+	stem := fmt.Sprintf("%020d", value.Sequence)
+	if exactPath(value.SearchProjection.Path, "search/"+stem+".json") != nil || !digestPattern.MatchString(value.SearchProjection.Digest) ||
+		value.SearchProjection.RecordCount != len(value.Records) {
+		return value, strictError("invalid search projection")
+	}
+	for index, partition := range value.Partitions {
+		if partition.Query == "" || partition.SizeMin < 0 || partition.SizeMax < partition.SizeMin || partition.SizeMax > 1<<20 || partition.TotalCount < 0 || partition.TotalCount > 1000 {
+			return value, strictError("invalid partition %d", index)
+		}
+	}
+	if err := validateRecords(value.Records, generated, true); err != nil {
+		return value, err
+	}
+	return value, nil
+}
+
+func parseSearch(body []byte) (Search, error) {
+	var value Search
+	if err := strictDecode(body, &value, MaxSearchBytes); err != nil {
+		return value, strictError("search: %v", err)
+	}
+	if err := exactObject(body, []string{"search_schema_version", "sequence", "generated_at", "records"}); err != nil {
+		return value, strictError("search: %v", err)
+	}
+	var root map[string]json.RawMessage
+	_ = json.Unmarshal(body, &root)
+	if err := validateNested(root, false); err != nil {
+		return value, err
+	}
+	if value.SearchSchemaVersion != 1 || value.Sequence < 1 || value.Records == nil || len(value.Records) > 10_000 {
+		return value, strictError("invalid search projection identity")
+	}
+	generated, err := parseTimestamp(value.GeneratedAt)
+	if err != nil {
+		return value, strictError("search generated_at: %v", err)
+	}
+	if err := validateRecords(value.Records, generated, false); err != nil {
+		return value, err
+	}
+	return value, nil
+}
+
+func validateNested(root map[string]json.RawMessage, snapshot bool) error {
+	var projection map[string]json.RawMessage
+	if snapshot {
+		if err := exactObject(root["search_projection"], []string{"path", "digest", "record_count"}); err != nil {
+			return strictError("search projection: %v", err)
+		}
+		var partitions []json.RawMessage
+		if err := json.Unmarshal(root["partitions"], &partitions); err != nil {
+			return strictError("partitions: %v", err)
+		}
+		for _, item := range partitions {
+			if err := exactObject(item, []string{"query", "size_min", "size_max", "total_count"}); err != nil {
+				return strictError("partition: %v", err)
+			}
+		}
+		_ = projection
+	}
+	var records []json.RawMessage
+	if err := json.Unmarshal(root["records"], &records); err != nil {
+		return strictError("records: %v", err)
+	}
+	common := []string{"slug", "name", "description", "owner", "repository", "package_path", "revision", "version", "license", "schema_version", "components", "mcp_transports", "compatible_clients", "authentication", "status", "runtime_reviewed", "tree_digest", "manifest_digest", "stars", "repository_updated_at", "reviewed_distribution_id", "availability"}
+	for _, raw := range records {
+		fields := append([]string(nil), common...)
+		if snapshot {
+			fields = append(fields, "author", "first_seen", "last_seen")
+		}
+		if err := exactObject(raw, fields); err != nil {
+			return strictError("record: %v", err)
+		}
+		var record map[string]json.RawMessage
+		_ = json.Unmarshal(raw, &record)
+		if err := exactObject(record["components"], []string{"extensions", "mcp", "skills"}); err != nil {
+			return strictError("components: %v", err)
+		}
+		if snapshot && string(record["author"]) != "null" {
+			var author map[string]json.RawMessage
+			if err := json.Unmarshal(record["author"], &author); err != nil {
+				return strictError("author: %v", err)
+			}
+			allowed := map[string]bool{"name": true, "email": true, "url": true}
+			if len(author) < 1 || len(author) > 3 || author["name"] == nil {
+				return strictError("author fields are invalid")
+			}
+			for key := range author {
+				if !allowed[key] {
+					return strictError("unknown author field %q", key)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func validateRecords(records []Record, generated time.Time, snapshot bool) error {
+	seenIdentity, seenSlug := map[string]bool{}, map[string]bool{}
+	for index, record := range records {
+		if !repositoryPattern.MatchString(record.Repository) || record.Owner != strings.SplitN(record.Repository, "/", 2)[0] || !packagePathPattern.MatchString(record.PackagePath) || !shaPattern.MatchString(record.Revision) ||
+			record.SchemaVersion != "1.0.0" || !digestPattern.MatchString(record.TreeDigest) || !digestPattern.MatchString(record.ManifestDigest) || record.Stars < 0 ||
+			record.Status != "conformant_unreviewed" || record.RuntimeReviewed || (record.Availability != "available" && record.Availability != "unavailable") {
+			return strictError("invalid record %d identity", index)
+		}
+		expectedSlug := "discovery:" + record.Repository
+		if record.PackagePath != "" {
+			expectedSlug += "//" + record.PackagePath
+		}
+		identity := strings.ToLower(record.Repository + "\x00" + record.PackagePath)
+		if record.Slug != expectedSlug || seenIdentity[identity] || seenSlug[record.Slug] {
+			return strictError("duplicate or non-canonical record %q", record.Slug)
+		}
+		seenIdentity[identity], seenSlug[record.Slug] = true, true
+		if utf8.RuneCountInString(record.Name) < 1 || utf8.RuneCountInString(record.Name) > 64 || utf8.RuneCountInString(record.Description) > 500 ||
+			record.Components.Extensions < 0 || record.Components.MCP < 0 || record.Components.Skills < 0 {
+			return strictError("invalid record %q metadata", record.Slug)
+		}
+		if err := enumList(record.MCPTransports, []string{"sse", "stdio", "streamable-http"}, true); err != nil {
+			return strictError("record %q transports: %v", record.Slug, err)
+		}
+		// ChatGPT compatibility requires a separately registered app binding.
+		// Unreviewed Discovery conformance cannot establish that trust boundary.
+		if err := enumList(record.CompatibleClients, []string{"codex", "cursor", "copilot", "vscode", "kiro"}, false); err != nil {
+			return strictError("record %q clients: %v", record.Slug, err)
+		}
+		if record.Authentication != "required" && record.Authentication != "not_required" && record.Authentication != "unknown" {
+			return strictError("record %q authentication is invalid", record.Slug)
+		}
+		if _, err := parseTimestamp(record.RepositoryUpdatedAt); err != nil {
+			return strictError("record %q repository_updated_at is invalid", record.Slug)
+		}
+		if snapshot {
+			first, firstErr := parseTimestamp(record.FirstSeen)
+			last, lastErr := parseTimestamp(record.LastSeen)
+			if firstErr != nil || lastErr != nil || first.After(last) || last.After(generated) || (record.Author != nil && strings.TrimSpace(record.Author.Name) == "") {
+				return strictError("record %q seen interval or author is invalid", record.Slug)
+			}
+		} else if record.Author != nil || record.FirstSeen != "" || record.LastSeen != "" {
+			return strictError("search record %q contains snapshot-only fields", record.Slug)
+		}
+	}
+	if !sort.SliceIsSorted(records, func(i, j int) bool {
+		if records[i].Repository != records[j].Repository {
+			return records[i].Repository < records[j].Repository
+		}
+		if strings.ToLower(records[i].PackagePath) != strings.ToLower(records[j].PackagePath) {
+			return strings.ToLower(records[i].PackagePath) < strings.ToLower(records[j].PackagePath)
+		}
+		return records[i].Slug < records[j].Slug
+	}) {
+		return strictError("records are not canonically ordered")
+	}
+	return nil
+}
+
+func enumList(values, allowed []string, lexical bool) error {
+	if values == nil {
+		return errors.New("array is null")
+	}
+	positions := map[string]int{}
+	for index, value := range allowed {
+		positions[value] = index
+	}
+	previous := -1
+	for _, value := range values {
+		position, ok := positions[value]
+		if !ok || position <= previous {
+			return errors.New("values are unknown, duplicated, or out of canonical order")
+		}
+		previous = position
+	}
+	if lexical && !sort.StringsAreSorted(values) {
+		return errors.New("values are not sorted")
+	}
+	return nil
+}
+
+func ValidityError(snapshot Snapshot, now time.Time) error {
+	generated, err := parseTimestamp(snapshot.GeneratedAt)
+	if err != nil {
+		return err
+	}
+	expires, err := parseTimestamp(snapshot.ExpiresAt)
+	if err != nil {
+		return err
+	}
+	if now.UTC().Before(generated) {
+		return ErrClockSkew
+	}
+	if !now.UTC().Before(expires) {
+		return ErrExpired
+	}
+	return nil
+}
+
+func trustedKey(store TrustStore, id string) (TrustedKey, error) {
+	seen := map[string]bool{}
+	for _, key := range store.Keys {
+		if seen[key.ID] || !keyIDPattern.MatchString(key.ID) || len(key.PublicKey) != ed25519.PublicKeySize || (key.State != KeyCurrent && key.State != KeyNext && key.State != KeyRetired) {
+			return TrustedKey{}, fmt.Errorf("%w: malformed configured key %s", ErrUnknownKey, key.ID)
+		}
+		seen[key.ID] = true
+	}
+	for _, key := range store.Keys {
+		if key.ID == id {
+			if key.State == KeyRetired {
+				return TrustedKey{}, fmt.Errorf("%w: %s", ErrRetiredKey, id)
+			}
+			return key, nil
+		}
+	}
+	return TrustedKey{}, fmt.Errorf("%w: %s", ErrUnknownKey, id)
+}
+
+func strictDecode(body []byte, destination any, limit int) error {
+	if len(body) == 0 || len(body) > limit || !json.Valid(body) {
+		return errors.New("empty, oversized, or invalid JSON")
+	}
+	if err := rejectDuplicateKeys(body); err != nil {
+		return err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(destination); err != nil {
+		return err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return errors.New("trailing JSON value")
+	}
+	return nil
+}
+
+func rejectDuplicateKeys(body []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	if err := scanJSONValue(decoder); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		return errors.New("trailing JSON")
+	}
+	return nil
+}
+
+func scanJSONValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delimiter, compound := token.(json.Delim)
+	if !compound {
+		return nil
+	}
+	switch delimiter {
+	case '{':
+		keys := map[string]bool{}
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := keyToken.(string)
+			if !ok || keys[key] {
+				return fmt.Errorf("duplicate or invalid JSON key %q", key)
+			}
+			keys[key] = true
+			if err := scanJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		_, err = decoder.Token()
+		return err
+	case '[':
+		for decoder.More() {
+			if err := scanJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		_, err = decoder.Token()
+		return err
+	default:
+		return errors.New("unexpected JSON delimiter")
+	}
+}
+
+func exactObject(body []byte, fields []string) error {
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(body, &object); err != nil {
+		return err
+	}
+	if len(object) != len(fields) {
+		return errors.New("object fields do not match schema")
+	}
+	for _, field := range fields {
+		if _, ok := object[field]; !ok {
+			return fmt.Errorf("missing field %q", field)
+		}
+	}
+	return nil
+}
+
+func exactPath(actual, expected string) error {
+	if actual != expected || strings.ContainsAny(actual, `\:`) || strings.HasPrefix(actual, "/") || path.Clean(actual) != actual {
+		return errors.New("unsafe artifact path")
+	}
+	return nil
+}
+
+func parseTimestamp(value string) (time.Time, error) {
+	if !timestampPattern.MatchString(value) {
+		return time.Time{}, errors.New("timestamp must use second-precision UTC")
+	}
+	return time.Parse(time.RFC3339, value)
+}
+
+func strictError(format string, arguments ...any) error {
+	return fmt.Errorf("%w: %s", ErrStrictJSON, fmt.Sprintf(format, arguments...))
+}

--- a/install/integrationctl/agentplugins/adapters/discoveryv1/models.go
+++ b/install/integrationctl/agentplugins/adapters/discoveryv1/models.go
@@ -367,7 +367,6 @@ func parseSearch(body []byte) (Search, error) {
 }
 
 func validateNested(root map[string]json.RawMessage, snapshot bool) error {
-	var projection map[string]json.RawMessage
 	if snapshot {
 		if err := exactObject(root["search_projection"], []string{"path", "digest", "record_count"}); err != nil {
 			return strictError("search projection: %v", err)
@@ -381,7 +380,6 @@ func validateNested(root map[string]json.RawMessage, snapshot bool) error {
 				return strictError("partition: %v", err)
 			}
 		}
-		_ = projection
 	}
 	var records []json.RawMessage
 	if err := json.Unmarshal(root["records"], &records); err != nil {
@@ -469,8 +467,9 @@ func validateRecords(records []Record, generated time.Time, snapshot bool) error
 		if records[i].Repository != records[j].Repository {
 			return records[i].Repository < records[j].Repository
 		}
-		if strings.ToLower(records[i].PackagePath) != strings.ToLower(records[j].PackagePath) {
-			return strings.ToLower(records[i].PackagePath) < strings.ToLower(records[j].PackagePath)
+		left, right := strings.ToLower(records[i].PackagePath), strings.ToLower(records[j].PackagePath)
+		if left != right {
+			return left < right
 		}
 		return records[i].Slug < records[j].Slug
 	}) {

--- a/install/integrationctl/agentplugins/domain/directory.go
+++ b/install/integrationctl/agentplugins/domain/directory.go
@@ -284,9 +284,10 @@ type DirectorySelection struct {
 }
 
 var (
-	ErrDirectoryNotFound   = errors.New("directory selector not found")
-	ErrDirectoryAmbiguous  = errors.New("directory selector is ambiguous")
-	ErrDirectoryIneligible = errors.New("no eligible directory release")
+	ErrDirectoryNotFound     = errors.New("directory selector not found")
+	ErrDirectoryAmbiguous    = errors.New("directory selector is ambiguous")
+	ErrDirectoryIneligible   = errors.New("no eligible directory release")
+	ErrDirectoryNoSafeUpdate = errors.New("no safe directory update")
 )
 
 // ResolveDirectory is deterministic and side-effect free. It selects one
@@ -676,11 +677,16 @@ func uniqueClients(values []ClientID) []ClientID {
 }
 func ineligibleError(id string, reasons []eligibilityReason) error {
 	parts := []string{}
+	noSafeUpdate := false
 	for _, r := range reasons {
 		parts = append(parts, r.message)
+		noSafeUpdate = noSafeUpdate || r.code == "no_safe_update"
 	}
 	if len(parts) == 0 {
 		parts = []string{"no release matches the operation"}
+	}
+	if noSafeUpdate {
+		return fmt.Errorf("%w: %w in %q: %s", ErrDirectoryIneligible, ErrDirectoryNoSafeUpdate, id, strings.Join(parts, "; "))
 	}
 	return fmt.Errorf("%w in %q: %s", ErrDirectoryIneligible, id, strings.Join(parts, "; "))
 }

--- a/install/integrationctl/agentplugins/domain/directory_test.go
+++ b/install/integrationctl/agentplugins/domain/directory_test.go
@@ -203,6 +203,20 @@ func TestResolveDirectoryOperationMatrixAndTopLevelRevocation(t *testing.T) {
 	}
 }
 
+func TestResolveDirectoryUpdateWithoutSuccessorReturnsTypedNoSafeUpdate(t *testing.T) {
+	snapshot := testDirectory()
+	request := request("owner/tool", ClientCodex)
+	request.Operation = DirectoryUpdate
+	request.Recorded = &RecordedDirectoryRelease{
+		ProductID: "tool", DistributionID: "owner/tool", ReleaseSequence: 3,
+		ResolvedRevision: testRelease(3, "").PackageSource.Revision,
+	}
+	_, err := ResolveDirectory(snapshot, request)
+	if !errors.Is(err, ErrDirectoryIneligible) || !errors.Is(err, ErrDirectoryNoSafeUpdate) {
+		t.Fatalf("no-successor update error = %v", err)
+	}
+}
+
 func TestResolveDirectoryRecordedReAddRetainsExactRelease(t *testing.T) {
 	s := testDirectory()
 	recorded := &RecordedDirectoryRelease{ProductID: "tool", DistributionID: "owner/tool", ReleaseSequence: 2, ResolvedRevision: testRelease(2, "").PackageSource.Revision}

--- a/npm/agentplugins/README.md
+++ b/npm/agentplugins/README.md
@@ -23,7 +23,7 @@ binary matching the exact npm version, verifies the SHA-256 embedded in the npm
 tarball, then caches it under XDG Cache or LocalAppData. It never falls back to
 `latest` and never sends `GITHUB_TOKEN` to public downloads.
 
-Release 0.1.5 passed exact native npm bootstrap proofs on all six supported
+Release 0.1.15 passed exact native npm bootstrap proofs on all six supported
 platforms:
 
 | OS | x64 | arm64 |
@@ -38,8 +38,12 @@ the binary runs.
 ```bash
 npx universal-agent-plugins doctor
 npx universal-agent-plugins list
+npx universal-agent-plugins search docs
+npx universal-agent-plugins validate ./my-plugin
 npx universal-agent-plugins add context7 --dry-run --target cursor
 npx universal-agent-plugins add context7 --target codex,cursor,kiro
+npx universal-agent-plugins outdated --all
+npx universal-agent-plugins update --all
 npx universal-agent-plugins update context7 --target codex,cursor,kiro
 npx universal-agent-plugins repair context7 --target codex,cursor,kiro
 npx universal-agent-plugins remove context7 --target codex,cursor,kiro
@@ -50,6 +54,15 @@ npx universal-agent-plugins switch context7 --to upstash/context7
 reapplies or reactivates the recorded revision; it does not update or change
 source. `switch` moves the complete installation to a qualified Directory
 distribution or exact source, so it uses `--to` instead of `--target`.
+
+`search` combines reviewed Directory releases with a separately signed
+Discovery Index. Discovery results remain visibly unreviewed and use an exact,
+publisher-qualified selector such as `discovery:owner/repo//path`. Before any
+mutation, the CLI reacquires the indexed commit and validates the package. The
+index signature authenticates discovery metadata; it does not endorse package
+code or runtime behavior. `outdated` is read-only. `update --all` preserves each
+installation's recorded source and targets and performs a complete batch
+preflight before applying updates.
 
 A successful non-dry-run, multi-target `add --format json` includes one
 `data.acquisition` proof and a `data.target_outcomes` object keyed by every

--- a/repotests/integrations_claude_lifecycle_e2e_test.go
+++ b/repotests/integrations_claude_lifecycle_e2e_test.go
@@ -452,6 +452,7 @@ add_state() {
     printf '%s\t%s\t1\n' "$plugin_ref" "$scope" >> "$tmp"
   fi
   mv "$tmp" "$state_file"
+  return 0
 }
 
 has_state() {
@@ -528,6 +529,7 @@ record_marketplace() {
     printf '%s\t%s\n' "$marketplace_name" "$root" >> "$tmp"
   fi
   mv "$tmp" "$marketplaces_file"
+  return 0
 }
 
 marketplace_root() {


### PR DESCRIPTION
## Summary
- add fail-closed signed Discovery Index loading and caching
- add install, search, validate, outdated, and update --all UX
- preserve exact-source lifecycle, rollback, and existing state compatibility

## Verification
- go test ./... -count=1
- npm test
- npm pack --dry-run --ignore-scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `search` for discovering compatible plugins with trust and source details.
  * Added `validate` for checking packages and viewing conformance information.
  * Added read-only `outdated` status checks, including `--all`.
  * Added batch `update --all` with complete preflight validation before changes.
  * Added `install` as an alias for `add`.
  * Added support for signed Discovery Index sources.

* **Documentation**
  * Updated command examples and documented search, validation, outdated, and batch update behavior.

* **Bug Fixes**
  * Improved process cleanup and safer Discovery data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->