### PR TITLE
fix(agentplugins): keep dry-run client processes inert

### DIFF
--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
@@ -171,6 +171,11 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 		}
 	}
 	if err != nil {
+		if applied.Phase == usecase.GroupPhasePlanned && !applied.Mutated {
+			combined.Status, combined.Failed, combined.Succeeded = "preflight_failed", len(inputs), 0
+			_ = renderAddMultiResult(cmd, opts, combined, loaded.envelope)
+			return fmt.Errorf("group apply preflight failed; no target was changed: %w%s", err, addGroupNextAction(combined.Targets))
+		}
 		combined.Status = groupFailureStatus(applied.Phase)
 		combined.Failed = len(inputs) - combined.Succeeded
 		_ = renderAddMultiResult(cmd, opts, combined, loaded.envelope)

--- a/install/integrationctl/agentplugins/providers/native_identity.go
+++ b/install/integrationctl/agentplugins/providers/native_identity.go
@@ -52,6 +52,17 @@ const (
 )
 
 func (observer NativeIdentityObserver) ObserveNativeIdentity(ctx context.Context, client domain.DetectedClient, plan domain.DeliveryPlan, managed *domain.ClientBinding) (domain.NativeIdentityObservation, error) {
+	return observer.observeIdentity(ctx, client, plan, managed, true)
+}
+
+// ObservePreparedIdentity inspects only filesystem-backed package identities.
+// It deliberately excludes native CLI discovery so dry-run cannot launch the
+// detected client executable.
+func (observer NativeIdentityObserver) ObservePreparedIdentity(ctx context.Context, client domain.DetectedClient, plan domain.DeliveryPlan, managed *domain.ClientBinding) (domain.NativeIdentityObservation, error) {
+	return observer.observeIdentity(ctx, client, plan, managed, false)
+}
+
+func (observer NativeIdentityObserver) observeIdentity(ctx context.Context, client domain.DetectedClient, plan domain.DeliveryPlan, managed *domain.ClientBinding, includeNativeRegistry bool) (domain.NativeIdentityObservation, error) {
 	if err := ctx.Err(); err != nil {
 		return domain.NativeIdentityObservation{}, err
 	}
@@ -64,22 +75,26 @@ func (observer NativeIdentityObserver) ObserveNativeIdentity(ctx context.Context
 	if preparedErr != nil {
 		prepared = registryIndeterminate
 	}
-	nativeAttempted := observer.Runner != nil && strings.TrimSpace(plan.NativeRegistryExecutable) != "" &&
+	nativeAttempted := includeNativeRegistry && observer.Runner != nil && strings.TrimSpace(plan.NativeRegistryExecutable) != "" &&
 		(client.ClientID == domain.ClientCodex || client.ClientID == domain.ClientCopilot || client.ClientID == domain.ClientVSCode)
-	nativeCtx := ctx
-	cancelNative := func() {}
-	if nativeAttempted {
-		timeout := observer.DiscoveryTimeout
-		if timeout <= 0 {
-			timeout = defaultNativeDiscoveryTimeout
+	native := registryClear
+	if includeNativeRegistry {
+		nativeCtx := ctx
+		cancelNative := func() {}
+		if nativeAttempted {
+			timeout := observer.DiscoveryTimeout
+			if timeout <= 0 {
+				timeout = defaultNativeDiscoveryTimeout
+			}
+			nativeCtx, cancelNative = context.WithTimeout(ctx, timeout)
 		}
-		nativeCtx, cancelNative = context.WithTimeout(ctx, timeout)
-	}
-	native, err := observer.inspectNativeRegistry(nativeCtx, client, plan, managed)
-	cancelNative()
-	if err != nil {
-		return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate, NativeDiscoveryState: domain.NativeIdentityIndeterminate,
-			NativeDiscoveryAttempted: nativeAttempted}, err
+		var err error
+		native, err = observer.inspectNativeRegistry(nativeCtx, client, plan, managed)
+		cancelNative()
+		if err != nil {
+			return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate, NativeDiscoveryState: domain.NativeIdentityIndeterminate,
+				NativeDiscoveryAttempted: nativeAttempted}, err
+		}
 	}
 	discoveryState := domain.NativeIdentityAbsent
 	discoveryReconciled := false

--- a/install/integrationctl/agentplugins/providers/native_identity_test.go
+++ b/install/integrationctl/agentplugins/providers/native_identity_test.go
@@ -86,6 +86,24 @@ func TestNativeIdentityCodexUsesExactCLIRegistryIdentity(t *testing.T) {
 	}
 }
 
+func TestPreparedIdentityInspectsFilesWithoutLaunchingNativeCLI(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "prepared")
+	plan := identityPlan(root)
+	plan.NativeRegistryExecutable = "/test/bin/codex"
+	writeIdentityFile(t, filepath.Join(root, "foreign", "plugin.json"), `{"name":"demo"}`)
+	runner := &identityRunner{}
+
+	observation, err := (NativeIdentityObserver{Runner: runner}).ObservePreparedIdentity(
+		context.Background(), domain.DetectedClient{ClientID: domain.ClientCodex}, plan, nil,
+	)
+	if err != nil || observation.State != domain.NativeIdentityUnmanaged {
+		t.Fatalf("observation = %+v, err = %v", observation, err)
+	}
+	if len(runner.commands) != 0 || observation.NativeDiscoveryAttempted {
+		t.Fatalf("prepared observation launched native discovery: commands=%#v observation=%+v", runner.commands, observation)
+	}
+}
+
 func TestNativeIdentityCodexManualModeReadsAuthoritativeConfig(t *testing.T) {
 	configRoot := filepath.Join(t.TempDir(), ".codex")
 	plan := identityPlan(filepath.Join(t.TempDir(), "prepared"))

--- a/install/integrationctl/agentplugins/usecase/group.go
+++ b/install/integrationctl/agentplugins/usecase/group.go
@@ -303,7 +303,7 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 			if err := service.observeGroupPreparedIdentity(ctx, target.Client, plan, managed, input.Repair); err != nil {
 				return result, err
 			}
-			if managed != nil {
+			if managed != nil && !input.Repair {
 				if err := service.verifyManagedTarget(ctx, target.Client, target.Scope, *managed, "group dry-run"); err != nil {
 					return result, err
 				}

--- a/install/integrationctl/agentplugins/usecase/group.go
+++ b/install/integrationctl/agentplugins/usecase/group.go
@@ -299,10 +299,12 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 			return result, fmt.Errorf("update target %s is not installed", target.Client.ClientID)
 		}
 		result.Targets[targetIndex].Plan = plan
-		if !input.DryRun {
-			if err := service.observeGroupNativeIdentity(ctx, target.Client, plan, managed, input.Repair); err != nil {
+		if input.DryRun {
+			if err := service.observeGroupPreparedIdentity(ctx, target.Client, plan, managed, input.Repair); err != nil {
 				return result, err
 			}
+		} else if err := service.observeGroupNativeIdentity(ctx, target.Client, plan, managed, input.Repair); err != nil {
+			return result, err
 		}
 		noChange := managed != nil && !input.Repair && !input.Switch && groupPackageUnchanged(*managed, target) && containsSurface(managed.AffectedSurfaces, string(target.Client.ClientID))
 		if noChange {
@@ -698,6 +700,21 @@ func (service Service) observeGroupNativeIdentity(ctx context.Context, client do
 	if err != nil {
 		return fmt.Errorf("observe native identity for %s: %w", client.ClientID, err)
 	}
+	return validateGroupNativeIdentityObservation(observation, managed)
+}
+
+func (service Service) observeGroupPreparedIdentity(ctx context.Context, client domain.DetectedClient, plan domain.DeliveryPlan, managed *domain.ClientBinding, repair bool) error {
+	if !repair {
+		return service.observePreparedIdentity(ctx, client, plan, managed)
+	}
+	observation, err := service.preparedIdentityObservation(ctx, client, plan, managed)
+	if err != nil {
+		return fmt.Errorf("observe prepared identity for %s: %w", client.ClientID, err)
+	}
+	return validateGroupNativeIdentityObservation(observation, managed)
+}
+
+func validateGroupNativeIdentityObservation(observation domain.NativeIdentityObservation, managed *domain.ClientBinding) error {
 	if observation.State == domain.NativeIdentityAbsent && managed != nil {
 		return nil
 	}

--- a/install/integrationctl/agentplugins/usecase/group.go
+++ b/install/integrationctl/agentplugins/usecase/group.go
@@ -299,8 +299,10 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 			return result, fmt.Errorf("update target %s is not installed", target.Client.ClientID)
 		}
 		result.Targets[targetIndex].Plan = plan
-		if err := service.observeGroupNativeIdentity(ctx, target.Client, plan, managed, input.Repair); err != nil {
-			return result, err
+		if !input.DryRun {
+			if err := service.observeGroupNativeIdentity(ctx, target.Client, plan, managed, input.Repair); err != nil {
+				return result, err
+			}
 		}
 		noChange := managed != nil && !input.Repair && !input.Switch && groupPackageUnchanged(*managed, target) && containsSurface(managed.AffectedSurfaces, string(target.Client.ClientID))
 		if noChange {

--- a/install/integrationctl/agentplugins/usecase/group.go
+++ b/install/integrationctl/agentplugins/usecase/group.go
@@ -303,6 +303,11 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 			if err := service.observeGroupPreparedIdentity(ctx, target.Client, plan, managed, input.Repair); err != nil {
 				return result, err
 			}
+			if managed != nil {
+				if err := service.verifyManagedTarget(ctx, target.Client, target.Scope, *managed, "group dry-run"); err != nil {
+					return result, err
+				}
+			}
 		} else if err := service.observeGroupNativeIdentity(ctx, target.Client, plan, managed, input.Repair); err != nil {
 			return result, err
 		}

--- a/install/integrationctl/agentplugins/usecase/group_test.go
+++ b/install/integrationctl/agentplugins/usecase/group_test.go
@@ -125,12 +125,13 @@ func TestGroupedDryRunDoesNotObserveNativeClientIdentity(t *testing.T) {
 	kiro := domain.DetectedClient{ClientID: domain.ClientKiro, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".kiro")}
 	observer := &countingNativeObserver{}
 	service.NativeObserver = observer
+	targets := []AddInput{
+		addInput(t, cursor, "https://example.com/dry-run"),
+		addInput(t, kiro, "https://example.com/dry-run"),
+	}
 
 	result, err := service.AddGroup(context.Background(), GroupInput{
-		Targets: []AddInput{
-			addInput(t, cursor, "https://example.com/dry-run"),
-			addInput(t, kiro, "https://example.com/dry-run"),
-		},
+		Targets:          targets,
 		OperationGroupID: "group-dry-run",
 		DryRun:           true,
 	})
@@ -149,6 +150,25 @@ func TestGroupedDryRunDoesNotObserveNativeClientIdentity(t *testing.T) {
 	}
 	if result.Mutated || len(state.Installations) != 0 {
 		t.Fatalf("group dry-run mutated state: result=%+v state=%+v", result, state)
+	}
+
+	installed, err := service.AddGroup(context.Background(), GroupInput{
+		Targets: targets, OperationGroupID: "group-install", Confirmed: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(installed.Targets[0].Plan.ActivePath, "plugin.json"), []byte("tampered"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	observer.calls, observer.preparedCalls = 0, 0
+	if _, err := service.AddGroup(context.Background(), GroupInput{
+		Targets: targets, OperationGroupID: "group-tampered-dry-run", DryRun: true,
+	}); err == nil || !strings.Contains(err.Error(), "changed or is missing") {
+		t.Fatalf("tampered group dry-run error = %v", err)
+	}
+	if observer.calls != 0 || observer.preparedCalls != 1 {
+		t.Fatalf("tampered group dry-run observations: native=%d prepared=%d", observer.calls, observer.preparedCalls)
 	}
 }
 

--- a/install/integrationctl/agentplugins/usecase/group_test.go
+++ b/install/integrationctl/agentplugins/usecase/group_test.go
@@ -119,6 +119,36 @@ func TestGroupedPreflightFailureMutatesNoTarget(t *testing.T) {
 	}
 }
 
+func TestGroupedDryRunDoesNotObserveNativeClientIdentity(t *testing.T) {
+	t.Parallel()
+	service, store, cursor := serviceFixture(t)
+	kiro := domain.DetectedClient{ClientID: domain.ClientKiro, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".kiro")}
+	observer := &countingNativeObserver{}
+	service.NativeObserver = observer
+
+	result, err := service.AddGroup(context.Background(), GroupInput{
+		Targets: []AddInput{
+			addInput(t, cursor, "https://example.com/dry-run"),
+			addInput(t, kiro, "https://example.com/dry-run"),
+		},
+		OperationGroupID: "group-dry-run",
+		DryRun:           true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observer.calls != 0 {
+		t.Fatalf("group dry-run observed native client identity %d times", observer.calls)
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Mutated || len(state.Installations) != 0 {
+		t.Fatalf("group dry-run mutated state: result=%+v state=%+v", result, state)
+	}
+}
+
 func TestSwitchGroupPreservesOwnedPluginDataAcrossDistributionSwitchReverseAndRollback(t *testing.T) {
 	t.Parallel()
 	service, store, cursor := serviceFixture(t)
@@ -326,6 +356,10 @@ type fixedNativeObserver struct {
 	err         error
 }
 
+type countingNativeObserver struct {
+	calls int
+}
+
 type failNthVerificationStager struct {
 	verificationFailureStager
 	calls  int
@@ -363,4 +397,9 @@ func (*failNthGroupActivator) Deactivate(context.Context, domain.DeactivationReq
 
 func (observer fixedNativeObserver) ObserveNativeIdentity(context.Context, domain.DetectedClient, domain.DeliveryPlan, *domain.ClientBinding) (domain.NativeIdentityObservation, error) {
 	return observer.observation, observer.err
+}
+
+func (observer *countingNativeObserver) ObserveNativeIdentity(context.Context, domain.DetectedClient, domain.DeliveryPlan, *domain.ClientBinding) (domain.NativeIdentityObservation, error) {
+	observer.calls++
+	return domain.NativeIdentityObservation{State: domain.NativeIdentityAbsent}, nil
 }

--- a/install/integrationctl/agentplugins/usecase/group_test.go
+++ b/install/integrationctl/agentplugins/usecase/group_test.go
@@ -140,6 +140,9 @@ func TestGroupedDryRunDoesNotObserveNativeClientIdentity(t *testing.T) {
 	if observer.calls != 0 {
 		t.Fatalf("group dry-run observed native client identity %d times", observer.calls)
 	}
+	if observer.preparedCalls != 2 {
+		t.Fatalf("group dry-run prepared observations = %d, want 2", observer.preparedCalls)
+	}
 	state, err := store.Load()
 	if err != nil {
 		t.Fatal(err)
@@ -357,7 +360,8 @@ type fixedNativeObserver struct {
 }
 
 type countingNativeObserver struct {
-	calls int
+	calls         int
+	preparedCalls int
 }
 
 type failNthVerificationStager struct {
@@ -402,4 +406,12 @@ func (observer fixedNativeObserver) ObserveNativeIdentity(context.Context, domai
 func (observer *countingNativeObserver) ObserveNativeIdentity(context.Context, domain.DetectedClient, domain.DeliveryPlan, *domain.ClientBinding) (domain.NativeIdentityObservation, error) {
 	observer.calls++
 	return domain.NativeIdentityObservation{State: domain.NativeIdentityAbsent}, nil
+}
+
+func (observer *countingNativeObserver) ObservePreparedIdentity(_ context.Context, _ domain.DetectedClient, _ domain.DeliveryPlan, managed *domain.ClientBinding) (domain.NativeIdentityObservation, error) {
+	observer.preparedCalls++
+	if managed == nil {
+		return domain.NativeIdentityObservation{State: domain.NativeIdentityAbsent}, nil
+	}
+	return domain.NativeIdentityObservation{State: domain.NativeIdentityManaged, Digest: managedDigest(*managed)}, nil
 }

--- a/install/integrationctl/agentplugins/usecase/service.go
+++ b/install/integrationctl/agentplugins/usecase/service.go
@@ -241,16 +241,33 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 		binding := state.Installations[installationIndex].Clients[clientBindingID]
 		managedBinding = &binding
 	}
-	if managedBinding == nil {
-		if err := service.observeNativeIdentity(ctx, input.Client, plan, nil); err != nil {
-			return result, err
-		}
-	}
 	if input.DistributionSuspended && normalizedOriginMode(input.OriginMode) == domain.OriginModeDirectory && !isMaterialized {
 		return result, fmt.Errorf("distribution is suspended; adding a target is blocked")
 	}
 	if !isMaterialized && (input.ActivationComplete || input.AuthComplete) {
 		return result, fmt.Errorf("lifecycle completion flags require an already materialized package; run add first, then rerun add with the completion flags")
+	}
+	if input.DryRun {
+		if replace && !isMaterialized {
+			return result, fmt.Errorf("plugin is not materialized for %s; use add", input.Client.ClientID)
+		}
+		if isMaterialized {
+			current := state.Installations[installationIndex].Clients[clientBindingID]
+			result.Activation = lifecycleOutcome(current)
+			if err := service.verifyManagedTarget(ctx, input.Client, input.Scope, current, "dry-run"); err != nil {
+				return result, err
+			}
+			if !replace && !packageRevisionMatches(current.PackageRevision, input.Envelope) {
+				return result, fmt.Errorf("plugin is already materialized for %s at a different revision; use update", input.Client.ClientID)
+			}
+			result.NoChange = !replace && lifecycleConverged(current)
+		}
+		return result, nil
+	}
+	if managedBinding == nil {
+		if err := service.observeNativeIdentity(ctx, input.Client, plan, nil); err != nil {
+			return result, err
+		}
 	}
 	if isMaterialized && !replace {
 		current := state.Installations[installationIndex].Clients[clientBindingID]
@@ -317,9 +334,6 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 			}
 			return service.resume(ctx, input, result, installationID, clientBindingID, previousClient)
 		}
-	}
-	if input.DryRun {
-		return result, nil
 	}
 	if !input.Confirmed {
 		result.RequiresConfirmation = true

--- a/install/integrationctl/agentplugins/usecase/service.go
+++ b/install/integrationctl/agentplugins/usecase/service.go
@@ -53,6 +53,13 @@ type NativeIdentityObserver interface {
 	ObserveNativeIdentity(context.Context, domain.DetectedClient, domain.DeliveryPlan, *domain.ClientBinding) (domain.NativeIdentityObservation, error)
 }
 
+// PreparedIdentityObserver is the process-inert subset used by dry-run. It may
+// inspect package files and prepared registries, but must not launch a client
+// executable or query a remote registry.
+type PreparedIdentityObserver interface {
+	ObservePreparedIdentity(context.Context, domain.DetectedClient, domain.DeliveryPlan, *domain.ClientBinding) (domain.NativeIdentityObservation, error)
+}
+
 type PluginDataManager interface {
 	EnsureData(context.Context, string, string, string) (domain.DataReceipt, bool, error)
 	ValidateData(context.Context, domain.DataReceipt) error
@@ -248,6 +255,9 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 		return result, fmt.Errorf("lifecycle completion flags require an already materialized package; run add first, then rerun add with the completion flags")
 	}
 	if input.DryRun {
+		if err := service.observePreparedIdentity(ctx, input.Client, plan, managedBinding); err != nil {
+			return result, err
+		}
 		if replace && !isMaterialized {
 			return result, fmt.Errorf("plugin is not materialized for %s; use add", input.Client.ClientID)
 		}
@@ -1254,6 +1264,18 @@ func (service Service) observeNativeIdentity(ctx context.Context, client domain.
 	if err != nil {
 		return fmt.Errorf("observe native identity for %s: %w", client.ClientID, err)
 	}
+	return validateNativeIdentityObservation(observation, managed)
+}
+
+func (service Service) observePreparedIdentity(ctx context.Context, client domain.DetectedClient, plan domain.DeliveryPlan, managed *domain.ClientBinding) error {
+	observation, err := service.preparedIdentityObservation(ctx, client, plan, managed)
+	if err != nil {
+		return fmt.Errorf("observe prepared identity for %s: %w", client.ClientID, err)
+	}
+	return validateNativeIdentityObservation(observation, managed)
+}
+
+func validateNativeIdentityObservation(observation domain.NativeIdentityObservation, managed *domain.ClientBinding) error {
 	switch observation.State {
 	case NativeIdentityAbsent:
 		if managed != nil && managed.Materialization != domain.MaterializationAbsent {
@@ -1282,6 +1304,17 @@ func (service Service) nativeIdentityObservation(ctx context.Context, client dom
 	if service.NativeObserver != nil {
 		return service.NativeObserver.ObserveNativeIdentity(ctx, client, plan, managed)
 	}
+	return service.filesystemIdentityObservation(ctx, plan, managed)
+}
+
+func (service Service) preparedIdentityObservation(ctx context.Context, client domain.DetectedClient, plan domain.DeliveryPlan, managed *domain.ClientBinding) (domain.NativeIdentityObservation, error) {
+	if observer, ok := service.NativeObserver.(PreparedIdentityObserver); ok {
+		return observer.ObservePreparedIdentity(ctx, client, plan, managed)
+	}
+	return service.filesystemIdentityObservation(ctx, plan, managed)
+}
+
+func (service Service) filesystemIdentityObservation(ctx context.Context, plan domain.DeliveryPlan, managed *domain.ClientBinding) (domain.NativeIdentityObservation, error) {
 	// Every backend gets a fail-closed filesystem observation even when it has
 	// no richer namespace-aware observer. A specialized observer may prove
 	// qualified coexistence; the fallback never does.

--- a/install/integrationctl/agentplugins/usecase/service_test.go
+++ b/install/integrationctl/agentplugins/usecase/service_test.go
@@ -31,6 +31,8 @@ func TestAddDryRunAndUnconfirmedPlanDoNotMutateStateOrClient(t *testing.T) {
 		mode := mode
 		t.Run(mode, func(t *testing.T) {
 			service, store, client := serviceFixture(t)
+			observer := &countingNativeObserver{}
+			service.NativeObserver = observer
 			input := addInput(t, client, "https://example.com/one")
 			input.DryRun = mode == "dry_run"
 			input.Confirmed = false
@@ -50,6 +52,9 @@ func TestAddDryRunAndUnconfirmedPlanDoNotMutateStateOrClient(t *testing.T) {
 			}
 			if _, err := os.Lstat(result.Plan.ActivePath); !os.IsNotExist(err) {
 				t.Fatalf("client path mutated: %v", err)
+			}
+			if mode == "dry_run" && observer.calls != 0 {
+				t.Fatalf("dry-run observed native client identity %d times", observer.calls)
 			}
 		})
 	}
@@ -631,6 +636,36 @@ func TestNoChangeChecksManagedDigestBeforeReturning(t *testing.T) {
 	}
 	if _, err := service.Add(context.Background(), input); err == nil || !strings.Contains(err.Error(), "changed or is missing") {
 		t.Fatalf("no-change error = %v", err)
+	}
+}
+
+func TestNoChangeDryRunChecksManagedDigestWithoutNativeObservation(t *testing.T) {
+	t.Parallel()
+	service, store, client := serviceFixture(t)
+	input := addInput(t, client, "https://example.com/no-change-dry-run")
+	input.Confirmed = true
+	installed, err := service.Add(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observer := &countingNativeObserver{}
+	service.NativeObserver = observer
+	if err := os.WriteFile(filepath.Join(installed.Plan.ActivePath, "plugin.json"), []byte("tampered"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	input.DryRun, input.Confirmed = true, false
+	if _, err := service.Add(context.Background(), input); err == nil || !strings.Contains(err.Error(), "changed or is missing") {
+		t.Fatalf("dry-run managed digest error = %v", err)
+	}
+	if observer.calls != 0 {
+		t.Fatalf("dry-run observed native client identity %d times", observer.calls)
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Installations) != 1 {
+		t.Fatalf("dry-run changed state: %+v", state.Installations)
 	}
 }
 

--- a/install/integrationctl/agentplugins/usecase/service_test.go
+++ b/install/integrationctl/agentplugins/usecase/service_test.go
@@ -56,6 +56,9 @@ func TestAddDryRunAndUnconfirmedPlanDoNotMutateStateOrClient(t *testing.T) {
 			if mode == "dry_run" && observer.calls != 0 {
 				t.Fatalf("dry-run observed native client identity %d times", observer.calls)
 			}
+			if mode == "dry_run" && observer.preparedCalls != 1 {
+				t.Fatalf("dry-run prepared observations = %d, want 1", observer.preparedCalls)
+			}
 		})
 	}
 }
@@ -659,6 +662,9 @@ func TestNoChangeDryRunChecksManagedDigestWithoutNativeObservation(t *testing.T)
 	}
 	if observer.calls != 0 {
 		t.Fatalf("dry-run observed native client identity %d times", observer.calls)
+	}
+	if observer.preparedCalls != 1 {
+		t.Fatalf("dry-run prepared observations = %d, want 1", observer.preparedCalls)
 	}
 	state, err := store.Load()
 	if err != nil {


### PR DESCRIPTION
## Summary

- keep native client registry processes inert during single-target and grouped dry-runs
- retain filesystem registry collision, persisted-path, and package-digest preflight
- preserve all-target native identity checks before any real grouped mutation
- report unchanged real apply preflight failures as no-mutation failures

## Verification

- focused Go lifecycle, provider, and CLI suites pass locally and on pinned Linux Go 1.25.13
- tampered installed targets fail grouped dry-run without launching native discovery
- hosted isolated Context7 reproduction plans Codex, Cursor, and Kiro with 3/3 success and mutated=false
- the same sandbox previously failed because dry-run invoked codex plugin list without authentication