### PR TITLE
fix(agentplugins): clarify Windsurf skills activation

### DIFF
--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -462,8 +462,13 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 	case domain.ClientWindsurf:
 		if !activator.AutomaticallyActivates(request) {
 			outcome.Activation = domain.ActivationManual
-			outcome.UserActions = append(outcome.UserActions, "select one legacy Windsurf channel and add the prepared MCP servers manually")
-			outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf("Windsurf: import MCP servers from %s; Devin cloud-synced configuration is never changed automatically", filepath.Join(request.Delivery.ActivePath, "mcp.json")))
+			if hasSupportedMCP(request.Plan.Components) {
+				outcome.UserActions = append(outcome.UserActions, "select one legacy Windsurf channel and add the prepared MCP servers manually")
+				outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf("Windsurf: import MCP servers from %s; Devin cloud-synced configuration is never changed automatically", filepath.Join(request.Delivery.ActivePath, "mcp.json")))
+			} else {
+				outcome.UserActions = append(outcome.UserActions, "use the prepared skills manually in Windsurf; agentplugins does not claim automatic skill activation")
+				outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf("Windsurf: prepared skills remain at %s; Devin cloud-synced configuration is never changed automatically", filepath.Join(request.Delivery.ActivePath, "skills")))
+			}
 			return outcome, nil
 		}
 		if request.VerifyOnly {

--- a/install/integrationctl/agentplugins/providers/windsurf_native_test.go
+++ b/install/integrationctl/agentplugins/providers/windsurf_native_test.go
@@ -154,7 +154,13 @@ func TestWindsurfSkillsOnlyAndDevinOnlyRemainManual(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if outcome.Activation != domain.ActivationManual || len(outcome.UserActions) == 0 || !strings.Contains(strings.Join(outcome.LocalActions, " "), "never changed automatically") {
+	userActions := strings.Join(outcome.UserActions, " ")
+	localActions := strings.Join(outcome.LocalActions, " ")
+	if outcome.Activation != domain.ActivationManual ||
+		!strings.Contains(userActions, "does not claim automatic skill activation") ||
+		strings.Contains(userActions, "MCP") ||
+		!strings.Contains(localActions, filepath.Join(request.Delivery.ActivePath, "skills")) ||
+		!strings.Contains(localActions, "never changed automatically") {
 		t.Fatalf("Devin-only activation = %+v", outcome)
 	}
 }


### PR DESCRIPTION
## Summary
- distinguish skills-only Windsurf packages from MCP packages
- point users to the prepared skills directory without claiming automatic activation
- keep Devin cloud-synced configuration untouched

## Verification
- go test ./install/integrationctl/agentplugins/providers ./install/integrationctl/agentplugins/usecase ./install/integrationctl/agentplugins/planner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved manual activation guidance for plans containing only skills.
  * Clarified that prepared skills remain available at the delivery path.
  * Confirmed that cloud-synced configuration is never changed automatically.
  * Preserved MCP server import guidance when supported MCP components are included.

* **Bug Fixes**
  * Updated activation instructions to accurately reflect the plan’s available components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->