### PR TITLE
fix(agentplugins): clean managed Codex marketplaces

### DIFF
--- a/install/integrationctl/agentplugins/domain/clients.go
+++ b/install/integrationctl/agentplugins/domain/clients.go
@@ -190,6 +190,7 @@ type DeactivationRequest struct {
 	Confirmed           bool                    `json:"confirmed"`
 	PhysicalArtifactID  string                  `json:"physical_artifact_id"`
 	BackendExecutable   string                  `json:"-"`
+	ManagedArtifactPath string                  `json:"-"`
 	NativeObjects       []NativeObjectOwnership `json:"-"`
 }
 

--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -64,7 +64,17 @@ func (activator Activator) Deactivate(ctx context.Context, request domain.Deacti
 	case domain.ClientCursor:
 		return outcome, nil
 	case domain.ClientCodex:
-		return requireExternalUninstall(outcome, request.ExternalUninstalled, "uninstall the plugin in Codex, then rerun remove with `--external-uninstalled` (also use the flag if it was never activated)"), nil
+		if !request.ExternalUninstalled {
+			return requireExternalUninstall(outcome, false, "uninstall the plugin in Codex, then rerun remove with `--external-uninstalled` (also use the flag if it was never activated)"), nil
+		}
+		if !request.Confirmed || strings.TrimSpace(request.BackendExecutable) == "" || activator.Runner == nil {
+			return requireExternalUninstall(outcome, true, ""), nil
+		}
+		if err := activator.deactivateCodexMarketplace(ctx, request); err != nil {
+			return outcome, err
+		}
+		outcome.ExternalRemovalComplete = true
+		return outcome, nil
 	case domain.ClientChatGPT:
 		return requireExternalUninstall(outcome, request.ExternalUninstalled, "uninstall the plugin in ChatGPT Plugins, then rerun remove with `--external-uninstalled` (also use the flag if it was never activated)"), nil
 	case domain.ClientKiro:
@@ -392,6 +402,25 @@ func (activator Activator) deactivateCopilot(ctx context.Context, request domain
 	remove, err := activator.runCopilotResult(ctx, request.BackendExecutable, "plugin", "marketplace", "remove", marketplace)
 	if err != nil && !commandOutputContains(remove, "is not registered") {
 		return err
+	}
+	return nil
+}
+
+func (activator Activator) deactivateCodexMarketplace(ctx context.Context, request domain.DeactivationRequest) error {
+	if strings.TrimSpace(request.PhysicalArtifactID) == "" {
+		return fmt.Errorf("managed Codex marketplace identity is missing")
+	}
+	marketplace := managedMarketplaceName(request.PhysicalArtifactID)
+	registered, err := managedCodexMarketplaceRegistered(request.Client.ConfigRoot, marketplace, request.ManagedArtifactPath)
+	if err != nil {
+		return err
+	}
+	if !registered {
+		return nil
+	}
+	remove, err := activator.runClientResult(ctx, "Codex CLI", request.BackendExecutable, "plugin", "marketplace", "remove", marketplace, "--json")
+	if err != nil && !commandOutputContains(remove, "not configured or installed") {
+		return fmt.Errorf("remove managed Codex marketplace %s: %w", marketplace, err)
 	}
 	return nil
 }

--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -67,11 +67,27 @@ func (activator Activator) Deactivate(ctx context.Context, request domain.Deacti
 		if !request.ExternalUninstalled {
 			return requireExternalUninstall(outcome, false, "uninstall the plugin in Codex, then rerun remove with `--external-uninstalled` (also use the flag if it was never activated)"), nil
 		}
-		if !request.Confirmed || strings.TrimSpace(request.BackendExecutable) == "" || activator.Runner == nil {
+		if !request.Confirmed {
 			return requireExternalUninstall(outcome, true, ""), nil
 		}
-		if err := activator.deactivateCodexMarketplace(ctx, request); err != nil {
+		if strings.TrimSpace(request.PhysicalArtifactID) == "" {
+			return outcome, fmt.Errorf("managed Codex marketplace identity is missing")
+		}
+		marketplace := managedMarketplaceName(request.PhysicalArtifactID)
+		registered, err := managedCodexMarketplaceRegistered(request.Client.ConfigRoot, marketplace, request.ManagedArtifactPath)
+		if err != nil {
 			return outcome, err
+		}
+		if registered {
+			if strings.TrimSpace(request.BackendExecutable) == "" || activator.Runner == nil {
+				outcome.Activation = domain.ActivationManual
+				outcome.ArtifactRemovalAllowed = false
+				outcome.UserActions = []string{fmt.Sprintf("run `codex plugin marketplace remove %s --json`, then retry removal", marketplace)}
+				return outcome, nil
+			}
+			if err := activator.removeCodexMarketplace(ctx, request.BackendExecutable, marketplace); err != nil {
+				return outcome, err
+			}
 		}
 		outcome.ExternalRemovalComplete = true
 		return outcome, nil
@@ -406,19 +422,8 @@ func (activator Activator) deactivateCopilot(ctx context.Context, request domain
 	return nil
 }
 
-func (activator Activator) deactivateCodexMarketplace(ctx context.Context, request domain.DeactivationRequest) error {
-	if strings.TrimSpace(request.PhysicalArtifactID) == "" {
-		return fmt.Errorf("managed Codex marketplace identity is missing")
-	}
-	marketplace := managedMarketplaceName(request.PhysicalArtifactID)
-	registered, err := managedCodexMarketplaceRegistered(request.Client.ConfigRoot, marketplace, request.ManagedArtifactPath)
-	if err != nil {
-		return err
-	}
-	if !registered {
-		return nil
-	}
-	remove, err := activator.runClientResult(ctx, "Codex CLI", request.BackendExecutable, "plugin", "marketplace", "remove", marketplace, "--json")
+func (activator Activator) removeCodexMarketplace(ctx context.Context, executable, marketplace string) error {
+	remove, err := activator.runClientResult(ctx, "Codex CLI", executable, "plugin", "marketplace", "remove", marketplace, "--json")
 	if err != nil && !commandOutputContains(remove, "not configured or installed") {
 		return fmt.Errorf("remove managed Codex marketplace %s: %w", marketplace, err)
 	}

--- a/install/integrationctl/agentplugins/providers/activator_test.go
+++ b/install/integrationctl/agentplugins/providers/activator_test.go
@@ -791,6 +791,86 @@ func TestDeactivatorPreviewsThenRemovesNativeCopilotLifecycle(t *testing.T) {
 	}
 }
 
+func TestDeactivatorPreviewsThenCleansManagedCodexMarketplace(t *testing.T) {
+	t.Parallel()
+	runner := &recordingRunner{}
+	request := codexDeactivationRequest(t)
+	preview, err := (Activator{Runner: runner}).Deactivate(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !preview.ArtifactRemovalAllowed || !preview.ExternalRemovalComplete || len(runner.commands) != 0 {
+		t.Fatalf("preview = %+v, commands = %+v", preview, runner.commands)
+	}
+	request.Confirmed = true
+	outcome, err := (Activator{Runner: runner}).Deactivate(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.ArtifactRemovalAllowed || !outcome.ExternalRemovalComplete {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+	want := [][]string{{
+		"/test/bin/codex", "plugin", "marketplace", "remove",
+		managedMarketplaceName(request.PhysicalArtifactID), "--json",
+	}}
+	if got := commandArgv(runner.commands); !reflect.DeepEqual(got, want) {
+		t.Fatalf("commands = %#v, want %#v", got, want)
+	}
+}
+
+func TestDeactivatorTreatsAbsentManagedCodexMarketplaceAsClean(t *testing.T) {
+	t.Parallel()
+	runner := &recordingRunner{run: func(command legacyports.Command) legacyports.CommandResult {
+		return legacyports.CommandResult{ExitCode: 1, Stderr: []byte("marketplace `agentplugins-demo` is not configured or installed")}
+	}}
+	request := codexDeactivationRequest(t)
+	request.Confirmed = true
+	outcome, err := (Activator{Runner: runner}).Deactivate(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.ArtifactRemovalAllowed || !outcome.ExternalRemovalComplete {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+}
+
+func TestDeactivatorRetainsManagedCodexArtifactWhenMarketplaceCleanupFails(t *testing.T) {
+	t.Parallel()
+	runner := &recordingRunner{run: func(command legacyports.Command) legacyports.CommandResult {
+		return legacyports.CommandResult{ExitCode: 1, Stderr: []byte("config write failed")}
+	}}
+	request := codexDeactivationRequest(t)
+	request.Confirmed = true
+	outcome, err := (Activator{Runner: runner}).Deactivate(context.Background(), request)
+	if err == nil || !strings.Contains(err.Error(), "remove managed Codex marketplace") {
+		t.Fatalf("outcome = %+v, error = %v", outcome, err)
+	}
+	if outcome.ExternalRemovalComplete {
+		t.Fatalf("failed cleanup claimed external completion: %+v", outcome)
+	}
+}
+
+func TestDeactivatorNeverRemovesSameNameUserCodexMarketplace(t *testing.T) {
+	t.Parallel()
+	runner := &recordingRunner{}
+	request := codexDeactivationRequest(t)
+	request.Confirmed = true
+	marketplace := managedMarketplaceName(request.PhysicalArtifactID)
+	writeTestFile(t, filepath.Join(request.Client.ConfigRoot, "config.toml"), fmt.Sprintf(`
+[marketplaces.%s]
+source_type = "local"
+source = "/user/replaced-marketplace"
+`, marketplace))
+	outcome, err := (Activator{Runner: runner}).Deactivate(context.Background(), request)
+	if err == nil || !strings.Contains(err.Error(), "no longer points at the managed artifact") {
+		t.Fatalf("outcome = %+v, error = %v", outcome, err)
+	}
+	if len(runner.commands) != 0 || outcome.ExternalRemovalComplete {
+		t.Fatalf("user marketplace was targeted: outcome=%+v commands=%+v", outcome, runner.commands)
+	}
+}
+
 func TestDeactivatorTreatsAlreadyAbsentNativeObjectsAsRemoved(t *testing.T) {
 	t.Parallel()
 	runner := &recordingRunner{run: func(command legacyports.Command) legacyports.CommandResult {
@@ -888,6 +968,29 @@ func TestChatGPTActivationCanOnlyCompleteByExplicitAttestation(t *testing.T) {
 	}
 	if outcome.Activation != domain.ActivationActive || outcome.Verification != domain.VerificationInstalled || !outcome.ActivationAttested {
 		t.Fatalf("ChatGPT attestation = %+v", outcome)
+	}
+}
+
+func codexDeactivationRequest(t *testing.T) domain.DeactivationRequest {
+	t.Helper()
+	configRoot := t.TempDir()
+	managedArtifact := filepath.Join(t.TempDir(), "managed", "demo")
+	physicalArtifactID := "demo-0123456789ab"
+	marketplace := managedMarketplaceName(physicalArtifactID)
+	writeTestFile(t, filepath.Join(configRoot, "config.toml"), fmt.Sprintf(`
+[marketplaces.%s]
+source_type = "local"
+source = %q
+
+[marketplaces.user-marketplace]
+source_type = "local"
+source = "/user/marketplace"
+`, marketplace, managedArtifact))
+	return domain.DeactivationRequest{
+		Client: domain.DetectedClient{ClientID: domain.ClientCodex, ConfigRoot: configRoot}, DeclaredName: "demo",
+		CurrentActivation: domain.ActivationActive, BackendExecutable: "/test/bin/codex",
+		PhysicalArtifactID: physicalArtifactID, ManagedArtifactPath: managedArtifact,
+		ExternalUninstalled: true,
 	}
 }
 

--- a/install/integrationctl/agentplugins/providers/activator_test.go
+++ b/install/integrationctl/agentplugins/providers/activator_test.go
@@ -871,6 +871,39 @@ source = "/user/replaced-marketplace"
 	}
 }
 
+func TestDeactivatorRetainsManagedCodexArtifactWhenCLIIsUnavailable(t *testing.T) {
+	t.Parallel()
+	request := codexDeactivationRequest(t)
+	request.Confirmed = true
+	request.BackendExecutable = ""
+	outcome, err := (Activator{}).Deactivate(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	marketplace := managedMarketplaceName(request.PhysicalArtifactID)
+	if outcome.ArtifactRemovalAllowed || outcome.ExternalRemovalComplete || outcome.Activation != domain.ActivationManual ||
+		len(outcome.UserActions) != 1 || !strings.Contains(outcome.UserActions[0], marketplace) {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+}
+
+func TestDeactivatorAllowsIdempotentCodexRemovalWhenRegistryIsAlreadyAbsent(t *testing.T) {
+	t.Parallel()
+	request := codexDeactivationRequest(t)
+	request.Confirmed = true
+	request.BackendExecutable = ""
+	if err := os.Remove(filepath.Join(request.Client.ConfigRoot, "config.toml")); err != nil {
+		t.Fatal(err)
+	}
+	outcome, err := (Activator{}).Deactivate(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.ArtifactRemovalAllowed || !outcome.ExternalRemovalComplete || outcome.Activation != domain.ActivationNotRequired {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+}
+
 func TestDeactivatorTreatsAlreadyAbsentNativeObjectsAsRemoved(t *testing.T) {
 	t.Parallel()
 	runner := &recordingRunner{run: func(command legacyports.Command) legacyports.CommandResult {

--- a/install/integrationctl/agentplugins/providers/codex_marketplace_cleanup.go
+++ b/install/integrationctl/agentplugins/providers/codex_marketplace_cleanup.go
@@ -1,0 +1,56 @@
+package providers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+// managedCodexMarketplaceRegistered proves that the exact manager-owned
+// marketplace still points at the exact managed package before native cleanup.
+// A same-name user replacement is never removed.
+func managedCodexMarketplaceRegistered(configRoot, marketplace, managedArtifactPath string) (bool, error) {
+	if strings.TrimSpace(configRoot) == "" || strings.TrimSpace(managedArtifactPath) == "" {
+		return false, fmt.Errorf("managed Codex marketplace ownership evidence is incomplete")
+	}
+	body, err := os.ReadFile(filepath.Join(configRoot, "config.toml"))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("inspect managed Codex marketplace config: %w", err)
+	}
+	var document map[string]any
+	if err := toml.Unmarshal(body, &document); err != nil {
+		return false, fmt.Errorf("inspect managed Codex marketplace config: %w", err)
+	}
+	marketplaces, ok := document["marketplaces"].(map[string]any)
+	if !ok {
+		if _, present := document["marketplaces"]; present {
+			return false, fmt.Errorf("refuse managed Codex marketplace cleanup because the registry shape is not recognized")
+		}
+		return false, nil
+	}
+	entryValue, present := marketplaces[marketplace]
+	if !present {
+		return false, nil
+	}
+	entry, ok := entryValue.(map[string]any)
+	if !ok {
+		return false, fmt.Errorf("refuse managed Codex marketplace cleanup because %s has an unrecognized entry", marketplace)
+	}
+	source, ok := entry["source"].(string)
+	if !ok || strings.TrimSpace(source) == "" {
+		return false, fmt.Errorf("refuse managed Codex marketplace cleanup because %s has no local source", marketplace)
+	}
+	if sourceType, present := entry["source_type"]; present && sourceType != "local" {
+		return false, fmt.Errorf("refuse managed Codex marketplace cleanup because %s is not a local source", marketplace)
+	}
+	if filepath.Clean(source) != filepath.Clean(managedArtifactPath) {
+		return false, fmt.Errorf("refuse managed Codex marketplace cleanup because %s no longer points at the managed artifact", marketplace)
+	}
+	return true, nil
+}

--- a/install/integrationctl/agentplugins/usecase/remove.go
+++ b/install/integrationctl/agentplugins/usecase/remove.go
@@ -97,6 +97,7 @@ func (service Service) Remove(ctx context.Context, input RemoveInput) (RemoveRes
 		Confirmed:           input.Confirmed && !input.DryRun,
 		PhysicalArtifactID:  client.PhysicalArtifact,
 		BackendExecutable:   input.BackendExecutable,
+		ManagedArtifactPath: client.TargetLocator,
 		NativeObjects:       append([]domain.NativeObjectOwnership(nil), client.NativeObjects...),
 	})
 	result.Deactivation = deactivation

--- a/install/integrationctl/agentplugins/usecase/remove_group.go
+++ b/install/integrationctl/agentplugins/usecase/remove_group.go
@@ -127,7 +127,8 @@ func (service Service) RemoveGroup(ctx context.Context, input RemoveGroupInput) 
 		outcome, err := service.Activator.Deactivate(ctx, domain.DeactivationRequest{Client: targetInput.Client, DeclaredName: installation.DeclaredName,
 			CurrentActivation: client.Activation, Interactive: targetInput.Interactive, ExternalUninstalled: targetInput.ExternalUninstalled,
 			Confirmed: false, PhysicalArtifactID: client.PhysicalArtifact, BackendExecutable: targetInput.BackendExecutable,
-			NativeObjects: append([]domain.NativeObjectOwnership(nil), client.NativeObjects...)})
+			ManagedArtifactPath: client.TargetLocator,
+			NativeObjects:       append([]domain.NativeObjectOwnership(nil), client.NativeObjects...)})
 		result.Targets[targetIndex].Deactivation = outcome
 		if err != nil {
 			return result, err
@@ -155,7 +156,8 @@ func (service Service) RemoveGroup(ctx context.Context, input RemoveGroupInput) 
 		outcome, err := service.Activator.Deactivate(ctx, domain.DeactivationRequest{Client: item.input.Client, DeclaredName: installation.DeclaredName,
 			CurrentActivation: item.client.Activation, Interactive: item.input.Interactive, ExternalUninstalled: item.input.ExternalUninstalled,
 			Confirmed: true, PhysicalArtifactID: item.client.PhysicalArtifact, BackendExecutable: item.input.BackendExecutable,
-			NativeObjects: append([]domain.NativeObjectOwnership(nil), item.client.NativeObjects...)})
+			ManagedArtifactPath: item.client.TargetLocator,
+			NativeObjects:       append([]domain.NativeObjectOwnership(nil), item.client.NativeObjects...)})
 		for _, resultIndex := range item.resultIndexes {
 			result.Targets[resultIndex].Deactivation = outcome
 		}

--- a/install/integrationctl/agentplugins/usecase/service_test.go
+++ b/install/integrationctl/agentplugins/usecase/service_test.go
@@ -1733,6 +1733,60 @@ func TestRemovePlanExposesExternalUninstallAndPreservesCodexArtifactUntilAcknowl
 	}
 }
 
+func TestRemoveCleansNativeCodexMarketplaceBeforeManagedArtifactDeletion(t *testing.T) {
+	t.Parallel()
+	service, store, _ := serviceFixture(t)
+	client := domain.DetectedClient{
+		ClientID: domain.ClientCodex, Status: domain.DetectionDetected,
+		ConfigRoot: filepath.Join(t.TempDir(), ".codex"),
+	}
+	runner := &codexCleanupUsecaseRunner{configRoot: client.ConfigRoot}
+	if result := runner.writeConfig(false); result.ExitCode != 0 {
+		t.Fatalf("seed Codex config: %s", result.Stderr)
+	}
+	service.Activator = providers.Activator{Runner: runner}
+	add := addInput(t, client, "https://example.com/codex-cleanup")
+	add.Confirmed = true
+	add.BackendExecutable = "/test/bin/codex"
+	installed, err := service.Add(context.Background(), add)
+	if err != nil {
+		t.Fatal(err)
+	}
+	removed, err := service.Remove(context.Background(), RemoveInput{
+		Selector: installed.InstallationID, Client: client, Scope: domain.ScopeUser,
+		Confirmed: true, ExternalUninstalled: true, BackendExecutable: "/test/bin/codex",
+		OperationID: "operation-remove-native-codex",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !removed.Mutated || !removed.Deactivation.ExternalRemovalComplete {
+		t.Fatalf("remove result = %+v", removed)
+	}
+	marketplace := providers.ManagedMarketplaceName(installed.Plan.PhysicalArtifactID)
+	wantCleanup := []string{"/test/bin/codex", "plugin", "marketplace", "remove", marketplace, "--json"}
+	if got := runner.commands[len(runner.commands)-1].Argv; !reflect.DeepEqual(got, wantCleanup) {
+		t.Fatalf("last command = %#v, want cleanup %#v", got, wantCleanup)
+	}
+	config, err := os.ReadFile(filepath.Join(client.ConfigRoot, "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(config), marketplace) || !strings.Contains(string(config), "user-marketplace") {
+		t.Fatalf("Codex config did not preserve only the user marketplace:\n%s", config)
+	}
+	if _, err := os.Lstat(installed.Plan.ActivePath); !os.IsNotExist(err) {
+		t.Fatalf("managed Codex artifact survived successful cleanup: %v", err)
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Installations) != 1 || len(state.Installations[0].Clients) != 0 || !state.Installations[0].DataRetained {
+		t.Fatalf("remove state = %+v", state.Installations)
+	}
+}
+
 func TestRemoveRefusesUserEditedManagedPackage(t *testing.T) {
 	t.Parallel()
 	service, store, client := serviceFixture(t)
@@ -1899,6 +1953,59 @@ func (activator *observedActivator) PreflightActivation(domain.ActivationRequest
 type fixedUsecaseRunner struct {
 	result legacyports.CommandResult
 	err    error
+}
+
+type codexCleanupUsecaseRunner struct {
+	commands           []legacyports.Command
+	configRoot         string
+	managedMarketplace string
+	managedPath        string
+}
+
+func (runner *codexCleanupUsecaseRunner) Run(_ context.Context, command legacyports.Command) (legacyports.CommandResult, error) {
+	runner.commands = append(runner.commands, command)
+	if len(command.Argv) >= 5 && command.Argv[1] == "plugin" && command.Argv[2] == "marketplace" && command.Argv[3] == "add" {
+		runner.managedPath = command.Argv[4]
+		runner.managedMarketplace = providers.ManagedMarketplaceName(filepath.Base(command.Argv[4]))
+		return runner.writeConfig(true), nil
+	}
+	if len(command.Argv) >= 5 && command.Argv[1] == "plugin" && command.Argv[2] == "marketplace" && command.Argv[3] == "remove" {
+		if command.Argv[4] != runner.managedMarketplace {
+			return legacyports.CommandResult{ExitCode: 1, Stderr: []byte("unexpected marketplace")}, nil
+		}
+		return runner.writeConfig(false), nil
+	}
+	if len(command.Argv) >= 4 && command.Argv[1] == "plugin" && command.Argv[2] == "list" {
+		marketplace := ""
+		name := "demo"
+		for _, prior := range runner.commands {
+			if len(prior.Argv) >= 4 && prior.Argv[1] == "plugin" && prior.Argv[2] == "add" {
+				parts := strings.SplitN(prior.Argv[3], "@", 2)
+				if len(parts) == 2 {
+					name, marketplace = parts[0], parts[1]
+				}
+			}
+		}
+		return legacyports.CommandResult{Stdout: []byte(fmt.Sprintf(
+			`{"installed":[{"pluginId":%q,"name":%q,"marketplaceName":%q,"installed":true,"enabled":true}]}`,
+			name+"@"+marketplace, name, marketplace,
+		))}, nil
+	}
+	return legacyports.CommandResult{}, nil
+}
+
+func (runner *codexCleanupUsecaseRunner) writeConfig(includeManaged bool) legacyports.CommandResult {
+	if err := os.MkdirAll(runner.configRoot, 0o700); err != nil {
+		return legacyports.CommandResult{ExitCode: 1, Stderr: []byte(err.Error())}
+	}
+	body := "[marketplaces.user-marketplace]\nsource_type = \"local\"\nsource = \"/user/marketplace\"\n"
+	if includeManaged {
+		body += fmt.Sprintf("\n[marketplaces.%s]\nsource_type = \"local\"\nsource = %q\n", runner.managedMarketplace, runner.managedPath)
+	}
+	if err := os.WriteFile(filepath.Join(runner.configRoot, "config.toml"), []byte(body), 0o600); err != nil {
+		return legacyports.CommandResult{ExitCode: 1, Stderr: []byte(err.Error())}
+	}
+	return legacyports.CommandResult{}
 }
 
 func (runner fixedUsecaseRunner) Run(context.Context, legacyports.Command) (legacyports.CommandResult, error) {


### PR DESCRIPTION
## Summary

- remove the exact manager-owned Codex marketplace before deleting its materialized package
- refuse cleanup when the marketplace name was replaced or points outside the recorded managed path
- keep state and artifacts recoverable when Codex is unavailable or cleanup fails
- preserve idempotent removal when the marketplace is already absent

## Evidence

A public `universal-agent-plugins@0.1.20` isolated lifecycle exposed a stale marketplace reference after remove. The next `codex plugin list` failed because the configured local marketplace pointed at an already removed directory.

Focused provider and lifecycle tests, race tests, and vet pass. All tests use temporary fixtures; no user project is involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex plugin removal now cleans up managed marketplaces automatically when possible.
  * Provides manual removal guidance when the Codex CLI is unavailable or cleanup cannot be completed.
  * Protects user-owned marketplaces from accidental removal.
  * Handles already-removed marketplaces safely.

* **Bug Fixes**
  * Managed plugin artifacts are retained when marketplace cleanup fails, enabling safe retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->