### PR TITLE
ci(agentplugins): separate binary production from npm publish

### DIFF
--- a/.github/workflows/agentplugins-npm-publish.yml
+++ b/.github/workflows/agentplugins-npm-publish.yml
@@ -101,9 +101,7 @@ jobs:
           max_attempts=30
           for attempt in $(seq 1 "${max_attempts}"); do
             published_version="$(npm view --prefer-online "${NPM_PACKAGE}@${version}" version 2>/dev/null || true)"
-            latest_version="$(npm view --prefer-online "${NPM_PACKAGE}@latest" version 2>/dev/null || true)"
-            if [[ "${published_version}" = "${version}" ]] && \
-              [[ "${latest_version}" = "${version}" ]]; then
+            if [[ "${published_version}" = "${version}" ]]; then
               available=true
               break
             fi
@@ -111,6 +109,12 @@ jobs:
             sleep 10
           done
           test "${available}" = true
+          latest_version="$(npm view --prefer-online "${NPM_PACKAGE}@latest" version 2>/dev/null || true)"
+          if [[ -n "${latest_version}" ]]; then
+            echo "informational: ${NPM_PACKAGE}@latest is ${latest_version}; auditing exact historical version ${version}"
+          else
+            echo "warning: ${NPM_PACKAGE}@latest could not be resolved; exact historical version ${version} is available" >&2
+          fi
           npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"
           npm audit signatures --json --include-attestations > audit-signatures.json
           jq -e --arg package "${NPM_PACKAGE}" --arg version "${version}" '

--- a/.github/workflows/agentplugins-npm-publish.yml
+++ b/.github/workflows/agentplugins-npm-publish.yml
@@ -1,4 +1,4 @@
-name: Agentplugins NPM Publish
+name: Agentplugins NPM Historical Audit
 
 on:
   workflow_dispatch:
@@ -7,182 +7,29 @@ on:
         description: Existing immutable stable release tag
         required: true
       verify_only:
-        description: Verify an existing public version without publishing
+        description: Required retired-publisher guard; only historical verification is supported
         required: false
-        default: false
+        default: true
         type: boolean
 
 permissions:
   contents: read
 
 jobs:
-  release-identity:
-    if: ${{ !inputs.verify_only }}
+  audit-mode:
     runs-on: ubuntu-24.04
