### PR TITLE
fix(agentplugins): filter automatic targets by package

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,12 @@ source.
 
 ### Choose clients
 
-In an interactive terminal, `add` without `--target` detects supported clients.
-One detected client is selected automatically. With several clients, the CLI
-shows a multi-select with all detected clients selected by default; press Enter
-to keep all of them. Scripts and CI must choose explicitly, for example
+In an interactive terminal, `add` without `--target` detects installed clients,
+checks which of them the selected package can serve from one release, and skips
+incompatible clients before showing the confirmation. One compatible client is
+selected automatically. With several compatible clients, the CLI shows a
+multi-select with all of them selected by default; press Enter to keep all of
+them. Scripts and CI must choose explicitly, for example
 `--target claude,gemini,opencode`. The same comma-separated syntax works with
 `add`, `update`, `repair`, and `remove`.
 

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -27,9 +27,12 @@ func newAddCommand(app App, opts *options) *cobra.Command {
 			}
 			var detectedClients []domain.DetectedClient
 			if strings.TrimSpace(opts.target) == "" && app.Terminal {
-				selection, clients, err := promptDetectedTargets(cmd.Context(), cmd, app)
+				selection, clients, preloaded, err := promptCompatibleDetectedTargets(cmd.Context(), cmd, app, args[0])
 				if err != nil {
 					return err
+				}
+				if preloaded != nil && preloaded.cleanup != nil {
+					defer preloaded.cleanup()
 				}
 				detectedClients = clients
 				opts.target = selection
@@ -46,13 +49,18 @@ func newAddCommand(app App, opts *options) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				writeProgress(app, opts.format, "Resolving and validating Agent Plugin...")
-				loaded, err := app.loadPackageFor(cmd.Context(), args[0], withDetectedClients(app.addResolutionRequest(args[0], targets), detected))
-				if err != nil {
-					return err
-				}
-				if loaded.cleanup != nil {
-					defer loaded.cleanup()
+				var loaded loadedPackage
+				if preloaded != nil {
+					loaded = *preloaded
+				} else {
+					writeProgress(app, opts.format, "Resolving and validating Agent Plugin...")
+					loaded, err = app.loadPackageFor(cmd.Context(), args[0], withDetectedClients(app.addResolutionRequest(args[0], targets), detected))
+					if err != nil {
+						return err
+					}
+					if loaded.cleanup != nil {
+						defer loaded.cleanup()
+					}
 				}
 				return runAddManyLoaded(cmd.Context(), cmd, app, opts, loaded, targets, activationComplete, authComplete, detectedClientValues(detected))
 			}
@@ -171,23 +179,21 @@ func runAddLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *option
 	return err
 }
 
