### PR TITLE
fix(agentplugins): read both directory evidence lanes

### DIFF
--- a/cli/plugin-kit-ai/internal/agentpluginscli/search.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/search.go
@@ -451,7 +451,7 @@ func searchHasRuntimeEvidence(snapshot domain.DirectorySnapshot, distribution st
 		_, active := current[evidence.ID]
 		if active && evidence.DistributionID == distribution && evidence.ReleaseSequence == sequence &&
 			(client == "" || evidence.Client == client) &&
-			evidence.Level == "runtime" && evidence.Outcome == "passed" && evidence.HasTrustedEligibilityProvenance() {
+			evidence.Level == "runtime" && evidence.Outcome == "passed" && evidence.HasTrustedEligibilityProvenanceAtSequence(snapshot.Sequence) {
 			return true
 		}
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/source.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/source.go
@@ -586,13 +586,13 @@ func applyDirectoryCompatibility(loaded *loadedPackage, bundle directoryv1.Verif
 		return err
 	}
 	compatibility := make(map[string]domain.CatalogCompatibility, len(policy.Targets))
-	current := currentDirectoryEvidence(bundle.Snapshot.Evidence, policy.CurrentEvidence)
+	current := currentDirectoryEvidence(bundle.Snapshot.Sequence, bundle.Snapshot.Evidence, policy.CurrentEvidence)
 	for _, target := range policy.Targets {
 		capabilities, _ := clientplanner.Capabilities(target.Client)
 		packageMode, _ := stableCatalogPackageMode(capabilities.PackageMode)
 		applicable := make([]domain.DirectoryEvidence, 0, len(current))
 		for _, evidence := range current {
-			if evidence.HasTrustedEligibilityProvenance() && directoryEvidenceApplies(evidence, selection, target.Client, environment) {
+			if evidence.HasTrustedEligibilityProvenanceAtSequence(bundle.Snapshot.Sequence) && directoryEvidenceApplies(evidence, selection, target.Client, environment) {
 				applicable = append(applicable, evidence)
 			}
 		}
@@ -616,14 +616,14 @@ func applyDirectoryCompatibility(loaded *loadedPackage, bundle directoryv1.Verif
 	return nil
 }
 
-func currentDirectoryEvidence(history []domain.DirectoryEvidence, ids []string) []domain.DirectoryEvidence {
+func currentDirectoryEvidence(sequence uint64, history []domain.DirectoryEvidence, ids []string) []domain.DirectoryEvidence {
 	byID := make(map[string]domain.DirectoryEvidence, len(history))
 	for _, evidence := range history {
 		byID[evidence.ID] = evidence
 	}
 	current := make([]domain.DirectoryEvidence, 0, len(ids))
 	for _, id := range ids {
-		if evidence, ok := byID[id]; ok && evidence.HasTrustedProvenance() {
+		if evidence, ok := byID[id]; ok && evidence.HasTrustedProvenanceAtSequence(sequence) {
 			current = append(current, evidence)
 		}
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/source_directory_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/source_directory_test.go
@@ -147,6 +147,30 @@ func TestDirectoryPackageSchemaEvidenceAppliesToEveryTarget(t *testing.T) {
 	}
 }
 
+func TestDirectoryCompatibilityRetainsVerifiedLegacyEvidence(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	evidence := domain.DirectoryEvidence{
+		ID: "legacy-materialization", ProductID: "demo", DistributionID: "owner/demo", ReleaseSequence: 1,
+		PackageTreeDigest: digest, ManifestDigest: "sha256:" + strings.Repeat("b", 64),
+		SourceRepository: "owner/demo", SourceRevision: strings.Repeat("c", 40), SourcePath: "plugin",
+		Level: "materialization", Outcome: "passed", Client: domain.ClientCursor,
+		ClientVersion: "0.50.0", InstallerVersion: "1.2.3", AdapterVersion: "0.1.13",
+		OS: "linux", Architecture: "amd64",
+	}
+	policy := domain.DirectoryReleasePolicy{Targets: []domain.DirectoryTarget{{Client: domain.ClientCursor, Delivery: "managed"}}, CurrentEvidence: []string{evidence.ID}}
+	bundle := directoryv1.VerifiedBundle{Digest: "sha256:directory", Snapshot: domain.DirectorySnapshot{Sequence: 13, Evidence: []domain.DirectoryEvidence{evidence}}}
+	loaded := loadedPackage{}
+	selection := domain.DirectorySelection{DistributionID: evidence.DistributionID, ReleaseSequence: evidence.ReleaseSequence, TreeDigest: digest}
+	environment := directoryEvidenceEnvironment{InstallerVersion: "1.2.3", OS: "linux", Architecture: "amd64", ClientVersions: map[domain.ClientID]string{domain.ClientCursor: "0.50.0"}}
+	if err := applyDirectoryCompatibility(&loaded, bundle, selection, policy, environment); err != nil {
+		t.Fatal(err)
+	}
+	compatibility := loaded.envelope.CatalogEvidence.Compatibility[string(domain.ClientCursor)]
+	if len(loaded.envelope.CatalogEvidence.CurrentEvidence) != 1 || len(compatibility.Evidence) != 1 || compatibility.EvidenceOutcomes["materialization"] != "passed" {
+		t.Fatalf("legacy evidence was not retained: %+v", loaded.envelope.CatalogEvidence)
+	}
+}
+
 func TestUntrustedCurrentEvidenceCannotCreateTestedCompatibility(t *testing.T) {
 	digest := "sha256:" + strings.Repeat("a", 64)
 	selection := domain.DirectorySelection{DistributionID: "owner/demo", ReleaseSequence: 1, TreeDigest: digest}

--- a/install/integrationctl/agentplugins/adapters/directoryv1/directoryv1_test.go
+++ b/install/integrationctl/agentplugins/adapters/directoryv1/directoryv1_test.go
@@ -80,6 +80,26 @@ func TestSnapshotEvidenceCutoverAcceptsBothStrictShapes(t *testing.T) {
 	if _, err := ParseSnapshot(wireBody); !errors.Is(err, ErrStrictJSON) {
 		t.Fatalf("legacy field accepted after cutover: %v", err)
 	}
+
+	wire = fixtureSnapshot(15)
+	var raw map[string]any
+	if err := json.Unmarshal(encodeSnapshot(t, wire), &raw); err != nil {
+		t.Fatal(err)
+	}
+	raw["evidence"].([]any)[0].(map[string]any)["product_id"] = ""
+	wireBody, _ = json.Marshal(raw)
+	if _, err := ParseSnapshot(wireBody); !errors.Is(err, ErrStrictJSON) {
+		t.Fatalf("empty legacy field accepted after cutover: %v", err)
+	}
+}
+
+func encodeSnapshot(t *testing.T, value domain.DirectorySnapshot) []byte {
+	t.Helper()
+	body, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
 }
 
 func signedFixture(t *testing.T, sequence uint64, key TrustedKey, private ed25519.PrivateKey) ([]byte, []byte, Pointer) {

--- a/install/integrationctl/agentplugins/adapters/directoryv1/directoryv1_test.go
+++ b/install/integrationctl/agentplugins/adapters/directoryv1/directoryv1_test.go
@@ -40,9 +40,46 @@ func fixtureSnapshot(sequence uint64) domain.DirectorySnapshot {
 	release := domain.DirectoryRelease{Sequence: 9, PackageVersion: "not-semver", ManifestName: "tool", AgentPluginsSchema: supportedPluginSchema, PackageSource: domain.DirectorySource{Repository: "owner/repo", Revision: "0123456789012345678901234567890123456789", Path: "plugin"}, TreeDigestAlgorithm: domain.TreeDigestAlgorithm, TreeDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", ManifestDigest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", Components: []string{"mcp", "skills"}, PublishedAt: "2026-08-20T10:00:00Z"}
 	policy := domain.DirectoryReleasePolicy{ReleaseSequence: 9, Status: domain.ReleaseActive, MinimumInstallerVersion: "1.0.0", Targets: []domain.DirectoryTarget{{Client: domain.ClientCodex, Scopes: []domain.InstallScope{domain.ScopeUser}, Delivery: "managed", Authentication: domain.AuthenticationRequirementUnknown}, {Client: domain.ClientCursor, Scopes: []domain.InstallScope{domain.ScopeUser}, Delivery: "managed", Authentication: domain.AuthenticationRequirementUnknown}}, CurrentEvidence: []string{"schema-pass"}}
 	evidence := domain.DirectoryEvidence{SchemaVersion: 1, ID: "schema-pass", DistributionID: "owner/tool", ReleaseSequence: 9, PackageTreeDigest: release.TreeDigest, Level: "schema", Outcome: "passed", Artifact: domain.DirectoryEvidenceArtifact{Repository: "owner/evidence", Revision: "abcdefabcdefabcdefabcdefabcdefabcdefabcd", Path: "evidence/schema.json", Digest: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"}, Trust: &domain.DirectoryEvidenceTrust{Kind: "github_actions", Workflow: "owner/evidence/.github/workflows/directory.yml", SourceRef: "refs/heads/main", SourceDigest: "abcdefabcdefabcdefabcdefabcdefabcdefabcd"}}
+	if sequence < domain.DirectoryEvidenceTrustCutoverSequence {
+		evidence.ProductID = "tool"
+		evidence.ManifestDigest = release.ManifestDigest
+		evidence.SourceRepository = release.PackageSource.Repository
+		evidence.SourceRevision = release.PackageSource.Revision
+		evidence.SourcePath = release.PackageSource.Path
+		evidence.AdapterVersion = "0.1.13"
+		evidence.Trust = nil
+	}
 	product := domain.DirectoryProduct{SchemaVersion: 1, ID: "tool", DisplayName: "Tool", Description: "Tool description", ManifestName: "tool", Aliases: []string{"tool"}, ReservedAliases: []string{"tool"}, Categories: []string{"tools"}, MinimumCapabilities: domain.DirectoryMinimumCapabilities{Skills: "optional", MCP: "required"}, DefaultDistribution: "owner/tool", Distributions: []string{"owner/tool"}}
 	distribution := domain.DirectoryDistribution{SchemaVersion: 1, ID: "owner/tool", ProductID: "tool", Kind: domain.DistributionUpstream, Status: domain.DistributionActive, Packager: "owner", Releases: []domain.DirectoryRelease{release}, ReleasePolicies: []domain.DirectoryReleasePolicy{policy}}
 	return domain.DirectorySnapshot{SnapshotSchemaVersion: 1, Sequence: sequence, PublicationID: fmt.Sprintf("publication-%d", sequence), SourceCommit: "abcdefabcdefabcdefabcdefabcdefabcdefabcd", GeneratedAt: "2026-08-20T11:00:00Z", ExpiresAt: "2026-09-19T11:00:00Z", Products: []domain.DirectoryProduct{product}, Distributions: []domain.DirectoryDistribution{distribution}, Evidence: []domain.DirectoryEvidence{evidence}, Revocations: []domain.DirectoryRevocation{}}
+}
+
+func TestSnapshotEvidenceCutoverAcceptsBothStrictShapes(t *testing.T) {
+	legacy := fixtureSnapshot(13)
+	legacyBody, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParseSnapshot(legacyBody); err != nil {
+		t.Fatalf("legacy production evidence rejected: %v", err)
+	}
+
+	legacy.Evidence[0].SourceRevision = strings.Repeat("f", 40)
+	legacyBody, _ = json.Marshal(legacy)
+	if _, err := ParseSnapshot(legacyBody); !errors.Is(err, ErrStrictJSON) {
+		t.Fatalf("legacy source rebind accepted: %v", err)
+	}
+
+	wire := fixtureSnapshot(15)
+	wireBody, _ := json.Marshal(wire)
+	if _, err := ParseSnapshot(wireBody); err != nil {
+		t.Fatalf("wire evidence rejected: %v", err)
+	}
+	wire.Evidence[0].AdapterVersion = "0.1.13"
+	wireBody, _ = json.Marshal(wire)
+	if _, err := ParseSnapshot(wireBody); !errors.Is(err, ErrStrictJSON) {
+		t.Fatalf("legacy field accepted after cutover: %v", err)
+	}
 }
 
 func signedFixture(t *testing.T, sequence uint64, key TrustedKey, private ed25519.PrivateKey) ([]byte, []byte, Pointer) {

--- a/install/integrationctl/agentplugins/adapters/directoryv1/validate.go
+++ b/install/integrationctl/agentplugins/adapters/directoryv1/validate.go
@@ -242,6 +242,7 @@ func validateSnapshot(v domain.DirectorySnapshot) error {
 	}
 
 	evidence := map[string]domain.DirectoryEvidence{}
+	legacyEvidence := v.Sequence < domain.DirectoryEvidenceTrustCutoverSequence
 	for i, e := range v.Evidence {
 		where := fmt.Sprintf("evidence[%d]", i)
 		if e.SchemaVersion != 1 || !evidenceIDPattern.MatchString(e.ID) || !distributionPattern.MatchString(e.DistributionID) || e.ReleaseSequence < 1 || !digestPattern.MatchString(e.PackageTreeDigest) {
@@ -253,6 +254,18 @@ func validateSnapshot(v domain.DirectorySnapshot) error {
 		r, ok := releases[releaseKey(e.DistributionID, e.ReleaseSequence)]
 		if !ok || r.TreeDigest != e.PackageTreeDigest {
 			return strictError("%s release/digest mismatch", where)
+		}
+		distribution := distributions[e.DistributionID]
+		if legacyEvidence {
+			if e.Trust != nil || e.ProductID != distribution.ProductID || e.ManifestDigest != r.ManifestDigest ||
+				e.SourceRepository != r.PackageSource.Repository || e.SourceRevision != r.PackageSource.Revision || e.SourcePath != r.PackageSource.Path {
+				return strictError("%s legacy evidence source identity mismatch", where)
+			}
+			if e.AdapterVersion != "" && strings.TrimSpace(e.AdapterVersion) == "" {
+				return strictError("%s invalid adapter version", where)
+			}
+		} else if e.ProductID != "" || e.ManifestDigest != "" || e.SourceRepository != "" || e.SourceRevision != "" || e.SourcePath != "" || e.AdapterVersion != "" {
+			return strictError("%s legacy evidence fields after cutover", where)
 		}
 		if !oneOf(e.Level, "schema", "materialization", "discovery", "runtime", "oauth") || !oneOf(e.Outcome, "passed", "failed", "inconclusive", "not_tested", "not_applicable") {
 			return strictError("%s invalid result", where)
@@ -278,11 +291,17 @@ func validateSnapshot(v domain.DirectorySnapshot) error {
 				if !workflowPattern.MatchString(e.Trust.Workflow) || !sourceRefPattern.MatchString(e.Trust.SourceRef) || !shaPattern.MatchString(e.Trust.SourceDigest) || !e.HasTrustedProvenance() {
 					return strictError("%s invalid trust", where)
 				}
-			} else if e.Trust.Kind != "reviewed_external" || e.Trust.Workflow != "" || e.Trust.SourceRef != "" || e.Trust.SourceDigest != "" {
+				for _, artifact := range []*domain.DirectoryEvidenceArtifact{e.Trust.BundleManifest, e.Trust.LaunchArtifact, e.Trust.ObserverArtifact, e.Trust.EvidenceIndex} {
+					if artifact != nil && (!repositoryPattern.MatchString(artifact.Repository) || !shaPattern.MatchString(artifact.Revision) || artifact.Path == "" || !digestPattern.MatchString(artifact.Digest)) {
+						return strictError("%s invalid trust artifact", where)
+					}
+				}
+			} else if e.Trust.Kind != "reviewed_external" || e.Trust.Workflow != "" || e.Trust.SourceRef != "" || e.Trust.SourceDigest != "" ||
+				e.Trust.BundleManifest != nil || e.Trust.LaunchArtifact != nil || e.Trust.ObserverArtifact != nil || e.Trust.EvidenceIndex != nil {
 				return strictError("%s invalid trust", where)
 			}
 		}
-		if !e.HasTrustedProvenance() {
+		if !e.HasTrustedProvenanceAtSequence(v.Sequence) {
 			return strictError("%s lacks recognized trusted provenance", where)
 		}
 		evidence[e.ID] = e
@@ -468,6 +487,11 @@ func requireSnapshotFields(body []byte) error {
 	if err := requiredMap(root, "snapshot_schema_version", "sequence", "publication_id", "source_commit", "generated_at", "expires_at", "products", "distributions", "evidence", "revocations"); err != nil {
 		return err
 	}
+	var sequence uint64
+	if err := json.Unmarshal(root["sequence"], &sequence); err != nil {
+		return err
+	}
+	legacyEvidence := sequence < domain.DirectoryEvidenceTrustCutoverSequence
 	var products []map[string]json.RawMessage
 	if err := json.Unmarshal(root["products"], &products); err != nil {
 		return err
@@ -559,7 +583,13 @@ func requireSnapshotFields(body []byte) error {
 		return err
 	}
 	for _, e := range evidence {
-		if err := requiredMap(e, "schema_version", "id", "distribution_id", "release_sequence", "package_tree_digest", "level", "outcome", "artifact"); err != nil {
+		required := []string{"schema_version", "id", "distribution_id", "release_sequence", "package_tree_digest", "level", "outcome", "artifact"}
+		if legacyEvidence {
+			required = append(required, "product_id", "manifest_digest", "source_repository", "source_revision", "source_path")
+		} else {
+			required = append(required, "trust")
+		}
+		if err := requiredMap(e, required...); err != nil {
 			return err
 		}
 		var artifact map[string]json.RawMessage
@@ -568,6 +598,26 @@ func requireSnapshotFields(body []byte) error {
 		}
 		if err := requiredMap(artifact, "repository", "revision", "path", "digest"); err != nil {
 			return err
+		}
+		if raw, ok := e["trust"]; ok {
+			var trust map[string]json.RawMessage
+			if err := json.Unmarshal(raw, &trust); err != nil {
+				return err
+			}
+			if err := requiredMap(trust, "kind"); err != nil {
+				return err
+			}
+			for _, field := range []string{"bundle_manifest", "launch_artifact", "observer_artifact", "evidence_index"} {
+				if artifactRaw, present := trust[field]; present {
+					var trustArtifact map[string]json.RawMessage
+					if err := json.Unmarshal(artifactRaw, &trustArtifact); err != nil {
+						return err
+					}
+					if err := requiredMap(trustArtifact, "repository", "revision", "path", "digest"); err != nil {
+						return err
+					}
+				}
+			}
 		}
 	}
 	var revocations []map[string]json.RawMessage

--- a/install/integrationctl/agentplugins/adapters/directoryv1/validate.go
+++ b/install/integrationctl/agentplugins/adapters/directoryv1/validate.go
@@ -585,8 +585,16 @@ func requireSnapshotFields(body []byte) error {
 	for _, e := range evidence {
 		required := []string{"schema_version", "id", "distribution_id", "release_sequence", "package_tree_digest", "level", "outcome", "artifact"}
 		if legacyEvidence {
+			if _, present := e["trust"]; present {
+				return fmt.Errorf("legacy evidence cannot contain trust")
+			}
 			required = append(required, "product_id", "manifest_digest", "source_repository", "source_revision", "source_path")
 		} else {
+			for _, field := range []string{"product_id", "manifest_digest", "source_repository", "source_revision", "source_path", "adapter_version"} {
+				if _, present := e[field]; present {
+					return fmt.Errorf("wire evidence cannot contain legacy field %q", field)
+				}
+			}
 			required = append(required, "trust")
 		}
 		if err := requiredMap(e, required...); err != nil {

--- a/install/integrationctl/agentplugins/domain/directory.go
+++ b/install/integrationctl/agentplugins/domain/directory.go
@@ -139,14 +139,20 @@ type DirectoryAppBinding struct {
 type DirectoryEvidence struct {
 	SchemaVersion      int                       `json:"schema_version"`
 	ID                 string                    `json:"id"`
+	ProductID          string                    `json:"product_id,omitempty"`
 	DistributionID     string                    `json:"distribution_id"`
 	ReleaseSequence    uint64                    `json:"release_sequence"`
 	PackageTreeDigest  string                    `json:"package_tree_digest"`
+	ManifestDigest     string                    `json:"manifest_digest,omitempty"`
+	SourceRepository   string                    `json:"source_repository,omitempty"`
+	SourceRevision     string                    `json:"source_revision,omitempty"`
+	SourcePath         string                    `json:"source_path,omitempty"`
 	Level              string                    `json:"level"`
 	Outcome            string                    `json:"outcome"`
 	Client             ClientID                  `json:"client,omitempty"`
 	ClientVersion      string                    `json:"client_version,omitempty"`
 	InstallerVersion   string                    `json:"installer_version,omitempty"`
+	AdapterVersion     string                    `json:"adapter_version,omitempty"`
 	OS                 string                    `json:"os,omitempty"`
 	Architecture       string                    `json:"architecture,omitempty"`
 	DependencyIdentity string                    `json:"dependency_identity,omitempty"`
@@ -155,11 +161,17 @@ type DirectoryEvidence struct {
 	Trust              *DirectoryEvidenceTrust   `json:"trust,omitempty"`
 }
 
+const DirectoryEvidenceTrustCutoverSequence uint64 = 15
+
 type DirectoryEvidenceTrust struct {
-	Kind         string `json:"kind"`
-	Workflow     string `json:"workflow,omitempty"`
-	SourceRef    string `json:"source_ref,omitempty"`
-	SourceDigest string `json:"source_digest,omitempty"`
+	Kind             string                     `json:"kind"`
+	Workflow         string                     `json:"workflow,omitempty"`
+	SourceRef        string                     `json:"source_ref,omitempty"`
+	SourceDigest     string                     `json:"source_digest,omitempty"`
+	BundleManifest   *DirectoryEvidenceArtifact `json:"bundle_manifest,omitempty"`
+	LaunchArtifact   *DirectoryEvidenceArtifact `json:"launch_artifact,omitempty"`
+	ObserverArtifact *DirectoryEvidenceArtifact `json:"observer_artifact,omitempty"`
+	EvidenceIndex    *DirectoryEvidenceArtifact `json:"evidence_index,omitempty"`
 }
 
 type DirectoryEvidenceArtifact struct {
@@ -194,10 +206,23 @@ func (e DirectoryEvidence) HasTrustedProvenance() bool {
 		workflowPrefix := e.Artifact.Repository + "/.github/workflows/"
 		return strings.HasPrefix(e.Trust.Workflow, workflowPrefix) && e.Artifact.Revision == e.Trust.SourceDigest
 	case "reviewed_external":
-		return e.Trust.Workflow == "" && e.Trust.SourceRef == "" && e.Trust.SourceDigest == ""
+		return e.Trust.Workflow == "" && e.Trust.SourceRef == "" && e.Trust.SourceDigest == "" &&
+			e.Trust.BundleManifest == nil && e.Trust.LaunchArtifact == nil && e.Trust.ObserverArtifact == nil && e.Trust.EvidenceIndex == nil
 	default:
 		return false
 	}
+}
+
+// HasTrustedProvenanceAtSequence recognizes both immutable schema-1 evidence
+// lanes. Sequences 1-14 used release-bound legacy identity fields; sequence 15
+// and later use the explicit trust object. A populated trust object always uses
+// the current path so domain-only fixtures cannot accidentally become legacy.
+func (e DirectoryEvidence) HasTrustedProvenanceAtSequence(sequence uint64) bool {
+	if e.Trust != nil {
+		return e.HasTrustedProvenance()
+	}
+	return sequence > 0 && sequence < DirectoryEvidenceTrustCutoverSequence && e.ProductID != "" && e.ManifestDigest != "" &&
+		e.SourceRepository != "" && e.SourceRevision != "" && e.SourcePath != ""
 }
 
 // HasTrustedEligibilityProvenance applies the schema-1 compatibility rule for
@@ -210,6 +235,18 @@ func (e DirectoryEvidence) HasTrustedEligibilityProvenance() bool {
 	}
 	if e.Level == "schema" || e.Level == "materialization" {
 		return e.Trust.Kind == "github_actions"
+	}
+	return e.Level == "discovery" || e.Level == "runtime" || e.Level == "oauth"
+}
+
+// HasTrustedEligibilityProvenanceAtSequence applies the eligibility-level
+// rules after recognizing the historical or current provenance lane.
+func (e DirectoryEvidence) HasTrustedEligibilityProvenanceAtSequence(sequence uint64) bool {
+	if !e.HasTrustedProvenanceAtSequence(sequence) {
+		return false
+	}
+	if e.Level == "schema" || e.Level == "materialization" {
+		return e.Trust == nil || e.Trust.Kind == "github_actions"
 	}
 	return e.Level == "discovery" || e.Level == "runtime" || e.Level == "oauth"
 }
@@ -520,7 +557,7 @@ func releaseEligibility(snapshot DirectorySnapshot, product DirectoryProduct, di
 		}
 	}
 	for _, evidenceID := range policy.CurrentEvidence {
-		if e := evidenceByID(snapshot, evidenceID); e != nil && e.HasTrustedEligibilityProvenance() && directoryEvidenceApplies(*e, distribution, release, "", request) && e.Level == "schema" && e.Outcome == "failed" {
+		if e := evidenceByID(snapshot, evidenceID); e != nil && e.HasTrustedEligibilityProvenanceAtSequence(snapshot.Sequence) && directoryEvidenceApplies(*e, distribution, release, "", request) && e.Level == "schema" && e.Outcome == "failed" {
 			return &eligibilityReason{"blocking_evidence", "current trusted schema evidence failed"}
 		}
 	}
@@ -537,7 +574,7 @@ func releaseEligibility(snapshot DirectorySnapshot, product DirectoryProduct, di
 			return &eligibilityReason{"upstream_materialization_required", "upstream release lacks current passed materialization evidence for " + string(target)}
 		}
 		for _, evidenceID := range policy.CurrentEvidence {
-			if e := evidenceByID(snapshot, evidenceID); e != nil && e.HasTrustedEligibilityProvenance() && directoryEvidenceApplies(*e, distribution, release, target, request) && (e.Level == "materialization" || e.Level == "discovery" || e.Level == "runtime" || e.Level == "oauth") && e.Outcome == "failed" {
+			if e := evidenceByID(snapshot, evidenceID); e != nil && e.HasTrustedEligibilityProvenanceAtSequence(snapshot.Sequence) && directoryEvidenceApplies(*e, distribution, release, target, request) && (e.Level == "materialization" || e.Level == "discovery" || e.Level == "runtime" || e.Level == "oauth") && e.Outcome == "failed" {
 				return &eligibilityReason{"blocking_evidence", "current trusted " + e.Level + " evidence failed for " + string(target)}
 			}
 		}
@@ -577,7 +614,7 @@ func directoryEligibilityTargets(targets []ClientID) []ClientID {
 func hasPassedUpstreamMaterialization(snapshot DirectorySnapshot, distribution DirectoryDistribution, release DirectoryRelease, policy DirectoryReleasePolicy, client ClientID) bool {
 	for _, evidenceID := range policy.CurrentEvidence {
 		evidence := evidenceByID(snapshot, evidenceID)
-		if evidence != nil && evidence.HasTrustedEligibilityProvenance() && evidence.DistributionID == distribution.ID && evidence.ReleaseSequence == release.Sequence &&
+		if evidence != nil && evidence.HasTrustedEligibilityProvenanceAtSequence(snapshot.Sequence) && evidence.DistributionID == distribution.ID && evidence.ReleaseSequence == release.Sequence &&
 			evidence.PackageTreeDigest == release.TreeDigest && evidence.Client == client && evidence.Level == "materialization" && evidence.Outcome == "passed" {
 			return true
 		}

--- a/install/integrationctl/agentplugins/domain/directory_test.go
+++ b/install/integrationctl/agentplugins/domain/directory_test.go
@@ -80,6 +80,31 @@ func TestResolveDirectoryDeclaredDefaultFallbackQualifiedAndSequence(t *testing.
 	}
 }
 
+func TestResolveDirectoryAcceptsReleaseBoundLegacyEvidence(t *testing.T) {
+	snapshot := testDirectory()
+	snapshot.Sequence = 13
+	upstream := snapshot.Distributions[2]
+	for index := range snapshot.Evidence {
+		evidence := &snapshot.Evidence[index]
+		for _, release := range upstream.Releases {
+			if release.Sequence != evidence.ReleaseSequence {
+				continue
+			}
+			evidence.ProductID = upstream.ProductID
+			evidence.ManifestDigest = release.ManifestDigest
+			evidence.SourceRepository = release.PackageSource.Repository
+			evidence.SourceRevision = release.PackageSource.Revision
+			evidence.SourcePath = release.PackageSource.Path
+			evidence.AdapterVersion = "0.1.13"
+			evidence.Trust = nil
+		}
+	}
+	selected, err := ResolveDirectory(snapshot, request("owner/tool", ClientCodex))
+	if err != nil || selected.ReleaseSequence != 3 {
+		t.Fatalf("legacy upstream evidence was not eligible: %+v %v", selected, err)
+	}
+}
+
 func TestResolveDirectoryRejectsUnknownAndMismatchedDelivery(t *testing.T) {
 	for _, test := range []struct {
 		name, delivery string


### PR DESCRIPTION
## What changed

- Accept the immutable legacy evidence shape used by signed Directory sequences 1-14.
- Keep the trust-based shape strict for sequence 15 and later.
- Bind legacy product, manifest, repository, revision, and path fields to the selected release.
- Preserve sequence-aware provenance through resolution, compatibility, and search.
- Model the optional trust artifacts defined by the current schema.

## Evidence

- Current production Directory sequence 13 parses successfully.
- Staged wire Directory sequence 19 parses successfully.
- Unknown fields, cross-lane fields, and legacy source rebinds still fail closed.
- Targeted domain, Directory adapter, and CLI tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory evidence validation using snapshot-specific trust information.
  * Preserved compatibility with verified legacy evidence while enforcing stricter validation for newer snapshots.
  * Rejected outdated or mismatched legacy evidence after the trust transition.
  * Validated trust artifacts and strengthened handling of external review evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->