### PR TITLE
fix(agentplugins): support directory cache persistence on Windows

### DIFF
--- a/.github/workflows/polyglot-smoke.yml
+++ b/.github/workflows/polyglot-smoke.yml
@@ -52,3 +52,5 @@ jobs:
           go test -count=1 -run 'TestPluginKitAIBundle(Fetch(URL(PythonRequirementsFlow|ClaudeNodeTypeScriptFlow)|GitHub(ClaudeNodeTypeScriptFlow|LatestClaudeNodeTypeScriptFlow))|PublishFetch(PythonRequirementsFlow|ClaudeNodeTypeScriptFlow))$' ./repotests
           go test -count=1 -run '^TestNPMCLIPackage' ./repotests
           go test -count=1 -run '^TestPythonCLIPackage' ./repotests
+          (cd install/integrationctl && go test -count=1 -run '^TestCacheAtomicPermissionsPreservationAndOfflineExpiry$' ./agentplugins/adapters/directoryv1)
+          (cd install/integrationctl && go test -count=1 -run '^TestInterruptedCacheReplacementRetainsLKG$' ./agentplugins/adapters/discoveryv1)

--- a/install/integrationctl/agentplugins/adapters/directoryv1/cache.go
+++ b/install/integrationctl/agentplugins/adapters/directoryv1/cache.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/atomicfile"
 )
 
 type Cache struct {
@@ -198,12 +200,7 @@ func (cache Cache) reconcileVerified(verified VerifiedBundle, trust TrustStore, 
 		return VerifiedBundle{}, err
 	}
 	ok = true
-	dir, err := os.Open(directory)
-	if err != nil {
-		return VerifiedBundle{}, err
-	}
-	defer dir.Close()
-	if err := dir.Sync(); err != nil {
+	if err := atomicfile.SyncDirectory(directory); err != nil {
 		return VerifiedBundle{}, err
 	}
 	verified.Source = BundleSourceCache

--- a/install/integrationctl/agentplugins/adapters/directoryv1/directoryv1_test.go
+++ b/install/integrationctl/agentplugins/adapters/directoryv1/directoryv1_test.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -538,7 +539,7 @@ func TestCacheAtomicPermissionsPreservationAndOfflineExpiry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Mode().Perm() != 0600 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0600 {
 		t.Fatalf("cache mode %o", info.Mode().Perm())
 	}
 	lowerSnapshot, lowerEnvelope, _ := signedFixture(t, 19, key, private)

--- a/install/integrationctl/agentplugins/adapters/discoveryv1/cache.go
+++ b/install/integrationctl/agentplugins/adapters/discoveryv1/cache.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/atomicfile"
 )
 
 type Cache struct {
@@ -189,12 +191,7 @@ func (cache Cache) reconcile(verified VerifiedBundle, trust TrustStore, persist 
 		return VerifiedBundle{}, err
 	}
 	ok = true
-	dir, err := os.Open(directory)
-	if err != nil {
-		return VerifiedBundle{}, err
-	}
-	defer dir.Close()
-	if err := dir.Sync(); err != nil {
+	if err := atomicfile.SyncDirectory(directory); err != nil {
 		return VerifiedBundle{}, err
 	}
 	verified.Source = BundleSourceCache


### PR DESCRIPTION
## Summary

- route Directory and Discovery cache parent sync through the existing platform-aware atomic file helper
- preserve durable directory sync on Unix and the established Windows no-op contract
- run both cache persistence regressions in the Linux and Windows polyglot lanes

## Why

The Windows release E2E reached the verified snapshot rename, then failed because `os.File.Sync` does not support directory handles there. The shared atomic file adapter already handles this portability boundary correctly.

## Verification

- `git diff --check`
- GitHub required and Windows polyglot checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache replacement reliability and durability.
  * Preserved the last known-good cache when replacements are interrupted.
  * Improved cache permission preservation and offline expiry handling.
* **Tests**
  * Added integration coverage for atomic cache updates, permissions, offline expiry, and interrupted replacements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->