### PR TITLE
fix(agentplugins): retry interrupted Darwin exit observation

### DIFF
--- a/install/integrationctl/adapters/process/osrunner_tree_darwin.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_darwin.go
@@ -22,6 +22,7 @@ type commandContainment struct {
 	cmd              *exec.Cmd
 	kqueue           int
 	exitObservation  latchedExitObservation
+	kevent           func(int, []unix.Kevent_t, []unix.Kevent_t, *unix.Timespec) (int, error)
 	liveGroupMembers func(int) (int, error)
 	killGroup        func(int, syscall.Signal) error
 }
@@ -69,7 +70,13 @@ func (containment *commandContainment) attach(cmd *exec.Cmd) error {
 	change := unix.Kevent_t{}
 	unix.SetKevent(&change, cmd.Process.Pid, unix.EVFILT_PROC, unix.EV_ADD|unix.EV_ENABLE|unix.EV_CLEAR)
 	change.Fflags = unix.NOTE_EXIT
-	_, err := unix.Kevent(containment.kqueue, []unix.Kevent_t{change}, nil, nil)
+	var err error
+	for {
+		_, err = containment.callKevent([]unix.Kevent_t{change}, nil, nil)
+		if !errors.Is(err, syscall.EINTR) {
+			break
+		}
+	}
 	if errors.Is(err, syscall.ESRCH) {
 		containment.exitObservation.latch()
 		return nil
@@ -128,9 +135,22 @@ func (containment *commandContainment) exited() (bool, error) {
 	return containment.exitObservation.observe(func() (bool, error) {
 		events := make([]unix.Kevent_t, 1)
 		timeout := unix.Timespec{}
-		n, err := unix.Kevent(containment.kqueue, nil, events, &timeout)
+		n, err := containment.callKevent(nil, events, &timeout)
+		if errors.Is(err, syscall.EINTR) {
+			// A signal can interrupt this non-blocking observation after Git or
+			// another short-lived child exits. The NOTE_EXIT event remains queued,
+			// so let the supervised poll retry instead of failing a clean command.
+			return false, nil
+		}
 		return err == nil && n > 0 && events[0].Fflags&unix.NOTE_EXIT != 0, err
 	})
+}
+
+func (containment *commandContainment) callKevent(changes, events []unix.Kevent_t, timeout *unix.Timespec) (int, error) {
+	if containment.kevent != nil {
+		return containment.kevent(containment.kqueue, changes, events, timeout)
+	}
+	return unix.Kevent(containment.kqueue, changes, events, timeout)
 }
 
 func (containment *commandContainment) groupMembers(pgid int) (int, error) {

--- a/install/integrationctl/adapters/process/osrunner_tree_darwin_test.go
+++ b/install/integrationctl/adapters/process/osrunner_tree_darwin_test.go
@@ -1,0 +1,53 @@
+//go:build darwin
+
+package process
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestDarwinExitObservationRetriesAfterInterruptedSystemCall(t *testing.T) {
+	calls := 0
+	containment := &commandContainment{kevent: func(_ int, _ []unix.Kevent_t, events []unix.Kevent_t, _ *unix.Timespec) (int, error) {
+		calls++
+		if calls == 1 {
+			return 0, syscall.EINTR
+		}
+		events[0].Fflags = unix.NOTE_EXIT
+		return 1, nil
+	}}
+
+	if exited, err := containment.exited(); err != nil || exited {
+		t.Fatalf("interrupted observation = %v, %v, want pending without error", exited, err)
+	}
+	if exited, err := containment.exited(); err != nil || !exited {
+		t.Fatalf("retried observation = %v, %v, want exit", exited, err)
+	}
+}
+
+func TestDarwinAttachRetriesInterruptedRegistration(t *testing.T) {
+	calls := 0
+	containment := &commandContainment{kevent: func(_ int, changes []unix.Kevent_t, _ []unix.Kevent_t, _ *unix.Timespec) (int, error) {
+		calls++
+		if len(changes) != 1 {
+			t.Fatalf("registration changes = %d, want 1", len(changes))
+		}
+		if calls == 1 {
+			return 0, syscall.EINTR
+		}
+		return 0, nil
+	}}
+	cmd := exec.Command("true")
+	cmd.Process = &os.Process{Pid: 1234}
+	if err := containment.attach(cmd); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("registration calls = %d, want 2", calls)
+	}
+}


### PR DESCRIPTION
## Summary

- Treat `EINTR` from the non-blocking Darwin kqueue exit observation as a retryable poll
- Retry interrupted kqueue registration before supervising a child process
- Add Darwin regression tests for both boundaries

## Why

`agentplugins add owner/repo@FULL_SHA//path` could fetch successfully with Git itself but fail on macOS with `observe process exit: interrupted system call`. The supervisor was treating a transient `kevent(2)` interruption as a command failure after the child had exited cleanly.

## Verification

- `go test ./adapters/process -count=10`
- `go test ./agentplugins/adapters/sourceacquisition -count=3`
- Full `cli/plugin-kit-ai` Go suite
- Reproduced the original full-SHA GitHub fetch through `sourceacquisition.OSRunner` before the fix and verified the same fetch succeeds after it

The complete integrationctl suite also exposes pre-existing case-insensitive filesystem and timing failures on macOS outside this change; required CI remains authoritative for those platform-specific fixtures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved process monitoring on macOS when system notifications are temporarily interrupted.
  - Commands now continue monitoring and register correctly instead of failing during transient interruptions.

- **Tests**
  - Added coverage for interrupted process registration and exit detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->