-func promptDetectedTargets(ctx context.Context, cmd *cobra.Command, app App) (string, []domain.DetectedClient, error) {
-	clients, err := app.Detector.Detect(ctx)
-	if err != nil {
-		return "", nil, fmt.Errorf("detect AI clients: %w", err)
-	}
-	var detected []domain.DetectedClient
-	for _, client := range clients {
-		if client.Status == domain.DetectionDetected && supportedTarget(client.ClientID) {
-			detected = append(detected, client)
-		}
-	}
+func promptTargetChoices(cmd *cobra.Command, detected, skipped, allClients []domain.DetectedClient) (string, []domain.DetectedClient, error) {
 	if len(detected) == 0 {
 		return "", nil, fmt.Errorf("no supported local AI client was detected; use --target chatgpt for ChatGPT, or install/detect another client")
 	}
 	sort.SliceStable(detected, func(i, j int) bool { return targetOrder(detected[i].ClientID) < targetOrder(detected[j].ClientID) })
+	sort.SliceStable(skipped, func(i, j int) bool { return targetOrder(skipped[i].ClientID) < targetOrder(skipped[j].ClientID) })
+	if len(skipped) > 0 {
+		names := make([]string, len(skipped))
+		for index, client := range skipped {
+			names[index] = client.DisplayName
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Skipped installed clients that this package cannot install together: %s\n", strings.Join(names, ", "))
+	}
 	if len(detected) == 1 {
-		return string(detected[0].ClientID), clients, nil
+		return string(detected[0].ClientID), allClients, nil
 	}
 	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Detected supported clients (all selected by default):")
 	for index, client := range detected {
@@ -204,7 +210,7 @@ func promptDetectedTargets(ctx context.Context, cmd *cobra.Command, app App) (st
 		for index, client := range detected {
 			values[index] = string(client.ClientID)
 		}
-		return strings.Join(values, ","), clients, nil
+		return strings.Join(values, ","), allClients, nil
 	}
 	seen := make(map[int]struct{})
 	var values []string
@@ -219,7 +225,7 @@ func promptDetectedTargets(ctx context.Context, cmd *cobra.Command, app App) (st
 		seen[choice] = struct{}{}
 		values = append(values, string(detected[choice-1].ClientID))
 	}
-	return strings.Join(values, ","), clients, nil
+	return strings.Join(values, ","), allClients, nil
 }
 
 // detectSelectedTargetsForLifecycleResolution keeps ambient discovery strictly

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -916,6 +916,25 @@ func TestInteractiveAddDefaultsDetectedMultiselectToAll(t *testing.T) {
 	assertClientBindings(t, fixture, domain.MaterializationMaterialized, 1)
 }
 
+func TestInteractiveAddSkipsDetectedClientThatPackageCannotServe(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, []domain.DetectedClient{
+		fixtureClient(t, domain.ClientChatGPT), fixtureClient(t, domain.ClientCursor),
+	})
+	plugin := writeCLIPlugin(t)
+	writeCLIMCP(t, plugin)
+	stdout, _, err := fixture.executeInput(true, "\n", "add", plugin, "--dry-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "Skipped installed clients that this package cannot install together: chatgpt") {
+		t.Fatalf("package-aware interactive output = %q", stdout)
+	}
+	if strings.Contains(stdout, "Detected supported clients (all selected by default)") {
+		t.Fatalf("single compatible target unexpectedly prompted for multiple clients: %q", stdout)
+	}
+}
+
 func TestInteractiveAddProbesOnlyTargetsSelectedAfterReadOnlyDetection(t *testing.T) {
 	clientCodex := fixtureClient(t, domain.ClientCodex)
 	clientCursor := fixtureClient(t, domain.ClientCursor)
@@ -925,9 +944,15 @@ func TestInteractiveAddProbesOnlyTargetsSelectedAfterReadOnlyDetection(t *testin
 	command := &cobra.Command{}
 	command.SetIn(strings.NewReader("1\n"))
 	command.SetOut(io.Discard)
-	selection, clients, err := promptDetectedTargets(context.Background(), command, fixture.app)
+	selection, clients, loaded, err := promptCompatibleDetectedTargets(context.Background(), command, fixture.app, writeCLIPlugin(t))
 	if err != nil {
 		t.Fatal(err)
+	}
+	if loaded == nil {
+		t.Fatal("direct package was not retained across interactive target selection")
+	}
+	if loaded.cleanup != nil {
+		defer loaded.cleanup()
 	}
 	targets, err := parseTargetOption(selection)
 	if err != nil {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/directory_rollout_semantics_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/directory_rollout_semantics_test.go
@@ -339,6 +339,25 @@ func TestInteractiveSharedSurfaceAddRequiresSignedPeerEligibilityBeforeAcquisiti
 	}
 }
 
+func TestInteractiveDirectoryAddOffersOnlyOneCompleteSignedTargetSet(t *testing.T) {
+	rollout := newRolloutDirectoryFixture(t,
+		[]domain.ClientID{domain.ClientCursor},
+		[]domain.ClientID{domain.ClientCursor})
+	rollout.cli.app.Detector = staticDetector{clients: []domain.DetectedClient{
+		fixtureClient(t, domain.ClientCodex), fixtureClient(t, domain.ClientCursor),
+	}}
+	stdout, _, err := rollout.cli.executeInput(true, "\n", "add", "rollout-demo", "--dry-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "Skipped installed clients that this package cannot install together: codex") {
+		t.Fatalf("package-aware Directory output = %q", stdout)
+	}
+	if rollout.acquirer.verifiedCalls != 1 {
+		t.Fatalf("Directory package acquired %d times, want exactly once after target selection", rollout.acquirer.verifiedCalls)
+	}
+}
+
 func TestDirectoryRepairRejectsRecordedTuplePackageSourceRebindBeforeAcquisition(t *testing.T) {
 	rollout := newRolloutDirectoryFixture(t, []domain.ClientID{domain.ClientCursor}, []domain.ClientID{domain.ClientCursor})
 	if _, _, err := rollout.cli.execute(false, "add", "rollout-demo", "--target", "cursor"); err != nil {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/interactive_targets.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/interactive_targets.go
@@ -1,0 +1,255 @@
+package agentpluginscli
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/discoveryv1"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	clientplanner "github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/planner"
+	"github.com/spf13/cobra"
+)
+
+// promptCompatibleDetectedTargets keeps the no-flag path convenient without
+// turning ambient client detection into an unsafe all-or-nothing guess. It
+// first narrows the installed clients to one complete target set that the
+// selected package can actually serve, then asks the user to confirm it.
+func promptCompatibleDetectedTargets(ctx context.Context, cmd *cobra.Command, app App, source string) (string, []domain.DetectedClient, *loadedPackage, error) {
+	clients, err := app.Detector.Detect(ctx)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("detect AI clients: %w", err)
+	}
+	detected := detectedSupportedClients(clients)
+	if len(detected) == 0 {
+		selection, all, err := promptTargetChoices(cmd, detected, nil, clients)
+		return selection, all, nil, err
+	}
+
+	compatible, preloaded, err := app.compatibleDetectedTargets(ctx, source, detected)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	skipped := subtractDetectedClients(detected, compatible)
+	selection, all, err := promptTargetChoices(cmd, compatible, skipped, clients)
+	if err != nil {
+		if preloaded != nil && preloaded.cleanup != nil {
+			_ = preloaded.cleanup()
+		}
+		return "", nil, nil, err
+	}
+	return selection, all, preloaded, nil
+}
+
+func detectedSupportedClients(clients []domain.DetectedClient) []domain.DetectedClient {
+	result := make([]domain.DetectedClient, 0, len(clients))
+	for _, client := range clients {
+		if client.Status == domain.DetectionDetected && supportedTarget(client.ClientID) {
+			result = append(result, client)
+		}
+	}
+	sort.SliceStable(result, func(i, j int) bool { return targetOrder(result[i].ClientID) < targetOrder(result[j].ClientID) })
+	return result
+}
+
+func subtractDetectedClients(all, selected []domain.DetectedClient) []domain.DetectedClient {
+	kept := make(map[domain.ClientID]struct{}, len(selected))
+	for _, client := range selected {
+		kept[client.ClientID] = struct{}{}
+	}
+	result := make([]domain.DetectedClient, 0, len(all)-len(selected))
+	for _, client := range all {
+		if _, ok := kept[client.ClientID]; !ok {
+			result = append(result, client)
+		}
+	}
+	return result
+}
+
+func (app App) compatibleDetectedTargets(ctx context.Context, source string, detected []domain.DetectedClient) ([]domain.DetectedClient, *loadedPackage, error) {
+	switch {
+	case strings.HasPrefix(source, "discovery:"):
+		compatible, err := app.compatibleDiscoveryTargets(ctx, source, detected)
+		return compatible, nil, err
+	case isDirectorySelector(source):
+		compatible, err := app.compatibleDirectoryTargets(ctx, source, detected)
+		return compatible, nil, err
+	default:
+		loaded, err := app.loadPackageFor(ctx, source, app.addResolutionRequest(source, nil))
+		if err != nil {
+			return nil, nil, err
+		}
+		compatible := app.compatibleLoadedTargets(ctx, loaded, detected)
+		if len(compatible) == 0 {
+			if loaded.cleanup != nil {
+				_ = loaded.cleanup()
+			}
+			return nil, nil, fmt.Errorf("the package cannot be installed in any detected supported client; use --target to inspect a specific client")
+		}
+		return compatible, &loaded, nil
+	}
+}
+
+func (app App) compatibleDiscoveryTargets(ctx context.Context, selector string, detected []domain.DetectedClient) ([]domain.DetectedClient, error) {
+	if app.DiscoveryClient == nil {
+		return nil, fmt.Errorf("signed Discovery Index dependencies are unavailable; use owner/repository@FULL_SHA[//path]")
+	}
+	bundle, err := app.DiscoveryClient.Load(ctx, 0)
+	if err != nil {
+		return nil, fmt.Errorf("load signed Discovery Index: %w", err)
+	}
+	record, err := resolveDiscoveryRecord(bundle, selector)
+	if err != nil {
+		return nil, err
+	}
+	allowed := make(map[string]struct{}, len(record.CompatibleClients))
+	for _, client := range record.CompatibleClients {
+		allowed[client] = struct{}{}
+	}
+	compatible := make([]domain.DetectedClient, 0, len(detected))
+	for _, client := range detected {
+		if _, ok := allowed[string(client.ClientID)]; ok {
+			compatible = append(compatible, client)
+		}
+	}
+	if len(compatible) == 0 {
+		return nil, fmt.Errorf("discovery package %q cannot be installed in any detected supported client; use --target to inspect a specific client", selector)
+	}
+	return compatible, nil
+}
+
+func (app App) compatibleDirectoryTargets(ctx context.Context, selector string, detected []domain.DetectedClient) ([]domain.DetectedClient, error) {
+	if app.DirectoryClient == nil || app.StateStore == nil {
+		return nil, fmt.Errorf("signed Directory dependencies are unavailable; use a direct local or exact full-SHA source")
+	}
+	state, err := app.StateStore.Load()
+	if err != nil {
+		return nil, err
+	}
+	bundle, err := app.DirectoryClient.Load(ctx, installedDirectoryFloor(state))
+	if err != nil {
+		return nil, fmt.Errorf("load signed Directory: %w", err)
+	}
+	request, err := retainDirectoryRelease(bundle.Snapshot, state, selector, app.addResolutionRequest(selector, nil))
+	if err != nil {
+		return nil, err
+	}
+	resolveSelector := selector
+	if request.Selector != "" {
+		resolveSelector = request.Selector
+	}
+	clients := detectedClientMap(detected)
+	environment := directoryEnvironment(clients)
+	environment.InstallerVersion = app.Version
+	operation := request.Operation
+	if operation == "" {
+		operation = domain.DirectoryInstall
+	}
+
+	// At most ten clients are supported, so enumerating subsets is bounded to
+	// 1,023 pure resolver calls. This preserves one signed distribution/release
+	// for the complete set instead of combining incompatible per-client picks.
+	var singleTargetErr error
+	for size := len(detected); size >= 1; size-- {
+		var match []domain.DetectedClient
+		forEachDetectedSubset(detected, size, func(candidate []domain.DetectedClient) bool {
+			targets := make([]domain.ClientID, len(candidate))
+			for index, client := range candidate {
+				targets[index] = client.ClientID
+			}
+			_, resolveErr := domain.ResolveDirectory(bundle.Snapshot, domain.DirectoryResolveRequest{
+				Selector: resolveSelector, Targets: targets, Scope: domain.ScopeUser,
+				InstallerVersion: app.Version, ClientVersions: environment.ClientVersions,
+				OS: runtime.GOOS, Architecture: runtime.GOARCH, DependencyIdentity: environment.DependencyIdentity,
+				SchemaVersion: "1.0.0", Operation: operation, Recorded: request.Recorded,
+			})
+			if size == 1 && singleTargetErr == nil && resolveErr != nil {
+				singleTargetErr = resolveErr
+			}
+			if resolveErr == nil {
+				match = append([]domain.DetectedClient(nil), candidate...)
+				return false
+			}
+			return true
+		})
+		if len(match) > 0 {
+			return match, nil
+		}
+	}
+	if singleTargetErr != nil {
+		return nil, singleTargetErr
+	}
+	return nil, fmt.Errorf("no signed Directory release for %q supports any detected client", selector)
+}
+
+func forEachDetectedSubset(values []domain.DetectedClient, size int, visit func([]domain.DetectedClient) bool) {
+	if size < 1 || size > len(values) {
+		return
+	}
+	indices := make([]int, size)
+	var walk func(int, int) bool
+	walk = func(depth, start int) bool {
+		if depth == size {
+			candidate := make([]domain.DetectedClient, size)
+			for index, valueIndex := range indices {
+				candidate[index] = values[valueIndex]
+			}
+			return visit(candidate)
+		}
+		for index := start; index <= len(values)-(size-depth); index++ {
+			indices[depth] = index
+			if !walk(depth+1, index+1) {
+				return false
+			}
+		}
+		return true
+	}
+	walk(0, 0)
+}
+
+func (app App) compatibleLoadedTargets(ctx context.Context, loaded loadedPackage, detected []domain.DetectedClient) []domain.DetectedClient {
+	clientMap := detectedClientMap(detected)
+	planner := clientplanner.Planner{ManagedRoot: app.ManagedRoot, Detected: clientMap}
+	physicalID := domain.ComputePhysicalArtifactID(loaded.envelope.Manifest.Name, "00000000-0000-4000-8000-000000000000")
+	compatible := make([]domain.DetectedClient, 0, len(detected))
+	for _, client := range detected {
+		candidate := cloneLoadedPackage(loaded)
+		if err := prepareLoadedPackageForClient(&candidate, client.ClientID); err != nil {
+			continue
+		}
+		plan, err := planner.Plan(ctx, candidate.envelope, client, domain.ScopeUser, physicalID)
+		if err == nil && plan.Status != domain.PlanUnsupported {
+			compatible = append(compatible, client)
+		}
+	}
+	return compatible
+}
+
+func detectedClientMap(clients []domain.DetectedClient) map[domain.ClientID]domain.DetectedClient {
+	result := make(map[domain.ClientID]domain.DetectedClient, len(clients))
+	for _, client := range clients {
+		result[client.ClientID] = client
+	}
+	return result
+}
+
+func resolveDiscoveryRecord(bundle discoveryv1.VerifiedBundle, selector string) (discoveryv1.Record, error) {
+	var matches []discoveryv1.Record
+	for _, record := range bundle.Search.Records {
+		if record.Slug == selector {
+			matches = append(matches, record)
+		}
+	}
+	if len(matches) == 0 {
+		return discoveryv1.Record{}, fmt.Errorf("discovery package %q was not found", selector)
+	}
+	if len(matches) != 1 {
+		return discoveryv1.Record{}, fmt.Errorf("discovery package %q is ambiguous", selector)
+	}
+	if matches[0].Availability != "available" {
+		return discoveryv1.Record{}, fmt.Errorf("discovery package %q is unavailable and cannot be newly acquired", selector)
+	}
+	return matches[0], nil
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/source.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/source.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/catalog"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/directoryv1"
-	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/discoveryv1"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/packagedigest"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 	clientplanner "github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/planner"
@@ -268,21 +267,9 @@ func (app App) acquireDiscovery(ctx context.Context, selector string, request pa
 	if err != nil {
 		return loadedPackage{}, fmt.Errorf("load signed Discovery Index: %w", err)
 	}
-	var matches []discoveryv1.Record
-	for _, record := range bundle.Search.Records {
-		if record.Slug == selector {
-			matches = append(matches, record)
-		}
-	}
-	if len(matches) != 1 {
-		if len(matches) == 0 {
-			return loadedPackage{}, fmt.Errorf("discovery package %q was not found", selector)
-		}
-		return loadedPackage{}, fmt.Errorf("discovery package %q is ambiguous", selector)
-	}
-	record := matches[0]
-	if record.Availability != "available" {
-		return loadedPackage{}, fmt.Errorf("discovery package %q is unavailable and cannot be newly acquired", selector)
+	record, err := resolveDiscoveryRecord(bundle, selector)
+	if err != nil {
+		return loadedPackage{}, err
 	}
 	for _, target := range request.Targets {
 		compatible := false


### PR DESCRIPTION
## Summary

- make interactive `add` resolve package compatibility before offering detected clients
- preserve one signed Directory distribution and release for the complete automatic target set
- filter Discovery and direct packages without mutating client state
- explain skipped installed clients and keep scripts explicit with `--target`

## Verification

- `go test ./cli/plugin-kit-ai/internal/agentpluginscli -count=1`
- `make test-required`
- `make generated-check`
- `make vet`

This fixes the default no-flag flow used by the Universal Agent Plugins site: an installed but incompatible client can no longer make the whole automatic install fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Interactive `add` now detects installed clients and selects only those compatible with the chosen package.
  - Incompatible installed clients are skipped and clearly reported.
  - Compatible clients are preselected in the confirmation prompt.
  - Packages are acquired once after target selection, improving the installation flow.

- **Bug Fixes**
  - Prevented installation attempts for clients that a package cannot support.
  - Added clearer handling for packages with no compatible installed clients.

- **Documentation**
  - Updated the “Choose clients” guidance to describe installed and compatible client selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->