### PR TITLE
fix(agentplugins): validate Directory ChatGPT bindings

### DIFF
--- a/cli/plugin-kit-ai/internal/agentpluginscli/source.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/source.go
@@ -598,11 +598,19 @@ func applyDirectoryCompatibility(loaded *loadedPackage, bundle directoryv1.Verif
 		}
 		entry := domain.CatalogCompatibility{Package: packageMode, Verification: directoryVerification(applicable), Authentication: target.Authentication, Evidence: applicable, EvidenceOutcomes: directoryEvidenceOutcomes(applicable)}
 		if target.AppBinding != nil {
-			mcpURL := ""
-			if server, ok := loaded.envelope.MCP.Servers[target.AppBinding.MCPServer]; ok {
-				mcpURL, _ = server.Decoded["url"].(string)
+			server, ok := loaded.envelope.MCP.Servers[target.AppBinding.MCPServer]
+			if !ok || !loaded.envelope.MCP.Enabled {
+				return fmt.Errorf("signed Directory ChatGPT app binding references missing MCP server %q", target.AppBinding.MCPServer)
 			}
-			entry.AppBinding = &domain.CatalogAppBinding{AppKey: target.AppBinding.AppKey, ID: target.AppBinding.ID, MCPServer: target.AppBinding.MCPServer, MCPURL: mcpURL}
+			mcpURL, ok := server.Decoded["url"].(string)
+			if !ok {
+				return fmt.Errorf("signed Directory ChatGPT app binding MCP server %q has no remote URL", target.AppBinding.MCPServer)
+			}
+			binding := domain.CatalogAppBinding{AppKey: target.AppBinding.AppKey, ID: target.AppBinding.ID, MCPServer: target.AppBinding.MCPServer, MCPURL: mcpURL}
+			if err := catalog.ValidateAppBindingReference(binding); err != nil {
+				return fmt.Errorf("signed Directory ChatGPT app binding is invalid: %w", err)
+			}
+			entry.AppBinding = &binding
 		}
 		compatibility[string(target.Client)] = entry
 	}
@@ -782,7 +790,11 @@ func prepareLoadedPackageForClient(loaded *loadedPackage, clientID domain.Client
 		return nil
 	}
 	binding := *compatibility.AppBinding
-	if err := catalog.ValidateAppBinding(binding); err != nil {
+	validateBinding := catalog.ValidateAppBinding
+	if loaded.origin == domain.OriginModeDirectory {
+		validateBinding = catalog.ValidateAppBindingReference
+	}
+	if err := validateBinding(binding); err != nil {
 		return fmt.Errorf("Directory ChatGPT app binding is invalid: %w", err)
 	}
 	server, ok := loaded.envelope.MCP.Servers[binding.MCPServer]

--- a/cli/plugin-kit-ai/internal/agentpluginscli/source_directory_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/source_directory_test.go
@@ -57,6 +57,138 @@ func TestDirectoryCompatibilityUsesStablePublicPackageModes(t *testing.T) {
 	}
 }
 