-    outputs:
-      commit: ${{ steps.identity.outputs.commit }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-          ref: ${{ inputs.tag }}
-      - name: Freeze exact release identity
-        id: identity
+      - name: Enforce retired publisher boundary
         env:
-          TAG: ${{ inputs.tag }}
-          WORKFLOW_COMMIT: ${{ github.sha }}
-          WORKFLOW_REF: ${{ github.ref }}
+          VERIFY_ONLY: ${{ inputs.verify_only }}
         run: |
-          if [[ ! "${TAG}" =~ ^agentplugins-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "invalid agentplugins stable tag: ${TAG}" >&2
+          if [[ "${VERIFY_ONLY}" != "true" ]]; then
+            echo "npm publication is retired in plugin-kit-ai; dispatch with verify_only=true to audit a historical version" >&2
             exit 1
           fi
-          git fetch --force origin main:refs/remotes/origin/main "refs/tags/${TAG}:refs/tags/${TAG}"
-          commit="$(git rev-parse HEAD)"
-          test "${WORKFLOW_REF}" = "refs/heads/main"
-          if [[ "${WORKFLOW_COMMIT}" != "${commit}" ]]; then
-            echo "npm publish workflow source does not match the exact tagged main commit" >&2
-            exit 1
-          fi
-          test "${commit}" = "$(git rev-parse refs/remotes/origin/main)"
-          test "${commit}" = "$(git rev-list -n 1 "refs/tags/${TAG}")"
-          echo "commit=${commit}" >> "${GITHUB_OUTPUT}"
-
-  prepublish-conformance:
-    needs: release-identity
-    if: ${{ !inputs.verify_only }}
-    uses: ./.github/workflows/agentplugins-platform-proof.yml
-    permissions:
-      contents: read
-      attestations: read
-    with:
-      tag: ${{ inputs.tag }}
-      expected_commit: ${{ needs.release-identity.outputs.commit }}
-      allow_legacy_manifest: false
-
-  publish:
-    needs: [release-identity, prepublish-conformance]
-    if: ${{ !inputs.verify_only }}
-    runs-on: ubuntu-latest
-    environment: npm-agentplugins
-    outputs:
-      package_name: ${{ steps.publish-gate.outputs.package_name }}
-    permissions:
-      contents: read
-      id-token: write
-      attestations: read
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-          ref: ${{ inputs.tag }}
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org
-          package-manager-cache: false
-      - name: Install pinned npm with trusted publishing support
-        run: npm install --global npm@12.0.2
-      - name: Validate explicit stable publication gate
-        id: publish-gate
-        env:
-          TAG: ${{ inputs.tag }}
-          READY: ${{ vars.NPM_AGENTPLUGINS_PUBLISH_READY }}
-        run: |
-          if [[ ! "${TAG}" =~ ^agentplugins-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "invalid agentplugins stable tag: ${TAG}" >&2
-            exit 1
-          fi
-          test "${READY}" = "true"
-          git fetch --force origin main:refs/remotes/origin/main "refs/tags/${TAG}:refs/tags/${TAG}"
-          head_commit="$(git rev-parse HEAD)"
-          test "${head_commit}" = "${{ needs.release-identity.outputs.commit }}"
-          test "${{ needs.prepublish-conformance.outputs.gate_eligible }}" = "true"
-          test "${head_commit}" = "$(git rev-parse refs/remotes/origin/main)"
-          test "${head_commit}" = "$(git rev-list -n 1 "refs/tags/${TAG}")"
-          echo "commit=${head_commit}" >> "${GITHUB_OUTPUT}"
-          package_name="$(node -p 'require("./npm/agentplugins/package.json").name')"
-          package_name_length="$(printf '%s' "${package_name}" | wc -c | tr -d ' ')"
-          if [[ ! "${package_name}" =~ ^(@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$ ]] || [[ "${package_name_length}" -gt 214 ]]; then
-            echo "invalid npm package name in npm/agentplugins/package.json" >&2
-            exit 1
-          fi
-          test "$(node -p 'require("./npm/agentplugins/package.json").bin.agentplugins')" = "bin/agentplugins.js"
-          echo "package_name=${package_name}" >> "${GITHUB_OUTPUT}"
-          registry_error="${RUNNER_TEMP}/agentplugins-npm-view.err"
-          if npm view "${package_name}" versions --json >/dev/null 2>"${registry_error}"; then
-            exists=true
-          elif grep -q 'E404' "${registry_error}"; then
-            exists=false
-          else
-            echo "unable to prove whether ${package_name} already exists in npm" >&2
-            cat "${registry_error}" >&2
-            exit 1
-          fi
-          if [[ "${exists}" != "true" ]]; then
-            echo "${package_name} does not exist yet; trusted publishing only supports existing packages" >&2
-            exit 1
-          fi
-      - name: Download and verify all release assets
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ inputs.tag }}
-        run: |
-          mkdir -p "${RUNNER_TEMP}/agentplugins-assets"
-          gh release download "${TAG}" --repo "${GITHUB_REPOSITORY}" --dir "${RUNNER_TEMP}/agentplugins-assets"
-          cd "${RUNNER_TEMP}/agentplugins-assets"
-          node "${GITHUB_WORKSPACE}/npm/agentplugins/scripts/release-assets.js" verify \
-            "${PWD}" "${TAG}" "${{ steps.publish-gate.outputs.commit }}"
-          for asset in agentplugins_* checksums.txt release-manifest.json; do
-            gh attestation verify "${asset}" \
-              --repo "${GITHUB_REPOSITORY}" \
-              --signer-workflow "github.com/${GITHUB_REPOSITORY}/.github/workflows/agentplugins-release.yml" \
-              --source-digest "${{ steps.publish-gate.outputs.commit }}"
-          done
-      - name: Download exact six-platform-tested npm tarball
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ${{ needs.prepublish-conformance.outputs.tarball_artifact }}
-          path: ${{ runner.temp }}/agentplugins-tested-package
-      - name: Revalidate exact tested tarball publication identity
-        env:
-          TAG: ${{ inputs.tag }}
-          TARBALL_FILE: ${{ needs.prepublish-conformance.outputs.tarball_file }}
-          EXPECTED_PACKAGE: ${{ needs.prepublish-conformance.outputs.package_name }}
-        run: |
-          version="${TAG#agentplugins-v}"
-          tarball="${RUNNER_TEMP}/agentplugins-tested-package/${TARBALL_FILE}"
-          test -s "${tarball}"
-          install_root="${RUNNER_TEMP}/agentplugins-publish-inspection"
-          npm install --prefix "${install_root}" --ignore-scripts --no-audit --no-fund --save-exact "${tarball}"
-          package_root="${install_root}/node_modules/${EXPECTED_PACKAGE}"
-          test "$(node -p 'require(process.argv[1]).version' "${package_root}/package.json")" = "${version}"
-          test "$(node -p 'require(process.argv[1]).name' "${package_root}/package.json")" = "${EXPECTED_PACKAGE}"
-          test "$(node -p 'require(process.argv[1]).bin.agentplugins' "${package_root}/package.json")" = "bin/agentplugins.js"
-          test "$(node -p 'Boolean(require(process.argv[1]).scripts?.preinstall || require(process.argv[1]).scripts?.install || require(process.argv[1]).scripts?.postinstall)' "${package_root}/package.json")" = "false"
-          node -e '
-            const fs = require("node:fs");
-            const npmAssets = JSON.parse(fs.readFileSync(process.argv[1]));
-            const release = JSON.parse(fs.readFileSync(process.argv[2]));
-            if (npmAssets.version !== release.version || npmAssets.tag !== release.tag) throw new Error("npm manifest identity mismatch");
-            for (const [key, asset] of Object.entries(release.assets)) {
-              const pin = npmAssets.assets?.[key];
-              if (!pin || pin.file !== asset.file || pin.sha256 !== asset.sha256 || pin.size !== asset.size) {
-                throw new Error(`npm asset pin mismatch: ${key}`);
-              }
-            }
-            if (Object.keys(npmAssets.assets || {}).length !== 6) throw new Error("npm manifest target count mismatch");
-          ' "${package_root}/assets.json" "${RUNNER_TEMP}/agentplugins-tested-package/verified-release.json"
-      - name: Publish stable release with provenance
-        env:
-          TARBALL: ${{ runner.temp }}/agentplugins-tested-package/${{ needs.prepublish-conformance.outputs.tarball_file }}
-        run: npm publish --access public --tag latest --provenance "${TARBALL}"
 
   verify:
-    needs: publish
-    if: ${{ always() && !cancelled() && (inputs.verify_only || needs.publish.result == 'success') }}
+    needs: audit-mode
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/agentplugins-platform-proof.yml
+++ b/.github/workflows/agentplugins-platform-proof.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       allow_legacy_manifest:
-        description: Audit a schema-v1 historical release; never eligible as an npm publish gate
+        description: Audit a schema-v1 historical release; never eligible for the strict producer contract
         required: false
         default: false
         type: boolean
@@ -76,7 +76,7 @@ on:
         description: Filename of the exact tested npm tarball
         value: ${{ jobs.prepare.outputs.tarball_file }}
       gate_eligible:
-        description: Whether the release uses the strict publish-gate manifest
+        description: Whether the release uses the strict schema-v2 producer manifest
         value: ${{ jobs.prepare.outputs.gate_eligible }}
       bootstrap_mode:
         description: Exact cold-bootstrap evidence source used by native jobs

--- a/.github/workflows/agentplugins-release.yml
+++ b/.github/workflows/agentplugins-release.yml
@@ -6,6 +6,13 @@ on:
       tag:
         description: Exact stable tag, for example agentplugins-v0.1.0
         required: true
+      producer_mode:
+        description: Bounded release contract; publishes verified GitHub binary assets only
+        required: true
+        default: binary-only
+        type: choice
+        options:
+          - binary-only
 
 permissions:
   contents: read
@@ -37,9 +44,14 @@ jobs:
         id: identity
         env:
           TAG: ${{ inputs.tag }}
+          PRODUCER_MODE: ${{ inputs.producer_mode }}
           WORKFLOW_COMMIT: ${{ github.sha }}
           WORKFLOW_REF: ${{ github.ref }}
         run: |
+          if [[ "${PRODUCER_MODE}" != "binary-only" ]]; then
+            echo "unsupported agentplugins producer mode: ${PRODUCER_MODE}" >&2
+            exit 1
+          fi
           if [[ ! "${TAG}" =~ ^agentplugins-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "invalid agentplugins stable tag: ${TAG}" >&2
             exit 1

--- a/docs/agentplugins-release.md
+++ b/docs/agentplugins-release.md
@@ -98,7 +98,10 @@ environment, OIDC write permission, token, or publish-ready gate. Its
 closed. Dispatch it with `verify_only=true` and an existing historical tag to
 verify the public registry version, signature, provenance, and isolated
 lifecycle. Historical audit mode does not require the tag to point to current
-`main` and does not rerun the schema-v2 six-platform release proof.
+`main` and does not rerun the schema-v2 six-platform release proof. The audit
+waits only for the exact `package@version` named by the historical tag. The
+current `latest` dist-tag is logged for context but is non-blocking, so a newer
+UAP publication does not invalidate or delay an older immutable-version audit.
 
 The UAP facade publisher must consume an exact public tag and verify the release
 manifest version, source commit, six filenames, byte sizes, SHA-256 digests, and

--- a/docs/agentplugins-release.md
+++ b/docs/agentplugins-release.md
@@ -1,7 +1,8 @@
 # Agentplugins stable release
 
-This runbook is for maintainers. Do not create a release, publish npm, or change
-the `latest` dist-tag without explicit owner approval for that exact version.
+This runbook is for maintainers. Do not create a release without explicit owner
+approval for that exact version. This repository must not publish the npm facade
+or change its `latest` dist-tag.
 
 ## Required gates
 
@@ -17,15 +18,12 @@ the `latest` dist-tag without explicit owner approval for that exact version.
   and runtime evidence cover the released package trees.
 - The catalog embedded in the `agentplugins` binary is byte-identical to that
   released catalog and its compiled SHA-256 pin matches.
-- `agentplugins-release` and `npm-agentplugins` require a reviewer and allow
-  deployment only from `main`. Dispatch both workflows from the exact `main`
-  commit referenced by the release tag; their source-commit guards reject a
-  newer or older workflow revision.
-- npm trusted publishing is bound to repository `777genius/plugin-kit-ai`,
-  workflow `agentplugins-npm-publish.yml`, environment `npm-agentplugins`, and
-  the `npm publish` permission.
-- `NPM_AGENTPLUGINS_PUBLISH_READY` stays `false` until the exact publish is
-  approved.
+- `agentplugins-release` requires a reviewer and allows deployment only from
+  `main`. Dispatch it from the exact `main` commit referenced by the release
+  tag; its source-commit guard rejects a newer or older workflow revision.
+- Select the required `binary-only` producer mode. This repository publishes
+  only the verified GitHub binary release; npm publication belongs to the UAP
+  facade release process outside this repository.
 
 For the first catalog release, merge its catalog PR with history preserved. If
 it is squash-merged or rebase-merged, regenerate the catalog from the resulting
@@ -36,7 +34,8 @@ project is tagged.
 
 1. Create the approved annotated stable tag on current `main` and push only that
    tag.
-2. Dispatch `Agentplugins Release Assets` with the exact tag.
+2. Dispatch `Agentplugins Release Assets` with the exact tag and the required
+   `binary-only` producer mode.
 3. Review the frozen commit and approve the `agentplugins-release`
    environment deployment.
 4. Confirm the workflow attests all six binaries, `checksums.txt`, and
@@ -52,8 +51,11 @@ project is tagged.
    it reverifies the draft identity, manifest, assets, and attestations.
    It promotes that exact draft only after all six native platform proofs succeed.
 7. Verify the resulting public release contains six platform binaries,
-   `checksums.txt`, and `release-manifest.json`, and verify GitHub attestations
-   before allowing npm publication.
+   `checksums.txt`, and `release-manifest.json`, and verify GitHub attestations.
+   This exact stable public release is the immutable producer handoff consumed
+   by the separately owned UAP npm facade workflow.
+   A standalone public-release platform proof continues to prove the normal
+   anonymous GitHub release download without changing publication ownership.
 
 The workflow rejects every existing public release. A rerun accepts an existing
 draft only when its tag, frozen commit, draft status, complete asset set, and
@@ -81,30 +83,27 @@ Do not add a bootstrap token back to the workflow. If the package disappears
 from npm, the registry preflight must fail closed instead of attempting to
 recreate it.
 
-## Later stable publications
+## Producer cutover and historical npm audits
 
-Use the same immutable asset workflow, temporarily open the publish-ready gate,
-then dispatch the npm workflow with the exact tag. Review and approve the
-`npm-agentplugins` environment deployment. The workflow must publish through
-GitHub OIDC with provenance and must pass the exact-version registry smoke
-after an exact-version, scripts-disabled install verifies both the registry
-signature and SLSA provenance attestation. Only then may it run `add`, `info`,
-read-only `doctor`, no-change `update`, `remove`, and final absent-state
-verification in an isolated HOME.
-The public-release platform proof uses a cold cache without the local draft
-override and therefore proves the normal anonymous GitHub release download.
-The publish-ready gate must be returned to `false` immediately after the publish
-job finishes, regardless of the verification result. Registry verification
-must still prove the `latest` dist-tag resolves to the exact published version
-and that JSON output contains no absolute runner paths. It runs as a separate
-job after publication, waits up to five minutes with online metadata refreshes,
-and can be retried without attempting to republish an immutable npm version.
-The same workflow can be dispatched with `verify_only=true` and the existing
-historical tag after publication. That mode skips release identity,
-schema-v2 six-platform proof, and the protected publish job entirely; it does
-not require the tag to point to current `main` or require opening the
-publish-ready gate, and only runs public registry, provenance, and isolated
-lifecycle verification.
+For this and later cutover releases, plugin-kit-ai remains the binary producer.
+The release workflow still builds, attests, draft-proves, and promotes the same
+six assets plus `checksums.txt` and `release-manifest.json`; it does not publish
+an npm package. The npm tarball created inside the platform proof is an ephemeral
+test input only and is never a release asset or registry publication artifact.
+
+`.github/workflows/agentplugins-npm-publish.yml` is retained at its historical
+path as a read-only audit workflow. It has no npm publishing job, protected npm
+environment, OIDC write permission, token, or publish-ready gate. Its
+`verify_only` input defaults to `true`; explicitly setting it to `false` fails
+closed. Dispatch it with `verify_only=true` and an existing historical tag to
+verify the public registry version, signature, provenance, and isolated
+lifecycle. Historical audit mode does not require the tag to point to current
+`main` and does not rerun the schema-v2 six-platform release proof.
+
+The UAP facade publisher must consume an exact public tag and verify the release
+manifest version, source commit, six filenames, byte sizes, SHA-256 digests, and
+GitHub artifact attestations before publication. Publisher implementation and
+npm authority are intentionally outside this repository.
 
 Never publish an empty placeholder, reuse a tag, overwrite release assets, or
 resolve a binary through an unpinned GitHub `latest` release.

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -303,7 +303,7 @@ func TestAgentpluginsHistoricalAuditAllowsLatestToBeNewer(t *testing.T) {
 	mustContain(t, npmVerifyJob, `if [[ "${published_version}" = "${version}" ]]; then`)
 	mustContain(t, npmVerifyJob, `test "${available}" = true`)
 	mustNotContain(t, npmVerifyJob, `[[ "${latest_version}" = "${version}" ]]`)
-	mustAppearBefore(t, npmVerifyJob, `test "${available}" = true`, `latest_version="$(npm view --prefer-online "${NPM_PACKAGE}@latest" version 2/dev/null || true)"`)
+	mustAppearBefore(t, npmVerifyJob, `test "${available}" = true`, `latest_version="$(npm view --prefer-online "${NPM_PACKAGE}@latest" version 2>/dev/null || true)"`)
 }
 
 func TestAgentpluginsReadmesUseUnversionedNpxExamples(t *testing.T) {

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -17,9 +17,7 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	releaseDraftJob := yamlJob(t, releaseWorkflow, "stage-draft")
 	releaseProofJob := yamlJob(t, releaseWorkflow, "platform-proof")
 	releasePromoteJob := yamlJob(t, releaseWorkflow, "promote-release")
-	npmReleaseIdentityJob := yamlJob(t, npmWorkflow, "release-identity")
-	npmPrepublishConformanceJob := yamlJob(t, npmWorkflow, "prepublish-conformance")
-	npmPublishJob := yamlJob(t, npmWorkflow, "publish")
+	npmAuditModeJob := yamlJob(t, npmWorkflow, "audit-mode")
 	npmVerifyJob := yamlJob(t, npmWorkflow, "verify")
 	removedBoundaryScript := readRepoFile(t, root, "scripts", "check-removed-contract-boundary.sh")
 	runbook := readRepoFile(t, root, "docs", "agentplugins-release.md")
@@ -36,6 +34,15 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		mustContain(t, makefile, want)
 	}
 
+	for _, want := range []string{
+		"producer_mode:",
+		"default: binary-only",
+		"options:\n          - binary-only",
+		"PRODUCER_MODE: ${{ inputs.producer_mode }}",
+		"unsupported agentplugins producer mode",
+	} {
+		mustContain(t, releaseWorkflow, want)
+	}
 	mustContain(t, releaseWorkflow, "actions/attest@")
 	mustContain(t, releaseWorkflow, "gh release create")
 	mustAppearBefore(t, releaseWorkflow, "actions/attest@", "gh release create")
@@ -88,34 +95,36 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		mustContain(t, releaseWorkflow, name)
 	}
 
-	mustContain(t, npmReleaseIdentityJob, "if: ${{ !inputs.verify_only }}")
-	mustContain(t, npmReleaseIdentityJob, `test "${commit}" = "$(git rev-parse refs/remotes/origin/main)"`)
-	mustContain(t, npmReleaseIdentityJob, `test "${WORKFLOW_REF}" = "refs/heads/main"`)
-	mustContain(t, npmReleaseIdentityJob, "npm publish workflow source does not match the exact tagged main commit")
-	mustContain(t, npmReleaseIdentityJob, `git fetch --force origin main:refs/remotes/origin/main "refs/tags/${TAG}:refs/tags/${TAG}"`)
-	mustContain(t, npmReleaseIdentityJob, `test "${commit}" = "$(git rev-list -n 1 "refs/tags/${TAG}")"`)
-	mustContain(t, npmPrepublishConformanceJob, "needs: release-identity")
-	mustContain(t, npmPrepublishConformanceJob, "if: ${{ !inputs.verify_only }}")
-	mustContain(t, npmPrepublishConformanceJob, "allow_legacy_manifest: false")
-	mustContain(t, npmPrepublishConformanceJob, "contents: read")
 	for _, want := range []string{
-		"needs: [release-identity, prepublish-conformance]",
-		"if: ${{ !inputs.verify_only }}",
-		"environment: npm-agentplugins",
-		"id-token: write",
-		`package_name="$(node -p 'require("./npm/agentplugins/package.json").name')"`,
-		`test "$(node -p 'require("./npm/agentplugins/package.json").bin.agentplugins')" = "bin/agentplugins.js"`,
-		`npm view "${package_name}" versions --json`,
-		"grep -q 'E404'",
-		"unable to prove whether ${package_name} already exists in npm",
-		"npm publish --access public --tag latest --provenance",
-		"trusted publishing only supports existing packages",
+		"name: Agentplugins NPM Historical Audit",
+		"verify_only:",
+		"default: true",
+		"only historical verification is supported",
 	} {
-		mustContain(t, npmPublishJob, want)
+		mustContain(t, npmWorkflow, want)
 	}
 	for _, want := range []string{
-		"needs: publish",
-		"always() && !cancelled() && (inputs.verify_only || needs.publish.result == 'success')",
+		"Enforce retired publisher boundary",
+		"VERIFY_ONLY: ${{ inputs.verify_only }}",
+		"npm publication is retired in plugin-kit-ai",
+		"dispatch with verify_only=true",
+	} {
+		mustContain(t, npmAuditModeJob, want)
+	}
+	for _, unwanted := range []string{
+		"release-identity:",
+		"prepublish-conformance:",
+		"publish:",
+		"npm publish",
+		"environment: npm-agentplugins",
+		"id-token: write",
+		"NPM_AGENTPLUGINS_PUBLISH_READY",
+		"uses: ./.github/workflows/agentplugins-platform-proof.yml",
+	} {
+		mustNotContain(t, npmWorkflow, unwanted)
+	}
+	for _, want := range []string{
+		"needs: audit-mode",
 		`ref: ${{ inputs.tag }}`,
 		"Resolve immutable verification target",
 		`NPM_PACKAGE: ${{ steps.verify-target.outputs.package_name }}`,
@@ -146,7 +155,7 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		mustContain(t, npmVerifyJob, want)
 	}
 	mustContain(t, npmWorkflow, "verify_only:")
-	mustContain(t, npmWorkflow, "Verify an existing public version without publishing")
+	mustContain(t, npmWorkflow, "only historical verification is supported")
 	for _, unwanted := range []string{
 		"npm view agentplugins versions --json",
 		"npm view agentplugins version >/dev/null",
@@ -157,7 +166,6 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	} {
 		mustNotContain(t, npmWorkflow, unwanted)
 	}
-	mustNotContain(t, npmPublishJob, "Verify exact published stable lifecycle from a clean project")
 	mustNotContain(t, npmVerifyJob, "npm publish --access public --tag latest --provenance")
 	mustNotContain(t, npmVerifyJob, "environment: npm-agentplugins")
 	mustNotContain(t, npmVerifyJob, "id-token: write")
@@ -177,7 +185,7 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	for _, want := range []string{
 		"workflow_call:",
 		"allow_legacy_manifest:",
-		"Audit a schema-v1 historical release; never eligible as an npm publish gate",
+		"Audit a schema-v1 historical release; never eligible for the strict producer contract",
 		"native runtime E2E (${{ matrix.target }})",
 		"target: darwin-amd64",
 		"target: darwin-arm64",
@@ -248,11 +256,7 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	}
 	mustNotContain(t, platformWorkflow, "target_commitish")
 	mustNotContain(t, platformWorkflow, `releases/tags/${TAG}`)
-	mustContain(t, npmWorkflow, "uses: ./.github/workflows/agentplugins-platform-proof.yml")
-	mustContain(t, npmWorkflow, "test \"${{ needs.prepublish-conformance.outputs.gate_eligible }}\" = \"true\"")
 	mustContain(t, readRepoFile(t, root, "npm", "agentplugins", "scripts", "platform-proof.js"), "assertPublicJSONPathFree")
-	mustAppearBefore(t, npmWorkflow, "prepublish-conformance:", "npm publish --access public --tag latest --provenance")
-	mustContain(t, npmWorkflow, "npm publish --access public --tag latest --provenance \"${TARBALL}\"")
 	mustNotContain(t, npmWorkflow, "add context7")
 
 	mustContain(t, removedBoundaryScript, "if command -v rg")
@@ -268,18 +272,18 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		"short-lived bootstrap",
 		"disallow bypass-2FA tokens",
 		"Do not add a bootstrap token back",
-		"publish through",
-		"GitHub OIDC with provenance",
-		"`latest` dist-tag resolves to the exact published version",
-		"returned to `false` immediately after the publish",
-		"dispatched with `verify_only=true`",
-		"historical tag after publication",
-		"skips release identity",
-		"schema-v2 six-platform proof",
-		"not require the tag to point to current `main`",
-		"public registry, provenance, and isolated",
+		"required `binary-only` producer mode",
+		"six assets plus `checksums.txt` and `release-manifest.json`",
+		"test input only and is never a release asset",
+		"retained at its historical",
+		"read-only audit workflow",
+		"`verify_only` input defaults to `true`",
+		"explicitly setting it to `false` fails",
+		"does not require the tag to point to current",
+		"does not rerun the schema-v2 six-platform release proof",
+		"manifest version, source commit, six filenames, byte sizes, SHA-256 digests",
 		"same-run frozen",
-		"normal anonymous GitHub release download",
+		"anonymous GitHub release download",
 	} {
 		mustContain(t, runbook, want)
 	}

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -130,7 +130,9 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		`NPM_PACKAGE: ${{ steps.verify-target.outputs.package_name }}`,
 		`npm view --prefer-online "${NPM_PACKAGE}@${version}" version`,
 		`npm view --prefer-online "${NPM_PACKAGE}@latest" version`,
-		`[[ "${latest_version}" = "${version}" ]]`,
+		`if [[ "${published_version}" = "${version}" ]]; then`,
+		"informational: ${NPM_PACKAGE}@latest is ${latest_version}; auditing exact historical version ${version}",
+		"warning: ${NPM_PACKAGE}@latest could not be resolved; exact historical version ${version} is available",
 		"max_attempts=30",
 		`npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`,
 		"npm audit signatures --json --include-attestations",
@@ -171,10 +173,12 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	mustNotContain(t, npmVerifyJob, "id-token: write")
 	mustNotContain(t, npmVerifyJob, "platform-proof")
 	mustNotContain(t, npmVerifyJob, "--target cursor --yes")
+	mustNotContain(t, npmVerifyJob, `[[ "${latest_version}" = "${version}" ]]`)
 	mustAppearBefore(t, npmVerifyJob, "Resolve immutable verification target", `npm view --prefer-online "${NPM_PACKAGE}@${version}" version`)
 	mustAppearBefore(t, npmVerifyJob, `npm view --prefer-online "${NPM_PACKAGE}@${version}" version`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
-	mustAppearBefore(t, npmVerifyJob, `npm view --prefer-online "${NPM_PACKAGE}@latest" version`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
 	mustAppearBefore(t, npmVerifyJob, `test "${available}" = true`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
+	mustAppearBefore(t, npmVerifyJob, `test "${available}" = true`, `npm view --prefer-online "${NPM_PACKAGE}@latest" version`)
+	mustAppearBefore(t, npmVerifyJob, `npm view --prefer-online "${NPM_PACKAGE}@latest" version`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
 	mustAppearBefore(t, npmVerifyJob, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`, "npm audit signatures --json --include-attestations")
 	mustAppearBefore(t, npmVerifyJob, "npm audit signatures --json --include-attestations", "run_agentplugins version")
 	mustNotContain(t, npmVerifyJob, `.data.result.`)
@@ -287,6 +291,19 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	} {
 		mustContain(t, runbook, want)
 	}
+}
+
+func TestAgentpluginsHistoricalAuditAllowsLatestToBeNewer(t *testing.T) {
+	root := RepoRoot(t)
+	npmWorkflow := readRepoFile(t, root, ".github", "workflows", "agentplugins-npm-publish.yml")
+	npmVerifyJob := yamlJob(t, npmWorkflow, "verify")
+
+	// A historical version remains auditable after a later owner advances the
+	// latest dist-tag. Only exact package@version existence may open the gate.
+	mustContain(t, npmVerifyJob, `if [[ "${published_version}" = "${version}" ]]; then`)
+	mustContain(t, npmVerifyJob, `test "${available}" = true`)
+	mustNotContain(t, npmVerifyJob, `[[ "${latest_version}" = "${version}" ]]`)
+	mustAppearBefore(t, npmVerifyJob, `test "${available}" = true`, `latest_version="$(npm view --prefer-online "${NPM_PACKAGE}@latest" version 2/dev/null || true)"`)
 }
 
 func TestAgentpluginsReadmesUseUnversionedNpxExamples(t *testing.T) {


### PR DESCRIPTION
## Summary

- make `plugin-kit-ai` the explicit binary-only producer for `agentplugins`
- preserve six-platform assets, checksums, release manifest, attestations, draft idempotence, and native platform proofs
- retire npm publication from this repository while retaining fail-closed historical registry verification
- update release contracts and maintainer documentation for the ownership cutover

## Verification

- 33 npm tests passed
- npm package dry-run passed
- workflow YAML/static contract checks passed
- `git diff --check`

GitHub Actions remains the authoritative Go and cross-platform gate. No release, tag, npm publication, VM, or real user project was touched.
