### PR TITLE
fix(release): make staged npm audit hermetic

### DIFF
--- a/.github/workflows/agentplugins-platform-proof.yml
+++ b/.github/workflows/agentplugins-platform-proof.yml
@@ -211,8 +211,12 @@ jobs:
           stage="${RUNNER_TEMP}/agentplugins-npm-${version}"
           mkdir -p "${stage}"
           cp -R release-source/npm/agentplugins/. "${stage}/"
+          git -C release-source diff --quiet HEAD -- \
+            docs/AGENTPLUGINS_CLIENT_E2E.md \
+            docs/evidence/agentplugins-client-e2e-2026-08-30.json
           node proof-tools/npm/agentplugins/scripts/stage-release.js \
-            "${stage}" "${assets}" "${version}" "${commit}" "${policy[@]}"
+            "${stage}" "${assets}" "${version}" "${commit}" "${policy[@]}" \
+            --evidence-root "${GITHUB_WORKSPACE}/release-source/docs"
           (cd "${stage}" && npm test && npm pack --dry-run --ignore-scripts)
           pack_json="$(cd "${stage}" && npm pack --ignore-scripts --json)"
           tarball_file="$(jq -er 'if length == 1 then .[0].filename else error("expected one npm tarball") end' <<<"${pack_json}")"

--- a/npm/agentplugins/scripts/stage-release.js
+++ b/npm/agentplugins/scripts/stage-release.js
@@ -18,6 +18,10 @@ const PLATFORMS = [
   ["win32", "x64"],
   ["win32", "arm64"]
 ];
