### PR TITLE
fix(agentplugins): support root packages beside submodules

### DIFF
--- a/install/integrationctl/agentplugins/adapters/directoryv1/client.go
+++ b/install/integrationctl/agentplugins/adapters/directoryv1/client.go
@@ -413,16 +413,23 @@ func parseImmutableGitHubIdentity(value string) (domain.DirectorySource, bool) {
 	case strings.HasPrefix(value, "github:"):
 		value = strings.TrimPrefix(value, "github:")
 	}
-	if strings.Contains(value, "://") || strings.Count(value, "//") != 1 {
+	if strings.Contains(value, "://") || strings.Count(value, "//") > 1 {
 		return domain.DirectorySource{}, false
 	}
-	repositoryRevision, subpath, ok := strings.Cut(value, "//")
-	if !ok || strings.Count(repositoryRevision, "@") != 1 {
+	repositoryRevision := value
+	subpath := ""
+	if strings.Contains(value, "//") {
+		repositoryRevision, subpath, _ = strings.Cut(value, "//")
+		if subpath == "" {
+			return domain.DirectorySource{}, false
+		}
+	}
+	if strings.Count(repositoryRevision, "@") != 1 {
 		return domain.DirectorySource{}, false
 	}
 	repository, revision, ok := strings.Cut(repositoryRevision, "@")
 	identity := domain.DirectorySource{Repository: repository, Revision: revision, Path: subpath}
-	if !ok || !directRepositoryPattern.MatchString(identity.Repository) || !shaPattern.MatchString(identity.Revision) || validateSourcePath(identity.Path) != nil {
+	if !ok || !directRepositoryPattern.MatchString(identity.Repository) || !shaPattern.MatchString(identity.Revision) || (identity.Path != "" && validateSourcePath(identity.Path) != nil) {
 		return domain.DirectorySource{}, false
 	}
 	return identity, true

--- a/install/integrationctl/agentplugins/adapters/directoryv1/directoryv1_test.go
+++ b/install/integrationctl/agentplugins/adapters/directoryv1/directoryv1_test.go
@@ -830,6 +830,22 @@ func TestDirectExactRequiresNoDirectory(t *testing.T) {
 			}
 		})
 	}
