### PR TITLE
fix(agentplugins): align loader with 1.0 conformance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,31 @@ jobs:
 
       - name: Run vet (all workspace modules)
         run: make vet
+
+      # The proposal discussed in agentplugins/agent-plugins-spec#81 is not a
+      # normative part of the specification. Pinning the exact revision keeps
+      # this interoperability contract reproducible until a new revision is
+      # reviewed deliberately.
+      - name: Check out pinned Agent Plugins conformance corpus
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: Booyaka101/agent-plugins-conformance-kit
+          ref: 4d163c6281a9b4929f482f387efe340b4dc175a1
+          path: .ci/agent-plugins-conformance-kit
+          persist-credentials: false
+
+      - name: Build pinned conformance corpus
+        working-directory: .ci/agent-plugins-conformance-kit
+        run: |
+          npm ci --ignore-scripts
+          npm run build
+
+      - name: Run Agent Plugins loader conformance
+        run: |
+          go build -o "$RUNNER_TEMP/agentplugins-conformance-adapter" ./cli/plugin-kit-ai/cmd/agentplugins-conformance-adapter
+          node .ci/agent-plugins-conformance-kit/dist/cli.js verify
+          node .ci/agent-plugins-conformance-kit/dist/cli.js run \
+            --adapter "$RUNNER_TEMP/agentplugins-conformance-adapter" \
+            --strict-reporting \
+            --quiet \
+            --json "$RUNNER_TEMP/agentplugins-conformance.json"

--- a/cli/plugin-kit-ai/cmd/agentplugins-conformance-adapter/main.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins-conformance-adapter/main.go
@@ -1,0 +1,104 @@
+// Command agentplugins-conformance-adapter exposes the standard loader through
+// the process protocol used by the Agent Plugins conformance corpus. It only
+// parses package files; it never installs a package or starts an MCP server.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/loader"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/specregistry"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+type namedEntry struct {
+	What   string `json:"what,omitempty"`
+	Field  string `json:"field,omitempty"`
+	RuleID string `json:"ruleId,omitempty"`
+}
+
+type loadReport struct {
+	Rejected *string `json:"rejected"`
+	Loaded   struct {
+		Skills     []string `json:"skills"`
+		MCPServers []string `json:"mcpServers"`
+	} `json:"loaded"`
+	Skipped  []namedEntry `json:"skipped"`
+	Reported []namedEntry `json:"reported"`
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	if len(args) != 1 {
+		fmt.Fprintln(stderr, "usage: agentplugins-conformance-adapter PLUGIN_DIR")
+		return 2
+	}
+	report, err := inspect(args[0])
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	if err := json.NewEncoder(stdout).Encode(report); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	return 0
+}
+
+func inspect(root string) (loadReport, error) {
+	result := emptyReport()
+	registry, err := specregistry.New()
+	if err != nil {
+		return result, fmt.Errorf("create schema registry: %w", err)
+	}
+	envelope, loadErr := (loader.Loader{Registry: registry}).Load(context.Background(), domain.LoadInput{SnapshotRoot: root})
+	if loadErr != nil {
+		reason := loadErr.Error()
+		result.Rejected = &reason
+		return result, nil
+	}
+	for name := range envelope.Skills {
+		result.Loaded.Skills = append(result.Loaded.Skills, name)
+	}
+	for name := range envelope.MCP.Servers {
+		result.Loaded.MCPServers = append(result.Loaded.MCPServers, name)
+	}
+	sort.Strings(result.Loaded.Skills)
+	sort.Strings(result.Loaded.MCPServers)
+	if envelope.Inventory.InvalidSkillsRoot {
+		result.Skipped = append(result.Skipped, namedEntry{What: "skills"})
+	}
+	for _, name := range envelope.Inventory.InvalidSkills {
+		result.Skipped = append(result.Skipped, namedEntry{What: "skills/" + name})
+	}
+	if envelope.MCP.Present && !envelope.MCP.Enabled {
+		result.Skipped = append(result.Skipped, namedEntry{What: "mcp.json"})
+	}
+	for name := range envelope.MCP.InvalidServer {
+		result.Skipped = append(result.Skipped, namedEntry{What: "mcp.json#" + name})
+	}
+	for _, diagnostic := range envelope.Diagnostics {
+		switch diagnostic.Code {
+		case "plugin_unknown_field", "plugin_extensions_ignored":
+			result.Reported = append(result.Reported, namedEntry{Field: diagnostic.Item})
+		}
+	}
+	sort.Slice(result.Skipped, func(i, j int) bool { return result.Skipped[i].What < result.Skipped[j].What })
+	sort.Slice(result.Reported, func(i, j int) bool { return result.Reported[i].Field < result.Reported[j].Field })
+	return result, nil
+}
+
+func emptyReport() loadReport {
+	result := loadReport{Skipped: []namedEntry{}, Reported: []namedEntry{}}
+	result.Loaded.Skills = []string{}
+	result.Loaded.MCPServers = []string{}
+	return result
+}

--- a/cli/plugin-kit-ai/cmd/agentplugins-conformance-adapter/main_test.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins-conformance-adapter/main_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInspectReportsIgnoredV1ExtensionsAndNeverExecutesComponents(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "plugin.json"), `{"$schema":"https://agent-plugins.org/schemas/1.0.0/plugin.schema.json","name":"fixture","unknown":true,"extensions":[]}`)
+	writeFile(t, filepath.Join(root, "mcp.json"), `{"$schema":"https://agent-plugins.org/schemas/1.0.0/mcp.schema.json","mcpServers":{"docs":{"type":"stdio","command":"definitely-not-executed"}}}`)
+
+	report, err := inspect(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Rejected != nil || len(report.Loaded.MCPServers) != 1 {
+		t.Fatalf("report = %+v", report)
+	}
+	if got := []string{report.Reported[0].Field, report.Reported[1].Field}; got[0] != "extensions" || got[1] != "unknown" {
+		t.Fatalf("reported = %+v", report.Reported)
+	}
+}
+
+func TestRunEmitsProtocolReport(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "plugin.json"), `{"$schema":"https://agent-plugins.org/schemas/1.0.0/plugin.schema.json","name":"fixture"}`)
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{root}, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
+	}
+	var report loadReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode report: %v", err)
+	}
+	if report.Rejected != nil || report.Loaded.Skills == nil || report.Skipped == nil || report.Reported == nil {
+		t.Fatalf("protocol report = %+v", report)
+	}
+}
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -2387,7 +2387,7 @@ func TestOfficialHooksFailClosedBeforeDryRunOrMutation(t *testing.T) {
 	}
 }
 