+func TestDirectoryChatGPTBindingDerivesAuthenticatedMCPURLAndPrepares(t *testing.T) {
+	t.Parallel()
+	loaded := loadedPackage{
+		origin: domain.OriginModeDirectory,
+		envelope: domain.PackageEnvelope{MCP: domain.MCPComponent{Present: true, Enabled: true, Servers: map[string]domain.MCPServer{
+			"cloudflare-docs": {Name: "cloudflare-docs", Type: "streamable-http", Decoded: map[string]any{"type": "streamable-http", "url": "https://docs.mcp.cloudflare.com/mcp"}},
+		}}},
+	}
+	policy := domain.DirectoryReleasePolicy{Targets: []domain.DirectoryTarget{{
+		Client: domain.ClientChatGPT, Delivery: "manual_activation", Authentication: domain.AuthenticationRequirementNotRequired,
+		AppBinding: &domain.DirectoryAppBinding{AppKey: "cloudflare-docs", ID: "asdk_app_cloudflare_docs_123", MCPServer: "cloudflare-docs"},
+	}}}
+	if err := applyDirectoryCompatibility(&loaded, directoryv1.VerifiedBundle{Digest: "sha256:" + strings.Repeat("a", 64)}, domain.DirectorySelection{}, policy, directoryEvidenceEnvironment{}); err != nil {
+		t.Fatal(err)
+	}
+	binding := loaded.hints.Compatibility[string(domain.ClientChatGPT)].AppBinding
+	if binding == nil || binding.MCPURL != "https://docs.mcp.cloudflare.com/mcp" || binding.RuntimeEvidence != "" || binding.RuntimeEvidenceRevision != "" {
+		t.Fatalf("Directory binding = %+v", binding)
+	}
+	if err := prepareLoadedPackageForClient(&loaded, domain.ClientChatGPT); err != nil {
+		t.Fatal(err)
+	}
+	if !loaded.envelope.App.Enabled || loaded.envelope.App.Bindings["cloudflare-docs"].ID != "asdk_app_cloudflare_docs_123" {
+		t.Fatalf("prepared app = %+v", loaded.envelope.App)
+	}
+
+	clone := cloneLoadedPackage(loaded)
+	if err := prepareLoadedPackageForClient(&clone, domain.ClientChatGPT); err != nil {
+		t.Fatalf("Directory clone lost source-specific validation: %v", err)
+	}
+}
+
+func TestDirectoryChatGPTBindingFailsBeforeCompatibilityOrAppMutation(t *testing.T) {
+	t.Parallel()
+	base := loadedPackage{origin: domain.OriginModeDirectory, envelope: domain.PackageEnvelope{MCP: domain.MCPComponent{Present: true, Enabled: true, Servers: map[string]domain.MCPServer{
+		"docs": {Name: "docs", Type: "streamable-http", Decoded: map[string]any{"url": "https://example.test/mcp"}},
+	}}}}
+	validTarget := domain.DirectoryTarget{Client: domain.ClientChatGPT, Delivery: "manual_activation", Authentication: domain.AuthenticationRequirementNotRequired,
+		AppBinding: &domain.DirectoryAppBinding{AppKey: "docs", ID: "asdk_app_docs_123", MCPServer: "docs"}}
+	tests := []struct {
+		name   string
+		mutate func(*loadedPackage, *domain.DirectoryTarget)
+	}{
+		{name: "missing server", mutate: func(_ *loadedPackage, target *domain.DirectoryTarget) {
+			target.AppBinding.MCPServer, target.AppBinding.AppKey = "other", "other"
+		}},
+		{name: "unsafe URL", mutate: func(loaded *loadedPackage, _ *domain.DirectoryTarget) {
+			loaded.envelope.MCP.Servers["docs"] = domain.MCPServer{Name: "docs", Decoded: map[string]any{"url": "https://user@example.test/mcp"}}
+		}},
+		{name: "malformed identity", mutate: func(_ *loadedPackage, target *domain.DirectoryTarget) { target.AppBinding.ID = "not/an/id" }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			loaded := base
+			loaded.envelope.MCP.Servers = map[string]domain.MCPServer{"docs": base.envelope.MCP.Servers["docs"]}
+			target := validTarget
+			binding := *validTarget.AppBinding
+			target.AppBinding = &binding
+			test.mutate(&loaded, &target)
+			err := applyDirectoryCompatibility(&loaded, directoryv1.VerifiedBundle{}, domain.DirectorySelection{}, domain.DirectoryReleasePolicy{Targets: []domain.DirectoryTarget{target}}, directoryEvidenceEnvironment{})
+			if err == nil {
+				t.Fatal("invalid Directory binding accepted")
+			}
+			if loaded.hints.Compatibility != nil || loaded.envelope.CatalogEvidence != nil || loaded.envelope.App.Present {
+				t.Fatalf("validation failure mutated package: %+v", loaded)
+			}
+		})
+	}
+
+	loaded := base
+	if err := applyDirectoryCompatibility(&loaded, directoryv1.VerifiedBundle{}, domain.DirectorySelection{}, domain.DirectoryReleasePolicy{Targets: []domain.DirectoryTarget{validTarget}}, directoryEvidenceEnvironment{}); err != nil {
+		t.Fatal(err)
+	}
+	loaded.envelope.MCP.Servers["docs"] = domain.MCPServer{Name: "docs", Decoded: map[string]any{"url": "https://other.example.test/mcp"}}
+	if err := prepareLoadedPackageForClient(&loaded, domain.ClientChatGPT); err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("MCP URL substitution accepted: %v", err)
+	}
+}
+
+func TestDirectoryChatGPTDryRunPreparesManualActivationWithoutState(t *testing.T) {
+	t.Parallel()
+	client := fixtureClient(t, domain.ClientChatGPT)
+	client.Version = "fixture-client"
+	fixture := newCLIFixture(t, []domain.DetectedClient{client})
+	plugin := writeCLIPlugin(t)
+	writeCLIMCP(t, plugin)
+	loaded, err := fixture.app.acquireLocal(context.Background(), plugin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	treeDigest, manifestDigest := loaded.envelope.TreeDigest, loaded.envelope.ManifestDigest
+	if err := loaded.cleanup(); err != nil {
+		t.Fatal(err)
+	}
+	revision := strings.Repeat("a", 40)
+	release := domain.DirectoryRelease{
+		Sequence: 1, PackageVersion: "1.0.0", ManifestName: "demo", AgentPluginsSchema: domain.PluginSchemaV1,
+		PackageSource:       domain.DirectorySource{Repository: "owner/demo", Revision: revision, Path: "plugin"},
+		TreeDigestAlgorithm: domain.TreeDigestAlgorithm, TreeDigest: treeDigest, ManifestDigest: manifestDigest,
+		Components: []string{"mcp"}, PublishedAt: "2026-08-21T00:00:00Z",
+	}
+	materialization := intendedTrustedDirectoryEvidence(domain.DirectoryEvidence{ID: "passed/materialization/chatgpt", DistributionID: "owner/demo", ReleaseSequence: 1,
+		PackageTreeDigest: treeDigest, Level: "materialization", Outcome: "passed", Client: domain.ClientChatGPT,
+		ClientVersion: client.Version, InstallerVersion: fixture.app.Version})
+	policy := domain.DirectoryReleasePolicy{
+		ReleaseSequence: 1, Status: domain.ReleaseActive, MinimumInstallerVersion: "0.1.0", CurrentEvidence: []string{materialization.ID},
+		Targets: []domain.DirectoryTarget{{Client: domain.ClientChatGPT, Scopes: []domain.InstallScope{domain.ScopeUser}, Delivery: "manual_activation", Authentication: domain.AuthenticationRequirementNotRequired,
+			AppBinding: &domain.DirectoryAppBinding{AppKey: "demo", ID: "asdk_app_demo_123", MCPServer: "demo"}}},
+	}
+	snapshot := domain.DirectorySnapshot{
+		SnapshotSchemaVersion: 1, Sequence: 17, SourceCommit: strings.Repeat("b", 40),
+		Products: []domain.DirectoryProduct{{SchemaVersion: 1, ID: "demo", DisplayName: "Demo", Description: "Demo", ManifestName: "demo", Aliases: []string{"demo"}, ReservedAliases: []string{"demo"}, Categories: []string{},
+			MinimumCapabilities: domain.DirectoryMinimumCapabilities{Skills: "optional", MCP: "required"}, DefaultDistribution: "owner/demo", Distributions: []string{"owner/demo"}}},
+		Distributions: []domain.DirectoryDistribution{{SchemaVersion: 1, ID: "owner/demo", ProductID: "demo", Kind: domain.DistributionUpstream, Status: domain.DistributionActive, Packager: "owner", Releases: []domain.DirectoryRelease{release}, ReleasePolicies: []domain.DirectoryReleasePolicy{policy}}},
+		Evidence:      []domain.DirectoryEvidence{materialization}, Revocations: []domain.DirectoryRevocation{},
+	}
+	directory := &fixedDirectoryClient{bundle: directoryv1.VerifiedBundle{Snapshot: snapshot, Digest: "sha256:" + strings.Repeat("c", 64)}}
+	acquirer := &localBackedSourceAcquirer{delegate: fixture.app.SourceAcquirer, root: plugin}
+	fixture.app.DirectoryClient, fixture.app.SourceAcquirer = directory, acquirer
+	stdout, _, err := fixture.execute(false, "add", "demo", "--target", "chatgpt", "--dry-run", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, `"manual_activation_required"`) || directory.calls != 1 || acquirer.verifiedCalls != 1 {
+		t.Fatalf("Directory ChatGPT dry run = %s; calls directory=%d verified=%d", stdout, directory.calls, acquirer.verifiedCalls)
+	}
+	state, err := fixture.store.Load()
+	if err != nil || len(state.Installations) != 0 {
+		t.Fatalf("dry run mutated state: %+v, %v", state, err)
+	}
+}
+
 func TestDirectoryCompatibilityPreservesEvidenceAndExactApplicability(t *testing.T) {
 	t.Parallel()
 	digest := "sha256:" + strings.Repeat("a", 64)

--- a/cli/plugin-kit-ai/internal/agentpluginscli/source_directory_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/source_directory_test.go
@@ -91,6 +91,7 @@ func TestDirectoryChatGPTBindingDerivesAuthenticatedMCPURLAndPrepares(t *testing
 
 func TestDirectoryChatGPTBindingFailsBeforeCompatibilityOrAppMutation(t *testing.T) {
 	t.Parallel()
+	fixture := newCLIFixture(t, nil)
 	base := loadedPackage{origin: domain.OriginModeDirectory, envelope: domain.PackageEnvelope{MCP: domain.MCPComponent{Present: true, Enabled: true, Servers: map[string]domain.MCPServer{
 		"docs": {Name: "docs", Type: "streamable-http", Decoded: map[string]any{"url": "https://example.test/mcp"}},
 	}}}}
@@ -105,6 +106,12 @@ func TestDirectoryChatGPTBindingFailsBeforeCompatibilityOrAppMutation(t *testing
 		}},
 		{name: "unsafe URL", mutate: func(loaded *loadedPackage, _ *domain.DirectoryTarget) {
 			loaded.envelope.MCP.Servers["docs"] = domain.MCPServer{Name: "docs", Decoded: map[string]any{"url": "https://user@example.test/mcp"}}
+		}},
+		{name: "empty URL hostname", mutate: func(loaded *loadedPackage, _ *domain.DirectoryTarget) {
+			loaded.envelope.MCP.Servers["docs"] = domain.MCPServer{Name: "docs", Decoded: map[string]any{"url": "https://:443/mcp"}}
+		}},
+		{name: "overflow URL port", mutate: func(loaded *loadedPackage, _ *domain.DirectoryTarget) {
+			loaded.envelope.MCP.Servers["docs"] = domain.MCPServer{Name: "docs", Decoded: map[string]any{"url": "https://example.test:65536/mcp"}}
 		}},
 		{name: "malformed identity", mutate: func(_ *loadedPackage, target *domain.DirectoryTarget) { target.AppBinding.ID = "not/an/id" }},
 	}
@@ -122,6 +129,10 @@ func TestDirectoryChatGPTBindingFailsBeforeCompatibilityOrAppMutation(t *testing
 			}
 			if loaded.hints.Compatibility != nil || loaded.envelope.CatalogEvidence != nil || loaded.envelope.App.Present {
 				t.Fatalf("validation failure mutated package: %+v", loaded)
+			}
+			state, stateErr := fixture.store.Load()
+			if stateErr != nil || len(state.Installations) != 0 {
+				t.Fatalf("validation failure mutated state: %+v, %v", state, stateErr)
 			}
 		})
 	}

