### PR TITLE
fix(agentplugins): recognize live Copilot plugins

### DIFF
--- a/cli/plugin-kit-ai/internal/agentpluginscli/idempotent_update_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/idempotent_update_test.go
@@ -1,0 +1,124 @@
+package agentpluginscli
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers"
+	legacyports "github.com/777genius/plugin-kit-ai/install/integrationctl/ports"
+)
+
+type liveCopilotRunner struct {
+	path string
+	spec string
+}
+
+func (runner *liveCopilotRunner) Run(_ context.Context, command legacyports.Command) (legacyports.CommandResult, error) {
+	args := command.Argv
+	if len(args) >= 5 && args[1] == "plugin" && args[2] == "marketplace" && args[3] == "add" {
+		runner.path = args[4]
+	}
+	if len(args) >= 4 && args[1] == "plugin" && args[2] == "install" {
+		runner.spec = args[3]
+	}
+	if len(args) >= 3 && args[1] == "plugin" && args[2] == "list" {
+		return legacyports.CommandResult{Stdout: []byte("Live Plugins (loaded from a local marketplace directory, never copied):\n  • " + runner.spec + " (v1.0.0) (enabled)\n      from " + runner.path + "\n")}, nil
+	}
+	return legacyports.CommandResult{}, nil
+}
+
+func TestImmediateMultiTargetUpdateReusesNativeBindings(t *testing.T) {
+	t.Parallel()
+	targets := []domain.ClientID{
+		domain.ClientKiro,
+		domain.ClientGemini,
+		domain.ClientOpenCode,
+		domain.ClientCline,
+		domain.ClientWindsurf,
+	}
+	clients := make([]domain.DetectedClient, 0, len(targets))
+	names := make([]string, 0, len(targets))
+	for _, target := range targets {
+		clients = append(clients, fixtureClient(t, target))
+		names = append(names, string(target))
+	}
+	fixture := newCLIFixture(t, clients)
+	plugin := writeCLIPlugin(t)
+	writeCLIMCP(t, plugin)
+	selected := strings.Join(names, ",")
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", selected, "--format", "json"); err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, err := fixture.execute(false, "update", "demo", "--target", selected, "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var envelope struct {
+		Data struct {
+			Status  string `json:"status"`
+			Targets []struct {
+				Output struct {
+					Result struct {
+						NoChange bool `json:"no_change"`
+						Mutated  bool `json:"mutated"`
+					} `json:"result"`
+				} `json:"output"`
+			} `json:"targets"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if envelope.Data.Status != "completed" || len(envelope.Data.Targets) != len(targets) {
+		t.Fatalf("update result = %+v", envelope.Data)
+	}
+	for _, target := range envelope.Data.Targets {
+		if !target.Output.Result.NoChange || target.Output.Result.Mutated {
+			t.Fatalf("update was not idempotent: %+v", target)
+		}
+	}
+}
+
+func TestImmediateSharedCopilotUpdateAcceptsExactLiveRegistration(t *testing.T) {
+	t.Parallel()
+	copilot := fixtureClient(t, domain.ClientCopilot)
+	copilot.ExecutablePath = "/test/bin/copilot"
+	fixture := newCLIFixture(t, []domain.DetectedClient{copilot, fixtureClient(t, domain.ClientVSCode)})
+	runner := &liveCopilotRunner{}
+	fixture.app.Lifecycle.Activator = providers.Activator{Runner: runner}
+	plugin := writeCLIPlugin(t)
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "copilot,vscode", "--format", "json"); err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, err := fixture.execute(false, "update", "demo", "--target", "copilot,vscode", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var envelope struct {
+		Data struct {
+			Status  string `json:"status"`
+			Targets []struct {
+				Output struct {
+					Result struct {
+						NoChange bool `json:"no_change"`
+						Mutated  bool `json:"mutated"`
+					} `json:"result"`
+				} `json:"output"`
+			} `json:"targets"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if envelope.Data.Status != "completed" || len(envelope.Data.Targets) != 2 {
+		t.Fatalf("update result = %+v", envelope.Data)
+	}
+	for _, target := range envelope.Data.Targets {
+		if !target.Output.Result.NoChange || target.Output.Result.Mutated {
+			t.Fatalf("update was not idempotent: %+v", target)
+		}
+	}
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/read_reconciliation.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/read_reconciliation.go
@@ -144,12 +144,17 @@ func reconcileClientIdentity(ctx context.Context, app App, installation domain.I
 	if !hasReconciledOwnershipReceipt(binding, expectedArtifact, installation.DeclaredName) {
 		return result
 	}
+	declaredVersion := installation.Package.Version
+	if binding.PackageRevision != nil {
+		declaredVersion = binding.PackageRevision.Version
+	}
 	target, err := app.Lifecycle.Targets.ResolveTarget(ctx, bindingClient, domain.InstallScope(binding.Scope), expectedArtifact)
 	if err != nil || filepath.Clean(target.ActivePath) != filepath.Clean(binding.TargetLocator) {
 		return result
 	}
 	plan := domain.DeliveryPlan{
 		ClientID: bindingClient.ClientID, Scope: domain.InstallScope(binding.Scope), DeclaredName: installation.DeclaredName,
+		DeclaredVersion:    declaredVersion,
 		PhysicalArtifactID: expectedArtifact, TargetAnchor: target.TargetAnchor, TargetRoot: target.TargetRoot, ActivePath: target.ActivePath,
 		NativeRegistryRoot: observerClient.ConfigRoot, NativeRegistryExecutable: observerClient.ExecutablePath,
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/read_reconciliation_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/read_reconciliation_test.go
@@ -21,7 +21,9 @@ func TestInfoReconcilesExactCopilotIdentityWithoutMutationOrPathLeak(t *testing.
 		Version: "1.0.80", ExecutablePath: "/test/bin/copilot", ConfigRoot: filepath.Join(fixture.root, "home", ".copilot")}
 	detector := &observedProbingDetector{clients: []domain.DetectedClient{client}}
 	fixture.app.Detector = detector
-	fixture.app.Lifecycle.NativeObserver = reconciledNativeObserver{}
+	observer := &capturingNativeObserver{observation: domain.NativeIdentityObservation{State: domain.NativeIdentityManaged, ReceiptReconciled: true,
+		NativeDiscoveryReconciled: true, NativeDiscoveryState: domain.NativeIdentityManaged, NativeDiscoveryAttempted: true}}
+	fixture.app.Lifecycle.NativeObserver = observer
 
 	installationID := "00000000-0000-4000-8000-000000000001"
 	physical := domain.ComputePhysicalArtifactID("demo", installationID)
@@ -35,13 +37,14 @@ func TestInfoReconcilesExactCopilotIdentityWithoutMutationOrPathLeak(t *testing.
 		ClientBindingID: bindingID, ClientID: string(domain.ClientCopilot), Scope: string(domain.ScopeUser), TargetLocator: target.ActivePath,
 		PhysicalArtifact: physical, Materialization: domain.MaterializationMaterialized, Activation: domain.ActivationActive,
 		Authentication: domain.AuthenticationNotRequired, Policy: domain.PolicyAllowed, Verification: domain.VerificationInstalled,
-		NativeObjects: []domain.NativeObjectOwnership{{ObjectID: "package:copilot:" + physical, Kind: "managed_package_directory", LogicalName: "demo", ManagedDigest: digest}},
-		Receipts:      []domain.MutationReceipt{{OperationID: "op-0000000000000001", Sequence: 1, ClientBindingID: bindingID, AfterDigest: digest, Phase: "committed"}},
+		PackageRevision: &domain.ClientPackageRevision{Version: "1.7.0-uap.1", TreeDigest: "sha256:tree", ManifestDigest: "sha256:manifest"},
+		NativeObjects:   []domain.NativeObjectOwnership{{ObjectID: "package:copilot:" + physical, Kind: "managed_package_directory", LogicalName: "demo", ManagedDigest: digest}},
+		Receipts:        []domain.MutationReceipt{{OperationID: "op-0000000000000001", Sequence: 1, ClientBindingID: bindingID, AfterDigest: digest, Phase: "committed"}},
 	}
 	state := domain.StateFileV2{SchemaVersion: domain.StateSchemaVersion, Installations: []domain.Installation{{
 		InstallationID: installationID, DeclaredName: "demo",
 		Source:  domain.SourceBinding{SourceBindingID: "src_demo", RequestedSource: "demo", CanonicalSource: "https://example.test/demo", ResolvedRevision: strings.Repeat("a", 40), TreeDigest: "sha256:tree"},
-		Package: domain.PackageBinding{LoaderKind: domain.LoaderKindAgentPlugins, FormatID: domain.FormatIDAgentPluginsV1, SchemaURI: domain.PluginSchemaV1, DeclaredName: "demo", ManifestDigest: "sha256:manifest"},
+		Package: domain.PackageBinding{LoaderKind: domain.LoaderKindAgentPlugins, FormatID: domain.FormatIDAgentPluginsV1, SchemaURI: domain.PluginSchemaV1, DeclaredName: "demo", Version: "9.9.9", ManifestDigest: "sha256:manifest"},
 		Clients: map[string]domain.ClientBinding{bindingID: binding},
 	}}}
 	if err := fixture.store.Save(state); err != nil {
@@ -104,12 +107,39 @@ func TestInfoReconcilesExactCopilotIdentityWithoutMutationOrPathLeak(t *testing.
 	if detector.targetedCalls != 1 || detector.probeCalls != 0 || detector.readOnlyCalls != 0 || len(detector.targets) != 1 || detector.targets[0] != domain.ClientCopilot {
 		t.Fatalf("detector calls = read-only:%d probe:%d targeted:%d targets:%v", detector.readOnlyCalls, detector.probeCalls, detector.targetedCalls, detector.targets)
 	}
+	if len(observer.plans) != 1 || observer.plans[0].DeclaredVersion != "1.7.0-uap.1" {
+		t.Fatalf("observer plan did not use binding revision: %+v", observer.plans)
+	}
 }
 
 func TestInfoInvalidOwnershipReceiptIsInconclusive(t *testing.T) {
 	binding := domain.ClientBinding{ClientBindingID: "binding", ClientID: "copilot", PhysicalArtifact: "demo-0123456789ab"}
 	if hasReconciledOwnershipReceipt(binding, binding.PhysicalArtifact, "demo") {
 		t.Fatal("missing ownership receipt reconciled")
+	}
+}
+
+func TestInfoLegacyBindingFallsBackToInstallationVersion(t *testing.T) {
+	installationID := "00000000-0000-4000-8000-000000000002"
+	physical := domain.ComputePhysicalArtifactID("demo", installationID)
+	target := filepath.Join(t.TempDir(), "copilot", physical)
+	binding := validReconciliationBinding(installationID, domain.ClientCopilot, domain.ScopeUser, target, physical)
+	binding.PackageRevision = nil
+	installation := domain.Installation{InstallationID: installationID, DeclaredName: "demo",
+		Package: domain.PackageBinding{Version: "0.9.0"}, Clients: map[string]domain.ClientBinding{binding.ClientBindingID: binding}}
+	detector := &observedProbingDetector{clients: []domain.DetectedClient{{
+		ClientID: domain.ClientCopilot, Status: domain.DetectionDetected, Version: "1.0.82", ExecutablePath: "/test/bin/copilot",
+	}}}
+	observer := &capturingNativeObserver{observation: domain.NativeIdentityObservation{State: domain.NativeIdentityManaged}}
+	app := App{Detector: detector, Lifecycle: usecase.Service{
+		Targets: scopeTargetResolver{targets: map[domain.InstallScope]string{domain.ScopeUser: target}}, NativeObserver: observer,
+	}}
+	public := publicInstallationView(installation, true)
+	if err := reconcileInstalledInfo(context.Background(), app, installation, "copilot", &public); err != nil {
+		t.Fatal(err)
+	}
+	if len(observer.plans) != 1 || observer.plans[0].DeclaredVersion != "0.9.0" {
+		t.Fatalf("legacy observer plan = %+v", observer.plans)
 	}
 }
 
@@ -346,6 +376,7 @@ func validReconciliationBinding(installationID string, client domain.ClientID, s
 	return domain.ClientBinding{
 		ClientBindingID: bindingID, ClientID: string(client), Scope: string(scope), TargetLocator: target, PhysicalArtifact: physical,
 		Materialization: domain.MaterializationMaterialized,
+		PackageRevision: &domain.ClientPackageRevision{Version: "1.0.0", TreeDigest: "sha256:tree", ManifestDigest: "sha256:manifest"},
 		NativeObjects:   []domain.NativeObjectOwnership{{ObjectID: "package:" + string(client) + ":" + physical, Kind: "managed_package_directory", LogicalName: "demo", ManagedDigest: digest}},
 		Receipts:        []domain.MutationReceipt{{OperationID: "op-" + bindingID[:12], Sequence: 1, ClientBindingID: bindingID, AfterDigest: digest, Phase: "committed"}},
 	}
@@ -363,11 +394,13 @@ func (resolver scopeTargetResolver) ResolveTarget(_ context.Context, client doma
 type capturingNativeObserver struct {
 	observation domain.NativeIdentityObservation
 	clients     []domain.DetectedClient
+	plans       []domain.DeliveryPlan
 	err         error
 }
 
-func (observer *capturingNativeObserver) ObserveNativeIdentity(_ context.Context, client domain.DetectedClient, _ domain.DeliveryPlan, _ *domain.ClientBinding) (domain.NativeIdentityObservation, error) {
+func (observer *capturingNativeObserver) ObserveNativeIdentity(_ context.Context, client domain.DetectedClient, plan domain.DeliveryPlan, _ *domain.ClientBinding) (domain.NativeIdentityObservation, error) {
 	observer.clients = append(observer.clients, client)
+	observer.plans = append(observer.plans, plan)
 	return observer.observation, observer.err
 }
 

--- a/install/integrationctl/agentplugins/domain/clients.go
+++ b/install/integrationctl/agentplugins/domain/clients.go
@@ -199,6 +199,7 @@ type DeliveryPlan struct {
 	// are deliberately excluded from public output because registry locators
 	// can reveal local user paths.
 	DeclaredName             string `json:"-"`
+	DeclaredVersion          string `json:"-"`
 	NativeRegistryRoot       string `json:"-"`
 	NativeRegistryExecutable string `json:"-"`
 	// LocalPreparationAuthorized records signed package evidence that permits

--- a/install/integrationctl/agentplugins/planner/planner.go
+++ b/install/integrationctl/agentplugins/planner/planner.go
@@ -68,6 +68,7 @@ func (planner Planner) Plan(
 		Verification:       domain.VerificationPackageValid,
 		PhysicalArtifactID: physicalArtifactID,
 		DeclaredName:       envelope.Manifest.Name,
+		DeclaredVersion:    envelope.Manifest.Version,
 	}
 	planner.setNativeRegistry(&plan, client)
 	if client.Status != domain.DetectionDetected && client.ClientID != domain.ClientChatGPT {

--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -557,7 +557,7 @@ func (activator Activator) verifyCopilot(ctx context.Context, request domain.Act
 	if err != nil {
 		return fmt.Errorf("verify Copilot plugin listing: %w", err)
 	}
-	switch copilotPluginStatus(listed.Stdout, pluginSpec) {
+	switch copilotPluginStatus(listed.Stdout, pluginSpec, request.Delivery.ActivePath) {
 	case copilotStatusInstalled:
 		return nil
 	case copilotStatusAbsent:
@@ -974,6 +974,9 @@ func foldJSONKey(key string) string {
 }
 
 var copilotInstalledEntry = regexp.MustCompile(`^[ \t]+•[ \t]+([A-Za-z0-9][A-Za-z0-9._-]*@[A-Za-z0-9][A-Za-z0-9._-]*)[ \t]+\(v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?\)[ \t]*$`)
+var copilotLiveEntry = regexp.MustCompile(`^  • ([A-Za-z0-9][A-Za-z0-9._-]*@[A-Za-z0-9][A-Za-z0-9._-]*) \(v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?\) \(([A-Za-z0-9_-]+)\)$`)
+
+const copilotLiveHeader = "Live Plugins (loaded from a local marketplace directory, never copied):"
 
 type copilotStatus int
 
@@ -986,7 +989,52 @@ const (
 var errCopilotListContractUnknown = errors.New("Copilot plugin list output is not recognized")
 var errRecognizedNegativeEvidence = errors.New("recognized negative client evidence")
 
-func copilotPluginStatus(stdout []byte, expected string) copilotStatus {
+func copilotLivePluginStatus(stdout []byte, expected, expectedPath string) (copilotStatus, bool) {
+	document := strings.TrimSuffix(strings.ReplaceAll(string(stdout), "\r\n", "\n"), "\n")
+	lines := strings.Split(document, "\n")
+	if len(lines) == 0 || lines[0] != copilotLiveHeader {
+		return copilotStatusUnknown, false
+	}
+	if len(lines) < 3 || (len(lines)-1)%2 != 0 || strings.TrimSpace(expectedPath) == "" {
+		return copilotStatusUnknown, true
+	}
+	seen := make(map[string]bool, (len(lines)-1)/2)
+	matches := 0
+	for index := 1; index < len(lines); index += 2 {
+		entry := copilotLiveEntry.FindStringSubmatch(lines[index])
+		if len(entry) != 3 || seen[entry[1]] || (entry[2] != "enabled" && entry[2] != "disabled") {
+			return copilotStatusUnknown, true
+		}
+		seen[entry[1]] = true
+		const pathPrefix = "      from "
+		if !strings.HasPrefix(lines[index+1], pathPrefix) {
+			return copilotStatusUnknown, true
+		}
+		listedPath := strings.TrimPrefix(lines[index+1], pathPrefix)
+		if listedPath == "" || !filepath.IsAbs(listedPath) {
+			return copilotStatusUnknown, true
+		}
+		if entry[1] != expected {
+			continue
+		}
+		if entry[2] != "enabled" || filepath.Clean(listedPath) != filepath.Clean(expectedPath) {
+			return copilotStatusUnknown, true
+		}
+		matches++
+	}
+	if matches == 1 {
+		return copilotStatusInstalled, true
+	}
+	if matches > 1 {
+		return copilotStatusUnknown, true
+	}
+	return copilotStatusAbsent, true
+}
+
+func copilotPluginStatus(stdout []byte, expected, expectedPath string) copilotStatus {
+	if status, recognized := copilotLivePluginStatus(stdout, expected, expectedPath); recognized {
+		return status
+	}
 	inInstalledSection := false
 	recognizedSection := false
 	recognizedEntry := false

--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -557,7 +557,7 @@ func (activator Activator) verifyCopilot(ctx context.Context, request domain.Act
 	if err != nil {
 		return fmt.Errorf("verify Copilot plugin listing: %w", err)
 	}
-	switch copilotPluginStatus(listed.Stdout, pluginSpec, request.Delivery.ActivePath) {
+	switch copilotPluginStatus(listed.Stdout, pluginSpec, copilotMarketplaceVersion(request.Plan.DeclaredVersion), request.Delivery.ActivePath) {
 	case copilotStatusInstalled:
 		return nil
 	case copilotStatusAbsent:
@@ -973,8 +973,8 @@ func foldJSONKey(key string) string {
 	return folded.String()
 }
 
-var copilotInstalledEntry = regexp.MustCompile(`^[ \t]+•[ \t]+([A-Za-z0-9][A-Za-z0-9._-]*@[A-Za-z0-9][A-Za-z0-9._-]*)[ \t]+\(v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?\)[ \t]*$`)
-var copilotLiveEntry = regexp.MustCompile(`^  • ([A-Za-z0-9][A-Za-z0-9._-]*@[A-Za-z0-9][A-Za-z0-9._-]*) \(v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?\) \(([A-Za-z0-9_-]+)\)$`)
+var copilotInstalledEntry = regexp.MustCompile(`^[ \t]+•[ \t]+([A-Za-z0-9][A-Za-z0-9._-]*@[A-Za-z0-9][A-Za-z0-9._-]*)[ \t]+\(v([0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)\)[ \t]*$`)
+var copilotLiveEntry = regexp.MustCompile(`^  • ([A-Za-z0-9][A-Za-z0-9._-]*@[A-Za-z0-9][A-Za-z0-9._-]*) \(v([0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)\) \(([A-Za-z0-9_-]+)\)$`)
 
 const copilotLiveHeader = "Live Plugins (loaded from a local marketplace directory, never copied):"
 
@@ -989,20 +989,20 @@ const (
 var errCopilotListContractUnknown = errors.New("Copilot plugin list output is not recognized")
 var errRecognizedNegativeEvidence = errors.New("recognized negative client evidence")
 
-func copilotLivePluginStatus(stdout []byte, expected, expectedPath string) (copilotStatus, bool) {
+func copilotLivePluginStatus(stdout []byte, expected, expectedVersion, expectedPath string) (copilotStatus, bool) {
 	document := strings.TrimSuffix(strings.ReplaceAll(string(stdout), "\r\n", "\n"), "\n")
 	lines := strings.Split(document, "\n")
 	if len(lines) == 0 || lines[0] != copilotLiveHeader {
 		return copilotStatusUnknown, false
 	}
-	if len(lines) < 3 || (len(lines)-1)%2 != 0 || strings.TrimSpace(expectedPath) == "" {
+	if len(lines) < 3 || (len(lines)-1)%2 != 0 || strings.TrimSpace(expectedVersion) == "" || strings.TrimSpace(expectedPath) == "" {
 		return copilotStatusUnknown, true
 	}
 	seen := make(map[string]bool, (len(lines)-1)/2)
 	matches := 0
 	for index := 1; index < len(lines); index += 2 {
 		entry := copilotLiveEntry.FindStringSubmatch(lines[index])
-		if len(entry) != 3 || seen[entry[1]] || (entry[2] != "enabled" && entry[2] != "disabled") {
+		if len(entry) != 4 || seen[entry[1]] || (entry[3] != "enabled" && entry[3] != "disabled") {
 			return copilotStatusUnknown, true
 		}
 		seen[entry[1]] = true
@@ -1011,13 +1011,13 @@ func copilotLivePluginStatus(stdout []byte, expected, expectedPath string) (copi
 			return copilotStatusUnknown, true
 		}
 		listedPath := strings.TrimPrefix(lines[index+1], pathPrefix)
-		if listedPath == "" || !filepath.IsAbs(listedPath) {
+		if listedPath == "" || !filepath.IsAbs(listedPath) || listedPath != filepath.Clean(listedPath) {
 			return copilotStatusUnknown, true
 		}
 		if entry[1] != expected {
 			continue
 		}
-		if entry[2] != "enabled" || filepath.Clean(listedPath) != filepath.Clean(expectedPath) {
+		if entry[2] != expectedVersion || entry[3] != "enabled" || expectedPath != filepath.Clean(expectedPath) || listedPath != expectedPath {
 			return copilotStatusUnknown, true
 		}
 		matches++
@@ -1031,8 +1031,8 @@ func copilotLivePluginStatus(stdout []byte, expected, expectedPath string) (copi
 	return copilotStatusAbsent, true
 }
 
-func copilotPluginStatus(stdout []byte, expected, expectedPath string) copilotStatus {
-	if status, recognized := copilotLivePluginStatus(stdout, expected, expectedPath); recognized {
+func copilotPluginStatus(stdout []byte, expected, expectedVersion, expectedPath string) copilotStatus {
+	if status, recognized := copilotLivePluginStatus(stdout, expected, expectedVersion, expectedPath); recognized {
 		return status
 	}
 	inInstalledSection := false
@@ -1056,9 +1056,12 @@ func copilotPluginStatus(stdout []byte, expected, expectedPath string) copilotSt
 			continue
 		}
 		entry := copilotInstalledEntry.FindStringSubmatch(rawLine)
-		if len(entry) == 2 {
+		if len(entry) == 3 {
 			recognizedEntry = true
 			if entry[1] == expected {
+				if entry[2] != expectedVersion {
+					return copilotStatusUnknown
+				}
 				matches++
 			}
 			continue

--- a/install/integrationctl/agentplugins/providers/activator_test.go
+++ b/install/integrationctl/agentplugins/providers/activator_test.go
@@ -437,6 +437,43 @@ func TestCopilotExactVersion1078OutputRemainsSupported(t *testing.T) {
 	}
 }
 
+func TestCopilotLivePluginListingBindsEnabledIdentityAndManagedPath(t *testing.T) {
+	t.Parallel()
+	request := activationRequest(t, domain.ClientCopilot)
+	request.BackendExecutable = "/test/bin/copilot"
+	request.VerifyOnly = true
+	spec := "demo@" + managedMarketplaceName(request.Plan.PhysicalArtifactID)
+	live := func(status, path string) []byte {
+		return []byte(copilotLiveHeader + "\n  • " + spec + " (v1.7.0-uap.1) (" + status + ")\n      from " + path + "\n")
+	}
+
+	runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult {
+		return legacyports.CommandResult{Stdout: live("enabled", request.Delivery.ActivePath)}
+	}}
+	outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
+	if err != nil || outcome.Activation != domain.ActivationActive || outcome.Verification != domain.VerificationInstalled {
+		t.Fatalf("live outcome=%+v err=%v", outcome, err)
+	}
+
+	for name, body := range map[string][]byte{
+		"disabled":     live("disabled", request.Delivery.ActivePath),
+		"wrong path":   live("enabled", filepath.Join(t.TempDir(), "other")),
+		"missing path": []byte(copilotLiveHeader + "\n  • " + spec + " (v1.7.0-uap.1) (enabled)\n"),
+		"extra suffix": append(live("enabled", request.Delivery.ActivePath), []byte("unexpected\n")...),
+		"ansi prefix":  append([]byte("\x1b[32m"), live("enabled", request.Delivery.ActivePath)...),
+	} {
+		t.Run(name, func(t *testing.T) {
+			runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult {
+				return legacyports.CommandResult{Stdout: body}
+			}}
+			outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
+			if err != nil || outcome.Activation != domain.ActivationManual || outcome.AuthoritativeObservation {
+				t.Fatalf("unknown outcome=%+v err=%v", outcome, err)
+			}
+		})
+	}
+}
+
 func TestActivationAttestationCannotBypassObservableVerifier(t *testing.T) {
 	t.Parallel()
 	for _, client := range []domain.ClientID{domain.ClientCodex, domain.ClientCopilot, domain.ClientVSCode, domain.ClientKiro} {

--- a/install/integrationctl/agentplugins/providers/activator_test.go
+++ b/install/integrationctl/agentplugins/providers/activator_test.go
@@ -407,6 +407,7 @@ func TestCopilotUnknownOutputContractRemainsManual(t *testing.T) {
 		"stderr only":     {Stderr: []byte("Installed plugins:\n  • " + spec + " (v1.0.0)")},
 		"outside section": {Stdout: []byte("• " + spec + " (v1.0.0)")},
 		"bad version":     {Stdout: []byte("Installed plugins:\n  • " + spec + " (latest)")},
+		"wrong version":   {Stdout: []byte("Installed plugins:\n  • " + spec + " (v1.0.1)")},
 		"duplicate":       {Stdout: []byte("Installed plugins:\n  • " + spec + " (v1.0.0)\n  • " + spec + " (v1.0.0)")},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -425,6 +426,7 @@ func TestCopilotUnknownOutputContractRemainsManual(t *testing.T) {
 func TestCopilotExactVersion1078OutputRemainsSupported(t *testing.T) {
 	t.Parallel()
 	request := activationRequest(t, domain.ClientCopilot)
+	request.Plan.DeclaredVersion = "1.0.78"
 	request.BackendExecutable = "/test/bin/copilot"
 	request.VerifyOnly = true
 	spec := "demo@" + managedMarketplaceName(request.Plan.PhysicalArtifactID)
@@ -440,15 +442,16 @@ func TestCopilotExactVersion1078OutputRemainsSupported(t *testing.T) {
 func TestCopilotLivePluginListingBindsEnabledIdentityAndManagedPath(t *testing.T) {
 	t.Parallel()
 	request := activationRequest(t, domain.ClientCopilot)
+	request.Plan.DeclaredVersion = "1.7.0-uap.1"
 	request.BackendExecutable = "/test/bin/copilot"
 	request.VerifyOnly = true
 	spec := "demo@" + managedMarketplaceName(request.Plan.PhysicalArtifactID)
-	live := func(status, path string) []byte {
-		return []byte(copilotLiveHeader + "\n  • " + spec + " (v1.7.0-uap.1) (" + status + ")\n      from " + path + "\n")
+	live := func(version, status, path string) []byte {
+		return []byte(copilotLiveHeader + "\n  • " + spec + " (v" + version + ") (" + status + ")\n      from " + path + "\n")
 	}
 
 	runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult {
-		return legacyports.CommandResult{Stdout: live("enabled", request.Delivery.ActivePath)}
+		return legacyports.CommandResult{Stdout: live("1.7.0-uap.1", "enabled", request.Delivery.ActivePath)}
 	}}
 	outcome, err := (Activator{Runner: runner}).Activate(context.Background(), request)
 	if err != nil || outcome.Activation != domain.ActivationActive || outcome.Verification != domain.VerificationInstalled {
@@ -456,11 +459,13 @@ func TestCopilotLivePluginListingBindsEnabledIdentityAndManagedPath(t *testing.T
 	}
 
 	for name, body := range map[string][]byte{
-		"disabled":     live("disabled", request.Delivery.ActivePath),
-		"wrong path":   live("enabled", filepath.Join(t.TempDir(), "other")),
-		"missing path": []byte(copilotLiveHeader + "\n  • " + spec + " (v1.7.0-uap.1) (enabled)\n"),
-		"extra suffix": append(live("enabled", request.Delivery.ActivePath), []byte("unexpected\n")...),
-		"ansi prefix":  append([]byte("\x1b[32m"), live("enabled", request.Delivery.ActivePath)...),
+		"disabled":      live("1.7.0-uap.1", "disabled", request.Delivery.ActivePath),
+		"wrong version": live("1.7.0-uap.0", "enabled", request.Delivery.ActivePath),
+		"wrong path":    live("1.7.0-uap.1", "enabled", filepath.Join(t.TempDir(), "other")),
+		"dot path":      live("1.7.0-uap.1", "enabled", filepath.Dir(request.Delivery.ActivePath)+string(filepath.Separator)+"alias"+string(filepath.Separator)+".."+string(filepath.Separator)+filepath.Base(request.Delivery.ActivePath)),
+		"missing path":  []byte(copilotLiveHeader + "\n  • " + spec + " (v1.7.0-uap.1) (enabled)\n"),
+		"extra suffix":  append(live("1.7.0-uap.1", "enabled", request.Delivery.ActivePath), []byte("unexpected\n")...),
+		"ansi prefix":   append([]byte("\x1b[32m"), live("1.7.0-uap.1", "enabled", request.Delivery.ActivePath)...),
 	} {
 		t.Run(name, func(t *testing.T) {
 			runner := &recordingRunner{run: func(legacyports.Command) legacyports.CommandResult {
@@ -1077,7 +1082,7 @@ func activationRequest(t *testing.T, client domain.ClientID) domain.ActivationRe
 		DeclaredName: "demo",
 		Plan: domain.DeliveryPlan{
 			ClientID: client, ActivePath: active, PhysicalArtifactID: "demo-0123456789ab",
-			Authentication: domain.AuthenticationNotChecked,
+			DeclaredVersion: "1.0.0", Authentication: domain.AuthenticationNotChecked,
 		},
 		Delivery: domain.StagedDelivery{ClientID: client, OwnedBase: base, ActivePath: active},
 	}

--- a/install/integrationctl/agentplugins/providers/marketplaces.go
+++ b/install/integrationctl/agentplugins/providers/marketplaces.go
@@ -21,11 +21,16 @@ func ManagedMarketplaceName(physicalArtifactID string) string {
 	return managedMarketplaceName(physicalArtifactID)
 }
 
-func projectCopilotMarketplace(root string, envelope domain.PackageEnvelope, plan domain.DeliveryPlan) error {
-	version := strings.TrimSpace(envelope.Manifest.Version)
+func copilotMarketplaceVersion(version string) string {
+	version = strings.TrimSpace(version)
 	if version == "" {
-		version = "0.0.0"
+		return "0.0.0"
 	}
+	return version
+}
+
+func projectCopilotMarketplace(root string, envelope domain.PackageEnvelope, plan domain.DeliveryPlan) error {
+	version := copilotMarketplaceVersion(envelope.Manifest.Version)
 	description := strings.TrimSpace(envelope.Manifest.Description)
 	if description == "" {
 		description = "Managed Agent Plugin " + envelope.Manifest.Name

--- a/install/integrationctl/agentplugins/providers/native_identity.go
+++ b/install/integrationctl/agentplugins/providers/native_identity.go
@@ -336,7 +336,7 @@ func (observer NativeIdentityObserver) inspectCopilotCLI(ctx context.Context, pl
 	if managed != nil && strings.TrimSpace(managed.TargetLocator) != "" {
 		expectedPath = managed.TargetLocator
 	}
-	return copilotRegistryFindingAt(result.Stdout, plan.DeclaredName, managedMarketplaceName(plan.PhysicalArtifactID), expectedPath, managed != nil), nil
+	return copilotRegistryFindingAt(result.Stdout, plan.DeclaredName, managedMarketplaceName(plan.PhysicalArtifactID), copilotMarketplaceVersion(plan.DeclaredVersion), expectedPath, managed != nil), nil
 }
 
 func (observer NativeIdentityObserver) runNativeRegistry(ctx context.Context, command legacyports.Command) (legacyports.CommandResult, error) {
@@ -346,13 +346,13 @@ func (observer NativeIdentityObserver) runNativeRegistry(ctx context.Context, co
 	return observer.Runner.Run(ctx, command)
 }
 
-func copilotRegistryFinding(stdout []byte, name, expectedMarketplace string, owned bool) registryFinding {
-	return copilotRegistryFindingAt(stdout, name, expectedMarketplace, "", owned)
+func copilotRegistryFinding(stdout []byte, name, expectedMarketplace, expectedVersion string, owned bool) registryFinding {
+	return copilotRegistryFindingAt(stdout, name, expectedMarketplace, expectedVersion, "", owned)
 }
 
-func copilotRegistryFindingAt(stdout []byte, name, expectedMarketplace, expectedPath string, owned bool) registryFinding {
+func copilotRegistryFindingAt(stdout []byte, name, expectedMarketplace, expectedVersion, expectedPath string, owned bool) registryFinding {
 	expected := name + "@" + expectedMarketplace
-	if status, recognized := copilotLivePluginStatus(stdout, expected, expectedPath); recognized {
+	if status, recognized := copilotLivePluginStatus(stdout, expected, expectedVersion, expectedPath); recognized {
 		switch status {
 		case copilotStatusInstalled:
 			if !owned {
@@ -391,7 +391,7 @@ func copilotRegistryFindingAt(stdout []byte, name, expectedMarketplace, expected
 			return registryIndeterminate
 		}
 		match := copilotInstalledEntry.FindStringSubmatch(line)
-		if len(match) == 2 {
+		if len(match) == 3 {
 			if recognizedEmpty {
 				return registryIndeterminate
 			}
@@ -406,6 +406,9 @@ func copilotRegistryFindingAt(stdout []byte, name, expectedMarketplace, expected
 				return registryIndeterminate
 			}
 			if parts[0] == name && parts[1] == expectedMarketplace {
+				if match[2] != expectedVersion {
+					return registryIndeterminate
+				}
 				if !owned {
 					return registryCollision
 				}

--- a/install/integrationctl/agentplugins/providers/native_identity.go
+++ b/install/integrationctl/agentplugins/providers/native_identity.go
@@ -332,7 +332,11 @@ func (observer NativeIdentityObserver) inspectCopilotCLI(ctx context.Context, pl
 	if result.ExitCode != 0 {
 		return registryIndeterminate, fmt.Errorf("Copilot plugin registry command failed with exit code %d", result.ExitCode)
 	}
-	return copilotRegistryFinding(result.Stdout, plan.DeclaredName, managedMarketplaceName(plan.PhysicalArtifactID), managed != nil), nil
+	expectedPath := plan.ActivePath
+	if managed != nil && strings.TrimSpace(managed.TargetLocator) != "" {
+		expectedPath = managed.TargetLocator
+	}
+	return copilotRegistryFindingAt(result.Stdout, plan.DeclaredName, managedMarketplaceName(plan.PhysicalArtifactID), expectedPath, managed != nil), nil
 }
 
 func (observer NativeIdentityObserver) runNativeRegistry(ctx context.Context, command legacyports.Command) (legacyports.CommandResult, error) {
@@ -343,6 +347,24 @@ func (observer NativeIdentityObserver) runNativeRegistry(ctx context.Context, co
 }
 
 func copilotRegistryFinding(stdout []byte, name, expectedMarketplace string, owned bool) registryFinding {
+	return copilotRegistryFindingAt(stdout, name, expectedMarketplace, "", owned)
+}
+
+func copilotRegistryFindingAt(stdout []byte, name, expectedMarketplace, expectedPath string, owned bool) registryFinding {
+	expected := name + "@" + expectedMarketplace
+	if status, recognized := copilotLivePluginStatus(stdout, expected, expectedPath); recognized {
+		switch status {
+		case copilotStatusInstalled:
+			if !owned {
+				return registryCollision
+			}
+			return registryExpected
+		case copilotStatusAbsent:
+			return registryClear
+		default:
+			return registryIndeterminate
+		}
+	}
 	normalized := strings.ReplaceAll(string(stdout), "\r\n", "\n")
 	document := strings.TrimSuffix(normalized, "\n")
 	if document == "No plugins installed.\n\nUse 'copilot plugin install <source>' to install a plugin." {

--- a/install/integrationctl/agentplugins/providers/native_identity_test.go
+++ b/install/integrationctl/agentplugins/providers/native_identity_test.go
@@ -181,6 +181,8 @@ func TestCopilotLiveRegistryFindingRequiresExactIdentityStatusAndPath(t *testing
 		want  registryFinding
 	}{
 		{name: "managed", body: entry("demo", "enabled", path), owned: true, want: registryExpected},
+		{name: "managed with unrelated", body: entry("other", "enabled", path) + strings.TrimPrefix(entry("demo", "enabled", path), header), owned: true, want: registryExpected},
+		{name: "managed CRLF", body: strings.ReplaceAll(entry("demo", "enabled", path), "\n", "\r\n"), owned: true, want: registryExpected},
 		{name: "unowned collision", body: entry("demo", "enabled", path), want: registryCollision},
 		{name: "unrelated", body: entry("other", "enabled", path), owned: true, want: registryClear},
 		{name: "disabled", body: entry("demo", "disabled", path), owned: true, want: registryIndeterminate},

--- a/install/integrationctl/agentplugins/providers/native_identity_test.go
+++ b/install/integrationctl/agentplugins/providers/native_identity_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -162,6 +163,59 @@ func TestCopilotRegistryFindingRequiresExactNativeIdentity(t *testing.T) {
 				t.Fatalf("finding = %d, want %d", got, test.want)
 			}
 		})
+	}
+}
+
+func TestCopilotLiveRegistryFindingRequiresExactIdentityStatusAndPath(t *testing.T) {
+	t.Parallel()
+	marketplace := "agentplugins-demo-0123456789ab"
+	path := filepath.Join(t.TempDir(), "managed", "demo")
+	header := copilotLiveHeader + "\n"
+	entry := func(name, status, from string) string {
+		return header + "  • " + name + "@" + marketplace + " (v1.7.0-uap.1) (" + status + ")\n      from " + from + "\n"
+	}
+	tests := []struct {
+		name  string
+		body  string
+		owned bool
+		want  registryFinding
+	}{
+		{name: "managed", body: entry("demo", "enabled", path), owned: true, want: registryExpected},
+		{name: "unowned collision", body: entry("demo", "enabled", path), want: registryCollision},
+		{name: "unrelated", body: entry("other", "enabled", path), owned: true, want: registryClear},
+		{name: "disabled", body: entry("demo", "disabled", path), owned: true, want: registryIndeterminate},
+		{name: "wrong path", body: entry("demo", "enabled", filepath.Join(t.TempDir(), "other")), owned: true, want: registryIndeterminate},
+		{name: "duplicate", body: entry("demo", "enabled", path) + strings.TrimPrefix(entry("demo", "enabled", path), header), owned: true, want: registryIndeterminate},
+		{name: "missing from", body: header + "  • demo@" + marketplace + " (v1.7.0-uap.1) (enabled)\n", owned: true, want: registryIndeterminate},
+		{name: "extra suffix", body: entry("demo", "enabled", path) + "unexpected\n", owned: true, want: registryIndeterminate},
+		{name: "ansi prefix", body: "\x1b[32m" + entry("demo", "enabled", path), owned: true, want: registryIndeterminate},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := copilotRegistryFindingAt([]byte(test.body), "demo", marketplace, path, test.owned); got != test.want {
+				t.Fatalf("finding=%d want=%d", got, test.want)
+			}
+		})
+	}
+}
+
+func TestNativeIdentityCopilotAcceptsExactLiveManagedRegistration(t *testing.T) {
+	t.Parallel()
+	plan := identityPlan(filepath.Join(t.TempDir(), "prepared"))
+	plan.NativeRegistryExecutable = "/test/bin/copilot"
+	if err := os.MkdirAll(plan.ActivePath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeIdentityFile(t, filepath.Join(plan.ActivePath, "plugin.json"), `{"name":"demo"}`)
+	marketplace := managedMarketplaceName(plan.PhysicalArtifactID)
+	managed := &domain.ClientBinding{TargetLocator: plan.ActivePath, NativeObjects: []domain.NativeObjectOwnership{{Kind: "managed_package_directory", ManagedDigest: "sha256:owned"}}}
+	listing := copilotLiveHeader + "\n  • demo@" + marketplace + " (v1.7.0-uap.1) (enabled)\n      from " + plan.ActivePath + "\n"
+	runner := &identityRunner{result: legacyports.CommandResult{Stdout: []byte(listing)}}
+	observation, err := (NativeIdentityObserver{Runner: runner, Stager: acceptingPackageVerifier{}}).ObserveNativeIdentity(
+		context.Background(), domain.DetectedClient{ClientID: domain.ClientCopilot}, plan, managed,
+	)
+	if err != nil || observation.State != domain.NativeIdentityManaged || !observation.NativeDiscoveryReconciled {
+		t.Fatalf("observation=%+v err=%v", observation, err)
 	}
 }
 

--- a/install/integrationctl/agentplugins/providers/native_identity_test.go
+++ b/install/integrationctl/agentplugins/providers/native_identity_test.go
@@ -146,6 +146,7 @@ func TestCopilotRegistryFindingRequiresExactNativeIdentity(t *testing.T) {
 		want registryFinding
 	}{
 		{name: "exact", body: "Installed plugins:\n  • demo@" + marketplace + " (v1.0.0)\n", want: registryExpected},
+		{name: "wrong_version", body: "Installed plugins:\n  • demo@" + marketplace + " (v1.0.1)\n", want: registryIndeterminate},
 		{name: "unrelated", body: "Installed plugins:\n  • other@" + marketplace + " (v1.0.0)\n", want: registryClear},
 		{name: "duplicate", body: "Installed plugins:\n  • demo@" + marketplace + " (v1.0.0)\n  • demo@" + marketplace + " (v1.0.0)\n", want: registryIndeterminate},
 		{name: "absent_short", body: "No plugins installed.\n", want: registryIndeterminate},
@@ -159,7 +160,7 @@ func TestCopilotRegistryFindingRequiresExactNativeIdentity(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if got := copilotRegistryFinding([]byte(test.body), "demo", marketplace, true); got != test.want {
+			if got := copilotRegistryFinding([]byte(test.body), "demo", marketplace, "1.0.0", true); got != test.want {
 				t.Fatalf("finding = %d, want %d", got, test.want)
 			}
 		})
@@ -171,8 +172,8 @@ func TestCopilotLiveRegistryFindingRequiresExactIdentityStatusAndPath(t *testing
 	marketplace := "agentplugins-demo-0123456789ab"
 	path := filepath.Join(t.TempDir(), "managed", "demo")
 	header := copilotLiveHeader + "\n"
-	entry := func(name, status, from string) string {
-		return header + "  • " + name + "@" + marketplace + " (v1.7.0-uap.1) (" + status + ")\n      from " + from + "\n"
+	entry := func(name, version, status, from string) string {
+		return header + "  • " + name + "@" + marketplace + " (v" + version + ") (" + status + ")\n      from " + from + "\n"
 	}
 	tests := []struct {
 		name  string
@@ -180,21 +181,23 @@ func TestCopilotLiveRegistryFindingRequiresExactIdentityStatusAndPath(t *testing
 		owned bool
 		want  registryFinding
 	}{
-		{name: "managed", body: entry("demo", "enabled", path), owned: true, want: registryExpected},
-		{name: "managed with unrelated", body: entry("other", "enabled", path) + strings.TrimPrefix(entry("demo", "enabled", path), header), owned: true, want: registryExpected},
-		{name: "managed CRLF", body: strings.ReplaceAll(entry("demo", "enabled", path), "\n", "\r\n"), owned: true, want: registryExpected},
-		{name: "unowned collision", body: entry("demo", "enabled", path), want: registryCollision},
-		{name: "unrelated", body: entry("other", "enabled", path), owned: true, want: registryClear},
-		{name: "disabled", body: entry("demo", "disabled", path), owned: true, want: registryIndeterminate},
-		{name: "wrong path", body: entry("demo", "enabled", filepath.Join(t.TempDir(), "other")), owned: true, want: registryIndeterminate},
-		{name: "duplicate", body: entry("demo", "enabled", path) + strings.TrimPrefix(entry("demo", "enabled", path), header), owned: true, want: registryIndeterminate},
+		{name: "managed", body: entry("demo", "1.7.0-uap.1", "enabled", path), owned: true, want: registryExpected},
+		{name: "managed with unrelated", body: entry("other", "9.9.9", "enabled", path) + strings.TrimPrefix(entry("demo", "1.7.0-uap.1", "enabled", path), header), owned: true, want: registryExpected},
+		{name: "managed CRLF", body: strings.ReplaceAll(entry("demo", "1.7.0-uap.1", "enabled", path), "\n", "\r\n"), owned: true, want: registryExpected},
+		{name: "unowned collision", body: entry("demo", "1.7.0-uap.1", "enabled", path), want: registryCollision},
+		{name: "unrelated", body: entry("other", "9.9.9", "enabled", path), owned: true, want: registryClear},
+		{name: "disabled", body: entry("demo", "1.7.0-uap.1", "disabled", path), owned: true, want: registryIndeterminate},
+		{name: "wrong version", body: entry("demo", "1.7.0-uap.0", "enabled", path), owned: true, want: registryIndeterminate},
+		{name: "wrong path", body: entry("demo", "1.7.0-uap.1", "enabled", filepath.Join(t.TempDir(), "other")), owned: true, want: registryIndeterminate},
+		{name: "dot segment path", body: entry("demo", "1.7.0-uap.1", "enabled", filepath.Dir(path)+string(filepath.Separator)+"alias"+string(filepath.Separator)+".."+string(filepath.Separator)+filepath.Base(path)), owned: true, want: registryIndeterminate},
+		{name: "duplicate", body: entry("demo", "1.7.0-uap.1", "enabled", path) + strings.TrimPrefix(entry("demo", "1.7.0-uap.1", "enabled", path), header), owned: true, want: registryIndeterminate},
 		{name: "missing from", body: header + "  • demo@" + marketplace + " (v1.7.0-uap.1) (enabled)\n", owned: true, want: registryIndeterminate},
-		{name: "extra suffix", body: entry("demo", "enabled", path) + "unexpected\n", owned: true, want: registryIndeterminate},
-		{name: "ansi prefix", body: "\x1b[32m" + entry("demo", "enabled", path), owned: true, want: registryIndeterminate},
+		{name: "extra suffix", body: entry("demo", "1.7.0-uap.1", "enabled", path) + "unexpected\n", owned: true, want: registryIndeterminate},
+		{name: "ansi prefix", body: "\x1b[32m" + entry("demo", "1.7.0-uap.1", "enabled", path), owned: true, want: registryIndeterminate},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if got := copilotRegistryFindingAt([]byte(test.body), "demo", marketplace, path, test.owned); got != test.want {
+			if got := copilotRegistryFindingAt([]byte(test.body), "demo", marketplace, "1.7.0-uap.1", path, test.owned); got != test.want {
 				t.Fatalf("finding=%d want=%d", got, test.want)
 			}
 		})
@@ -204,6 +207,7 @@ func TestCopilotLiveRegistryFindingRequiresExactIdentityStatusAndPath(t *testing
 func TestNativeIdentityCopilotAcceptsExactLiveManagedRegistration(t *testing.T) {
 	t.Parallel()
 	plan := identityPlan(filepath.Join(t.TempDir(), "prepared"))
+	plan.DeclaredVersion = "1.7.0-uap.1"
 	plan.NativeRegistryExecutable = "/test/bin/copilot"
 	if err := os.MkdirAll(plan.ActivePath, 0o700); err != nil {
 		t.Fatal(err)
@@ -346,6 +350,7 @@ func identityPlan(root string) domain.DeliveryPlan {
 	artifact := "demo-0123456789ab"
 	return domain.DeliveryPlan{
 		DeclaredName:       "demo",
+		DeclaredVersion:    "1.0.0",
 		PhysicalArtifactID: artifact,
 		TargetRoot:         root,
 		ActivePath:         filepath.Join(root, artifact),

--- a/install/integrationctl/agentplugins/providers/stager_test.go
+++ b/install/integrationctl/agentplugins/providers/stager_test.go
@@ -389,6 +389,16 @@ func TestStagerBuildsManagedCopilotMarketplaceForCopilotAndVSCode(t *testing.T) 
 	}
 }
 
+func TestCopilotMarketplaceVersionDefaultsExactlyOnce(t *testing.T) {
+	t.Parallel()
+	if got := copilotMarketplaceVersion("  "); got != "0.0.0" {
+		t.Fatalf("empty projected version = %q", got)
+	}
+	if got := copilotMarketplaceVersion(" 1.7.0-uap.1 "); got != "1.7.0-uap.1" {
+		t.Fatalf("projected version = %q", got)
+	}
+}
+
 func TestStagerKeepsNativePackageAndSanitizesFailureBoundaries(t *testing.T) {
 	t.Parallel()
 	envelope := stagingEnvelope(t)

--- a/install/integrationctl/agentplugins/usecase/group.go
+++ b/install/integrationctl/agentplugins/usecase/group.go
@@ -275,6 +275,10 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 			if !sameNativeBackend(prior.input.Client.ClientID, target.Client.ClientID) {
 				return result, fmt.Errorf("targets collide on physical backend %s", key)
 			}
+			if prior.noChange {
+				result.Targets[targetIndex].NoChange = true
+				result.Targets[targetIndex].Activation = result.Targets[prior.resultIndexes[0]].Activation
+			}
 			prior.resultIndexes = append(prior.resultIndexes, targetIndex)
 			result.Targets[targetIndex].Plan = prior.plan
 			continue


### PR DESCRIPTION
## Summary
- recognize the exact Live Plugins output emitted by GitHub Copilot CLI 1.0.82
- bind native identity to the exact enabled plugin, projected version, canonical managed path, and marketplace
- preserve legacy installed-list and official empty-list contracts
- reuse the per-client package revision for read reconciliation, with the existing legacy fallback
- propagate no_change to both Copilot and VS Code when they share one physical backend

## Evidence
- provider, planner, use-case, and CLI package suites pass locally
- exact positive, mixed-list, CRLF, wrong-version, disabled, wrong-path, dot-segment, duplicate, malformed, ANSI, prefix, and suffix cases are covered
- immediate Copilot/VS Code add -> no-change update and info reconciliation are covered
- independent exact-head review: 0 High, 0 Medium
- reproduced and exercised only in disposable GitHub-hosted catalog E2E; no user project, account, OAuth, or VM was used