-func TestImplicitPortableHooksFailClosedBeforeDryRunOrMutation(t *testing.T) {
+func TestImplicitPortableHooksAreIgnoredAndNotStaged(t *testing.T) {
 	t.Parallel()
 	fixture := newCLIFixture(t, []domain.DetectedClient{{ClientID: domain.ClientChatGPT, DisplayName: "ChatGPT", Status: domain.DetectionNotDetected}})
 	plugin := writeCLIPlugin(t)
@@ -2397,20 +2397,29 @@ func TestImplicitPortableHooksFailClosedBeforeDryRunOrMutation(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(plugin, "hooks", "hooks.json"), []byte(`{}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := fixture.execute(false, "add", plugin, "--target", "chatgpt", "--dry-run", "--format", "json"); err == nil {
-		t.Fatal("implicit hook dry-run succeeded")
-	} else {
-		var loadErr *domain.LoadError
-		if !errors.As(err, &loadErr) || loadErr.Diagnostic.Code != "official_hooks_unsupported" || !strings.Contains(err.Error(), "remove the hooks directory") {
-			t.Fatalf("implicit hook dry-run error = %v", err)
-		}
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "chatgpt", "--dry-run", "--format", "json"); err != nil {
+		t.Fatalf("portable package with unsupported root directory failed validation: %v", err)
 	}
 	state, err := fixture.store.Load()
 	if err != nil || len(state.Installations) != 0 {
-		t.Fatalf("implicit hook dry-run mutated state: %+v, %v", state, err)
+		t.Fatalf("dry-run mutated state: %+v, %v", state, err)
 	}
 	if _, err := os.Stat(fixture.app.ManagedRoot); !os.IsNotExist(err) {
-		t.Fatalf("implicit hook dry-run mutated managed filesystem: %v", err)
+		t.Fatalf("dry-run mutated managed filesystem: %v", err)
+	}
+	if _, _, err := fixture.execute(false, "add", plugin, "--target", "chatgpt"); err != nil {
+		t.Fatalf("install portable package with ignored hooks: %v", err)
+	}
+	state, err = fixture.store.Load()
+	if err != nil || len(state.Installations) != 1 {
+		t.Fatalf("installed state = %+v, %v", state, err)
+	}
+	installed := onlyCLIClient(state.Installations[0]).TargetLocator
+	if _, err := os.Lstat(filepath.Join(installed, "hooks")); !os.IsNotExist(err) {
+		t.Fatalf("unsupported hooks survived staging: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(plugin, "hooks", "hooks.json")); err != nil {
+		t.Fatalf("source package was mutated: %v", err)
 	}
 }
 

--- a/install/integrationctl/agentplugins/adapters/loader/loader.go
+++ b/install/integrationctl/agentplugins/adapters/loader/loader.go
@@ -57,6 +57,11 @@ func (loader Loader) Load(ctx context.Context, input domain.LoadInput) (domain.P
 	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 		return domain.PackageEnvelope{}, domain.FatalLoad("snapshot_invalid", "plugin.json", "package snapshot root must be a real directory", err)
 	}
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return domain.PackageEnvelope{}, domain.FatalLoad("snapshot_invalid", "plugin.json", "resolve package snapshot root", err)
+	}
+	root = filepath.Clean(resolvedRoot)
 	manifestPath := filepath.Join(root, "plugin.json")
 	formatID := domain.FormatIDAgentPluginsV1
 	schemaVersion := "1.0.0"
@@ -66,14 +71,7 @@ func (loader Loader) Load(ctx context.Context, input domain.LoadInput) (domain.P
 	if err != nil {
 		return domain.PackageEnvelope{}, err
 	}
-	if err := rejectDiscoverableHooks(root); err != nil {
-		return domain.PackageEnvelope{}, domain.FatalLoad(
-			"official_hooks_unsupported", "hooks/hooks.json",
-			"lifecycle hooks are auto-discovered by official clients but are not modeled by agentplugins v0.1; remove the hooks directory before installation", err,
-		)
-	}
-
-	mcp, mcpDiagnostics := loader.loadMCP(mcpPath, manifest.SchemaURI, input.ExecutableFiles)
+	mcp, mcpDiagnostics := loader.loadMCP(mcpPath, manifest.SchemaURI)
 	diagnostics = append(diagnostics, mcpDiagnostics...)
 	var skills map[string]domain.Skill
 	var invalidSkills []string

--- a/install/integrationctl/agentplugins/adapters/loader/loader_test.go
+++ b/install/integrationctl/agentplugins/adapters/loader/loader_test.go
@@ -146,30 +146,32 @@ func TestLoadOfficialPackageRejectsLifecycleHooksUntilModeled(t *testing.T) {
 	}
 }
 
-func TestLoadRejectsImplicitLifecycleHooksForPortableAndOfficialPackages(t *testing.T) {
+func TestLoadRejectsImplicitLifecycleHooksForOfficialPackages(t *testing.T) {
 	t.Parallel()
-	for _, format := range []string{"portable", "official"} {
-		format := format
-		t.Run(format, func(t *testing.T) {
-			root := t.TempDir()
-			if format == "portable" {
-				writeLoaderFile(t, filepath.Join(root, "plugin.json"), `{"$schema":"https://agent-plugins.org/schemas/1.0.0/plugin.schema.json","name":"implicit-hooks","version":"1.0.0","description":"Implicit hooks"}`)
-			} else {
-				writeLoaderFile(t, filepath.Join(root, ".codex-plugin", "plugin.json"), `{"name":"implicit-hooks"}`)
-			}
-			writeLoaderFile(t, filepath.Join(root, "hooks", "hooks.json"), `{}`)
+	root := t.TempDir()
+	writeLoaderFile(t, filepath.Join(root, ".codex-plugin", "plugin.json"), `{"name":"implicit-hooks"}`)
+	writeLoaderFile(t, filepath.Join(root, "hooks", "hooks.json"), `{}`)
 
-			var err error
-			if format == "portable" {
-				_, err = testLoader(t).Load(context.Background(), domain.LoadInput{SnapshotRoot: root})
-			} else {
-				_, err = testOpenAILoader(t).Load(context.Background(), domain.LoadInput{SnapshotRoot: root})
-			}
-			var loadErr *domain.LoadError
-			if !errors.As(err, &loadErr) || loadErr.Diagnostic.Code != "official_hooks_unsupported" || !strings.Contains(err.Error(), "remove the hooks directory") {
-				t.Fatalf("implicit %s hooks error = %v", format, err)
-			}
-		})
+	_, err := testOpenAILoader(t).Load(context.Background(), domain.LoadInput{SnapshotRoot: root})
+	var loadErr *domain.LoadError
+	if !errors.As(err, &loadErr) || loadErr.Diagnostic.Code != "official_hooks_unsupported" || !strings.Contains(err.Error(), "remove the hooks directory") {
+		t.Fatalf("implicit official hooks error = %v", err)
+	}
+}
+
+func TestPortableLoaderIgnoresUnsupportedRootDirectories(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeMinimalPlugin(t, root, "portable-extra-directories")
+	writeLoaderFile(t, filepath.Join(root, "hooks", "hooks.json"), `{}`)
+	writeLoaderFile(t, filepath.Join(root, "commands", "run.md"), "not part of Agent Plugins 1.0\n")
+
+	envelope, err := testLoader(t).Load(context.Background(), domain.LoadInput{SnapshotRoot: root})
+	if err != nil {
+		t.Fatalf("portable loader interpreted unsupported root directory: %v", err)
+	}
+	if envelope.Manifest.Name != "portable-extra-directories" {
+		t.Fatalf("manifest = %+v", envelope.Manifest)
 	}
 }
 
@@ -233,22 +235,32 @@ func TestLoadFullPluginPreservesExtensionsAndUnknownFields(t *testing.T) {
 	}
 }
 
-func TestLoadRejectsInvalidKnownManifestFieldDespiteUnknownFieldTolerance(t *testing.T) {
+func TestLoadReportsAndIgnoresNonObjectExtensionsInV1(t *testing.T) {
 	t.Parallel()
-	for name, extensions := range map[string]string{
-		"non-object extensions":      `"invalid"`,
-		"non-object extension value": `{"com.example.invalid":"opaque"}`,
-	} {
+	for name, extensions := range map[string]string{"string": `"invalid"`, "array": `[]`} {
 		name, extensions := name, extensions
 		t.Run(name, func(t *testing.T) {
 			root := t.TempDir()
 			writeLoaderFile(t, filepath.Join(root, "plugin.json"), `{"$schema":"https://agent-plugins.org/schemas/1.0.0/plugin.schema.json","name":"invalid-extension","futureField":true,"extensions":`+extensions+`}`)
-			_, err := testLoader(t).Load(context.Background(), domain.LoadInput{SnapshotRoot: root})
-			var loadErr *domain.LoadError
-			if !errors.As(err, &loadErr) || loadErr.Diagnostic.Code != "plugin_schema_invalid" {
-				t.Fatalf("known-field violation error = %v", err)
+			envelope, err := testLoader(t).Load(context.Background(), domain.LoadInput{SnapshotRoot: root})
+			if err != nil {
+				t.Fatalf("Agent Plugins 1.0 requires report-and-ignore: %v", err)
+			}
+			if len(envelope.Manifest.Extensions) != 0 || len(envelope.Manifest.RawExtensions) != 0 || !hasDiagnostic(envelope.Diagnostics, "plugin_extensions_ignored") {
+				t.Fatalf("extensions were not reported and ignored: manifest=%+v diagnostics=%+v", envelope.Manifest, envelope.Diagnostics)
 			}
 		})
+	}
+}
+
+func TestLoadRejectsNonObjectExtensionMember(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeLoaderFile(t, filepath.Join(root, "plugin.json"), `{"$schema":"https://agent-plugins.org/schemas/1.0.0/plugin.schema.json","name":"invalid-extension","extensions":{"com.example.invalid":"opaque"}}`)
+	_, err := testLoader(t).Load(context.Background(), domain.LoadInput{SnapshotRoot: root})
+	var loadErr *domain.LoadError
+	if !errors.As(err, &loadErr) || loadErr.Diagnostic.Code != "plugin_schema_invalid" {
+		t.Fatalf("known-field violation error = %v", err)
 	}
 }
 
@@ -357,15 +369,9 @@ func TestStdioRejectsInvalidReservedContractAndExecutableRequirements(t *testing
 		prepare     func(*testing.T, string)
 		executables []string
 	}{
-		"placeholder path in command":  {server: `{"type":"stdio","command":"${PLUGIN_ROOT}/bin/server"}`},
-		"unknown reserved placeholder": {server: `{"type":"stdio","command":"node","args":["${PLUGIN_CACHE}"]}`},
-		"reserved root environment":    {server: `{"type":"stdio","command":"node","env":{"PLUGIN_ROOT":"override"}}`},
-		"reserved data environment":    {server: `{"type":"stdio","command":"node","env":{"PLUGIN_DATA":"override"}}`},
-		"missing bundled command":      {server: `{"type":"stdio","command":"./bin/server"}`, executables: []string{"bin/server"}},
-		"non-executable bundled command": {
-			server:  `{"type":"stdio","command":"./bin/server"}`,
-			prepare: func(t *testing.T, root string) { writeLoaderFile(t, filepath.Join(root, "bin", "server"), "fixture") },
-		},
+		"placeholder path in command": {server: `{"type":"stdio","command":"${PLUGIN_ROOT}/bin/server"}`},
+		"reserved root environment":   {server: `{"type":"stdio","command":"node","env":{"PLUGIN_ROOT":"override"}}`},
+		"reserved data environment":   {server: `{"type":"stdio","command":"node","env":{"PLUGIN_DATA":"override"}}`},
 	}
 	for name, test := range tests {
 		name, test := name, test
@@ -387,6 +393,104 @@ func TestStdioRejectsInvalidReservedContractAndExecutableRequirements(t *testing
 	}
 }
 
+func TestStdioLoaderPreservesUnknownPlaceholderAndDefersExecutableMode(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeMinimalPlugin(t, root, "deferred-stdio-policy")
+	writeLoaderFile(t, filepath.Join(root, "bin", "server"), "fixture")
+	writeLoaderFile(t, filepath.Join(root, "mcp.json"), `{"$schema":"https://agent-plugins.org/schemas/1.0.0/mcp.schema.json","mcpServers":{"local":{"type":"stdio","command":"./bin/server","args":["${PLUGIN_CACHE}"],"cwd":"./${PLUGIN_CACHE}"},"missing":{"type":"stdio","command":"./bin/missing"}}}`)
+	envelope, err := testLoader(t).Load(context.Background(), domain.LoadInput{SnapshotRoot: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, ok := envelope.MCP.Servers["local"]
+	if !ok || server.StdioRequirement == nil || server.StdioRequirement.Kind != domain.ExecutableBundled {
+		t.Fatalf("standard-valid server was rejected before runtime preflight: %+v", envelope.MCP)
+	}
+	args := server.Decoded["args"].([]any)
+	if args[0] != "${PLUGIN_CACHE}" {
+		t.Fatalf("unknown placeholder was not preserved literally: %+v", args)
+	}
+	if cwd := server.Decoded["cwd"]; cwd != "./${PLUGIN_CACHE}" {
+		t.Fatalf("unknown cwd placeholder was not preserved literally: %v", cwd)
+	}
+	if missing := envelope.MCP.Servers["missing"].StdioRequirement; missing == nil || missing.Kind != domain.ExecutableBundled || missing.BundledRelativePath != "bin/missing" {
+		t.Fatalf("missing bundled command was treated as a load-time configuration failure: %+v", envelope.MCP)
+	}
+}
+
+func TestRemoteServerSemanticValidation(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		server string
+		valid  bool
+	}{
+		"https":                   {server: `{"type":"streamable-http","url":"https://example.com/mcp"}`, valid: true},
+		"uppercase https":         {server: `{"type":"streamable-http","url":"HTTPS://example.com/mcp"}`, valid: true},
+		"loopback http":           {server: `{"type":"sse","url":"http://127.0.0.1:8080/sse"}`, valid: true},
+		"localhost http":          {server: `{"type":"streamable-http","url":"http://localhost:8080/mcp"}`, valid: true},
+		"relative":                {server: `{"type":"streamable-http","url":"/mcp"}`},
+		"non-http":                {server: `{"type":"streamable-http","url":"ftp://example.com/mcp"}`},
+		"remote cleartext":        {server: `{"type":"streamable-http","url":"http://example.com/mcp"}`},
+		"userinfo":                {server: `{"type":"streamable-http","url":"https://user@example.com/mcp"}`},
+		"fragment":                {server: `{"type":"streamable-http","url":"https://example.com/mcp#fragment"}`},
+		"empty fragment":          {server: `{"type":"streamable-http","url":"https://example.com/mcp#"}`},
+		"duplicate header casing": {server: `{"type":"streamable-http","url":"https://example.com/mcp","headers":{"Authorization":"a","authorization":"b"}}`},
+		"invalid header name":     {server: `{"type":"streamable-http","url":"https://example.com/mcp","headers":{"Bad Header":"x"}}`},
+		"invalid header value":    {server: "{\"type\":\"streamable-http\",\"url\":\"https://example.com/mcp\",\"headers\":{\"X-Test\":\"bad\\u000a\"}}"},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			writeMinimalPlugin(t, root, "remote-validation")
+			writeLoaderFile(t, filepath.Join(root, "mcp.json"), `{"$schema":"https://agent-plugins.org/schemas/1.0.0/mcp.schema.json","mcpServers":{"server":`+test.server+`}}`)
+			envelope, err := testLoader(t).Load(context.Background(), domain.LoadInput{SnapshotRoot: root})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, loaded := envelope.MCP.Servers["server"]
+			if loaded != test.valid {
+				t.Fatalf("loaded = %t, want %t; invalid=%+v", loaded, test.valid, envelope.MCP.InvalidServer)
+			}
+		})
+	}
+}
+
+func TestLoaderCanonicalizesFilesystemResolvedRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("root symlink aliases are platform-specific")
+	}
+	realRoot := t.TempDir()
+	writeMinimalPlugin(t, realRoot, "canonical-root")
+	writeLoaderFile(t, filepath.Join(realRoot, "bin", "server"), "fixture")
+	writeLoaderFile(t, filepath.Join(realRoot, "mcp.json"), `{"$schema":"https://agent-plugins.org/schemas/1.0.0/mcp.schema.json","mcpServers":{"server":{"type":"stdio","command":"./bin/server"}}}`)
+	aliasParent := t.TempDir()
+	alias := filepath.Join(aliasParent, "snapshot")
+	if err := os.Symlink(realRoot, alias); err != nil {
+		t.Fatal(err)
+	}
+	// The acquired root itself must stay a real directory, so exercise the same
+	// filesystem alias macOS exposes as /var -> /private/var through its parent.
+	rootViaAlias := filepath.Join(alias, ".")
+	_, err := testLoader(t).Load(context.Background(), domain.LoadInput{SnapshotRoot: rootViaAlias})
+	if err == nil {
+		t.Fatal("snapshot root symlink should remain rejected")
+	}
+	canonicalRoot := realRoot
+	envelope, err := testLoader(t).Load(context.Background(), domain.LoadInput{SnapshotRoot: canonicalRoot})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := filepath.EvalSymlinks(canonicalRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if envelope.SnapshotRoot != filepath.Clean(resolved) {
+		t.Fatalf("snapshot root = %q, want canonical %q", envelope.SnapshotRoot, filepath.Clean(resolved))
+	}
+}
+
 func TestStdioBundledCommandAllowsContainedInternalSymlink(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink fixture requires an unprivileged symlink platform")
@@ -405,6 +509,50 @@ func TestStdioBundledCommandAllowsContainedInternalSymlink(t *testing.T) {
 	requirement := envelope.MCP.Servers["linked"].StdioRequirement
 	if requirement == nil || requirement.Kind != domain.ExecutableBundled || requirement.BundledRelativePath != "bin/server-link" {
 		t.Fatalf("internal symlink command requirement = %+v diagnostics=%+v", requirement, envelope.Diagnostics)
+	}
+}
+
+func TestStdioBundledCommandRejectsExternalSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink fixture requires an unprivileged symlink platform")
+	}
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "server")
+	writeMinimalPlugin(t, root, "external-symlink-stdio")
+	writeLoaderFile(t, outside, "fixture")
+	if err := os.MkdirAll(filepath.Join(root, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "bin", "server")); err != nil {
+		t.Fatal(err)
+	}
+	writeLoaderFile(t, filepath.Join(root, "mcp.json"), `{"$schema":"https://agent-plugins.org/schemas/1.0.0/mcp.schema.json","mcpServers":{"linked":{"type":"stdio","command":"./bin/server"}}}`)
+	envelope, err := testLoader(t).Load(context.Background(), domain.LoadInput{SnapshotRoot: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := envelope.MCP.Servers["linked"]; exists || envelope.MCP.InvalidServer["linked"].Code != "mcp_server_invalid" {
+		t.Fatalf("external symlink command was accepted: %+v", envelope.MCP)
+	}
+}
+
+func TestStdioMissingBundledCommandRejectsExternalSymlinkAncestor(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink fixture requires an unprivileged symlink platform")
+	}
+	root := t.TempDir()
+	outside := t.TempDir()
+	writeMinimalPlugin(t, root, "external-symlink-ancestor-stdio")
+	if err := os.Symlink(outside, filepath.Join(root, "bin")); err != nil {
+		t.Fatal(err)
+	}
+	writeLoaderFile(t, filepath.Join(root, "mcp.json"), `{"$schema":"https://agent-plugins.org/schemas/1.0.0/mcp.schema.json","mcpServers":{"linked":{"type":"stdio","command":"./bin/missing"}}}`)
+	envelope, err := testLoader(t).Load(context.Background(), domain.LoadInput{SnapshotRoot: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := envelope.MCP.Servers["linked"]; exists || envelope.MCP.InvalidServer["linked"].Code != "mcp_server_invalid" {
+		t.Fatalf("missing command below an external symlink ancestor was accepted: %+v", envelope.MCP)
 	}
 }
 

--- a/install/integrationctl/agentplugins/adapters/loader/mcp.go
+++ b/install/integrationctl/agentplugins/adapters/loader/mcp.go
@@ -3,6 +3,8 @@ package loader
 import (
 	"encoding/json"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -13,7 +15,7 @@ import (
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 )
 
-func (loader Loader) loadMCP(filename, pluginSchema string, executableFiles []string) (domain.MCPComponent, []domain.Diagnostic) {
+func (loader Loader) loadMCP(filename, pluginSchema string) (domain.MCPComponent, []domain.Diagnostic) {
 	body, exists, err := readRegularFile(filename)
 	if !exists {
 		return domain.MCPComponent{}, nil
@@ -83,8 +85,11 @@ func (loader Loader) loadMCP(filename, pluginSchema string, executableFiles []st
 		var requirement *domain.StdioRequirement
 		if decodeErr == nil {
 			typeName, _ := decodedServer["type"].(string)
-			if typeName == "stdio" {
-				requirement, decodeErr = validateStdioServer(filepath.Dir(filename), decodedServer, executableFiles)
+			switch typeName {
+			case "stdio":
+				requirement, decodeErr = validateStdioServer(filepath.Dir(filename), decodedServer)
+			case "streamable-http", "sse":
+				decodeErr = validateRemoteServer(decodedServer)
 			}
 		}
 		if decodeErr != nil {
@@ -125,7 +130,7 @@ func schemaVersion(uri string) string {
 	return ""
 }
 
-func validateStdioServer(root string, config map[string]any, executableFiles []string) (*domain.StdioRequirement, error) {
+func validateStdioServer(root string, config map[string]any) (*domain.StdioRequirement, error) {
 	command, _ := config["command"].(string)
 	if command == "" {
 		return nil, fmt.Errorf("stdio command must be a non-empty executable token")
@@ -137,32 +142,8 @@ func validateStdioServer(root string, config map[string]any, executableFiles []s
 			return nil, err
 		}
 		candidate := filepath.Join(root, filepath.FromSlash(relative))
-		resolved, err := filepath.EvalSymlinks(candidate)
-		if err != nil {
-			return nil, fmt.Errorf("resolve bundled stdio command %q: %w", command, err)
-		}
-		contained, err := filepath.Rel(root, resolved)
-		if err != nil || contained == ".." || filepath.IsAbs(contained) || strings.HasPrefix(contained, ".."+string(filepath.Separator)) {
-			return nil, fmt.Errorf("bundled stdio command %q resolves outside the plugin root", command)
-		}
-		info, err := os.Stat(resolved)
-		if err != nil || !info.Mode().IsRegular() {
-			return nil, fmt.Errorf("bundled stdio command %q must name a regular file in the plugin root", command)
-		}
-		resolvedRelative, err := filepath.Rel(root, resolved)
-		if err != nil {
-			return nil, fmt.Errorf("resolve bundled stdio command %q relative to the plugin root: %w", command, err)
-		}
-		resolvedRelative = filepath.ToSlash(resolvedRelative)
-		executable := false
-		for _, item := range executableFiles {
-			if item == relative || item == resolvedRelative {
-				executable = true
-				break
-			}
-		}
-		if !executable {
-			return nil, fmt.Errorf("bundled stdio command %q is not marked executable", command)
+		if err := validateExistingCommandAncestor(root, candidate, command); err != nil {
+			return nil, err
 		}
 		requirement.Kind, requirement.BundledRelativePath = domain.ExecutableBundled, relative
 	}
@@ -194,9 +175,6 @@ func validateStdioServer(root string, config map[string]any, executableFiles []s
 		values = append(values, cwd)
 	}
 	for _, value := range values {
-		if err := validateReservedPlaceholders(value); err != nil {
-			return nil, err
-		}
 		if strings.Contains(value, "${PLUGIN_ROOT}") {
 			requirement.UsesPluginRoot = true
 		}
@@ -205,6 +183,96 @@ func validateStdioServer(root string, config map[string]any, executableFiles []s
 		}
 	}
 	return requirement, nil
+}
+
+func validateExistingCommandAncestor(root, candidate, command string) error {
+	current := candidate
+	for {
+		if _, err := os.Lstat(current); err == nil {
+			resolved, resolveErr := filepath.EvalSymlinks(current)
+			if resolveErr != nil {
+				return fmt.Errorf("resolve bundled stdio command %q: %w", command, resolveErr)
+			}
+			contained, relativeErr := filepath.Rel(root, resolved)
+			if relativeErr != nil || contained == ".." || filepath.IsAbs(contained) || strings.HasPrefix(contained, ".."+string(filepath.Separator)) {
+				return fmt.Errorf("bundled stdio command %q resolves outside the plugin root", command)
+			}
+			return nil
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("inspect bundled stdio command %q: %w", command, err)
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			return fmt.Errorf("bundled stdio command %q has no resolvable plugin-root ancestor", command)
+		}
+		current = parent
+	}
+}
+
+func validateRemoteServer(config map[string]any) error {
+	rawURL, _ := config["url"].(string)
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.Opaque != "" {
+		return fmt.Errorf("remote MCP URL must be an absolute HTTP or HTTPS URL")
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("remote MCP URL must use HTTP or HTTPS")
+	}
+	if parsed.User != nil || strings.Contains(rawURL, "#") {
+		return fmt.Errorf("remote MCP URL must not contain user information or a fragment")
+	}
+	host := parsed.Hostname()
+	if host == "" {
+		return fmt.Errorf("remote MCP URL requires a host")
+	}
+	if scheme == "http" && !strings.EqualFold(host, "localhost") {
+		address := net.ParseIP(host)
+		if address == nil || !address.IsLoopback() {
+			return fmt.Errorf("non-loopback remote MCP URLs must use HTTPS")
+		}
+	}
+	headers, _ := config["headers"].(map[string]any)
+	seen := make(map[string]struct{}, len(headers))
+	for name, rawValue := range headers {
+		value, _ := rawValue.(string)
+		if !validHTTPHeaderName(name) || !validHTTPHeaderValue(value) {
+			return fmt.Errorf("remote MCP header %q is not a valid HTTP field", name)
+		}
+		folded := strings.ToLower(name)
+		if _, duplicate := seen[folded]; duplicate {
+			return fmt.Errorf("remote MCP header %q is duplicated with different casing", name)
+		}
+		seen[folded] = struct{}{}
+	}
+	return nil
+}
+
+func validHTTPHeaderName(value string) bool {
+	if value == "" {
+		return false
+	}
+	for index := 0; index < len(value); index++ {
+		character := value[index]
+		if !((character >= 'a' && character <= 'z') ||
+			(character >= 'A' && character <= 'Z') ||
+			(character >= '0' && character <= '9') ||
+			strings.ContainsRune("!#$%&'*+-.^_`|~", rune(character))) {
+			return false
+		}
+	}
+	return true
+}
+
+func validHTTPHeaderValue(value string) bool {
+	for index := 0; index < len(value); index++ {
+		character := value[index]
+		if (character < 0x20 && character != '\t') || character == 0x7f {
+			return false
+		}
+	}
+	return true
 }
 
 func bundledCommandPath(command string) (string, error) {
@@ -237,7 +305,7 @@ func validateCWD(value string) error {
 	default:
 		return fmt.Errorf("stdio cwd must be ./-, PLUGIN_ROOT-, or PLUGIN_DATA-rooted")
 	}
-	if suffix == "" || path.IsAbs(suffix) || strings.Contains(suffix, `\\`) || strings.Contains(suffix, "${PLUGIN_") || path.Clean(suffix) != suffix || strings.HasPrefix(suffix, "../") {
+	if suffix == "" || path.IsAbs(suffix) || strings.Contains(suffix, `\\`) || path.Clean(suffix) != suffix || strings.HasPrefix(suffix, "../") {
 		return fmt.Errorf("stdio cwd escapes its declared root")
 	}
 	for _, segment := range strings.Split(suffix, "/") {
@@ -246,25 +314,6 @@ func validateCWD(value string) error {
 		}
 	}
 	return nil
-}
-
-func validateReservedPlaceholders(value string) error {
-	for offset := 0; ; {
-		index := strings.Index(value[offset:], "${PLUGIN_")
-		if index < 0 {
-			return nil
-		}
-		index += offset
-		end := strings.IndexByte(value[index:], '}')
-		if end < 0 {
-			return fmt.Errorf("unterminated reserved PLUGIN placeholder")
-		}
-		placeholder := value[index : index+end+1]
-		if placeholder != "${PLUGIN_ROOT}" && placeholder != "${PLUGIN_DATA}" {
-			return fmt.Errorf("unsupported reserved placeholder %q", placeholder)
-		}
-		offset = index + end + 1
-	}
 }
 
 func (loader Loader) loadOpenAIMCP(path string, declared bool) (domain.MCPComponent, []domain.Diagnostic) {

--- a/install/integrationctl/agentplugins/adapters/loader/plugin.go
+++ b/install/integrationctl/agentplugins/adapters/loader/plugin.go
@@ -63,20 +63,29 @@ func (loader Loader) loadPluginManifest(path string) (domain.PluginManifest, []d
 	extensions := map[string]json.RawMessage{}
 	var rawExtensions json.RawMessage
 	if raw, exists := rawFields["extensions"]; exists {
-		rawExtensions = append(json.RawMessage(nil), raw...)
 		var extensionFields map[string]json.RawMessage
 		if err := json.Unmarshal(raw, &extensionFields); err != nil || extensionFields == nil {
-			return domain.PluginManifest{}, diagnostics, "", domain.FatalLoad("plugin_schema_invalid", "plugin.json", "plugin.json extensions must be an object", err)
-		}
-		for namespace, extensionRaw := range extensionFields {
-			var extensionValue any
-			if err := decodeJSON(extensionRaw, &extensionValue); err != nil {
-				return domain.PluginManifest{}, diagnostics, "", domain.FatalLoad("plugin_schema_invalid", "plugin.json", fmt.Sprintf("plugin extension %q is malformed", namespace), err)
+			delete(validationDocument, "extensions")
+			diagnostics = append(diagnostics, domain.Diagnostic{
+				Severity: domain.SeverityWarning,
+				Boundary: domain.BoundaryPlugin,
+				Code:     "plugin_extensions_ignored",
+				Path:     "plugin.json",
+				Item:     "extensions",
+				Message:  "plugin.json extensions was reported and ignored because it is not an object",
+			})
+		} else {
+			rawExtensions = append(json.RawMessage(nil), raw...)
+			for namespace, extensionRaw := range extensionFields {
+				var extensionValue any
+				if err := decodeJSON(extensionRaw, &extensionValue); err != nil {
+					return domain.PluginManifest{}, diagnostics, "", domain.FatalLoad("plugin_schema_invalid", "plugin.json", fmt.Sprintf("plugin extension %q is malformed", namespace), err)
+				}
+				if _, object := extensionValue.(map[string]any); !object {
+					return domain.PluginManifest{}, diagnostics, "", domain.FatalLoad("plugin_schema_invalid", "plugin.json", fmt.Sprintf("plugin extension %q must be an object", namespace), nil)
+				}
+				extensions[namespace] = append(json.RawMessage(nil), extensionRaw...)
 			}
-			if _, object := extensionValue.(map[string]any); !object {
-				return domain.PluginManifest{}, diagnostics, "", domain.FatalLoad("plugin_schema_invalid", "plugin.json", fmt.Sprintf("plugin extension %q must be an object", namespace), nil)
-			}
-			extensions[namespace] = append(json.RawMessage(nil), extensionRaw...)
 		}
 	}
 	if err := loader.Registry.Validate(schemaURI, validationDocument); err != nil {

--- a/install/integrationctl/agentplugins/adapters/loader/skills.go
+++ b/install/integrationctl/agentplugins/adapters/loader/skills.go
@@ -38,15 +38,44 @@ func loadSkills(root string) (map[string]domain.Skill, []string, bool, []domain.
 	var invalid []string
 	var diagnostics []domain.Diagnostic
 	for _, entry := range entries {
+		if entry.Type()&os.ModeSymlink != 0 {
+			candidate := filepath.Join(root, entry.Name())
+			resolved, resolveErr := filepath.EvalSymlinks(candidate)
+			if resolveErr != nil || !pathContained(filepath.Dir(root), resolved) {
+				invalid = append(invalid, entry.Name())
+				diagnostics = append(diagnostics, skillDiagnostic("skill_path_unsafe", entry.Name(), "skill entry resolves outside the plugin root", resolveErr))
+			}
+			continue
+		}
 		if !entry.IsDir() {
 			continue
 		}
 		name := entry.Name()
 		skillPath := filepath.Join(root, name, "SKILL.md")
-		body, exists, readErr := readRegularFile(skillPath)
-		if readErr != nil || !exists {
+		skillInfo, statErr := os.Lstat(skillPath)
+		if os.IsNotExist(statErr) {
+			continue
+		}
+		if statErr != nil {
 			invalid = append(invalid, name)
-			diagnostics = append(diagnostics, skillDiagnostic("skill_missing", name, "skill directory requires an immediate SKILL.md", readErr))
+			diagnostics = append(diagnostics, skillDiagnostic("skill_read_failed", name, "inspect immediate SKILL.md", statErr))
+			continue
+		}
+		if skillInfo.Mode()&os.ModeSymlink != 0 {
+			resolved, resolveErr := filepath.EvalSymlinks(skillPath)
+			if resolveErr != nil || !pathContained(filepath.Dir(root), resolved) {
+				invalid = append(invalid, name)
+				diagnostics = append(diagnostics, skillDiagnostic("skill_path_unsafe", name, "SKILL.md resolves outside the plugin root", resolveErr))
+			}
+			continue
+		}
+		if !skillInfo.Mode().IsRegular() {
+			continue
+		}
+		body, readErr := os.ReadFile(skillPath)
+		if readErr != nil {
+			invalid = append(invalid, name)
+			diagnostics = append(diagnostics, skillDiagnostic("skill_read_failed", name, "read immediate SKILL.md", readErr))
 			continue
 		}
 		skill, parseErr := parseSkill(name, body)
@@ -59,6 +88,14 @@ func loadSkills(root string) (map[string]domain.Skill, []string, bool, []domain.
 	}
 	sort.Strings(invalid)
 	return skills, invalid, false, diagnostics
+}
+
+func pathContained(root, candidate string) bool {
+	if root == "" || candidate == "" {
+		return false
+	}
+	relative, err := filepath.Rel(root, candidate)
+	return err == nil && relative != ".." && !filepath.IsAbs(relative) && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
 }
 
 func parseSkill(directoryName string, body []byte) (domain.Skill, error) {

--- a/install/integrationctl/agentplugins/providers/gemini_native.go
+++ b/install/integrationctl/agentplugins/providers/gemini_native.go
@@ -486,9 +486,6 @@ func geminiNativeServer(server domain.MCPServer) (nativeconfig.Server, error) {
 		if err != nil {
 			return result, err
 		}
-		if strings.HasPrefix(result.Command, "./") {
-			result.Command = "${PLUGIN_ROOT}/" + strings.TrimPrefix(result.Command, "./")
-		}
 		result.CWD, err = getString("cwd")
 		if err != nil {
 			return result, err
@@ -562,12 +559,9 @@ func materializeGeminiServer(server nativeconfig.Server, packageRoot, dataRoot s
 	if server.Type != "stdio" {
 		return server, nil
 	}
-	resolve := func(value string) string {
-		value = strings.ReplaceAll(value, "${PLUGIN_ROOT}", packageRoot)
-		return strings.ReplaceAll(value, "${PLUGIN_DATA}", dataRoot)
-	}
-	if strings.Contains(server.Command, "${PLUGIN_ROOT}") {
-		server.Command = filepath.Clean(resolve(server.Command))
+	resolve := strings.NewReplacer("${PLUGIN_ROOT}", packageRoot, "${PLUGIN_DATA}", dataRoot).Replace
+	if strings.HasPrefix(server.Command, "./") {
+		server.Command = filepath.Clean(filepath.Join(packageRoot, filepath.FromSlash(strings.TrimPrefix(server.Command, "./"))))
 		if !pathContainedBy(packageRoot, server.Command) {
 			return server, fmt.Errorf("stdio command escapes PLUGIN_ROOT")
 		}

--- a/install/integrationctl/agentplugins/providers/gemini_native_test.go
+++ b/install/integrationctl/agentplugins/providers/gemini_native_test.go
@@ -177,13 +177,26 @@ func TestGeminiNativeLifecycleRejectsCollisionsAndUserChanges(t *testing.T) {
 
 func TestGeminiTransportProjection(t *testing.T) {
 	t.Parallel()
-	stdio, err := geminiNativeServer(domain.MCPServer{Name: "local", Type: "stdio", Decoded: map[string]any{"type": "stdio", "command": "node", "args": []any{"${PLUGIN_ROOT}/server.js"}, "env": map[string]any{"DATA": "${PLUGIN_DATA}"}, "cwd": "./workspace"}})
-	if err != nil || stdio.CWD != "${PLUGIN_ROOT}/workspace" {
+	stdio, err := geminiNativeServer(domain.MCPServer{Name: "local", Type: "stdio", Decoded: map[string]any{"type": "stdio", "command": "${PLUGIN_ROOT}", "args": []any{"${PLUGIN_ROOT}/server.js", "${PLUGIN_CACHE}"}, "env": map[string]any{"DATA": "${PLUGIN_DATA}", "UNKNOWN": "${HOME}"}, "cwd": "./${PLUGIN_CACHE}"}})
+	if err != nil || stdio.CWD != "${PLUGIN_ROOT}/${PLUGIN_CACHE}" {
 		t.Fatalf("stdio projection = %+v, %v", stdio, err)
 	}
+	packageRoot := filepath.Join(t.TempDir(), "plugin", "${PLUGIN_DATA}")
+	dataRoot := filepath.Join(t.TempDir(), "data")
+	stdio, err = materializeGeminiServer(stdio, packageRoot, dataRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stdio.Command != "${PLUGIN_ROOT}" || stdio.CWD != filepath.Join(packageRoot, "${PLUGIN_CACHE}") {
+		t.Fatalf("Gemini command/cwd projection = %+v", stdio)
+	}
+	if strings.Contains(stdio.CWD, dataRoot) {
+		t.Fatalf("Gemini recursively expanded replacement text: %+v", stdio)
+	}
 	for _, transport := range []string{"streamable-http", "sse"} {
-		server, err := geminiNativeServer(domain.MCPServer{Name: "remote", Type: transport, Decoded: map[string]any{"type": transport, "url": "https://example.test"}})
-		if err != nil || server.Type != "remote" || server.RemoteTransport != transport {
+		server, err := geminiNativeServer(domain.MCPServer{Name: "remote", Type: transport, Decoded: map[string]any{"type": transport, "url": "https://example.test/${PLUGIN_ROOT}", "headers": map[string]any{"X-Path": "${PLUGIN_DATA}"}}})
+		server, materializeErr := materializeGeminiServer(server, packageRoot, dataRoot)
+		if err != nil || materializeErr != nil || server.Type != "remote" || server.RemoteTransport != transport || server.URL != "https://example.test/${PLUGIN_ROOT}" || server.Headers["X-Path"] != "${PLUGIN_DATA}" {
 			t.Fatalf("%s projection = %+v, %v", transport, server, err)
 		}
 	}

--- a/install/integrationctl/agentplugins/providers/nativeconfig/kernel_test.go
+++ b/install/integrationctl/agentplugins/providers/nativeconfig/kernel_test.go
@@ -23,7 +23,7 @@ func TestMCPServersAddPreservesUnrelatedConfigAndResolvesExplicitPaths(t *testin
 		Codec:        CodecMCPServers,
 		Action:       ActionAdd,
 		Name:         "owned",
-		Server:       Server{Type: "stdio", Command: "node", Args: []string{"${PLUGIN_ROOT}/server.js", "--data=${PLUGIN_DATA}"}, Env: map[string]string{"ROOT": "${package.root}"}},
+		Server:       Server{Type: "stdio", Command: "node", Args: []string{"${PLUGIN_ROOT}/server.js", "--data=${PLUGIN_DATA}"}, Env: map[string]string{"ROOT": "${PLUGIN_ROOT}"}},
 		Placeholders: Placeholders{PackageRoot: "/explicit/pkg", DataRoot: "/explicit/data"},
 	})
 	if err != nil {
@@ -326,7 +326,6 @@ func TestPlaceholdersAndSchemaValidationFailBeforeWrite(t *testing.T) {
 	before := mustRead(t, path)
 	cases := []Server{
 		{Type: "stdio", Command: "node", Args: []string{"${PLUGIN_ROOT}/run.js"}},
-		{Type: "stdio", Command: "node", Args: []string{"${HOME}/run.js"}},
 		{Type: "stdio", Command: "node", Headers: map[string]string{"X": "ignored"}},
 		{Type: "remote", URL: "https://mcp.test", Command: "node"},
 		{Type: "stdio", Command: "", URL: "https://mcp.test"},
@@ -337,6 +336,57 @@ func TestPlaceholdersAndSchemaValidationFailBeforeWrite(t *testing.T) {
 			t.Fatalf("expected projection failure for %#v", server)
 		}
 		assertBytes(t, path, before)
+	}
+}
+
+func TestProjectionExpandsOnlyPortableStdioValueVariables(t *testing.T) {
+	placeholders := Placeholders{PackageRoot: "/pkg", DataRoot: "/data"}
+	stdio, err := projectServer(CodecMCPServers, Server{
+		Type:    "stdio",
+		Command: "${PLUGIN_ROOT}",
+		Args:    []string{"${PLUGIN_ROOT}/run.js", "${PLUGIN_CACHE}/literal"},
+		Env:     map[string]string{"CACHE": "${PLUGIN_DATA}/state", "UNKNOWN": "${HOME}"},
+		CWD:     "${PLUGIN_ROOT}/work",
+	}, placeholders)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stdio["command"] != "${PLUGIN_ROOT}" || stdio["cwd"] != "/pkg/work" {
+		t.Fatalf("stdio command/cwd = %+v", stdio)
+	}
+	args := stdio["args"].([]string)
+	if args[0] != "/pkg/run.js" || args[1] != "${PLUGIN_CACHE}/literal" {
+		t.Fatalf("stdio args = %+v", args)
+	}
+	env := stdio["env"].(map[string]string)
+	if env["CACHE"] != "/data/state" || env["UNKNOWN"] != "${HOME}" {
+		t.Fatalf("stdio env = %+v", env)
+	}
+
+	remote, err := projectServer(CodecMCPServers, Server{
+		Type:    "remote",
+		URL:     "https://example.test/${PLUGIN_ROOT}",
+		Headers: map[string]string{"X-Path": "${PLUGIN_DATA}"},
+	}, placeholders)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if remote["url"] != "https://example.test/${PLUGIN_ROOT}" {
+		t.Fatalf("remote URL was expanded: %+v", remote)
+	}
+	headers := remote["headers"].(map[string]string)
+	if headers["X-Path"] != "${PLUGIN_DATA}" {
+		t.Fatalf("remote headers were expanded: %+v", headers)
+	}
+
+	nonRecursive, err := projectServer(CodecMCPServers, Server{
+		Type: "stdio", Command: "node", Args: []string{"${PLUGIN_ROOT}/run.js"},
+	}, Placeholders{PackageRoot: "/pkg/${PLUGIN_DATA}", DataRoot: "/data"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := nonRecursive["args"].([]string)[0]; got != "/pkg/${PLUGIN_DATA}/run.js" {
+		t.Fatalf("replacement text was recursively expanded: %q", got)
 	}
 }
 

--- a/install/integrationctl/agentplugins/providers/nativeconfig/project.go
+++ b/install/integrationctl/agentplugins/providers/nativeconfig/project.go
@@ -44,7 +44,6 @@ func projectServer(codec Codec, server Server, placeholders Placeholders) (map[s
 	resolve := func(value string) (string, error) {
 		replacements := []struct{ token, value string }{
 			{"${PLUGIN_ROOT}", placeholders.PackageRoot},
-			{"${package.root}", placeholders.PackageRoot},
 			{"${PLUGIN_DATA}", placeholders.DataRoot},
 		}
 		for _, replacement := range replacements {
@@ -52,13 +51,12 @@ func projectServer(codec Codec, server Server, placeholders Placeholders) (map[s
 				if strings.TrimSpace(replacement.value) == "" {
 					return "", fmt.Errorf("explicit value for %s is required", replacement.token)
 				}
-				value = strings.ReplaceAll(value, replacement.token, replacement.value)
 			}
 		}
-		if strings.Contains(value, "${") {
-			return "", fmt.Errorf("unresolved placeholder in %q", value)
-		}
-		return value, nil
+		return strings.NewReplacer(
+			"${PLUGIN_ROOT}", placeholders.PackageRoot,
+			"${PLUGIN_DATA}", placeholders.DataRoot,
+		).Replace(value), nil
 	}
 	projectStrings := func(values []string) ([]string, error) {
 		out := make([]string, len(values))
@@ -77,27 +75,17 @@ func projectServer(codec Codec, server Server, placeholders Placeholders) (map[s
 		}
 		out := make(map[string]string, len(values))
 		for key, value := range values {
-			resolvedKey, err := resolve(key)
-			if err != nil {
-				return nil, err
-			}
 			resolvedValue, err := resolve(value)
 			if err != nil {
 				return nil, err
 			}
-			if _, exists := out[resolvedKey]; exists {
-				return nil, fmt.Errorf("placeholder expansion produced duplicate key %q", resolvedKey)
-			}
-			out[resolvedKey] = resolvedValue
+			out[key] = resolvedValue
 		}
 		return out, nil
 	}
 
 	if serverType == "stdio" {
-		command, err := resolve(server.Command)
-		if err != nil {
-			return nil, err
-		}
+		command := server.Command
 		if strings.TrimSpace(command) == "" || server.URL != "" || len(server.Headers) > 0 || server.RemoteTransport != "" {
 			return nil, fmt.Errorf("stdio MCP server requires command and forbids remote fields")
 		}
@@ -153,16 +141,16 @@ func projectServer(codec Codec, server Server, placeholders Placeholders) (map[s
 		return entry, nil
 	}
 
-	url, err := resolve(server.URL)
-	if err != nil {
-		return nil, err
-	}
+	url := server.URL
 	if strings.TrimSpace(url) == "" || server.Command != "" || len(server.Args) > 0 || len(server.Env) > 0 || server.CWD != "" {
 		return nil, fmt.Errorf("remote MCP server requires url and forbids local process fields")
 	}
-	headers, err := projectMap(server.Headers)
-	if err != nil {
-		return nil, err
+	var headers map[string]string
+	if len(server.Headers) > 0 {
+		headers = make(map[string]string, len(server.Headers))
+		for key, value := range server.Headers {
+			headers[key] = value
+		}
 	}
 	urlKey := "url"
 	if codec == CodecGemini {

--- a/install/integrationctl/agentplugins/providers/stager.go
+++ b/install/integrationctl/agentplugins/providers/stager.go
@@ -354,6 +354,9 @@ func validatePlanPaths(plan domain.DeliveryPlan) error {
 }
 
 func sanitizePackage(root string, envelope domain.PackageEnvelope, plan domain.DeliveryPlan) error {
+	if err := removeUnsupportedPortableHooks(root); err != nil {
+		return err
+	}
 	if err := removeInvalidAndUnsupportedSkills(root, envelope, plan); err != nil {
 		return err
 	}
@@ -363,7 +366,27 @@ func sanitizePackage(root string, envelope domain.PackageEnvelope, plan domain.D
 	if err := writeSanitizedApp(root, envelope, plan); err != nil {
 		return err
 	}
-	return writeSanitizedExtensions(root, plan)
+	return writeSanitizedExtensions(root, envelope, plan)
+}
+
+func removeUnsupportedPortableHooks(root string) error {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return fmt.Errorf("inspect staged package root: %w", err)
+	}
+	for _, entry := range entries {
+		if !strings.EqualFold(entry.Name(), "hooks") {
+			continue
+		}
+		candidate := filepath.Join(root, entry.Name())
+		if err := pathpolicy.RequireContainedChild(root, candidate); err != nil {
+			return fmt.Errorf("unsafe staged hooks path: %w", err)
+		}
+		if err := os.RemoveAll(candidate); err != nil {
+			return fmt.Errorf("remove unsupported staged hooks: %w", err)
+		}
+	}
+	return nil
 }
 
 func writeSanitizedApp(root string, envelope domain.PackageEnvelope, plan domain.DeliveryPlan) error {
@@ -438,14 +461,21 @@ func writeSanitizedMCP(root string, envelope domain.PackageEnvelope, plan domain
 	return writeJSON(path, document)
 }
 
-func writeSanitizedExtensions(root string, plan domain.DeliveryPlan) error {
+func writeSanitizedExtensions(root string, envelope domain.PackageEnvelope, plan domain.DeliveryPlan) error {
 	var unsupported []string
 	for _, component := range plan.Components {
 		if component.Kind == domain.ComponentExtension && component.Support == domain.SupportUnsupported {
 			unsupported = append(unsupported, component.Name)
 		}
 	}
-	if len(unsupported) == 0 {
+	ignoredInvalid := false
+	for _, diagnostic := range envelope.Diagnostics {
+		if diagnostic.Code == "plugin_extensions_ignored" {
+			ignoredInvalid = true
+			break
+		}
+	}
+	if len(unsupported) == 0 && !ignoredInvalid {
 		return nil
 	}
 	path := filepath.Join(root, "plugin.json")
@@ -456,6 +486,10 @@ func writeSanitizedExtensions(root string, plan domain.DeliveryPlan) error {
 	var document map[string]json.RawMessage
 	if err := json.Unmarshal(body, &document); err != nil {
 		return fmt.Errorf("decode staged plugin.json: %w", err)
+	}
+	if ignoredInvalid {
+		delete(document, "extensions")
+		return writeJSON(path, document)
 	}
 	var extensions map[string]json.RawMessage
 	if raw := document["extensions"]; len(raw) > 0 {
@@ -753,10 +787,7 @@ func cloneJSONValue(value any) any {
 }
 
 func applyStdioDataContract(config map[string]any, pluginRoot, dataPath string) error {
-	expand := func(value string) string {
-		value = strings.ReplaceAll(value, "${PLUGIN_ROOT}", pluginRoot)
-		return strings.ReplaceAll(value, "${PLUGIN_DATA}", dataPath)
-	}
+	expand := strings.NewReplacer("${PLUGIN_ROOT}", pluginRoot, "${PLUGIN_DATA}", dataPath).Replace
 	switch env := config["env"].(type) {
 	case map[string]any:
 		if _, exists := env["PLUGIN_ROOT"]; exists {

--- a/install/integrationctl/agentplugins/providers/stager_test.go
+++ b/install/integrationctl/agentplugins/providers/stager_test.go
@@ -14,6 +14,7 @@ import (
 func TestStagerBuildsOpenAIProjectionWithoutMutatingPortableSnapshot(t *testing.T) {
 	t.Parallel()
 	envelope := stagingEnvelope(t)
+	writeTestFile(t, filepath.Join(envelope.SnapshotRoot, "hooks", "hooks.json"), "{}\n")
 	plan := stagingPlan(t, domain.ClientCodex, domain.PackageProjection)
 	delivery, err := (Stager{}).Stage(context.Background(), envelope, plan, "operation-1", domain.CompatibilityHints{
 		OpenAIMCPAuth: map[string]domain.OpenAIMCPAuthHint{
@@ -33,6 +34,10 @@ func TestStagerBuildsOpenAIProjectionWithoutMutatingPortableSnapshot(t *testing.
 	if _, ok := portableManifest["extensions"]; !ok {
 		t.Fatal("source snapshot was mutated")
 	}
+	if _, err := os.Stat(filepath.Join(envelope.SnapshotRoot, "hooks", "hooks.json")); err != nil {
+		t.Fatalf("source hooks were mutated: %v", err)
+	}
+	assertMissing(t, filepath.Join(delivery.StagingPath, "hooks"))
 	stagedManifest := readObject(t, filepath.Join(delivery.StagingPath, "plugin.json"))
 	if _, ok := stagedManifest["extensions"]; ok {
 		t.Fatal("unsupported extension survived staged standard manifest")
@@ -60,6 +65,33 @@ func TestStagerBuildsOpenAIProjectionWithoutMutatingPortableSnapshot(t *testing.
 	standardServers := standardMCP["mcpServers"].(map[string]any)
 	if _, exists := standardServers["broken"]; exists {
 		t.Fatal("invalid MCP server survived staging")
+	}
+}
+
+func TestStagerRemovesReportedIgnoredV1Extensions(t *testing.T) {
+	t.Parallel()
+	envelope := stagingEnvelope(t)
+	writeTestFile(t, filepath.Join(envelope.SnapshotRoot, "plugin.json"), `{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "demo",
+  "extensions": []
+}`)
+	envelope.Manifest.Extensions = nil
+	envelope.Diagnostics = []domain.Diagnostic{{
+		Severity: domain.SeverityWarning,
+		Boundary: domain.BoundaryPlugin,
+		Code:     "plugin_extensions_ignored",
+		Path:     "plugin.json",
+		Item:     "extensions",
+	}}
+	plan := stagingPlan(t, domain.ClientCursor, domain.PackageNative)
+	delivery, err := (Stager{}).Stage(context.Background(), envelope, plan, "ignored-extensions", domain.CompatibilityHints{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := readObject(t, filepath.Join(delivery.StagingPath, "plugin.json"))
+	if _, exists := manifest["extensions"]; exists {
+		t.Fatal("reported-and-ignored extensions survived staging")
 	}
 }
 
@@ -311,13 +343,16 @@ func TestStagerProjectsCursorNativeManifestAndRuntimeContract(t *testing.T) {
 
 func TestStagerResolvesBundledStdioCommandForNativeProjection(t *testing.T) {
 	t.Parallel()
-	config := map[string]any{"command": "./bin/server"}
-	pluginRoot, dataPath := filepath.Join(t.TempDir(), "plugin"), filepath.Join(t.TempDir(), "data")
+	config := map[string]any{"command": "./bin/server", "args": []any{"${PLUGIN_ROOT}/config"}}
+	pluginRoot, dataPath := filepath.Join(t.TempDir(), "plugin", "${PLUGIN_DATA}"), filepath.Join(t.TempDir(), "data")
 	if err := applyStdioDataContract(config, pluginRoot, dataPath); err != nil {
 		t.Fatal(err)
 	}
 	if config["command"] != filepath.Join(pluginRoot, "bin", "server") || config["cwd"] != pluginRoot {
 		t.Fatalf("projected stdio config = %+v", config)
+	}
+	if got := config["args"].([]any)[0]; got != filepath.Join(pluginRoot, "config") || strings.Contains(got.(string), dataPath) {
+		t.Fatalf("replacement text was recursively expanded: %v", got)
 	}
 }
 

--- a/install/integrationctl/agentplugins/providers/windsurf_native.go
+++ b/install/integrationctl/agentplugins/providers/windsurf_native.go
@@ -483,24 +483,20 @@ func windsurfServer(server domain.MCPServer, packageRoot, dataRoot string) (nati
 }
 
 func resolveWindsurfPlaceholders(server nativeconfig.Server, packageRoot, dataRoot string) (nativeconfig.Server, error) {
+	if server.Type != "stdio" {
+		return server, nil
+	}
 	resolve := func(value string) (string, error) {
-		for _, replacement := range []struct{ token, value string }{{"${PLUGIN_ROOT}", packageRoot}, {"${package.root}", packageRoot}, {"${PLUGIN_DATA}", dataRoot}} {
+		for _, replacement := range []struct{ token, value string }{{"${PLUGIN_ROOT}", packageRoot}, {"${PLUGIN_DATA}", dataRoot}} {
 			if strings.Contains(value, replacement.token) {
 				if strings.TrimSpace(replacement.value) == "" {
 					return "", fmt.Errorf("explicit value for %s is required", replacement.token)
 				}
-				value = strings.ReplaceAll(value, replacement.token, replacement.value)
 			}
 		}
-		if strings.Contains(value, "${") {
-			return "", fmt.Errorf("unresolved placeholder in %q", value)
-		}
-		return value, nil
+		return strings.NewReplacer("${PLUGIN_ROOT}", packageRoot, "${PLUGIN_DATA}", dataRoot).Replace(value), nil
 	}
 	var err error
-	if server.Command, err = resolve(server.Command); err != nil {
-		return server, err
-	}
 	for index := range server.Args {
 		if server.Args[index], err = resolve(server.Args[index]); err != nil {
 			return server, err
@@ -508,14 +504,6 @@ func resolveWindsurfPlaceholders(server nativeconfig.Server, packageRoot, dataRo
 	}
 	for key, value := range server.Env {
 		if server.Env[key], err = resolve(value); err != nil {
-			return server, err
-		}
-	}
-	if server.URL, err = resolve(server.URL); err != nil {
-		return server, err
-	}
-	for key, value := range server.Headers {
-		if server.Headers[key], err = resolve(value); err != nil {
 			return server, err
 		}
 	}

--- a/install/integrationctl/agentplugins/providers/windsurf_native_test.go
+++ b/install/integrationctl/agentplugins/providers/windsurf_native_test.go
@@ -190,6 +190,45 @@ func TestWindsurfSSEUsesLegacyURLKey(t *testing.T) {
 	}
 }
 
+func TestWindsurfExpandsOnlyPortableStdioValues(t *testing.T) {
+	t.Parallel()
+	packageRoot := filepath.Join(t.TempDir(), "plugin", "${PLUGIN_DATA}")
+	dataRoot := filepath.Join(t.TempDir(), "data")
+	stdio, err := windsurfServer(domain.MCPServer{
+		Type: "stdio",
+		Decoded: map[string]any{
+			"type":    "stdio",
+			"command": "${PLUGIN_ROOT}",
+			"args":    []any{"${PLUGIN_ROOT}/run.js", "${PLUGIN_CACHE}/literal"},
+			"env":     map[string]any{"DATA": "${PLUGIN_DATA}/state", "UNKNOWN": "${HOME}"},
+		},
+	}, packageRoot, dataRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stdio.Command != "${PLUGIN_ROOT}" || stdio.Args[0] != filepath.Join(packageRoot, "run.js") || stdio.Args[1] != "${PLUGIN_CACHE}/literal" || stdio.Env["DATA"] != filepath.Join(dataRoot, "state") || stdio.Env["UNKNOWN"] != "${HOME}" {
+		t.Fatalf("Windsurf stdio placeholder projection = %+v", stdio)
+	}
+	if strings.Contains(stdio.Args[0], dataRoot) {
+		t.Fatalf("Windsurf recursively expanded replacement text: %+v", stdio.Args)
+	}
+
+	remote, err := windsurfServer(domain.MCPServer{
+		Type: "streamable-http",
+		Decoded: map[string]any{
+			"type":    "streamable-http",
+			"url":     "https://example.test/${PLUGIN_ROOT}",
+			"headers": map[string]any{"X-Path": "${PLUGIN_DATA}"},
+		},
+	}, packageRoot, dataRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if remote.URL != "https://example.test/${PLUGIN_ROOT}" || remote.Headers["X-Path"] != "${PLUGIN_DATA}" {
+		t.Fatalf("Windsurf remote literals were expanded: %+v", remote)
+	}
+}
+
 func TestWindsurfStagerRejectsUnsupportedCWDWithoutChangingProjection(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()


### PR DESCRIPTION
## Summary

- align Agent Plugins 1.0 manifest, skills, MCP URL/header, hook, and placeholder behavior with the published specification
- keep runtime readiness separate from parser validity and preserve literal values through client projections
- add a parser-only conformance adapter and run the exact pinned 133-fixture corpus in CI

## Verification

- Agent Plugins corpus `4d163c6281a9b4929f482f387efe340b4dc175a1`: 133/133 strict, 0 warnings
- `make vet`
- focused loader/provider/CLI tests
- `make test-required`: every changed package and repository suite passed; one unrelated macOS case-collision fixture fails identically on base `5ee12c47` because the host filesystem is case-insensitive
- `git diff --check`

This PR does not execute plugin code and does not contact or post to the specification project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for validating remote MCP servers using HTTP and HTTPS transports.
  - Added clearer conformance reporting for plugin loading results and diagnostics.

- **Bug Fixes**
  - Improved safety when plugins contain symlinks or files outside their package.
  - Portable packages with unsupported top-level hooks now load successfully, while those hooks are omitted from staged deliveries.
  - Invalid extension declarations are reported as warnings when possible.
  - Improved placeholder handling for stdio commands, arguments, working directories, and environment values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->