--- a/install/integrationctl/agentplugins/adapters/catalog/catalog.go
+++ b/install/integrationctl/agentplugins/adapters/catalog/catalog.go
@@ -247,7 +247,7 @@ func ValidateAppBindingReference(binding domain.CatalogAppBinding) error {
 		return err
 	}
 	parsed, err := url.Parse(binding.MCPURL)
-	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.Hostname() == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.String() != binding.MCPURL {
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.Hostname() == "" || strings.HasSuffix(parsed.Host, ":") || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.String() != binding.MCPURL {
 		return fmt.Errorf("mcp_url must be a normalized absolute HTTPS URL without userinfo, query, or fragment")
 	}
 	if port := parsed.Port(); port != "" {

--- a/install/integrationctl/agentplugins/adapters/catalog/catalog.go
+++ b/install/integrationctl/agentplugins/adapters/catalog/catalog.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -246,8 +247,14 @@ func ValidateAppBindingReference(binding domain.CatalogAppBinding) error {
 		return err
 	}
 	parsed, err := url.Parse(binding.MCPURL)
-	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.String() != binding.MCPURL {
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.Hostname() == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.String() != binding.MCPURL {
 		return fmt.Errorf("mcp_url must be a normalized absolute HTTPS URL without userinfo, query, or fragment")
+	}
+	if port := parsed.Port(); port != "" {
+		value, err := strconv.Atoi(port)
+		if err != nil || value < 1 || value > 65535 {
+			return fmt.Errorf("mcp_url port must be numeric and between 1 and 65535")
+		}
 	}
 	return nil
 }

--- a/install/integrationctl/agentplugins/adapters/catalog/catalog.go
+++ b/install/integrationctl/agentplugins/adapters/catalog/catalog.go
@@ -30,8 +30,6 @@ var (
 	commitPattern     = regexp.MustCompile(`^[0-9a-f]{40}$`)
 	digestPattern     = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
 	namePattern       = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]{0,63}$`)
-	appAliasPattern   = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
-	appIDPattern      = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._~:-]{0,255}$`)
 )
 
 var requiredCompatibility = legacyRequiredCompatibility()