+const EVIDENCE_FILES = [
+  "AGENTPLUGINS_CLIENT_E2E.md",
+  path.join("evidence", "agentplugins-client-e2e-2026-08-30.json")
+];
 
 function sha256(file) {
   return crypto.createHash("sha256").update(fs.readFileSync(file)).digest("hex");
@@ -35,6 +39,35 @@ function validatePackageMetadata(pkg) {
   return packageName;
 }
 
+function stageEvidence(packageRoot, evidenceRoot) {
+  if (!evidenceRoot) {
+    throw new Error("release staging requires the checked-in client E2E evidence root");
+  }
+  if (!path.isAbsolute(evidenceRoot)) {
+    throw new Error("client E2E evidence root must be absolute");
+  }
+  const rootStat = fs.lstatSync(evidenceRoot);
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+    throw new Error("client E2E evidence root must be a real directory");
+  }
+  const resolvedRoot = fs.realpathSync(evidenceRoot);
+  const destination = path.join(packageRoot, "test", "evidence-root");
+  fs.mkdirSync(destination, { recursive: true });
+  for (const sourceName of EVIDENCE_FILES) {
+    const source = path.join(evidenceRoot, sourceName);
+    if (!fs.realpathSync(source).startsWith(`${resolvedRoot}${path.sep}`)) {
+      throw new Error(`client E2E evidence escapes its exact root: ${sourceName}`);
+    }
+    const stat = fs.lstatSync(source);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size <= 0) {
+      throw new Error(`client E2E evidence is not a regular non-empty file: ${sourceName}`);
+    }
+    const target = path.join(destination, sourceName);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.copyFileSync(source, target, fs.constants.COPYFILE_EXCL);
+  }
+}
+
 function stage(packageRoot, assetRoot, version, commit, options = {}) {
   if (!VERSION.test(version)) {
     throw new Error(`invalid release version: ${version}`);
@@ -43,6 +76,7 @@ function stage(packageRoot, assetRoot, version, commit, options = {}) {
   const pkgPath = path.join(packageRoot, "package.json");
   const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
   const packageName = validatePackageMetadata(pkg);
+  stageEvidence(packageRoot, options.evidenceRoot);
   pkg.version = version;
   fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
   const assets = {};
@@ -69,12 +103,18 @@ function stage(packageRoot, assetRoot, version, commit, options = {}) {
 }
 
 function main() {
-  const [packageRoot, assetRoot, version, commit, policy] = process.argv.slice(2);
+  const [packageRoot, assetRoot, version, commit, ...args] = process.argv.slice(2);
   if (!packageRoot || !assetRoot || !version || !commit) {
-    throw new Error("usage: stage-release.js <package-root> <asset-root> <version> <commit> [allow-legacy-v1]");
+    throw new Error("usage: stage-release.js <package-root> <asset-root> <version> <commit> [allow-legacy-v1] --evidence-root <path>");
+  }
+  const allowLegacyManifest = args[0] === "allow-legacy-v1";
+  const evidenceIndex = allowLegacyManifest ? 1 : 0;
+  if (args[evidenceIndex] !== "--evidence-root" || !args[evidenceIndex + 1] || args.length !== evidenceIndex + 2) {
+    throw new Error("release staging requires an exact [allow-legacy-v1] --evidence-root <path> argument set");
   }
   const manifest = stage(path.resolve(packageRoot), path.resolve(assetRoot), version, commit, {
-    allowLegacyManifest: policy === "allow-legacy-v1"
+    allowLegacyManifest,
+    evidenceRoot: args[evidenceIndex + 1]
   });
   process.stdout.write(`Staged agentplugins ${manifest.version} with ${Object.keys(manifest.assets).length} pinned assets\n`);
 }
@@ -88,4 +128,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { stage, validatePackageMetadata };
+module.exports = { stage, stageEvidence, validatePackageMetadata };

--- a/npm/agentplugins/test/documentation-contract.test.js
+++ b/npm/agentplugins/test/documentation-contract.test.js
@@ -107,8 +107,12 @@ test("copyable direct-source examples use a marked replacement full SHA", () => 
 });
 
 test("checked-in client E2E evidence remains exact and auditable", () => {
-  const evidenceDoc = path.resolve(__dirname, "../../../docs/AGENTPLUGINS_CLIENT_E2E.md");
-  const transcriptPath = path.resolve(__dirname, "../../../docs/evidence/agentplugins-client-e2e-2026-08-30.json");
+  const stagedEvidence = path.resolve(__dirname, "evidence-root");
+  const evidenceRoot = fs.existsSync(stagedEvidence)
+    ? stagedEvidence
+    : path.resolve(__dirname, "../../../docs");
+  const evidenceDoc = path.join(evidenceRoot, "AGENTPLUGINS_CLIENT_E2E.md");
+  const transcriptPath = path.join(evidenceRoot, "evidence/agentplugins-client-e2e-2026-08-30.json");
   const markdown = fs.readFileSync(evidenceDoc, "utf8");
   const transcriptBytes = fs.readFileSync(transcriptPath);
   const transcript = JSON.parse(transcriptBytes.toString("utf8"));

--- a/npm/agentplugins/test/stage-release.test.js
+++ b/npm/agentplugins/test/stage-release.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const assert = require("node:assert/strict");
+const childProcess = require("node:child_process");
 const crypto = require("node:crypto");
 const fs = require("node:fs");
 const fsp = require("node:fs/promises");
@@ -10,9 +11,13 @@ const test = require("node:test");
 
 const { detectPlatform, expectedAssetName } = require("../lib/platform");
 const { prepareRelease, verifyRelease } = require("../scripts/release-assets");
-const { stage, validatePackageMetadata } = require("../scripts/stage-release");
+const { stage, stageEvidence, validatePackageMetadata } = require("../scripts/stage-release");
 
 const COMMIT = "a".repeat(40);
+const STAGED_EVIDENCE_ROOT = path.resolve(__dirname, "evidence-root");
+const EVIDENCE_ROOT = fs.existsSync(STAGED_EVIDENCE_ROOT)
+  ? STAGED_EVIDENCE_ROOT
+  : path.resolve(__dirname, "../../../docs");
 
 test("release staging embeds every exact platform asset hash", async (t) => {
   const root = await fsp.mkdtemp(path.join(os.tmpdir(), "agentplugins-stage-"));
@@ -32,7 +37,7 @@ test("release staging embeds every exact platform asset hash", async (t) => {
     await fsp.writeFile(path.join(assetsRoot, expectedAssetName(version, info)), `${info.key}\n`);
   }
   prepareRelease(assetsRoot, `agentplugins-v${version}`, COMMIT);
-  const manifest = stage(packageRoot, assetsRoot, version, COMMIT);
+  const manifest = stage(packageRoot, assetsRoot, version, COMMIT, { evidenceRoot: EVIDENCE_ROOT });
   assert.equal(manifest.version, version);
   assert.equal(manifest.npm_package, "universal-agent-plugins");
   assert.equal(Object.keys(manifest.assets).length, 6);
@@ -42,6 +47,56 @@ test("release staging embeds every exact platform asset hash", async (t) => {
   }
   const pkg = JSON.parse(await fsp.readFile(path.join(packageRoot, "package.json"), "utf8"));
   assert.equal(pkg.version, version);
+  assert.equal(
+    await fsp.readFile(path.join(packageRoot, "test/evidence-root/AGENTPLUGINS_CLIENT_E2E.md"), "utf8"),
+    await fsp.readFile(path.join(EVIDENCE_ROOT, "AGENTPLUGINS_CLIENT_E2E.md"), "utf8")
+  );
+});
+
+test("staged package tests are hermetic to repository layout and caller cwd", {
+  skip: process.env.AGENTPLUGINS_STAGED_TEST_CHILD === "1"
+}, async (t) => {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "agentplugins-hermetic-stage-"));
+  t.after(() => fsp.rm(root, { recursive: true, force: true }));
+  const packageRoot = path.join(root, "detached-layout", "package");
+  const assetsRoot = path.join(root, "release-assets");
+  const callerRoot = path.join(root, "unrelated-caller");
+  const npmCache = path.join(root, "npm-cache");
+  await fsp.cp(path.resolve(__dirname, ".."), packageRoot, { recursive: true });
+  await fsp.rm(path.join(packageRoot, "test", "evidence-root"), { recursive: true, force: true });
+  await fsp.mkdir(assetsRoot);
+  await fsp.mkdir(callerRoot);
+  const version = "0.1.22";
+  for (const [platform, arch] of [["darwin", "x64"], ["darwin", "arm64"], ["linux", "x64"], ["linux", "arm64"], ["win32", "x64"], ["win32", "arm64"]]) {
+    const info = detectPlatform(platform, arch);
+    await fsp.writeFile(path.join(assetsRoot, expectedAssetName(version, info)), `${info.key}\n`);
+  }
+  prepareRelease(assetsRoot, `agentplugins-v${version}`, COMMIT);
+  stage(packageRoot, assetsRoot, version, COMMIT, { evidenceRoot: EVIDENCE_ROOT });
+
+  const result = childProcess.spawnSync("npm", ["--prefix", packageRoot, "test"], {
+    cwd: callerRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      AGENTPLUGINS_STAGED_TEST_CHILD: "1",
+      NPM_CONFIG_CACHE: npmCache
+    }
+  });
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+
+  const packed = childProcess.spawnSync("npm", ["pack", "--ignore-scripts", "--json"], {
+    cwd: packageRoot,
+    encoding: "utf8",
+    env: { ...process.env, NPM_CONFIG_CACHE: npmCache }
+  });
+  assert.equal(packed.status, 0, `${packed.stdout}\n${packed.stderr}`);
+  const packResult = JSON.parse(packed.stdout);
+  assert.equal(packResult.length, 1);
+  const packedFiles = packResult[0].files.map(({ path: filename }) => filename);
+  assert.ok(packedFiles.includes("README.md"));
+  assert.ok(packedFiles.includes("assets.json"));
+  assert.equal(packedFiles.some((filename) => filename.startsWith("test/") || filename.includes("evidence-root")), false);
 });
 
 test("release verification fails closed on checksum, size, and manifest mismatch", async (t) => {
@@ -125,6 +180,7 @@ test("npm distribution name is independent from the agentplugins binary name", (
 });
 
 test("release staging rejects unsafe package metadata", () => {
+  assert.throws(() => stageEvidence("package", "docs"), /evidence root must be absolute/);
   for (const name of ["AgentPlugins", " agentplugins ", 123, null]) {
     assert.throws(
       () => validatePackageMetadata({ name, bin: { agentplugins: "bin/agentplugins.js" } }),

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -214,9 +214,15 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		"ref: ${{ inputs.expected_commit }}",
 		"agentplugins-proof-bundle",
 		"release-assets",
+		"git -C release-source diff --quiet HEAD --",
+		"docs/AGENTPLUGINS_CLIENT_E2E.md",
+		"docs/evidence/agentplugins-client-e2e-2026-08-30.json",
+		`--evidence-root "${GITHUB_WORKSPACE}/release-source/docs"`,
 	} {
 		mustContain(t, platformPrepareJob, want)
 	}
+	mustAppearBefore(t, platformPrepareJob, "git -C release-source diff --quiet HEAD --", "stage-release.js")
+	mustAppearBefore(t, platformPrepareJob, "stage-release.js", "npm test && npm pack --dry-run --ignore-scripts")
 	for _, want := range []string{
 		"ref: ${{ inputs.expected_commit }}",
 		`test "$(git rev-parse HEAD)" = "${{ inputs.expected_commit }}"`,


### PR DESCRIPTION
## Summary

- copy the exact release evidence into the staged npm test workspace
- bind that evidence to the verified release checkout and fail closed on missing, symlinked, or empty files
- keep the published npm tarball allowlist unchanged

## Why

The 0.1.22 release correctly stopped because the staged documentation test referenced a repository-relative path that no longer existed after staging. This makes that audit hermetic without weakening it.

## Verification

- independent security review: 0 High, 0 Medium
- focused documentation and staging tests: 10/10
- full npm suite: 32 passed, 1 intentional platform skip
- staged npm suite and release workflow contract tests passed
- npm pack contains the same 7 allowlisted files and no evidence fixture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release packages now include validated client end-to-end evidence documentation.
  * Staging supports explicitly selecting the evidence source directory.

* **Bug Fixes**
  * Added safeguards to prevent releases from using modified or incomplete evidence files.
  * Improved staging and packaging reliability when run from different working directories.
  * Confirmed evidence files remain excluded from the published package contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->