+	for _, canonical := range []string{
+		"owner/repo@" + revision,
+		"github:owner/repo@" + revision,
+		"https://github.com/owner/repo@" + revision,
+	} {
+		t.Run("repository root "+canonical, func(t *testing.T) {
+			selection, err := ResolveDirectExact(domain.SourceIdentity{
+				RequestedSource: canonical,
+				CanonicalSource: canonical,
+				Repository:      "owner/repo", ResolvedRevision: revision,
+			})
+			if err != nil || selection.Label != "direct source" {
+				t.Fatalf("exact repository-root source: %+v %v", selection, err)
+			}
+		})
+	}
 
 	invalid := map[string]domain.SourceIdentity{
 		"branch":              {CanonicalSource: "owner/repo@main//plugin", Repository: "owner/repo", PackageSubpath: "plugin", ResolvedRevision: "main"},

--- a/install/integrationctl/agentplugins/adapters/sourceacquisition/acquirer.go
+++ b/install/integrationctl/agentplugins/adapters/sourceacquisition/acquirer.go
@@ -256,6 +256,14 @@ func executablePathsFromTree(tree []byte, subpath string) ([]string, error) {
 		}
 		mode, objectType := string(fields[0]), string(fields[1])
 		if mode == "160000" || objectType == "commit" {
+			// A repository-root Agent Plugin may live beside unrelated Git
+			// submodules. The isolated checkout never fetches their content, so
+			// they cannot contribute files or executable bits to the snapshot.
+			// Keep rejecting a gitlink inside an explicitly selected package
+			// subpath, where omitting it could silently produce a partial package.
+			if subpath == "" {
+				continue
+			}
 			return nil, fmt.Errorf("Git submodule content is unsupported in plugin subpath")
 		}
 		if mode != "100755" {

--- a/install/integrationctl/agentplugins/adapters/sourceacquisition/acquirer_test.go
+++ b/install/integrationctl/agentplugins/adapters/sourceacquisition/acquirer_test.go
@@ -45,12 +45,16 @@ func TestAcquireGitHubExactSHASparselySnapshotsOnlyPluginRoot(t *testing.T) {
 	}
 }
 
-func TestAcquireGitHubRepositoryRootExcludesGitMetadata(t *testing.T) {
+func TestAcquireGitHubRepositoryRootExcludesGitDirectoryAndSubmoduleContent(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git is unavailable")
 	}
+	submodule := newRepository(t)
+	writeRepo(t, submodule, "README", "unrelated submodule content", 0o644)
+	_ = commit(t, submodule)
 	repository := newRepository(t)
 	writeRepo(t, repository, "plugin.json", `{"$schema":"https://agent-plugins.org/schemas/1.0.0/plugin.schema.json","name":"root"}`, 0o644)
+	runGit(t, "-c", "protocol.file.allow=always", "-C", repository, "submodule", "add", "--quiet", submodule, "third_party/unrelated")
 	revision := commit(t, repository)
 	acquirer := Acquirer{TempRoot: t.TempDir(), Runner: localGitTestRunner{}, URLForRepo: func(string) string { return repository }}
 	snapshot, err := acquirer.AcquireGitHub(context.Background(), "example/root-plugin", revision, "")
@@ -58,11 +62,14 @@ func TestAcquireGitHubRepositoryRootExcludesGitMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer packagedigest.Remove(snapshot)
-	if snapshot.FileCount != 1 || snapshot.Source.RequestedSource != "example/root-plugin@"+revision || strings.HasSuffix(snapshot.Source.CanonicalSource, "//") {
+	if snapshot.FileCount != 2 || snapshot.Source.RequestedSource != "example/root-plugin@"+revision || strings.HasSuffix(snapshot.Source.CanonicalSource, "//") {
 		t.Fatalf("root snapshot identity = %+v", snapshot)
 	}
 	if _, err := os.Lstat(filepath.Join(snapshot.Root, ".git")); !os.IsNotExist(err) {
 		t.Fatalf("Git metadata entered repository-root snapshot: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(snapshot.Root, "third_party", "unrelated", "README")); !os.IsNotExist(err) {
+		t.Fatalf("unfetched submodule content entered repository-root snapshot: %v", err)
 	}
 }
 
@@ -103,6 +110,10 @@ func TestExecutablePathsFromTreeArePluginRelative(t *testing.T) {
 	}
 	if _, err := executablePathsFromTree([]byte("160000 commit a\tplugin/vendor\x00"), "plugin"); err == nil || !strings.Contains(err.Error(), "submodule") {
 		t.Fatalf("submodule tree error = %v", err)
+	}
+	paths, err = executablePathsFromTree([]byte("160000 commit a\tthird_party/vendor\x00"), "")
+	if err != nil || len(paths) != 0 {
+		t.Fatalf("repository-root submodule executable paths = %v, %v", paths, err)
 	}
 }
 

--- a/install/integrationctl/agentplugins/adapters/sourceacquisition/acquirer_test.go
+++ b/install/integrationctl/agentplugins/adapters/sourceacquisition/acquirer_test.go
@@ -61,7 +61,11 @@ func TestAcquireGitHubRepositoryRootExcludesGitDirectoryAndSubmoduleContent(t *t
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer packagedigest.Remove(snapshot)
+	t.Cleanup(func() {
+		if err := packagedigest.Remove(snapshot); err != nil {
+			t.Errorf("remove repository-root snapshot: %v", err)
+		}
+	})
 	if snapshot.FileCount != 2 || snapshot.Source.RequestedSource != "example/root-plugin@"+revision || strings.HasSuffix(snapshot.Source.CanonicalSource, "//") {
 		t.Fatalf("root snapshot identity = %+v", snapshot)
 	}


### PR DESCRIPTION
## What changed

- accept documented immutable repository-root sources like owner/repo@FULL_SHA
- omit unfetched gitlink content when a root Agent Plugin lives beside unrelated submodules
- keep explicit package subpaths fail-closed when they contain a submodule

## Evidence

- focused directory and source acquisition suites pass
- full agentplugins CLI package suite passes
- exact ChromeDevTools PR head cb39d1d835c3baa3eff87501cd8c1de020604789 passed add/info/remove for codex,cursor,kiro in an isolated Linux sandbox
- update on the immutable direct source correctly requires explicit switch
- Chrome runtime itself was not invoked; the lifecycle test used isolated executable and ACP fixtures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub source references can now include a repository subpath after the revision.
  * Repository-root acquisitions now support repositories containing submodules without errors.
  * Submodule content is excluded from acquired snapshots, while explicit subpath selections continue to report unsupported submodule content clearly.
  * Direct repository-root sources are accepted across supported GitHub URL formats when pinned to a commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->