@@ -229,24 +227,27 @@ func validatePlugin(plugin domain.CatalogPlugin, schemaVersion int) error {
 }
 
 func ValidateAppBinding(binding domain.CatalogAppBinding) error {
-	if !appAliasPattern.MatchString(binding.AppKey) || !appAliasPattern.MatchString(binding.MCPServer) {
-		return fmt.Errorf("app_key and mcp_server must be safe aliases")
-	}
-	if binding.AppKey != binding.MCPServer {
-		return fmt.Errorf("app_key must equal mcp_server in v0.1")
-	}
-	if !appIDPattern.MatchString(binding.ID) {
-		return fmt.Errorf("id must be a non-empty opaque safe ASCII token")
-	}
-	parsed, err := url.Parse(binding.MCPURL)
-	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.String() != binding.MCPURL {
-		return fmt.Errorf("mcp_url must be a normalized absolute HTTPS URL without userinfo, query, or fragment")
+	if err := ValidateAppBindingReference(binding); err != nil {
+		return err
 	}
 	if err := validateSourcePath(binding.RuntimeEvidence); err != nil {
 		return fmt.Errorf("runtime_evidence: %w", err)
 	}
 	if !commitPattern.MatchString(binding.RuntimeEvidenceRevision) {
 		return fmt.Errorf("runtime_evidence_revision must be an exact lowercase Git commit")
+	}
+	return nil
+}
+
+// ValidateAppBindingReference validates the common registered-app identity
+// and URL contract without requiring legacy Catalog v2 runtime evidence.
+func ValidateAppBindingReference(binding domain.CatalogAppBinding) error {
+	if err := domain.ValidateAppBindingIdentity(binding.AppKey, binding.ID, binding.MCPServer); err != nil {
+		return err
+	}
+	parsed, err := url.Parse(binding.MCPURL)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.String() != binding.MCPURL {
+		return fmt.Errorf("mcp_url must be a normalized absolute HTTPS URL without userinfo, query, or fragment")
 	}
 	return nil
 }

--- a/install/integrationctl/agentplugins/adapters/catalog/catalog_test.go
+++ b/install/integrationctl/agentplugins/adapters/catalog/catalog_test.go
@@ -165,6 +165,8 @@ func TestValidateAppBindingReferenceRejectsInvalidHTTPSAuthority(t *testing.T) {
 	}
 	for _, mcpURL := range []string{
 		"https://:443/mcp",
+		"https://example.test:/mcp",
+		"https://[::1]:/mcp",
 		"https://example.test:0/mcp",
 		"https://example.test:65536/mcp",
 		"https://example.test:not-a-port/mcp",

--- a/install/integrationctl/agentplugins/adapters/catalog/catalog_test.go
+++ b/install/integrationctl/agentplugins/adapters/catalog/catalog_test.go
@@ -143,7 +143,10 @@ func TestCatalogRejectsUnsafeOrMisplacedChatGPTAppBinding(t *testing.T) {
 		"unsafe-evidence": strings.Replace(valid,
 			`"tests/e2e/results/chatgpt-context7.json"`, `"../outside.json"`, 1),
 		"bad-evidence-revision": strings.Replace(valid, strings.Repeat("e", 40), `not-a-commit`, 1),
-		"non-chatgpt":           strings.Replace(valid, `"authentication":"not_required"}`, `"authentication":"not_required","app_binding":{"app_key":"context7","id":"asdk_app_context7_123","mcp_server":"context7","mcp_url":"https://example.test/mcp","runtime_evidence":"tests/e2e/results/chatgpt-context7.json"}}`, 1),
+		"missing-evidence":      strings.Replace(valid, `"tests/e2e/results/chatgpt-context7.json"`, `""`, 1),
+		"missing-evidence-revision": strings.Replace(valid,
+			strings.Repeat("e", 40), ``, 1),
+		"non-chatgpt": strings.Replace(valid, `"authentication":"not_required"}`, `"authentication":"not_required","app_binding":{"app_key":"context7","id":"asdk_app_context7_123","mcp_server":"context7","mcp_url":"https://example.test/mcp","runtime_evidence":"tests/e2e/results/chatgpt-context7.json"}}`, 1),
 	} {
 		name, body := name, body
 		t.Run(name, func(t *testing.T) {

--- a/install/integrationctl/agentplugins/adapters/catalog/catalog_test.go
+++ b/install/integrationctl/agentplugins/adapters/catalog/catalog_test.go
@@ -157,6 +157,26 @@ func TestCatalogRejectsUnsafeOrMisplacedChatGPTAppBinding(t *testing.T) {
 	}
 }
 
+func TestValidateAppBindingReferenceRejectsInvalidHTTPSAuthority(t *testing.T) {
+	t.Parallel()
+	valid := domain.CatalogAppBinding{AppKey: "docs", ID: "asdk_app_docs_123", MCPServer: "docs", MCPURL: "https://example.test:443/mcp"}
+	if err := ValidateAppBindingReference(valid); err != nil {
+		t.Fatalf("valid reference rejected: %v", err)
+	}
+	for _, mcpURL := range []string{
+		"https://:443/mcp",
+		"https://example.test:0/mcp",
+		"https://example.test:65536/mcp",
+		"https://example.test:not-a-port/mcp",
+	} {
+		binding := valid
+		binding.MCPURL = mcpURL
+		if err := ValidateAppBindingReference(binding); err == nil {
+			t.Fatalf("invalid reference URL %q accepted", mcpURL)
+		}
+	}
+}
+
 func TestCatalogRejectsAnyCompatibilityMatrixDeviation(t *testing.T) {
 	t.Parallel()
 	tests := map[string]string{

--- a/install/integrationctl/agentplugins/adapters/directoryv1/directoryv1_test.go
+++ b/install/integrationctl/agentplugins/adapters/directoryv1/directoryv1_test.go
@@ -279,6 +279,18 @@ func TestSnapshotStrictSchemaOneSemantics(t *testing.T) {
 			v.Evidence[0].PackageTreeDigest = "sha256:" + strings.Repeat("d", 64)
 		}},
 		{"unsafe source path", func(v *domain.DirectorySnapshot) { v.Distributions[0].Releases[0].PackageSource.Path = "../plugin" }},
+		{"unsafe app binding alias", func(v *domain.DirectorySnapshot) {
+			v.Distributions[0].ReleasePolicies[0].Targets[0] = domain.DirectoryTarget{Client: domain.ClientChatGPT, Scopes: []domain.InstallScope{domain.ScopeUser}, Delivery: "prepared", Authentication: domain.AuthenticationRequirementUnknown,
+				AppBinding: &domain.DirectoryAppBinding{AppKey: "../docs", ID: "asdk_app_docs_123", MCPServer: "../docs"}}
+		}},
+		{"mismatched app binding aliases", func(v *domain.DirectorySnapshot) {
+			v.Distributions[0].ReleasePolicies[0].Targets[0] = domain.DirectoryTarget{Client: domain.ClientChatGPT, Scopes: []domain.InstallScope{domain.ScopeUser}, Delivery: "prepared", Authentication: domain.AuthenticationRequirementUnknown,
+				AppBinding: &domain.DirectoryAppBinding{AppKey: "docs", ID: "asdk_app_docs_123", MCPServer: "other"}}
+		}},
+		{"unsafe app binding id", func(v *domain.DirectorySnapshot) {
+			v.Distributions[0].ReleasePolicies[0].Targets[0] = domain.DirectoryTarget{Client: domain.ClientChatGPT, Scopes: []domain.InstallScope{domain.ScopeUser}, Delivery: "prepared", Authentication: domain.AuthenticationRequirementUnknown,
+				AppBinding: &domain.DirectoryAppBinding{AppKey: "docs", ID: "not/an/id", MCPServer: "docs"}}
+		}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/install/integrationctl/agentplugins/adapters/directoryv1/validate.go
+++ b/install/integrationctl/agentplugins/adapters/directoryv1/validate.go
@@ -363,6 +363,9 @@ func validatePolicy(p domain.DirectoryReleasePolicy) error {
 			if t.AppBinding == nil || t.AppBinding.AppKey == "" || t.AppBinding.ID == "" || t.AppBinding.MCPServer == "" {
 				return fmt.Errorf("chatgpt app binding required")
 			}
+			if err := domain.ValidateAppBindingIdentity(t.AppBinding.AppKey, t.AppBinding.ID, t.AppBinding.MCPServer); err != nil {
+				return fmt.Errorf("invalid chatgpt app binding: %w", err)
+			}
 		} else if t.AppBinding != nil {
 			return fmt.Errorf("app binding only allowed for chatgpt")
 		}

--- a/install/integrationctl/agentplugins/domain/catalog.go
+++ b/install/integrationctl/agentplugins/domain/catalog.go
@@ -1,5 +1,31 @@
 package domain
 
+import (
+	"fmt"
+	"regexp"
+)
+
+var (
+	appAliasPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+	appIDPattern    = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._~:-]{0,255}$`)
+)
+
+// ValidateAppBindingIdentity validates the signed identity tuple shared by
+// Directory and legacy Catalog app bindings. URL and legacy runtime evidence
+// are validated at their respective source boundaries.
+func ValidateAppBindingIdentity(appKey, id, mcpServer string) error {
+	if !appAliasPattern.MatchString(appKey) || !appAliasPattern.MatchString(mcpServer) {
+		return fmt.Errorf("app_key and mcp_server must be safe aliases")
+	}
+	if appKey != mcpServer {
+		return fmt.Errorf("app_key must equal mcp_server in v0.1")
+	}
+	if !appIDPattern.MatchString(id) {
+		return fmt.Errorf("id must be a non-empty opaque safe ASCII token")
+	}
+	return nil
+}
+
 const (
 	CatalogSchemaV1 = "https://github.com/777genius/universal-agent-plugins/schemas/catalog-v1.schema.json"
 	CatalogSchemaV2 = "https://github.com/777genius/universal-agent-plugins/schemas/catalog-v2.schema.json"


### PR DESCRIPTION
## Summary

- separate structural registered-app validation from legacy Catalog runtime evidence
- derive the ChatGPT MCP URL only from the authenticated package selected by signed Directory policy
- reject malformed app identities, HTTPS authorities and ports before package or state mutation

## Verification

- isolated Directory ChatGPT dry-run reaches manual activation and leaves State empty
- add, persisted State, repair dry-run and update dry-run pass in an isolated fixture
- legacy Catalog still requires runtime evidence and exact revision
- focused race tests, full affected Go packages, vet and diff-check pass
- independent exact-head security review: 0 High / 0 Medium

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for ChatGPT app bindings, including app identity, server references, and HTTPS endpoints.
  - Installations now reject unsafe, malformed, or incomplete binding details before making changes.
  - Directory-based app packages use the appropriate validation rules and preserve their source-specific behavior.
  - Dry-run installations correctly report when manual activation is required without changing local state.

- **Reliability**
  - Added safeguards for invalid server ports, hostnames, app identifiers, and missing verification evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->