### PR TITLE
fix(agentplugins): install Kiro standard components natively

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,11 @@ activate automatically, while others finish as prepared and print a manual
 activation step. OAuth and consent prompts stay visible and user-controlled;
 cancelling one preserves the package and reports authentication as pending or
 cancelled.
-For native MCP-only Kiro packages, supported Kiro CLI versions are checked
-after import through a bounded structured ACP v1 initialize/session handshake.
+Kiro skills are installed directly into the documented global skills path.
+For packages with MCP servers, agentplugins atomically merges only its owned
+entries into Kiro's global `mcp.json`, preserving unrelated user configuration,
+then checks supported Kiro CLI versions through a bounded structured ACP v1
+initialize/session handshake.
 It sends no prompt or model/tool turn and does not inject package endpoints;
 Kiro must load its installed native configuration and report connected servers
 with enabled tools. The verifier drains a bounded quiet settlement window,
@@ -89,9 +92,9 @@ long-lived ACP process through supervised containment. Automatic Kiro ACP
 verification is available only on Linux after capability preflight proves
 delegated cgroup v2 creation, atomic CLONE_INTO_CGROUP placement, and
 cgroup.kill. macOS, Windows, and Linux hosts without every required proof fail
-preflight before any native mutation. On those hosts, install or import the
-package manually in Kiro, activate it in Kiro's UI, and verify its servers
-there; that workflow is outside this automatic CLI path. Failure to start ACP
+preflight before any MCP mutation. On those hosts, use Kiro's documented manual
+skill and MCP configuration paths; that workflow is outside this automatic CLI
+path. Failure to start ACP
 after a supported preflight may still leave a manual verification action. This
 is activation evidence, not a runtime tool E2E claim.
 Once the ACP process starts, companion-launch failure (including a missing

--- a/install/integrationctl/agentplugins/domain/clients.go
+++ b/install/integrationctl/agentplugins/domain/clients.go
@@ -157,6 +157,9 @@ type ActivationRequest struct {
 	Replacing         bool           `json:"replacing"`
 	Interactive       bool           `json:"interactive"`
 	BackendExecutable string         `json:"-"`
+	// PreviousNativeObjects binds replacement preflight to the exact native
+	// objects recorded by the currently installed package revision.
+	PreviousNativeObjects []NativeObjectOwnership `json:"-"`
 	// VerifyOnly forbids client mutation and asks the provider to inspect the
 	// current client state. ActivationComplete is an explicit user attestation
 	// accepted only when verification is unavailable or returns unknown evidence.
@@ -179,14 +182,15 @@ type ActivationOutcome struct {
 }
 
 type DeactivationRequest struct {
-	Client              DetectedClient  `json:"client"`
-	DeclaredName        string          `json:"declared_name"`
-	CurrentActivation   ActivationState `json:"current_activation"`
-	Interactive         bool            `json:"interactive"`
-	ExternalUninstalled bool            `json:"external_uninstalled"`
-	Confirmed           bool            `json:"confirmed"`
-	PhysicalArtifactID  string          `json:"physical_artifact_id"`
-	BackendExecutable   string          `json:"-"`
+	Client              DetectedClient          `json:"client"`
+	DeclaredName        string                  `json:"declared_name"`
+	CurrentActivation   ActivationState         `json:"current_activation"`
+	Interactive         bool                    `json:"interactive"`
+	ExternalUninstalled bool                    `json:"external_uninstalled"`
+	Confirmed           bool                    `json:"confirmed"`
+	PhysicalArtifactID  string                  `json:"physical_artifact_id"`
+	BackendExecutable   string                  `json:"-"`
+	NativeObjects       []NativeObjectOwnership `json:"-"`
 }
 
 type DeactivationOutcome struct {

--- a/install/integrationctl/agentplugins/domain/state.go
+++ b/install/integrationctl/agentplugins/domain/state.go
@@ -124,6 +124,7 @@ type NativeObjectOwnership struct {
 	Kind            string `json:"kind"`
 	LogicalName     string `json:"logical_name,omitempty"`
 	Path            string `json:"path,omitempty"`
+	SourceRelative  string `json:"source_relative,omitempty"`
 	BeforeDigest    string `json:"before_digest,omitempty"`
 	ManagedDigest   string `json:"managed_digest,omitempty"`
 	ProtectionClass string `json:"protection_class"`

--- a/install/integrationctl/agentplugins/planner/planner.go
+++ b/install/integrationctl/agentplugins/planner/planner.go
@@ -145,6 +145,11 @@ func (planner Planner) Plan(
 		plan.Status = domain.PlanReady
 		plan.Activation = domain.ActivationPrepared
 	}
+	if plan.Status != domain.PlanUnsupported && client.ClientID == domain.ClientKiro &&
+		strings.TrimSpace(client.ConfigRoot) != "" && hasOnlyKiroNativeComponents(plan.Components) {
+		plan.Status = domain.PlanReady
+		plan.Activation = domain.ActivationPrepared
+	}
 
 	switch client.ClientID {
 	case domain.ClientCodex:
@@ -164,7 +169,7 @@ func (planner Planner) Plan(
 			plan.UserActions = append(plan.UserActions, "GitHub Copilot CLI is required for automatic activation")
 		}
 	case domain.ClientKiro:
-		plan.UserActions = append(plan.UserActions, "finish the prepared Power installation in Kiro")
+		plan.UserActions = append(plan.UserActions, "agentplugins will install and verify the package's global Kiro skills and MCP servers automatically")
 	case domain.ClientVSCode:
 		if strings.TrimSpace(planner.Detected[domain.ClientCopilot].ExecutablePath) != "" {
 			plan.UserActions = append(plan.UserActions, "agentplugins will install through GitHub Copilot CLI; VS Code discovers it automatically")
@@ -487,6 +492,20 @@ func hasSupportedKind(decisions []domain.ComponentDecision, kind domain.Componen
 		}
 	}
 	return false
+}
+
+func hasOnlyKiroNativeComponents(decisions []domain.ComponentDecision) bool {
+	found := false
+	for _, item := range decisions {
+		if item.Support == domain.SupportUnsupported {
+			continue
+		}
+		if item.Kind != domain.ComponentSkill && item.Kind != domain.ComponentMCPServer {
+			return false
+		}
+		found = true
+	}
+	return found
 }
 
 func missingChatGPTAppBindings(envelope domain.PackageEnvelope) []string {

--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -30,7 +30,11 @@ type Activator struct {
 // it cannot drift from the provider's activation paths.
 func (activator Activator) AutomaticallyActivates(request domain.ActivationRequest) bool {
 	if request.Client.ClientID == domain.ClientKiro {
-		return strings.TrimSpace(request.BackendExecutable) != "" && mcpOnly(request.Plan.Components) && isKiroCLI(request.BackendExecutable)
+		if strings.TrimSpace(request.Client.ConfigRoot) == "" || !kiroNativeComponents(request.Plan.Components) {
+			return false
+		}
+		return !hasSupportedMCP(request.Plan.Components) ||
+			(strings.TrimSpace(request.BackendExecutable) != "" && isKiroCLI(request.BackendExecutable))
 	}
 	return activationObservable(request, activator.Runner)
 }
@@ -38,7 +42,7 @@ func (activator Activator) AutomaticallyActivates(request domain.ActivationReque
 // PreflightActivation rejects lifecycle configurations that would otherwise
 // discover a missing required capability only after native client mutation.
 func (activator Activator) PreflightActivation(request domain.ActivationRequest) error {
-	if !activator.AutomaticallyActivates(request) || request.Client.ClientID != domain.ClientKiro {
+	if !activator.AutomaticallyActivates(request) || request.Client.ClientID != domain.ClientKiro || !hasSupportedMCP(request.Plan.Components) {
 		return nil
 	}
 	runner, ok := activator.Runner.(duplexCapabilityRunner)
@@ -64,7 +68,18 @@ func (activator Activator) Deactivate(ctx context.Context, request domain.Deacti
 	case domain.ClientChatGPT:
 		return requireExternalUninstall(outcome, request.ExternalUninstalled, "uninstall the plugin in ChatGPT Plugins, then rerun remove with `--external-uninstalled` (also use the flag if it was never activated)"), nil
 	case domain.ClientKiro:
-		return requireExternalUninstall(outcome, request.ExternalUninstalled, "remove the custom Power in Kiro, then rerun remove with `--external-uninstalled` (also use the flag if it was never imported)"), nil
+		if len(kiroObjects(request.NativeObjects)) == 0 {
+			return requireExternalUninstall(outcome, request.ExternalUninstalled, "remove the legacy custom Power in Kiro, then rerun remove with `--external-uninstalled`"), nil
+		}
+		if !request.Confirmed {
+			outcome.UserActions = append(outcome.UserActions, "agentplugins will remove its managed Kiro skills and MCP entries automatically")
+			return outcome, nil
+		}
+		if err := deactivateKiroNative(ctx, request); err != nil {
+			return outcome, err
+		}
+		outcome.ExternalRemovalComplete = true
+		return outcome, nil
 	case domain.ClientCopilot, domain.ClientVSCode:
 		if request.ExternalUninstalled {
 			outcome.ExternalRemovalComplete = true
@@ -193,34 +208,38 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 		}
 		return outcome, nil
 	case domain.ClientKiro:
-		if !mcpOnly(request.Plan.Components) {
+		if !activator.AutomaticallyActivates(request) {
 			outcome.Activation = domain.ActivationManual
-			outcome.UserActions = append(outcome.UserActions, "import the prepared package as a custom Power in Kiro, then verify it is active")
-			outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf("Kiro: Powers > Add Custom Power > Import power from a folder > select %s > Install, then verify %s is active", request.Delivery.ActivePath, request.DeclaredName))
+			outcome.UserActions = append(outcome.UserActions, "install a current Kiro CLI and rerun add to register the package's skills and MCP servers")
+			outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf("Kiro native installation requires a writable config root and, for MCP packages, a complete Kiro CLI distribution at %s", request.Delivery.ActivePath))
 			return outcome, nil
 		}
 		if request.VerifyOnly {
-			if err := activator.verifyKiroMCP(ctx, request); err != nil {
-				if errors.Is(err, errKiroACPContractUnknown) {
-					return manualKiroVerification(outcome, request), nil
+			if err := verifyKiroNativeObjects(request.Client.ConfigRoot, request.Delivery.NativeObjects, false); err != nil {
+				return failedActivation(outcome, "repair the managed Kiro skills and MCP configuration", err)
+			}
+			if hasSupportedMCP(request.Plan.Components) {
+				if err := activator.verifyKiroMCP(ctx, request); err != nil {
+					if errors.Is(err, errKiroACPContractUnknown) {
+						return manualKiroVerification(outcome, request), nil
+					}
+					return failedActivation(outcome, fmt.Sprintf("rerun structured Kiro ACP verification with `%s acp --agent-engine v3 --auth-method cli`", request.BackendExecutable), err)
 				}
-				return failedActivation(outcome, fmt.Sprintf("rerun structured Kiro ACP verification with `%s acp --agent-engine v3 --auth-method cli`", request.BackendExecutable), err)
 			}
 			outcome.Activation = domain.ActivationActive
 			outcome.Verification = domain.VerificationInstalled
 			return outcome, nil
 		}
-		if !activator.AutomaticallyActivates(request) {
-			outcome.Activation = domain.ActivationManual
-			outcome.UserActions = append(outcome.UserActions, "install kiro-cli and rerun add to import and verify the prepared MCP configuration")
-			outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf("install a complete Kiro CLI distribution (including kiro-cli-chat), then rerun add for %s to import and verify the native MCP configuration", request.Delivery.ActivePath))
-			return outcome, nil
+		if err := activateKiroNative(ctx, request); err != nil {
+			return failedActivation(outcome, "retry the managed Kiro native installation", err)
 		}
-		if err := activator.activateKiroMCP(ctx, request); err != nil {
-			if errors.Is(err, errKiroACPContractUnknown) {
-				return manualKiroVerification(outcome, request), nil
+		if hasSupportedMCP(request.Plan.Components) {
+			if err := activator.verifyKiroMCP(ctx, request); err != nil {
+				if errors.Is(err, errKiroACPContractUnknown) {
+					return manualKiroVerification(outcome, request), nil
+				}
+				return failedActivation(outcome, fmt.Sprintf("retry structured Kiro ACP verification with `%s acp --agent-engine v3 --auth-method cli`", request.BackendExecutable), err)
 			}
-			return failedActivation(outcome, fmt.Sprintf("rerun the MCP import from %s, then retry structured verification with `%s acp --agent-engine v3 --auth-method cli`", filepath.Join(request.Delivery.ActivePath, "mcp.json"), request.BackendExecutable), err)
 		}
 		outcome.Activation = domain.ActivationActive
 		outcome.Verification = domain.VerificationInstalled
@@ -347,14 +366,6 @@ func (activator Activator) verifyCodex(ctx context.Context, request domain.Activ
 	}
 }
 
-func (activator Activator) activateKiroMCP(ctx context.Context, request domain.ActivationRequest) error {
-	config := filepath.Join(request.Delivery.ActivePath, "mcp.json")
-	if _, err := activator.runClientResult(ctx, "Kiro CLI", request.BackendExecutable, "mcp", "import", "--file", config, "global", "--force"); err != nil {
-		return fmt.Errorf("import Kiro MCP configuration: %w", err)
-	}
-	return activator.verifyKiroMCP(ctx, request)
-}
-
 func (activator Activator) verifyKiroMCP(ctx context.Context, request domain.ActivationRequest) error {
 	runner, ok := activator.Runner.(duplexCommandRunner)
 	if !ok {
@@ -417,10 +428,13 @@ func failedActivation(outcome domain.ActivationOutcome, next string, err error) 
 	return outcome, err
 }
 
-func mcpOnly(components []domain.ComponentDecision) bool {
+func kiroNativeComponents(components []domain.ComponentDecision) bool {
 	found := false
 	for _, component := range components {
-		if component.Support == domain.SupportUnsupported || component.Kind != domain.ComponentMCPServer {
+		if component.Support == domain.SupportUnsupported {
+			continue
+		}
+		if component.Kind != domain.ComponentSkill && component.Kind != domain.ComponentMCPServer {
 			return false
 		}
 		found = true
@@ -676,8 +690,14 @@ func activationObservable(request domain.ActivationRequest, runner CommandRunner
 	case domain.ClientCodex, domain.ClientCopilot, domain.ClientVSCode:
 		return true
 	case domain.ClientKiro:
+		if !kiroNativeComponents(request.Plan.Components) || !isKiroCLI(request.BackendExecutable) {
+			return false
+		}
+		if !hasSupportedMCP(request.Plan.Components) {
+			return true
+		}
 		_, duplexAvailable := runner.(duplexCommandRunner)
-		return duplexAvailable && mcpOnly(request.Plan.Components) && isKiroCLI(request.BackendExecutable)
+		return duplexAvailable
 	default:
 		return false
 	}

--- a/install/integrationctl/agentplugins/providers/activator_test.go
+++ b/install/integrationctl/agentplugins/providers/activator_test.go
@@ -616,7 +616,7 @@ func TestClientListingDoesNotConvertUnknownAuthentication(t *testing.T) {
 	}
 }
 
-func TestActivatorPinsDetectedKiroExecutableForImportAndACPVerification(t *testing.T) {
+func TestActivatorPinsDetectedKiroExecutableForACPVerification(t *testing.T) {
 	t.Parallel()
 	runner := &recordingRunner{duplexOutput: connectedACP("demo-server"), duplexLive: true}
 	request := activationRequest(t, domain.ClientKiro)
@@ -629,10 +629,7 @@ func TestActivatorPinsDetectedKiroExecutableForImportAndACPVerification(t *testi
 	if outcome.Activation != domain.ActivationActive || outcome.Verification != domain.VerificationInstalled {
 		t.Fatalf("outcome = %+v", outcome)
 	}
-	want := [][]string{
-		{"/test/bin/kiro-cli", "mcp", "import", "--file", filepath.Join(request.Delivery.ActivePath, "mcp.json"), "global", "--force"},
-		{"/test/bin/kiro-cli", "acp", "--agent-engine", "v3", "--auth-method", "cli"},
-	}
+	want := [][]string{{"/test/bin/kiro-cli", "acp", "--agent-engine", "v3", "--auth-method", "cli"}}
 	if got := commandArgv(runner.commands); !reflect.DeepEqual(got, want) {
 		t.Fatalf("commands = %#v, want %#v", got, want)
 	}
@@ -671,17 +668,31 @@ func TestActivatorContainmentPreflightFailureCannotMutateKiro(t *testing.T) {
 	}
 }
 
-func TestActivatorKeepsKiroUIComponentsToOneActionableManualStep(t *testing.T) {
+func TestActivatorInstallsKiroSkillWithoutManualPowerImport(t *testing.T) {
 	t.Parallel()
 	request := activationRequest(t, domain.ClientKiro)
 	request.BackendExecutable = "/test/bin/kiro-cli"
 	request.Plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentSkill, Name: "guide", Support: domain.SupportNative}}
+	source := filepath.Join(request.Delivery.ActivePath, "skills", "guide")
+	writeTestFile(t, filepath.Join(source, "SKILL.md"), "---\nname: guide\ndescription: Guide\n---\n")
+	digest, err := digestKiroSkillDirectory(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Delivery.NativeObjects = []domain.NativeObjectOwnership{{
+		ObjectID: "kiro-skill:guide", Kind: kiroSkillObjectKind, LogicalName: "guide",
+		Path: filepath.Join(request.Client.ConfigRoot, "skills", "guide"), SourceRelative: "skills/guide",
+		ManagedDigest: digest, ProtectionClass: "managed",
+	}}
 	outcome, err := (Activator{Runner: &recordingRunner{}}).Activate(context.Background(), request)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if outcome.Activation != domain.ActivationManual || len(outcome.LocalActions) != 1 || !strings.Contains(outcome.LocalActions[0], request.Delivery.ActivePath) || !strings.Contains(outcome.LocalActions[0], "verify") {
+	if outcome.Activation != domain.ActivationActive || outcome.Verification != domain.VerificationInstalled {
 		t.Fatalf("outcome = %+v", outcome)
+	}
+	if _, err := os.Stat(filepath.Join(request.Client.ConfigRoot, "skills", "guide", "SKILL.md")); err != nil {
+		t.Fatalf("installed Kiro skill: %v", err)
 	}
 }
 
@@ -882,13 +893,14 @@ func TestChatGPTActivationCanOnlyCompleteByExplicitAttestation(t *testing.T) {
 
 func activationRequest(t *testing.T, client domain.ClientID) domain.ActivationRequest {
 	t.Helper()
-	base := filepath.Join(t.TempDir(), "managed")
+	root := t.TempDir()
+	base := filepath.Join(root, "managed")
 	active := filepath.Join(base, "demo")
 	if err := os.MkdirAll(active, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	return domain.ActivationRequest{
-		Client:       domain.DetectedClient{ClientID: client, Status: domain.DetectionDetected},
+		Client:       domain.DetectedClient{ClientID: client, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(root, ".kiro")},
 		DeclaredName: "demo",
 		Plan: domain.DeliveryPlan{
 			ClientID: client, ActivePath: active, PhysicalArtifactID: "demo-0123456789ab",

--- a/install/integrationctl/agentplugins/providers/kiro_native.go
+++ b/install/integrationctl/agentplugins/providers/kiro_native.go
@@ -1,0 +1,539 @@
+package providers
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/atomicfile"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/filetree"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/pathpolicy"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+const (
+	kiroSkillObjectKind = "kiro_global_skill_directory"
+	kiroMCPObjectKind   = "kiro_global_mcp_server"
+)
+
+func buildKiroNativeObjects(stagingRoot string, envelope domain.PackageEnvelope, plan domain.DeliveryPlan) ([]domain.NativeObjectOwnership, error) {
+	configRoot := strings.TrimSpace(plan.NativeRegistryRoot)
+	if configRoot == "" {
+		return nil, fmt.Errorf("Kiro config root is unavailable")
+	}
+	objects := make([]domain.NativeObjectOwnership, 0, len(envelope.Skills)+len(envelope.MCP.Servers))
+	for _, component := range plan.Components {
+		if component.Support == domain.SupportUnsupported {
+			continue
+		}
+		switch component.Kind {
+		case domain.ComponentSkill:
+			if err := pathpolicy.ValidateLeafID(component.Name); err != nil {
+				return nil, fmt.Errorf("invalid Kiro skill name %q: %w", component.Name, err)
+			}
+			skill, ok := envelope.Skills[component.Name]
+			if !ok {
+				return nil, fmt.Errorf("planned Kiro skill %q is missing", component.Name)
+			}
+			relative := filepath.FromSlash(strings.TrimSpace(skill.RelativePath))
+			if relative == "" {
+				relative = filepath.Join("skills", component.Name, "SKILL.md")
+			}
+			sourceRoot := filepath.Join(stagingRoot, filepath.Dir(relative))
+			if err := pathpolicy.RequireContainedChild(stagingRoot, sourceRoot); err != nil {
+				return nil, fmt.Errorf("unsafe Kiro skill source %q: %w", component.Name, err)
+			}
+			digest, err := digestKiroSkillDirectory(sourceRoot)
+			if err != nil {
+				return nil, fmt.Errorf("digest Kiro skill %q: %w", component.Name, err)
+			}
+			target := filepath.Join(configRoot, "skills", component.Name)
+			if err := validateKiroNativePath(configRoot, target); err != nil {
+				return nil, err
+			}
+			objects = append(objects, domain.NativeObjectOwnership{
+				ObjectID: "kiro-skill:" + component.Name, Kind: kiroSkillObjectKind,
+				LogicalName: component.Name, Path: target,
+				SourceRelative: filepath.ToSlash(filepath.Dir(relative)), ManagedDigest: digest,
+				ProtectionClass: "managed",
+			})
+		case domain.ComponentMCPServer:
+			if err := pathpolicy.ValidateLeafID(component.Name); err != nil {
+				return nil, fmt.Errorf("invalid Kiro MCP server name %q: %w", component.Name, err)
+			}
+			server, err := projectedKiroMCPServer(stagingRoot, component.Name)
+			if err != nil {
+				return nil, err
+			}
+			objects = append(objects, domain.NativeObjectOwnership{
+				ObjectID: "kiro-mcp:" + component.Name, Kind: kiroMCPObjectKind,
+				LogicalName: component.Name, Path: filepath.Join(configRoot, "settings", "mcp.json"),
+				ManagedDigest: digestJSONObject(server), ProtectionClass: "managed",
+			})
+		}
+	}
+	sort.Slice(objects, func(i, j int) bool { return objects[i].ObjectID < objects[j].ObjectID })
+	return objects, nil
+}
+
+func activateKiroNative(ctx context.Context, request domain.ActivationRequest) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return applyKiroNativeMutation(request.Client.ConfigRoot, request.Delivery.ActivePath, request.PreviousNativeObjects, request.Delivery.NativeObjects)
+}
+
+func deactivateKiroNative(ctx context.Context, request domain.DeactivationRequest) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return applyKiroNativeMutation(request.Client.ConfigRoot, "", request.NativeObjects, nil)
+}
+
+func verifyKiroNativeObjects(configRoot string, objects []domain.NativeObjectOwnership, allowMissing bool) error {
+	filtered := kiroObjects(objects)
+	for _, object := range filtered {
+		if err := validateKiroObject(configRoot, object); err != nil {
+			return err
+		}
+	}
+	mcp := map[string]any{}
+	if len(previousMCPObjects(filtered)) > 0 {
+		var err error
+		mcp, _, _, _, err = readKiroMCPConfig(filepath.Join(configRoot, "settings", "mcp.json"))
+		if err != nil {
+			return err
+		}
+	}
+	for _, object := range filtered {
+		switch object.Kind {
+		case kiroSkillObjectKind:
+			digest, err := digestKiroSkillDirectory(object.Path)
+			if os.IsNotExist(err) && allowMissing {
+				continue
+			}
+			if err != nil {
+				return fmt.Errorf("inspect managed Kiro skill %q: %w", object.LogicalName, err)
+			}
+			if digest != object.ManagedDigest {
+				return fmt.Errorf("managed Kiro skill %q changed outside agentplugins", object.LogicalName)
+			}
+		case kiroMCPObjectKind:
+			rawServer, exists := mcp[object.LogicalName]
+			if !exists && allowMissing {
+				continue
+			}
+			if !exists {
+				return fmt.Errorf("managed Kiro MCP server %q is missing", object.LogicalName)
+			}
+			server, ok := rawServer.(map[string]any)
+			if !ok {
+				return fmt.Errorf("managed Kiro MCP server %q is malformed", object.LogicalName)
+			}
+			if digestJSONObject(server) != object.ManagedDigest {
+				return fmt.Errorf("managed Kiro MCP server %q changed outside agentplugins", object.LogicalName)
+			}
+		}
+	}
+	return nil
+}
+
+func applyKiroNativeMutation(configRoot, activePath string, previous, desired []domain.NativeObjectOwnership) (resultErr error) {
+	configRoot = strings.TrimSpace(configRoot)
+	if configRoot == "" {
+		return fmt.Errorf("Kiro config root is unavailable")
+	}
+	previous, desired = kiroObjects(previous), kiroObjects(desired)
+	if err := verifyKiroNativeObjects(configRoot, previous, true); err != nil {
+		return err
+	}
+	previousByID, desiredByID := objectMap(previous), objectMap(desired)
+	for id, object := range desiredByID {
+		if prior, replacing := previousByID[id]; replacing {
+			if prior.Kind != object.Kind || prior.LogicalName != object.LogicalName || !sameCleanPath(prior.Path, object.Path) {
+				return fmt.Errorf("Kiro native object identity changed unexpectedly for %s", id)
+			}
+			continue
+		}
+		if err := requireKiroObjectAbsent(configRoot, object); err != nil {
+			return err
+		}
+	}
+
+	transactionRoot := ""
+	if hasKiroSkillObjects(previous) || hasKiroSkillObjects(desired) {
+		skillsRoot := filepath.Join(configRoot, "skills")
+		if err := validateKiroNativePath(configRoot, skillsRoot); err != nil {
+			return err
+		}
+		if err := os.MkdirAll(skillsRoot, 0o700); err != nil {
+			return fmt.Errorf("create Kiro skills root: %w", err)
+		}
+		var err error
+		transactionRoot, err = os.MkdirTemp(skillsRoot, ".agentplugins-native-")
+		if err != nil {
+			return fmt.Errorf("create Kiro native transaction: %w", err)
+		}
+		defer os.RemoveAll(transactionRoot)
+	}
+
+	staged := map[string]string{}
+	for id, object := range desiredByID {
+		if object.Kind != kiroSkillObjectKind {
+			continue
+		}
+		if strings.TrimSpace(activePath) == "" {
+			return fmt.Errorf("active package path is required for Kiro skill installation")
+		}
+		source := filepath.Join(activePath, filepath.FromSlash(object.SourceRelative))
+		if err := pathpolicy.RequireContainedChild(activePath, source); err != nil {
+			return fmt.Errorf("unsafe Kiro skill source for %q: %w", object.LogicalName, err)
+		}
+		target := filepath.Join(transactionRoot, "new-"+object.LogicalName)
+		if err := filetree.CopyDir(source, target); err != nil {
+			return fmt.Errorf("stage Kiro skill %q: %w", object.LogicalName, err)
+		}
+		digest, err := digestKiroSkillDirectory(target)
+		if err != nil || digest != object.ManagedDigest {
+			return fmt.Errorf("staged Kiro skill %q does not match its ownership digest", object.LogicalName)
+		}
+		staged[id] = target
+	}
+
+	mcpPath := filepath.Join(configRoot, "settings", "mcp.json")
+	mcp, originalMCP, originalMode, originalExists := map[string]any{}, []byte(nil), os.FileMode(0o600), false
+	hasMCPMutation := len(previousMCPObjects(previous))+len(previousMCPObjects(desired)) > 0
+	if hasMCPMutation {
+		var err error
+		mcp, originalMCP, originalMode, originalExists, err = readKiroMCPConfig(mcpPath)
+		if err != nil {
+			return err
+		}
+		for _, object := range previousByID {
+			if object.Kind == kiroMCPObjectKind {
+				delete(mcp, object.LogicalName)
+			}
+		}
+		for _, object := range desiredByID {
+			if object.Kind != kiroMCPObjectKind {
+				continue
+			}
+			server, err := projectedKiroMCPServer(activePath, object.LogicalName)
+			if err != nil {
+				return err
+			}
+			if digestJSONObject(server) != object.ManagedDigest {
+				return fmt.Errorf("projected Kiro MCP server %q does not match its ownership digest", object.LogicalName)
+			}
+			mcp[object.LogicalName] = server
+		}
+	}
+	newMCP := []byte(nil)
+	if hasMCPMutation {
+		var err error
+		newMCP, err = encodeKiroMCPConfig(originalMCP, mcp)
+		if err != nil {
+			return err
+		}
+	}
+
+	backups, installed := map[string]string{}, map[string]domain.NativeObjectOwnership{}
+	mcpWritten := false
+	rollback := func() error {
+		var rollbackErr error
+		if mcpWritten {
+			if originalExists {
+				rollbackErr = atomicfile.Write(mcpPath, originalMCP, originalMode)
+			} else if body, readErr := os.ReadFile(mcpPath); readErr == nil && bytes.Equal(body, newMCP) {
+				rollbackErr = os.Remove(mcpPath)
+			}
+		}
+		for id, object := range installed {
+			if digest, digestErr := digestKiroSkillDirectory(object.Path); digestErr == nil && digest == object.ManagedDigest {
+				if err := os.RemoveAll(object.Path); err != nil && rollbackErr == nil {
+					rollbackErr = err
+				}
+			}
+			if backup := backups[id]; backup != "" {
+				if err := os.Rename(backup, object.Path); err != nil && rollbackErr == nil {
+					rollbackErr = err
+				}
+				delete(backups, id)
+			}
+		}
+		for id, backup := range backups {
+			if err := os.Rename(backup, previousByID[id].Path); err != nil && rollbackErr == nil {
+				rollbackErr = err
+			}
+		}
+		return rollbackErr
+	}
+	defer func() {
+		if resultErr != nil {
+			if rollbackErr := rollback(); rollbackErr != nil {
+				resultErr = fmt.Errorf("%v; Kiro native rollback failed: %w", resultErr, rollbackErr)
+			}
+		}
+	}()
+
+	for id, object := range previousByID {
+		if object.Kind != kiroSkillObjectKind {
+			continue
+		}
+		if _, err := os.Lstat(object.Path); os.IsNotExist(err) {
+			continue
+		} else if err != nil {
+			return err
+		}
+		backup := filepath.Join(transactionRoot, "old-"+object.LogicalName)
+		if err := os.Rename(object.Path, backup); err != nil {
+			return fmt.Errorf("backup Kiro skill %q: %w", object.LogicalName, err)
+		}
+		backups[id] = backup
+	}
+	for id, source := range staged {
+		object := desiredByID[id]
+		if err := os.Rename(source, object.Path); err != nil {
+			return fmt.Errorf("activate Kiro skill %q: %w", object.LogicalName, err)
+		}
+		installed[id] = object
+	}
+	if hasMCPMutation {
+		if err := atomicfile.Write(mcpPath, newMCP, originalMode); err != nil {
+			return fmt.Errorf("write Kiro MCP configuration: %w", err)
+		}
+		mcpWritten = true
+	}
+	if err := verifyKiroNativeObjects(configRoot, desired, false); err != nil {
+		return err
+	}
+	return nil
+}
+
+func requireKiroObjectAbsent(configRoot string, object domain.NativeObjectOwnership) error {
+	if err := validateKiroObject(configRoot, object); err != nil {
+		return err
+	}
+	switch object.Kind {
+	case kiroSkillObjectKind:
+		if _, err := os.Lstat(object.Path); err == nil {
+			return fmt.Errorf("Kiro skill %q already exists without agentplugins ownership", object.LogicalName)
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+	case kiroMCPObjectKind:
+		mcp, _, _, _, err := readKiroMCPConfig(object.Path)
+		if err != nil {
+			return err
+		}
+		if _, exists := mcp[object.LogicalName]; exists {
+			return fmt.Errorf("Kiro MCP server %q already exists without agentplugins ownership", object.LogicalName)
+		}
+	}
+	return nil
+}
+
+func validateKiroObject(configRoot string, object domain.NativeObjectOwnership) error {
+	if err := pathpolicy.ValidateLeafID(object.LogicalName); err != nil {
+		return fmt.Errorf("invalid Kiro native object name %q: %w", object.LogicalName, err)
+	}
+	var expected string
+	switch object.Kind {
+	case kiroSkillObjectKind:
+		expected = filepath.Join(configRoot, "skills", object.LogicalName)
+	case kiroMCPObjectKind:
+		expected = filepath.Join(configRoot, "settings", "mcp.json")
+	default:
+		return fmt.Errorf("unsupported Kiro native object kind %q", object.Kind)
+	}
+	if !sameCleanPath(expected, object.Path) {
+		return fmt.Errorf("Kiro native object %q has an untrusted path", object.LogicalName)
+	}
+	return validateKiroNativePath(configRoot, object.Path)
+}
+
+func validateKiroNativePath(configRoot, path string) error {
+	if err := pathpolicy.RequireContainedChild(configRoot, path); err != nil {
+		return fmt.Errorf("unsafe Kiro native path: %w", err)
+	}
+	return nil
+}
+
+func projectedKiroMCPServer(root, name string) (map[string]any, error) {
+	if strings.TrimSpace(root) == "" {
+		return nil, fmt.Errorf("prepared Kiro package path is unavailable")
+	}
+	body, err := os.ReadFile(filepath.Join(root, "mcp.json"))
+	if err != nil {
+		return nil, fmt.Errorf("read projected Kiro MCP configuration: %w", err)
+	}
+	document, err := decodeStrictJSONObject(body)
+	if err != nil {
+		return nil, fmt.Errorf("decode projected Kiro MCP configuration: %w", err)
+	}
+	servers, ok := document["mcpServers"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("projected Kiro MCP configuration has no mcpServers object")
+	}
+	server, ok := servers[name].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("projected Kiro MCP server %q is missing", name)
+	}
+	return server, nil
+}
+
+func readKiroMCPConfig(path string) (servers map[string]any, original []byte, mode os.FileMode, exists bool, err error) {
+	mode = 0o600
+	body, readErr := os.ReadFile(path)
+	if os.IsNotExist(readErr) {
+		return map[string]any{}, nil, mode, false, nil
+	}
+	if readErr != nil {
+		return nil, nil, mode, false, fmt.Errorf("read Kiro MCP configuration: %w", readErr)
+	}
+	info, statErr := os.Lstat(path)
+	if statErr != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return nil, nil, mode, false, fmt.Errorf("Kiro MCP configuration must be a regular file")
+	}
+	document, decodeErr := decodeStrictJSONObject(body)
+	if decodeErr != nil {
+		return nil, nil, mode, false, fmt.Errorf("decode Kiro MCP configuration: %w", decodeErr)
+	}
+	if raw, present := document["mcpServers"]; present {
+		servers, exists = raw.(map[string]any)
+		if !exists {
+			return nil, nil, mode, false, fmt.Errorf("Kiro mcpServers must be an object")
+		}
+	} else {
+		servers = map[string]any{}
+	}
+	mode = info.Mode().Perm()
+	return servers, body, mode, true, nil
+}
+
+func encodeKiroMCPConfig(original []byte, servers map[string]any) ([]byte, error) {
+	document := map[string]any{}
+	if len(original) > 0 {
+		var err error
+		document, err = decodeStrictJSONObject(original)
+		if err != nil {
+			return nil, fmt.Errorf("decode existing Kiro MCP configuration: %w", err)
+		}
+	}
+	document["mcpServers"] = servers
+	body, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode Kiro MCP configuration: %w", err)
+	}
+	return append(body, '\n'), nil
+}
+
+func digestKiroSkillDirectory(root string) (string, error) {
+	hash := sha256.New()
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if relative == "." {
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("symlink is not allowed: %s", relative)
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		kind := byte('d')
+		if !entry.IsDir() {
+			if !info.Mode().IsRegular() {
+				return fmt.Errorf("special file is not allowed: %s", relative)
+			}
+			kind = 'f'
+		}
+		_, _ = hash.Write([]byte{kind, 0})
+		_, _ = io.WriteString(hash, filepath.ToSlash(relative))
+		_, _ = hash.Write([]byte{0})
+		if kind == 'f' {
+			if info.Mode().Perm()&0o111 != 0 {
+				_, _ = hash.Write([]byte{'x', 0})
+			} else {
+				_, _ = hash.Write([]byte{'-', 0})
+			}
+			file, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			_, copyErr := io.Copy(hash, file)
+			closeErr := file.Close()
+			if copyErr != nil {
+				return copyErr
+			}
+			if closeErr != nil {
+				return closeErr
+			}
+			_, _ = hash.Write([]byte{0})
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return "sha256:" + hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func digestJSONObject(value map[string]any) string {
+	body, _ := json.Marshal(value)
+	digest := sha256.Sum256(body)
+	return "sha256:" + hex.EncodeToString(digest[:])
+}
+
+func kiroObjects(objects []domain.NativeObjectOwnership) []domain.NativeObjectOwnership {
+	result := make([]domain.NativeObjectOwnership, 0, len(objects))
+	for _, object := range objects {
+		if object.Kind == kiroSkillObjectKind || object.Kind == kiroMCPObjectKind {
+			result = append(result, object)
+		}
+	}
+	return result
+}
+
+func previousMCPObjects(objects []domain.NativeObjectOwnership) []domain.NativeObjectOwnership {
+	result := []domain.NativeObjectOwnership{}
+	for _, object := range objects {
+		if object.Kind == kiroMCPObjectKind {
+			result = append(result, object)
+		}
+	}
+	return result
+}
+
+func hasKiroSkillObjects(objects []domain.NativeObjectOwnership) bool {
+	for _, object := range objects {
+		if object.Kind == kiroSkillObjectKind {
+			return true
+		}
+	}
+	return false
+}
+
+func objectMap(objects []domain.NativeObjectOwnership) map[string]domain.NativeObjectOwnership {
+	result := make(map[string]domain.NativeObjectOwnership, len(objects))
+	for _, object := range objects {
+		result[object.ObjectID] = object
+	}
+	return result
+}

--- a/install/integrationctl/agentplugins/providers/kiro_native_test.go
+++ b/install/integrationctl/agentplugins/providers/kiro_native_test.go
@@ -1,0 +1,121 @@
+package providers
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+func TestKiroNativeLifecyclePreservesUnmanagedConfiguration(t *testing.T) {
+	t.Parallel()
+	configRoot := filepath.Join(t.TempDir(), ".kiro")
+	mcpPath := filepath.Join(configRoot, "settings", "mcp.json")
+	writeTestFile(t, mcpPath, `{
+  "telemetry": {"enabled": false},
+  "mcpServers": {"unmanaged": {"url": "https://example.test/mcp"}}
+}`)
+
+	activeV1, desiredV1 := kiroNativeFixture(t, configRoot, "v1", "https://docs.example.test/v1")
+	if err := applyKiroNativeMutation(configRoot, activeV1, nil, desiredV1); err != nil {
+		t.Fatal(err)
+	}
+	assertKiroNativeState(t, configRoot, "v1", "https://docs.example.test/v1", true)
+
+	activeV2, desiredV2 := kiroNativeFixture(t, configRoot, "v2", "https://docs.example.test/v2")
+	if err := applyKiroNativeMutation(configRoot, activeV2, desiredV1, desiredV2); err != nil {
+		t.Fatal(err)
+	}
+	assertKiroNativeState(t, configRoot, "v2", "https://docs.example.test/v2", true)
+
+	if err := applyKiroNativeMutation(configRoot, "", desiredV2, nil); err != nil {
+		t.Fatal(err)
+	}
+	assertKiroNativeState(t, configRoot, "", "", false)
+}
+
+func TestKiroNativeLifecycleRejectsUnmanagedCollisionWithoutMutation(t *testing.T) {
+	t.Parallel()
+	configRoot := filepath.Join(t.TempDir(), ".kiro")
+	skillPath := filepath.Join(configRoot, "skills", "docs")
+	writeTestFile(t, filepath.Join(skillPath, "SKILL.md"), "unmanaged\n")
+	active, desired := kiroNativeFixture(t, configRoot, "managed", "https://docs.example.test/managed")
+	if err := applyKiroNativeMutation(configRoot, active, nil, desired); err == nil {
+		t.Fatal("unmanaged Kiro skill collision was accepted")
+	}
+	body, err := os.ReadFile(filepath.Join(skillPath, "SKILL.md"))
+	if err != nil || string(body) != "unmanaged\n" {
+		t.Fatalf("unmanaged skill changed: %q, %v", body, err)
+	}
+	if _, err := os.Stat(filepath.Join(configRoot, "settings", "mcp.json")); !os.IsNotExist(err) {
+		t.Fatalf("MCP config was mutated after collision: %v", err)
+	}
+}
+
+func TestKiroNativeRemovalRefusesUserModifiedOwnedSkill(t *testing.T) {
+	t.Parallel()
+	configRoot := filepath.Join(t.TempDir(), ".kiro")
+	active, desired := kiroNativeFixture(t, configRoot, "owned", "https://docs.example.test/owned")
+	if err := applyKiroNativeMutation(configRoot, active, nil, desired); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, filepath.Join(configRoot, "skills", "docs", "SKILL.md"), "user modification\n")
+	if err := applyKiroNativeMutation(configRoot, "", desired, nil); err == nil {
+		t.Fatal("modified managed skill was silently removed")
+	}
+	body, err := os.ReadFile(filepath.Join(configRoot, "skills", "docs", "SKILL.md"))
+	if err != nil || string(body) != "user modification\n" {
+		t.Fatalf("modified skill was not retained: %q, %v", body, err)
+	}
+}
+
+func kiroNativeFixture(t *testing.T, configRoot, marker, url string) (string, []domain.NativeObjectOwnership) {
+	t.Helper()
+	active := filepath.Join(t.TempDir(), "active")
+	skillRoot := filepath.Join(active, "skills", "docs")
+	writeTestFile(t, filepath.Join(skillRoot, "SKILL.md"), marker+"\n")
+	digest, err := digestKiroSkillDirectory(skillRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := map[string]any{"type": "streamable-http", "url": url}
+	body, err := json.Marshal(map[string]any{"mcpServers": map[string]any{"docs": server}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, filepath.Join(active, "mcp.json"), string(body))
+	return active, []domain.NativeObjectOwnership{
+		{ObjectID: "kiro-skill:docs", Kind: kiroSkillObjectKind, LogicalName: "docs", Path: filepath.Join(configRoot, "skills", "docs"), SourceRelative: "skills/docs", ManagedDigest: digest, ProtectionClass: "managed"},
+		{ObjectID: "kiro-mcp:docs", Kind: kiroMCPObjectKind, LogicalName: "docs", Path: filepath.Join(configRoot, "settings", "mcp.json"), ManagedDigest: digestJSONObject(server), ProtectionClass: "managed"},
+	}
+}
+
+func assertKiroNativeState(t *testing.T, configRoot, skillMarker, managedURL string, managedPresent bool) {
+	t.Helper()
+	skillPath := filepath.Join(configRoot, "skills", "docs", "SKILL.md")
+	if managedPresent {
+		body, err := os.ReadFile(skillPath)
+		if err != nil || string(body) != skillMarker+"\n" {
+			t.Fatalf("Kiro skill = %q, %v", body, err)
+		}
+	} else if _, err := os.Stat(skillPath); !os.IsNotExist(err) {
+		t.Fatalf("removed Kiro skill still exists: %v", err)
+	}
+	document := readObject(t, filepath.Join(configRoot, "settings", "mcp.json"))
+	if telemetry, ok := document["telemetry"].(map[string]any); !ok || telemetry["enabled"] != false {
+		t.Fatalf("unmanaged top-level Kiro config was not preserved: %+v", document)
+	}
+	servers := document["mcpServers"].(map[string]any)
+	if _, ok := servers["unmanaged"]; !ok {
+		t.Fatalf("unmanaged MCP server was not preserved: %+v", servers)
+	}
+	managed, exists := servers["docs"].(map[string]any)
+	if exists != managedPresent {
+		t.Fatalf("managed MCP presence = %v, want %v", exists, managedPresent)
+	}
+	if managedPresent && managed["url"] != managedURL {
+		t.Fatalf("managed MCP URL = %v, want %v", managed["url"], managedURL)
+	}
+}

--- a/install/integrationctl/agentplugins/providers/kiro_pipe_bytes_darwin.go
+++ b/install/integrationctl/agentplugins/providers/kiro_pipe_bytes_darwin.go
@@ -1,0 +1,12 @@
+//go:build darwin
+
+package providers
+
+import "golang.org/x/sys/unix"
+
+// FIONREAD is defined by Darwin's sys/filio.h but is not exported by x/sys.
+const darwinFIONREAD = 0x4004667f
+
+func queuedPipeBytes(fd int) (int, error) {
+	return unix.IoctlGetInt(fd, darwinFIONREAD)
+}

--- a/install/integrationctl/agentplugins/providers/kiro_pipe_bytes_linux.go
+++ b/install/integrationctl/agentplugins/providers/kiro_pipe_bytes_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package providers
+
+import "golang.org/x/sys/unix"
+
+func queuedPipeBytes(fd int) (int, error) {
+	return unix.IoctlGetInt(fd, unix.TIOCINQ)
+}

--- a/install/integrationctl/agentplugins/providers/kiro_pipe_unix.go
+++ b/install/integrationctl/agentplugins/providers/kiro_pipe_unix.go
@@ -42,7 +42,14 @@ func queuedACPRealPipeEvidence(reader io.Reader) (queued, eof bool, resultErr er
 			resultErr = fmt.Errorf("ACP pipe descriptor is invalid")
 			return
 		}
-		queued = events&unix.POLLIN != 0
+		if events&unix.POLLIN != 0 {
+			available, ioctlErr := queuedPipeBytes(int(fd))
+			if ioctlErr != nil {
+				resultErr = fmt.Errorf("inspect queued ACP pipe bytes: %w", ioctlErr)
+				return
+			}
+			queued = available > 0
+		}
 		eof = events&unix.POLLHUP != 0 && !queued
 	})
 	return queued, eof, errors.Join(resultErr, err)

--- a/install/integrationctl/agentplugins/providers/native_identity.go
+++ b/install/integrationctl/agentplugins/providers/native_identity.go
@@ -432,49 +432,75 @@ func inspectKiroRegistry(plan domain.DeliveryPlan, managed *domain.ClientBinding
 	if root == "" {
 		return registryIndeterminate, nil
 	}
-	// Custom Powers without MCP are activated manually and the adapter has no
-	// documented read-only registry contract for their installed identities.
-	// Their local prepared-package boundary was inspected above, so an
-	// absent/owned local package may be prepared safely. Mixed Powers still have
-	// to inspect every supported MCP name below; a manual skill surface must not
-	// hide a positive collision in Kiro's authoritative global MCP registry.
-	if !hasSupportedMCP(plan.Components) {
-		return registryClear, nil
-	}
 	if _, err := os.Lstat(root); os.IsNotExist(err) {
 		return registryClear, nil
 	} else if err != nil {
 		return registryIndeterminate, err
 	}
+	if managed != nil {
+		if err := verifyKiroNativeObjects(root, managed.NativeObjects, true); err != nil {
+			return registryIndeterminate, err
+		}
+	}
 	finding := registryClear
-	mcpPath := filepath.Join(root, "settings", "mcp.json")
-	body, err := os.ReadFile(mcpPath)
-	if os.IsNotExist(err) {
-		return finding, nil
-	}
-	if err != nil {
-		return registryIndeterminate, err
-	}
-	value, err := decodeStrictJSONObject(body)
-	if err != nil {
-		return registryIndeterminate, err
-	}
-	servers, ok := value["mcpServers"].(map[string]any)
-	if !ok {
-		return registryIndeterminate, nil
+	mcp := map[string]any{}
+	if hasSupportedMCP(plan.Components) {
+		mcpPath := filepath.Join(root, "settings", "mcp.json")
+		if err := validateKiroNativePath(root, mcpPath); err != nil {
+			return registryIndeterminate, err
+		}
+		var err error
+		mcp, _, _, _, err = readKiroMCPConfig(mcpPath)
+		if err != nil {
+			return registryIndeterminate, err
+		}
 	}
 	for _, component := range plan.Components {
-		if component.Kind != domain.ComponentMCPServer || component.Support == domain.SupportUnsupported {
+		if component.Support == domain.SupportUnsupported {
 			continue
 		}
-		if _, exists := servers[component.Name]; exists {
-			if managed == nil {
-				return registryCollision, nil
+		var exists bool
+		switch component.Kind {
+		case domain.ComponentSkill:
+			skillPath := filepath.Join(root, "skills", component.Name)
+			if err := validateKiroNativePath(root, skillPath); err != nil {
+				return registryIndeterminate, err
 			}
-			finding = registryExpected
+			_, statErr := os.Lstat(skillPath)
+			exists = statErr == nil
+			if statErr != nil && !os.IsNotExist(statErr) {
+				return registryIndeterminate, statErr
+			}
+		case domain.ComponentMCPServer:
+			_, exists = mcp[component.Name]
+		default:
+			continue
 		}
+		if !exists {
+			continue
+		}
+		if managed == nil {
+			return registryCollision, nil
+		}
+		if !managedKiroObjectExists(managed.NativeObjects, component.Kind, component.Name) {
+			return registryIndeterminate, nil
+		}
+		finding = registryExpected
 	}
 	return finding, nil
+}
+
+func managedKiroObjectExists(objects []domain.NativeObjectOwnership, kind domain.ComponentKind, name string) bool {
+	want := kiroSkillObjectKind
+	if kind == domain.ComponentMCPServer {
+		want = kiroMCPObjectKind
+	}
+	for _, object := range objects {
+		if object.Kind == want && object.LogicalName == name {
+			return true
+		}
+	}
+	return false
 }
 
 func hasSupportedMCP(components []domain.ComponentDecision) bool {

--- a/install/integrationctl/agentplugins/providers/stager.go
+++ b/install/integrationctl/agentplugins/providers/stager.go
@@ -219,6 +219,13 @@ func (stager Stager) stage(
 			ProtectionClass: "managed",
 		},
 	}
+	if plan.ClientID == domain.ClientKiro {
+		kiroObjects, err := buildKiroNativeObjects(stagingPath, envelope, plan)
+		if err != nil {
+			return domain.StagedDelivery{}, err
+		}
+		objects = append(objects, kiroObjects...)
+	}
 	return domain.StagedDelivery{
 		ClientID:       plan.ClientID,
 		OwnedBase:      plan.TargetRoot,

--- a/install/integrationctl/agentplugins/providers/stager_test.go
+++ b/install/integrationctl/agentplugins/providers/stager_test.go
@@ -124,6 +124,15 @@ func TestStagerProjectsKiroStdioRuntimeContractBeforeNativeImport(t *testing.T) 
 	if projected["cwd"] != plan.ActivePath {
 		t.Fatalf("Kiro cwd = %v, want %v", projected["cwd"], plan.ActivePath)
 	}
+	var foundMCP bool
+	for _, object := range delivery.NativeObjects {
+		if object.Kind == kiroMCPObjectKind && object.LogicalName == "local" {
+			foundMCP = object.Path == filepath.Join(plan.NativeRegistryRoot, "settings", "mcp.json") && strings.HasPrefix(object.ManagedDigest, "sha256:")
+		}
+	}
+	if !foundMCP {
+		t.Fatalf("Kiro MCP ownership was not staged: %+v", delivery.NativeObjects)
+	}
 }
 
 func TestStagerProjectsCursorNativeManifestAndRuntimeContract(t *testing.T) {
@@ -415,7 +424,7 @@ func stagingPlan(t *testing.T, client domain.ClientID, mode domain.PackageMode) 
 		status = domain.PlanManualActivationRequired
 		activation = domain.ActivationManual
 	}
-	return domain.DeliveryPlan{
+	plan := domain.DeliveryPlan{
 		ClientID: client, Scope: domain.ScopeUser, Status: status, PackageMode: mode,
 		Activation: activation, Authentication: domain.AuthenticationNotChecked,
 		Policy: domain.PolicyAllowed, Verification: domain.VerificationPackageValid,
@@ -426,6 +435,10 @@ func stagingPlan(t *testing.T, client domain.ClientID, mode domain.PackageMode) 
 			{Kind: domain.ComponentExtension, Name: "cursor", Support: domain.SupportUnsupported},
 		},
 	}
+	if client == domain.ClientKiro {
+		plan.NativeRegistryRoot = filepath.Join(t.TempDir(), ".kiro")
+	}
+	return plan
 }
 
 func supportFor(mode domain.PackageMode) domain.SupportLevel {

--- a/install/integrationctl/agentplugins/usecase/group.go
+++ b/install/integrationctl/agentplugins/usecase/group.go
@@ -554,6 +554,12 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 		}
 		outcome, activationErr := service.Activator.Activate(ctx, domain.ActivationRequest{Client: target.input.Client, Plan: target.plan, Delivery: delivery,
 			DeclaredName: target.input.Envelope.Manifest.Name, Replacing: replace, Interactive: target.input.Interactive, BackendExecutable: target.input.BackendExecutable,
+			PreviousNativeObjects: func() []domain.NativeObjectOwnership {
+				if target.managed == nil {
+					return nil
+				}
+				return append([]domain.NativeObjectOwnership(nil), target.managed.NativeObjects...)
+			}(),
 			VerifyOnly: target.noChange, ActivationComplete: target.input.ActivationComplete})
 		if target.noChange && target.managed != nil {
 			if activationErr == nil && !clientVerifierAvailable(target.input, target.plan) && target.managed.Activation == domain.ActivationActive && target.managed.Verification == domain.VerificationInstalled {

--- a/install/integrationctl/agentplugins/usecase/manual_remote_lifecycle_test.go
+++ b/install/integrationctl/agentplugins/usecase/manual_remote_lifecycle_test.go
@@ -52,7 +52,7 @@ func TestSignedChatGPTPreparationSupportsAddUpdateAndRepairWhileRemoteActivation
 	}
 }
 
-func TestNonMCPKiroPowerSupportsAddUpdateAndRepairWhileImportIsPending(t *testing.T) {
+func TestKiroSkillSupportsAutomaticAddUpdateAndRepair(t *testing.T) {
 	t.Parallel()
 	service, store, _ := serviceFixture(t)
 	service.NativeObserver = providers.NativeIdentityObserver{Stager: service.Stager}
@@ -63,8 +63,11 @@ func TestNonMCPKiroPowerSupportsAddUpdateAndRepairWhileImportIsPending(t *testin
 	if err != nil {
 		t.Fatal(err)
 	}
-	if added.Targets[0].Activation.Activation != domain.ActivationManual || added.Targets[0].Activation.Verification == domain.VerificationInstalled {
-		t.Fatalf("Kiro add claimed manual import completion: %+v", added.Targets[0])
+	if added.Targets[0].Activation.Activation != domain.ActivationActive || added.Targets[0].Activation.Verification != domain.VerificationInstalled {
+		t.Fatalf("Kiro add did not complete native installation: %+v", added.Targets[0])
+	}
+	if _, err := os.Stat(filepath.Join(client.ConfigRoot, "skills", "docs", "SKILL.md")); err != nil {
+		t.Fatalf("Kiro skill was not installed: %v", err)
 	}
 
 	update := kiroPowerInput(t, client, "2.0.0", "sha256:kiro-v2", "sha256:kiro-manifest-v2")
@@ -84,8 +87,8 @@ func TestNonMCPKiroPowerSupportsAddUpdateAndRepairWhileImportIsPending(t *testin
 	if err != nil {
 		t.Fatal(err)
 	}
-	if repaired.Targets[0].Activation.Activation != domain.ActivationManual || repaired.Targets[0].Activation.Verification == domain.VerificationInstalled {
-		t.Fatalf("Kiro repair claimed manual import completion: %+v", repaired.Targets[0])
+	if repaired.Targets[0].Activation.Activation != domain.ActivationActive || repaired.Targets[0].Activation.Verification != domain.VerificationInstalled {
+		t.Fatalf("Kiro repair did not restore native installation: %+v", repaired.Targets[0])
 	}
 }
 

--- a/install/integrationctl/agentplugins/usecase/manual_remote_lifecycle_test.go
+++ b/install/integrationctl/agentplugins/usecase/manual_remote_lifecycle_test.go
@@ -90,6 +90,20 @@ func TestKiroSkillSupportsAutomaticAddUpdateAndRepair(t *testing.T) {
 	if repaired.Targets[0].Activation.Activation != domain.ActivationActive || repaired.Targets[0].Activation.Verification != domain.VerificationInstalled {
 		t.Fatalf("Kiro repair did not restore native installation: %+v", repaired.Targets[0])
 	}
+	removed, err := service.RemoveGroup(context.Background(), RemoveGroupInput{
+		Selector:         added.InstallationID,
+		Targets:          []RemoveInput{{Client: client, Scope: domain.ScopeUser}},
+		OperationGroupID: "kiro-remove", Confirmed: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !removed.Mutated {
+		t.Fatalf("Kiro grouped remove did not mutate: %+v", removed)
+	}
+	if _, err := os.Stat(filepath.Join(client.ConfigRoot, "skills", "docs")); !os.IsNotExist(err) {
+		t.Fatalf("Kiro grouped remove retained managed skill: %v", err)
+	}
 }
 
 func signedChatGPTInput(t *testing.T, client domain.DetectedClient, version, treeDigest, manifestDigest string) AddInput {

--- a/install/integrationctl/agentplugins/usecase/remove.go
+++ b/install/integrationctl/agentplugins/usecase/remove.go
@@ -97,6 +97,7 @@ func (service Service) Remove(ctx context.Context, input RemoveInput) (RemoveRes
 		Confirmed:           input.Confirmed && !input.DryRun,
 		PhysicalArtifactID:  client.PhysicalArtifact,
 		BackendExecutable:   input.BackendExecutable,
+		NativeObjects:       append([]domain.NativeObjectOwnership(nil), client.NativeObjects...),
 	})
 	result.Deactivation = deactivation
 	if err != nil {

--- a/install/integrationctl/agentplugins/usecase/remove_group.go
+++ b/install/integrationctl/agentplugins/usecase/remove_group.go
@@ -126,7 +126,8 @@ func (service Service) RemoveGroup(ctx context.Context, input RemoveGroupInput) 
 		}
 		outcome, err := service.Activator.Deactivate(ctx, domain.DeactivationRequest{Client: targetInput.Client, DeclaredName: installation.DeclaredName,
 			CurrentActivation: client.Activation, Interactive: targetInput.Interactive, ExternalUninstalled: targetInput.ExternalUninstalled,
-			Confirmed: false, PhysicalArtifactID: client.PhysicalArtifact, BackendExecutable: targetInput.BackendExecutable})
+			Confirmed: false, PhysicalArtifactID: client.PhysicalArtifact, BackendExecutable: targetInput.BackendExecutable,
+			NativeObjects: append([]domain.NativeObjectOwnership(nil), client.NativeObjects...)})
 		result.Targets[targetIndex].Deactivation = outcome
 		if err != nil {
 			return result, err
@@ -153,7 +154,8 @@ func (service Service) RemoveGroup(ctx context.Context, input RemoveGroupInput) 
 		item := &planned[plannedIndex]
 		outcome, err := service.Activator.Deactivate(ctx, domain.DeactivationRequest{Client: item.input.Client, DeclaredName: installation.DeclaredName,
 			CurrentActivation: item.client.Activation, Interactive: item.input.Interactive, ExternalUninstalled: item.input.ExternalUninstalled,
-			Confirmed: true, PhysicalArtifactID: item.client.PhysicalArtifact, BackendExecutable: item.input.BackendExecutable})
+			Confirmed: true, PhysicalArtifactID: item.client.PhysicalArtifact, BackendExecutable: item.input.BackendExecutable,
+			NativeObjects: append([]domain.NativeObjectOwnership(nil), item.client.NativeObjects...)})
 		for _, resultIndex := range item.resultIndexes {
 			result.Targets[resultIndex].Deactivation = outcome
 		}

--- a/install/integrationctl/agentplugins/usecase/service.go
+++ b/install/integrationctl/agentplugins/usecase/service.go
@@ -422,6 +422,7 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 		},
 		DeclaredName: input.Envelope.Manifest.Name, Replacing: replace,
 		Interactive: input.Interactive, BackendExecutable: input.BackendExecutable,
+		PreviousNativeObjects: append([]domain.NativeObjectOwnership(nil), previousClient.NativeObjects...),
 	})
 	result.Activation = outcome
 	if activationErr != nil && outcome.Activation == "" {
@@ -492,7 +493,8 @@ func (service Service) resume(
 		Client: input.Client, Plan: result.Plan, Delivery: delivery,
 		DeclaredName: input.Envelope.Manifest.Name, Replacing: true,
 		Interactive: input.Interactive, BackendExecutable: input.BackendExecutable,
-		VerifyOnly: true, ActivationComplete: input.ActivationComplete,
+		PreviousNativeObjects: append([]domain.NativeObjectOwnership(nil), client.NativeObjects...),
+		VerifyOnly:            true, ActivationComplete: input.ActivationComplete,
 	})
 	// Authentication completion is a separate phase. Client installation/list
 	// evidence must never silently complete it.
@@ -540,7 +542,10 @@ func clientVerifierAvailable(input AddInput, plan domain.DeliveryPlan) bool {
 			return false
 		}
 		for _, component := range plan.Components {
-			if component.Support == domain.SupportUnsupported || component.Kind != domain.ComponentMCPServer {
+			if component.Support == domain.SupportUnsupported {
+				continue
+			}
+			if component.Kind != domain.ComponentSkill && component.Kind != domain.ComponentMCPServer {
 				return false
 			}
 		}
@@ -687,7 +692,7 @@ func (service Service) verifyClientReadOnly(ctx context.Context, input AddInput,
 		return domain.ActivationOutcome{}, nil
 	}
 	delivery := domain.StagedDelivery{ClientID: input.Client.ClientID, OwnedBase: result.Plan.TargetRoot, ActivePath: client.TargetLocator, ArtifactDigest: managedDigest(client), NativeObjects: client.NativeObjects}
-	outcome, err := service.Activator.Activate(ctx, domain.ActivationRequest{Client: input.Client, Plan: result.Plan, Delivery: delivery, DeclaredName: input.Envelope.Manifest.Name, Replacing: true, BackendExecutable: input.BackendExecutable, VerifyOnly: true})
+	outcome, err := service.Activator.Activate(ctx, domain.ActivationRequest{Client: input.Client, Plan: result.Plan, Delivery: delivery, DeclaredName: input.Envelope.Manifest.Name, Replacing: true, BackendExecutable: input.BackendExecutable, PreviousNativeObjects: append([]domain.NativeObjectOwnership(nil), client.NativeObjects...), VerifyOnly: true})
 	if outcome.Authentication == "" || outcome.Authentication == domain.AuthenticationNotChecked {
 		outcome.Authentication = client.Authentication
 	}

--- a/npm/agentplugins/README.md
+++ b/npm/agentplugins/README.md
@@ -114,9 +114,11 @@ pending or cancelled rather than runtime success. Directory badges and status
 describe only the exact schema, materialization, discovery, runtime, or OAuth
 evidence collected—not every plugin/client/environment combination.
 
-For native MCP-only Kiro packages, a complete supported Kiro CLI distribution
-is verified automatically after import with a bounded structured ACP v1
-initialize/session handshake. The handshake supplies no MCP definitions and
+Kiro skills are installed directly into the documented global skills path.
+For packages with MCP servers, agentplugins atomically merges only its owned
+entries into Kiro's global `mcp.json`, preserves unrelated configuration, and
+uses a complete supported Kiro CLI distribution for a bounded structured ACP
+v1 initialize/session handshake. The handshake supplies no MCP definitions and
 sends no prompt, model turn, tool call, or permission response: Kiro must load
 the installed native configuration and report each planned server connected
 with enabled tools. The verifier keeps ACP stdin open while it drains a bounded
@@ -125,9 +127,9 @@ protocol evidence before supervised containment stops and reaps the long-lived
 child. Automatic Kiro ACP verification is available only on Linux after
 capability preflight proves delegated cgroup v2 creation, atomic
 CLONE_INTO_CGROUP placement, and cgroup.kill. macOS, Windows, and Linux hosts
-without every required proof fail preflight before any native mutation. On
-those hosts, install or import the package manually in Kiro, activate it in
-Kiro's UI, and verify its servers there; that workflow is outside this
+without every required proof fail preflight before any MCP mutation. On those
+hosts, use Kiro's documented manual skill and MCP configuration paths; that
+workflow is outside this
 automatic CLI path. Failure to start ACP after a supported preflight may still
 leave a manual verification action. This proves session loading, not runtime
 tool end-to-end behavior. Once ACP starts, companion-launch


### PR DESCRIPTION
## Summary

- install Agent Plugins skills into Kiro global skills
- merge managed MCP entries into Kiro global mcp.json without changing unrelated configuration
- make add, update, repair, verification, and remove ownership-aware
- replace the obsolete mcp import flow and fix the Darwin ACP pipe EOF probe

## Verification

- `go test ./install/integrationctl/agentplugins/providers ./install/integrationctl/agentplugins/planner ./install/integrationctl/agentplugins/usecase`
- focused native lifecycle tests cover install, update, remove, collision, user modification, and unmanaged config preservation

## Safety

All runtime verification uses disposable homes and projects. No real user project is used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kiro integrations now automatically install and verify supported skills and MCP servers.
  * MCP configuration updates preserve unrelated user settings and servers.
  * Installation, upgrades, and removals are applied safely with rollback protection.

* **Bug Fixes**
  * Improved detection of configuration conflicts and user-modified managed files.
  * Enhanced verification of Kiro skills and MCP servers across supported platforms.

* **Documentation**
  * Updated Kiro setup guidance, including manual configuration steps when automatic activation is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->