### PR TITLE
feat: make Universal Agent Plugins the product facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,443 +1,231 @@
-# plugin-kit-ai
+# Universal Agent Plugins
 
-[![Required](https://github.com/777genius/plugin-kit-ai/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/777genius/plugin-kit-ai/actions/workflows/ci.yml)
-[![Docs](https://github.com/777genius/plugin-kit-ai/actions/workflows/docs.yml/badge.svg?branch=main)](https://github.com/777genius/plugin-kit-ai/actions/workflows/docs.yml)
-[![Polyglot Smoke](https://github.com/777genius/plugin-kit-ai/actions/workflows/polyglot-smoke.yml/badge.svg?branch=main)](https://github.com/777genius/plugin-kit-ai/actions/workflows/polyglot-smoke.yml)
-[![Release](https://img.shields.io/github/v/release/777genius/plugin-kit-ai?label=release)](https://github.com/777genius/plugin-kit-ai/releases)
-[![npm](https://img.shields.io/npm/v/plugin-kit-ai?label=npm)](https://www.npmjs.com/package/plugin-kit-ai)
-[![Go Reference](https://pkg.go.dev/badge/github.com/777genius/plugin-kit-ai/sdk.svg)](https://pkg.go.dev/github.com/777genius/plugin-kit-ai/sdk)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Required](https://github.com/777genius/universal-agent-plugins/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/777genius/universal-agent-plugins/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/777genius/universal-agent-plugins?label=release)](https://github.com/777genius/universal-agent-plugins/releases)
+[![npm](https://img.shields.io/npm/v/universal-agent-plugins?label=npm)](https://www.npmjs.com/package/universal-agent-plugins)
+[![Agent Plugins 1.0](https://img.shields.io/badge/Agent%20Plugins-1.0.0-7257FF)](https://agent-plugins.org/specification)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-Build one plugin and ship it to many AI agents.
-
-`plugin-kit-ai` keeps authored source under `plugin/`, generates the supported outputs you need, and helps you validate the repo before handoff.
-The honest promise is `one repo / many supported outputs`, not fake parity everywhere.
-
-## Install Agent Plugins 1.0
-
-Want to use a plugin rather than author one? `universal-agent-plugins` is the
-public npm package. It installs the `agentplugins` binary; both names run the
-same installer and lifecycle manager (Node.js 22+):
+Install and manage Agent Plugins 1.0 across your AI agents with one CLI.
 
 ```bash
-npx universal-agent-plugins add context7
+npx universal-agent-plugins add context7 --target cursor
 ```
 
-Short names resolve to immutable releases through the signed
-[Universal Agent Plugins Directory](https://github.com/777genius/universal-agent-plugins).
-The command shows the selected publisher, source, and verification status, so a
-community bridge is not mistaken for its upstream project. Direct local paths
-and exact GitHub revisions work without Directory submission.
+The command downloads a package once, verifies it, prepares the native format for
+the selected client or clients, and tells you about any remaining activation or
+OAuth step.
+
+This repository is the product home and npm facade source. The facade installs the `agentplugins` binary; `plugin-kit-ai` is the shared Go implementation engine
+during the repository rename and is not duplicated here.
+
+## Quick start
+
+You need Node.js 22 or newer.
+
+1. Pick a plugin from the Universal Agent Plugins Registry:
+   https://777genius.github.io/universal-agent-plugins-registry/
+2. Choose one or several clients explicitly:
+
+   ```bash
+   npx universal-agent-plugins add context7 --target codex,cursor
+   ```
+
+3. Open a new session in the client and follow the printed activation hint.
+4. Ask the agent to use the plugin. A real tool call is the useful runtime check.
+
+The same package is acquired once and planned for every selected target. The CLI
+does not silently modify every detected client.
+
+For an interactive terminal, omit --target to detect compatible installed
+clients and choose them in a multi-select. Scripts and CI should always pass
+--target.
+
+## Everyday commands
 
 ```bash
 npx universal-agent-plugins search docs
-npx universal-agent-plugins validate ./my-plugin
-npx universal-agent-plugins add context7 --dry-run --target cursor
+npx universal-agent-plugins info context7
 npx universal-agent-plugins add context7 --target codex,cursor,kiro
+npx universal-agent-plugins update context7 --target codex,cursor
+npx universal-agent-plugins repair context7 --target codex,cursor
+npx universal-agent-plugins switch context7 --to 777genius/context7
 npx universal-agent-plugins outdated --all
 npx universal-agent-plugins update --all
-npx universal-agent-plugins update context7 --target codex,cursor,kiro
-npx universal-agent-plugins repair context7 --target codex,cursor,kiro
-npx universal-agent-plugins remove context7 --target codex,cursor,kiro
-npx universal-agent-plugins switch context7 --to upstash/context7
-npx universal-agent-plugins add ./my-plugin --target cursor
-npx universal-agent-plugins add owner/repo@0123456789abcdef0123456789abcdef01234567//plugins/my-plugin --target cursor
+npx universal-agent-plugins remove context7 --target codex,cursor
+npx universal-agent-plugins doctor
 ```
 
-Replace the example SHA with the full lowercase 40-character commit SHA you
-reviewed; branches, tags, and abbreviated SHAs are rejected. `repair` reapplies
-the recorded revision; `update` selects a newer eligible release. `switch`
-moves the whole installation to a qualified Directory distribution or exact
-source.
+update keeps the recorded source. repair reapplies that source. switch is the
+explicit way to move to another reviewed distribution or exact source. remove
+changes only files owned by the CLI.
 
-### Choose clients
+## Any Agent Plugins 1.0 package
 
-In an interactive terminal, `add` without `--target` detects installed clients,
-checks which of them the selected package can serve from one release, and skips
-incompatible clients before showing the confirmation. One compatible client is
-selected automatically. With several compatible clients, the CLI shows a
-multi-select with all of them selected by default; press Enter to keep all of
-them. Scripts and CI must choose explicitly, for example
-`--target claude,gemini,opencode`. The same comma-separated syntax works with
-`add`, `update`, `repair`, and `remove`.
+The installed package is standard-first:
 
-Detection checks installed executables and documented configuration surfaces.
-It does not start an agent, log in, complete OAuth, or prove browser/tool
-runtime behavior.
+```text
+plugin.json
+├── skills/       optional reusable instructions
+├── mcp.json      optional MCP servers
+└── hooks/        optional client-supported hooks
+```
 
-The following matrix describes the current release source. New client support
-is available through `npx` once a release containing this source is published.
-The exact package, source revisions, commands, and limitations are recorded in
-the [isolated client E2E evidence](docs/AGENTPLUGINS_CLIENT_E2E.md).
+Use a local package or a pinned GitHub source without submitting it to the
+registry:
 
-| Client | Evidence |
+```bash
+npx universal-agent-plugins validate ./my-plugin
+npx universal-agent-plugins add ./my-plugin --target cursor
+npx universal-agent-plugins add \
+  owner/repository@0123456789abcdef0123456789abcdef01234567//path/to/plugin \
+  --target codex,cursor
+```
+
+Use a full 40-character commit SHA. Branches, tags, and abbreviated SHAs are
+rejected for remote installs.
+
+plugin.yaml is the legacy plugin-kit-ai authoring format. It is not merged with
+or allowed to override plugin.json.
+
+## Supported clients
+
+The CLI has adapters for:
+
+| Client | Delivery |
 | --- | --- |
-| Claude Code | Claude Code 2.1.205: real isolated exact-SHA `add`, native list, `repair`, safe update preflight, and `remove` lifecycle |
-| Gemini CLI | Gemini CLI 0.36.0: real isolated configuration and the same exact-source lifecycle |
-| OpenCode | OpenCode 1.18.4: real isolated configuration and the same exact-source lifecycle |
-| Cline | Real locally detected client; isolated native configuration and exact-source lifecycle; no client runtime or login |
-| Windsurf | Real locally detected configuration and exact-source lifecycle; no client runtime or login |
+| Codex | managed package or OpenAI compatibility package |
+| ChatGPT | registered app/binding where the package provides one |
+| Cursor | native Agent Plugin and MCP/skills projection |
+| GitHub Copilot CLI | native plugin and managed marketplace path |
+| VS Code | prepared Copilot-compatible package |
+| Kiro | native folder and Power import guidance |
+| Claude Code | client-specific skills/MCP projection |
+| Gemini CLI | client-specific configuration projection |
+| OpenCode | client-specific configuration projection |
+| Cline | client-specific configuration projection |
+| Windsurf | client-specific configuration projection |
 
-`search` combines the reviewed Directory with a separately signed Discovery
-Index. Unreviewed results use publisher-qualified `discovery:owner/repo//path`
-selectors and show their exact indexed commit before install. The CLI
-reacquires and validates those package bytes before mutation; the index
-signature authenticates metadata but is not a package or runtime endorsement.
-`outdated` is read-only, while `update --all` keeps every installation's
-recorded source and targets and fails the batch preflight before mutation if any
-planned update is unsafe.
+Compatibility is package-specific. A schema pass means that the package is
+well-formed; it does not prove runtime, OAuth, or activation in every client.
+The CLI prints installed, prepared, activation required, and authentication
+pending as separate outcomes.
 
-For Agent Plugins 1.0, the root `plugin.json` is the install authority. A
-`plugin.yaml` file is legacy `plugin-kit-ai` authoring input only: it is not
-merged with, converted into, or allowed to silently override `plugin.json`.
+## Find and verify plugins
 
-Before changing anything, the CLI resolves and validates the source and
-preflights every selected client. `--dry-run` prints that same read-only plan.
-`doctor` only inspects paths and filesystem metadata; it never launches a
-discovered client executable, and neither does a `--dry-run`. Non-dry-run
-lifecycle resolution may explicitly run a bounded `--version` probe when an
-exact client version is needed for signed Directory evidence. That probe
-receives an empty stdin and credential-free environment and runs outside the
-caller's working directory. If it cannot obtain a matching version,
-version-bound evidence remains unavailable rather than being inferred.
-Managed files and state are staged and committed together; a failure rolls back
-changes when ownership can be proven, or stops with recovery guidance without
-claiming success. Observed unowned entries fail closed before mutation. Portable
-filesystems cannot provide a linearizable content compare-and-swap against a
-non-cooperating client that writes in the final syscall-sized window, so the CLI
-rechecks and reports identity conflicts instead of promising impossible
-concurrency isolation. Client-controlled activation happens separately: some
-clients activate automatically, while others finish as prepared and print a
-manual activation step. OAuth and consent prompts stay visible and
-user-controlled; cancelling one preserves the package and reports
-authentication as pending or cancelled.
-Kiro skills are installed directly into the documented global skills path.
-For packages with MCP servers, agentplugins atomically merges only its owned
-entries into Kiro's global `mcp.json`, preserving unrelated user configuration,
-then checks supported Kiro CLI versions through a bounded structured ACP v1
-initialize/session handshake.
-It sends no prompt or model/tool turn and does not inject package endpoints;
-Kiro must load its installed native configuration and report connected servers
-with enabled tools. The verifier drains a bounded quiet settlement window,
-rejects EOF, partial bytes, or trailing contradictions, then stops and reaps the
-long-lived ACP process through supervised containment. Automatic Kiro ACP
-verification is available only on Linux after capability preflight proves
-delegated cgroup v2 creation, atomic CLONE_INTO_CGROUP placement, and
-cgroup.kill. macOS, Windows, and Linux hosts without every required proof fail
-preflight before any MCP mutation. On those hosts, use Kiro's documented manual
-skill and MCP configuration paths; that workflow is outside this automatic CLI
-path. Failure to start ACP
-after a supported preflight may still leave a manual verification action. This
-is activation evidence, not a runtime tool E2E claim.
-Once the ACP process starts, companion-launch failure (including a missing
-`kiro-cli-chat`), EOF, timeout, authentication failure, malformed or partial
-output, contradiction, and non-clean exit are authoritative activation
-failures; the managed package remains committed for explicit repair and is
-never reported active.
-Verification is reported for the exact plugin, client, runtime, and OAuth
-evidence available—not as a claim that every combination has been tested.
+search combines the reviewed Registry Directory with a signed public Discovery
+Index containing 2,500+ conformant package paths. Discovery records are
+unreviewed metadata, not endorsements. They install only through a
+publisher-qualified exact-SHA selector and are validated again before mutation.
 
-`universal-agent-plugins` is an independent community installer, not an official
-OpenAI CLI.
+The registry is optional for direct installs, but it makes reviewed short names,
+provenance, compatibility notes, and safe discovery convenient:
 
-Docs site:
+[Browse the registry](https://777genius.github.io/universal-agent-plugins-registry/) ·
+[Submit a package](https://github.com/777genius/universal-agent-plugins-registry/blob/main/CONTRIBUTING.md)
 
-- overview: [plugin-kit-ai documentation](https://777genius.github.io/plugin-kit-ai/docs/en/)
-- fastest start: [Quickstart](https://777genius.github.io/plugin-kit-ai/docs/en/guide/quickstart.html)
-- choose by job first: [Choose What You Are Building](https://777genius.github.io/plugin-kit-ai/docs/en/guide/choose-what-you-are-building.html)
-- one repo, many outputs: [What You Can Build](https://777genius.github.io/plugin-kit-ai/docs/en/guide/what-you-can-build.html)
-- delivery model guide: [Choose A Target](https://777genius.github.io/plugin-kit-ai/docs/en/guide/choose-a-target.html)
-- honest caveat: [Support Boundary](https://777genius.github.io/plugin-kit-ai/docs/en/reference/support-boundary.html)
+## Lifecycle safety
 
-Project policies:
+Before changing a client, the CLI validates the source and preflights every
+selected target. --dry-run prints the same plan without writing. Managed files
+and state are committed together; failures roll back what ownership proves safe
+or stop with a repair command. OAuth and consent remain visible and controlled
+by you. No install telemetry is sent.
 
-- support boundary: [docs/SUPPORT.md](docs/SUPPORT.md)
-- contributing: [CONTRIBUTING.md](CONTRIBUTING.md)
-- security: [SECURITY.md](SECURITY.md)
-- code of conduct: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+The CLI is an independent community project. It is not affiliated with OpenAI,
+Agent Plugins, or the vendors shown above.
+
+## Authoring and development
+
+This repository also retains the original plugin-kit-ai authoring tools. Use
+the authoring guide at docs/PLUGIN_KIT_AI_AUTHORING.md when you want to build,
+validate, or export a package rather than install one.
+
+Build one plugin and ship it to many AI agents. The repository includes starter templates for Codex and Claude across Go, Python, and Node/TypeScript.
+
+<details>
+<summary>Legacy authoring and SDK reference</summary>
+
+`plugin-kit-ai` keeps authored source under `plugin/`, generates the supported outputs you need, and helps you validate the repo before handoff. This includes supported outputs for Claude, Codex, Gemini, Cursor, and OpenCode where the repo shape allows it. The honest promise is `one repo / many supported outputs`, not fake parity everywhere.
+
+overview: [plugin-kit-ai documentation](https://777genius.github.io/plugin-kit-ai/docs/en/)
+fastest start: [Quickstart](https://777genius.github.io/plugin-kit-ai/docs/en/guide/quickstart.html)
+choose by job first: [Choose What You Are Building](https://777genius.github.io/plugin-kit-ai/docs/en/guide/choose-what-you-are-building.html)
+one repo, many outputs: [What You Can Build](https://777genius.github.io/plugin-kit-ai/docs/en/guide/what-you-can-build.html)
+honest caveat: [Support Boundary](https://777genius.github.io/plugin-kit-ai/docs/en/reference/support-boundary.html)
 
 ## Choose What You Are Building
 
 ### Connect an online service
 
-Use this when the plugin should connect to a hosted service like Notion, Stripe, Cloudflare, or Vercel.
-
-```bash
-plugin-kit-ai init my-plugin --template online-service
-cd my-plugin
-plugin-kit-ai inspect . --authoring
-plugin-kit-ai generate .
-plugin-kit-ai generate --check .
-plugin-kit-ai validate . --platform claude --strict
-```
-
-Real examples:
-
-- [notion](https://github.com/777genius/universal-plugins-for-ai-agents/tree/main/plugins/notion)
-- [stripe](https://github.com/777genius/universal-plugins-for-ai-agents/tree/main/plugins/stripe)
-- [cloudflare](https://github.com/777genius/universal-plugins-for-ai-agents/tree/main/plugins/cloudflare)
-- [vercel](https://github.com/777genius/universal-plugins-for-ai-agents/tree/main/plugins/vercel)
-
 ### Connect a local tool
 
-Use this when the plugin should call into a repo-owned tool or CLI like Docker Hub, Chrome DevTools, or HubSpot Developer.
-
-```bash
-plugin-kit-ai init my-plugin --template local-tool
-cd my-plugin
-plugin-kit-ai inspect . --authoring
-plugin-kit-ai generate .
-plugin-kit-ai generate --check .
-plugin-kit-ai validate . --platform claude --strict
-```
-
-Real examples:
-
-- [docker-hub](https://github.com/777genius/universal-plugins-for-ai-agents/tree/main/plugins/docker-hub)
-- [hubspot-developer](https://github.com/777genius/universal-plugins-for-ai-agents/tree/main/plugins/hubspot-developer)
-- [chrome-devtools](https://github.com/777genius/universal-plugins-for-ai-agents/tree/main/plugins/win4r/chrome-devtools-codex-plugin)
-
-### Build custom plugin logic - Advanced
-
-Use this when the product is defined by hooks, runtime behavior, or custom plugin code.
-
-This path is more powerful and more engineering-heavy than the first two starters.
-Plain `plugin-kit-ai init my-plugin` still exists as the legacy compatibility path for the older Codex runtime Go starter.
-
-```bash
-plugin-kit-ai init my-plugin --template custom-logic
-cd my-plugin
-plugin-kit-ai inspect . --authoring
-plugin-kit-ai validate . --platform codex-runtime --strict
-plugin-kit-ai test . --platform codex-runtime --event Notify
-```
-
-Guide:
-
-- [Build Custom Plugin Logic](https://777genius.github.io/plugin-kit-ai/docs/en/guide/build-custom-plugin-logic.html)
+### Build custom plugin logic
 
 ## Quick Start
 
-Want to try a real Agent Plugin without installing a CLI permanently?
-
-```bash
-npx universal-agent-plugins add context7
-```
-
-Building a plugin instead? Use `plugin-kit-ai` for authoring and generated
-output delivery. Its older `plugin-kit-ai add` lifecycle is not the default
-installer for portable Agent Plugins 1.0. Start with
-[Choose What You Are Building](#choose-what-you-are-building).
-
-Recommended authoring CLI install path:
-
 ```bash
 brew install 777genius/homebrew-plugin-kit-ai/plugin-kit-ai
-plugin-kit-ai version
-```
-
-Then create a repo from the path that matches the job:
-
-```bash
+npm: `npm i -g plugin-kit-ai` or `npx plugin-kit-ai@latest ...`
+pipx (`public-beta`, only when that release is published to PyPI): `pipx install plugin-kit-ai`
+fallback installer: `curl -fsSL https://raw.githubusercontent.com/777genius/plugin-kit-ai/main/scripts/install.sh | sh`
 plugin-kit-ai init my-plugin --template online-service
 plugin-kit-ai init my-plugin --template local-tool
 plugin-kit-ai init my-plugin --template custom-logic
+plugin-kit-ai init my-plugin
+plugin-kit-ai generate .
+plugin-kit-ai validate . --platform codex-runtime --strict
 ```
-
-Plain `plugin-kit-ai init my-plugin` still exists for backward compatibility, but it is no longer the recommended first start for new repos.
-Use one of the three job-first templates above unless you are intentionally maintaining the older Codex runtime Go path.
-
-## What You Get
-
-- one plugin repo that stays the source of truth
-- authored files under `plugin/`
-- generated root files that stay managed
-- supported outputs for Claude, Codex, Gemini, Cursor, and OpenCode where the repo shape allows it
-- a clean readiness check through `generate`, `generate --check`, and `validate --strict`
 
 ## Works Across Multiple Outputs
-
-- Claude
-- Codex package
-- Codex runtime
-- Gemini
-- OpenCode
-- Cursor
-
-That depth stays available, but you do not need to understand the whole target model before creating the repo.
-
 ## What To Do Next
-
-- run `plugin-kit-ai inspect . --authoring`
-- edit the repo under `plugin/`
-- regenerate after changes
-- validate the supported output you actually plan to ship first
-- only then add more outputs when the product really needs them
-
-Other supported CLI install methods:
-
-- npm: `npm i -g plugin-kit-ai` or `npx plugin-kit-ai@latest ...`
-- pipx (`public-beta`, only when that release is published to PyPI): `pipx install plugin-kit-ai`
-- fallback installer: `curl -fsSL https://raw.githubusercontent.com/777genius/plugin-kit-ai/main/scripts/install.sh | sh`
-- fallback one-shot command: `curl -fsSL https://raw.githubusercontent.com/777genius/plugin-kit-ai/main/scripts/install.sh | sh -s -- add notion --dry-run`
-- source build for maintainers of this repo: `go build -o bin/plugin-kit-ai ./cli/plugin-kit-ai/cmd/plugin-kit-ai`
-
 ## Keep This Rule In Mind
-
-- start with the job you need today
-- keep authored source under `plugin/` for new repos
-- let generated root files stay managed
-- add deeper target-specific behavior only when you need it
-- use advanced docs when you need exact target and support details
-
 ## Deep Product Details
-
-Everything below this point is for people comparing delivery models, import paths, and detailed support boundaries. If you only needed the main promise and first path, you can stop above.
-
 ## Go Deeper By Goal
-
 ### Fast Local Plugin
-
-Choose this when the plugin stays local to the repo and your team already works in Python or Node.
-
-- Main flow: `init -> doctor -> bootstrap -> generate -> validate --strict`
-- Runtime note: the execution machine still needs Python `3.10+` or Node.js `20+`
-- Delivery options: vendored helper by default, shared `plugin-kit-ai-runtime` when you want a reusable dependency, bundle handoff when the repo must travel
-
-This is a supported non-Go path, not a hidden fallback.
-Use the starter templates for Codex and Claude across Go, Python, and Node/TypeScript when you want the fastest copy-first path into a working repo.
-
-Start here:
-
-- [examples/starters/README.md](examples/starters/README.md)
-- [examples/local/README.md](examples/local/README.md)
-- [docs/CHOOSING_HELPER_DELIVERY_MODE.md](docs/CHOOSING_HELPER_DELIVERY_MODE.md)
-
 ### Production-Ready Plugin Repo
-
-Choose this when you want the strongest supported release and distribution story.
-
-- Online service path: `plugin-kit-ai init my-plugin --template online-service`
-- Local tool path: `plugin-kit-ai init my-plugin --template local-tool`
-- Advanced runtime path: `plugin-kit-ai init my-plugin --template custom-logic`
-- Package/config expansion later: `codex-package`, `gemini`, `opencode`, `cursor`
-- Real multi-target MCP-first example: [`context7` in universal-plugins-for-ai-agents](https://github.com/777genius/universal-plugins-for-ai-agents/tree/main/plugins/context7)
-
 ### Already Have Native Config
 
-Choose this when you are migrating existing Claude/Codex/Gemini/OpenCode/Cursor native files into the repo-owned workflow.
-
-```bash
-./bin/plugin-kit-ai import ./native-plugin --from codex-runtime
-./bin/plugin-kit-ai normalize ./my-plugin
-./bin/plugin-kit-ai generate ./my-plugin
-./bin/plugin-kit-ai validate ./my-plugin --platform codex-runtime --strict
-```
-
-## Stability Snapshot
-
-Stable by default:
-
-- the main public CLI contract
-- the recommended Go SDK path
-- Go scaffolds for the default Codex and Claude runtime lanes
-- the stable local Python and Node subset on `codex-runtime` and `claude`
-- `doctor`, `bootstrap`, `validate --strict`, `export`, and bundle handoff for that stable local subset
-
-Use carefully:
-
-- `generate`, `import`, and `normalize` are still `public-beta`
-- package and workspace-config targets have different guarantees than runtime targets
-- `shell` remains a bounded `public-beta` escape hatch
-
-For the precise contract:
-
-- [docs/generated/target_support_matrix.md](docs/generated/target_support_matrix.md)
-- [docs/generated/support_matrix.md](docs/generated/support_matrix.md)
-- [docs/SUPPORT.md](docs/SUPPORT.md)
-
-## Path Summary
-
-- Go is the recommended path when you want the strongest production story and the least downstream runtime friction.
-- Node/TypeScript is the main supported non-Go path for repo-local runtime plugins.
-- Python is the supported Python-first repo-local path.
-- Package and workspace-config targets are for packaging and configuration outputs, not for pretending every target behaves like a runtime plugin.
+[examples/starters/README.md](examples/starters/README.md)
+[examples/local/README.md](examples/local/README.md)
+[docs/CHOOSING_HELPER_DELIVERY_MODE.md](docs/CHOOSING_HELPER_DELIVERY_MODE.md)
+the stable local Python and Node subset on `codex-runtime` and `claude`
+`doctor`, `bootstrap`, `validate --strict`, `export`, and bundle handoff for that stable local subset
+`generate`, `import`, and `normalize` are still `public-beta`
+[docs/generated/target_support_matrix.md](docs/generated/target_support_matrix.md)
+[docs/generated/support_matrix.md](docs/generated/support_matrix.md)
+[docs/SUPPORT.md](docs/SUPPORT.md)
 
 ## SDK And CLI
 
-Go SDK packages:
-
-- `github.com/777genius/plugin-kit-ai/sdk`
-- `github.com/777genius/plugin-kit-ai/sdk/claude`
-- `github.com/777genius/plugin-kit-ai/sdk/codex`
-- `github.com/777genius/plugin-kit-ai/sdk/gemini`
-
-Useful starting points:
-
-- [sdk/README.md](sdk/README.md)
-- [docs/generated/support_matrix.md](docs/generated/support_matrix.md)
-- [docs/SUPPORT.md](docs/SUPPORT.md)
-
-Common CLI commands:
+Go SDK packages: `github.com/777genius/plugin-kit-ai/sdk/claude`, `github.com/777genius/plugin-kit-ai/sdk/codex`, and `github.com/777genius/plugin-kit-ai/sdk/gemini`.
 
 ```bash
-./bin/plugin-kit-ai init my-plugin
 ./bin/plugin-kit-ai doctor ./my-plugin
 ./bin/plugin-kit-ai bootstrap ./my-plugin
-./bin/plugin-kit-ai generate ./my-plugin
-./bin/plugin-kit-ai validate ./my-plugin --platform codex-runtime --strict
 ./bin/plugin-kit-ai import ./native-plugin --from codex-runtime
 ./bin/plugin-kit-ai capabilities --format json
 ```
 
-`plugin-kit-ai install` stays intentionally narrow: it installs third-party plugin binaries from GitHub Releases, verifies `checksums.txt`, and does not act as a self-update path for the CLI itself.
+`plugin-kit-ai validate --format json` now emits the versioned `plugin-kit-ai/validate-report` contract.
+[docs/CODEX_TARGET_BOUNDARY.md](docs/CODEX_TARGET_BOUNDARY.md)
+[docs/VALIDATE_JSON_CONTRACT.md](docs/VALIDATE_JSON_CONTRACT.md)
 
-For automation, `plugin-kit-ai validate --format json` now emits the versioned `plugin-kit-ai/validate-report` contract with `schema_version: 1` and explicit outcomes `passed`, `failed`, or `failed_strict_warnings`.
-For Codex lane selection, use [docs/CODEX_TARGET_BOUNDARY.md](docs/CODEX_TARGET_BOUNDARY.md). For the validation ABI itself, use [docs/VALIDATE_JSON_CONTRACT.md](docs/VALIDATE_JSON_CONTRACT.md).
-
-## Build And Test
-
-Requirements:
-
-- Go `1.25.13` for this monorepo workspace and its CI lanes
-- generated Go plugin projects created by `plugin-kit-ai init` remain on Go `1.22+`
-
-Common commands from repo root:
+</details>
 
 ```bash
-go run ./cmd/plugin-kit-ai-gen
-go build -o bin/plugin-kit-ai ./cli/plugin-kit-ai/cmd/plugin-kit-ai
-./bin/plugin-kit-ai version
-make test-polyglot-smoke
 go test ./...
+make vet
 ```
 
-## Repository And Docs Map
+- Contributing: CONTRIBUTING.md
+- Security policy: SECURITY.md
+- Support boundary: docs/SUPPORT.md
+- Client E2E evidence: docs/AGENTPLUGINS_CLIENT_E2E.md
+- Registry: https://github.com/777genius/universal-agent-plugins-registry
 
-Main repo areas:
+## License
 
-- `sdk`
-- `cli/plugin-kit-ai`
-- `install/plugininstall`
-- `examples/starters`
-- `examples/local`
-- `examples/plugins`
-- `repotests`
-- `docs`
-
-Canonical docs:
-
-- [docs/generated/support_matrix.md](docs/generated/support_matrix.md)
-- [docs/generated/target_support_matrix.md](docs/generated/target_support_matrix.md)
-- [docs/SUPPORT.md](docs/SUPPORT.md)
-- [docs/CODEX_TARGET_BOUNDARY.md](docs/CODEX_TARGET_BOUNDARY.md)
-- [docs/VALIDATE_JSON_CONTRACT.md](docs/VALIDATE_JSON_CONTRACT.md)
-- [docs/PRODUCTION.md](docs/PRODUCTION.md)
-- [docs/INSTALL_COMPATIBILITY.md](docs/INSTALL_COMPATIBILITY.md)
-- [docs/STATUS.md](docs/STATUS.md)
-
-Maintainer-only historical context:
-
-- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
-- [docs/FOUNDATION_REWRITE_VNEXT.md](docs/FOUNDATION_REWRITE_VNEXT.md)
-- [docs/adr/README.md](docs/adr/README.md)
+The Go engine and this repository remain under the existing MIT license. The
+registry keeps its Apache 2.0 license and third-party attribution. No code is
+relicensed by the repository rename.

--- a/docs/PLUGIN_KIT_AI_AUTHORING.md
+++ b/docs/PLUGIN_KIT_AI_AUTHORING.md
@@ -1,0 +1,443 @@
+# plugin-kit-ai
+
+[![Required](https://github.com/777genius/plugin-kit-ai/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/777genius/plugin-kit-ai/actions/workflows/ci.yml)
+[![Docs](https://github.com/777genius/plugin-kit-ai/actions/workflows/docs.yml/badge.svg?branch=main)](https://github.com/777genius/plugin-kit-ai/actions/workflows/docs.yml)
+[![Polyglot Smoke](https://github.com/777genius/plugin-kit-ai/actions/workflows/polyglot-smoke.yml/badge.svg?branch=main)](https://github.com/777genius/plugin-kit-ai/actions/workflows/polyglot-smoke.yml)
+[![Release](https://img.shields.io/github/v/release/777genius/plugin-kit-ai?label=release)](https://github.com/777genius/plugin-kit-ai/releases)
+[![npm](https://img.shields.io/npm/v/plugin-kit-ai?label=npm)](https://www.npmjs.com/package/plugin-kit-ai)
+[![Go Reference](https://pkg.go.dev/badge/github.com/777genius/plugin-kit-ai/sdk.svg)](https://pkg.go.dev/github.com/777genius/plugin-kit-ai/sdk)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+Build one plugin and ship it to many AI agents.
+
+`plugin-kit-ai` keeps authored source under `plugin/`, generates the supported outputs you need, and helps you validate the repo before handoff.
+The honest promise is `one repo / many supported outputs`, not fake parity everywhere.
+
+## Install Agent Plugins 1.0
+
+Want to use a plugin rather than author one? `universal-agent-plugins` is the
+public npm package. It installs the `agentplugins` binary; both names run the
+same installer and lifecycle manager (Node.js 22+):
+
+```bash
+npx universal-agent-plugins add context7
+```
+
+Short names resolve to immutable releases through the signed
+[Universal Agent Plugins Directory](https://github.com/777genius/universal-agent-plugins).
+The command shows the selected publisher, source, and verification status, so a
+community bridge is not mistaken for its upstream project. Direct local paths
+and exact GitHub revisions work without Directory submission.
+
+```bash
+npx universal-agent-plugins search docs
+npx universal-agent-plugins validate ./my-plugin
+npx universal-agent-plugins add context7 --dry-run --target cursor
+npx universal-agent-plugins add context7 --target codex,cursor,kiro
+npx universal-agent-plugins outdated --all
+npx universal-agent-plugins update --all
+npx universal-agent-plugins update context7 --target codex,cursor,kiro
+npx universal-agent-plugins repair context7 --target codex,cursor,kiro
+npx universal-agent-plugins remove context7 --target codex,cursor,kiro
+npx universal-agent-plugins switch context7 --to upstash/context7
+npx universal-agent-plugins add ./my-plugin --target cursor
+npx universal-agent-plugins add owner/repo@0123456789abcdef0123456789abcdef01234567//plugins/my-plugin --target cursor
+```
+
+Replace the example SHA with the full lowercase 40-character commit SHA you
+reviewed; branches, tags, and abbreviated SHAs are rejected. `repair` reapplies
+the recorded revision; `update` selects a newer eligible release. `switch`
+moves the whole installation to a qualified Directory distribution or exact
+source.
+
+### Choose clients
+
+In an interactive terminal, `add` without `--target` detects installed clients,
+checks which of them the selected package can serve from one release, and skips
+incompatible clients before showing the confirmation. One compatible client is
+selected automatically. With several compatible clients, the CLI shows a
+multi-select with all of them selected by default; press Enter to keep all of
+them. Scripts and CI must choose explicitly, for example
+`--target claude,gemini,opencode`. The same comma-separated syntax works with
+`add`, `update`, `repair`, and `remove`.
+
+Detection checks installed executables and documented configuration surfaces.
+It does not start an agent, log in, complete OAuth, or prove browser/tool
+runtime behavior.
+
+The following matrix describes the current release source. New client support
+is available through `npx` once a release containing this source is published.
+The exact package, source revisions, commands, and limitations are recorded in
+the [isolated client E2E evidence](docs/AGENTPLUGINS_CLIENT_E2E.md).
+
+| Client | Evidence |
+| --- | --- |
+| Claude Code | Claude Code 2.1.205: real isolated exact-SHA `add`, native list, `repair`, safe update preflight, and `remove` lifecycle |
+| Gemini CLI | Gemini CLI 0.36.0: real isolated configuration and the same exact-source lifecycle |
+| OpenCode | OpenCode 1.18.4: real isolated configuration and the same exact-source lifecycle |
+| Cline | Real locally detected client; isolated native configuration and exact-source lifecycle; no client runtime or login |
+| Windsurf | Real locally detected configuration and exact-source lifecycle; no client runtime or login |
+
+`search` combines the reviewed Directory with a separately signed Discovery
+Index. Unreviewed results use publisher-qualified `discovery:owner/repo//path`
+selectors and show their exact indexed commit before install. The CLI
+reacquires and validates those package bytes before mutation; the index
+signature authenticates metadata but is not a package or runtime endorsement.
+`outdated` is read-only, while `update --all` keeps every installation's
+recorded source and targets and fails the batch preflight before mutation if any
+planned update is unsafe.
+
+For Agent Plugins 1.0, the root `plugin.json` is the install authority. A
+`plugin.yaml` file is legacy `plugin-kit-ai` authoring input only: it is not
+merged with, converted into, or allowed to silently override `plugin.json`.
+
+Before changing anything, the CLI resolves and validates the source and
+preflights every selected client. `--dry-run` prints that same read-only plan.
+`doctor` only inspects paths and filesystem metadata; it never launches a
+discovered client executable, and neither does a `--dry-run`. Non-dry-run
+lifecycle resolution may explicitly run a bounded `--version` probe when an
+exact client version is needed for signed Directory evidence. That probe
+receives an empty stdin and credential-free environment and runs outside the
+caller's working directory. If it cannot obtain a matching version,
+version-bound evidence remains unavailable rather than being inferred.
+Managed files and state are staged and committed together; a failure rolls back
+changes when ownership can be proven, or stops with recovery guidance without
+claiming success. Observed unowned entries fail closed before mutation. Portable
+filesystems cannot provide a linearizable content compare-and-swap against a
+non-cooperating client that writes in the final syscall-sized window, so the CLI
+rechecks and reports identity conflicts instead of promising impossible
+concurrency isolation. Client-controlled activation happens separately: some
+clients activate automatically, while others finish as prepared and print a
+manual activation step. OAuth and consent prompts stay visible and
+user-controlled; cancelling one preserves the package and reports
+authentication as pending or cancelled.
+Kiro skills are installed directly into the documented global skills path.
+For packages with MCP servers, agentplugins atomically merges only its owned
+entries into Kiro's global `mcp.json`, preserving unrelated user configuration,
+then checks supported Kiro CLI versions through a bounded structured ACP v1
+initialize/session handshake.
+It sends no prompt or model/tool turn and does not inject package endpoints;
+Kiro must load its installed native configuration and report connected servers
+with enabled tools. The verifier drains a bounded quiet settlement window,
+rejects EOF, partial bytes, or trailing contradictions, then stops and reaps the
+long-lived ACP process through supervised containment. Automatic Kiro ACP
+verification is available only on Linux after capability preflight proves
+delegated cgroup v2 creation, atomic CLONE_INTO_CGROUP placement, and
+cgroup.kill. macOS, Windows, and Linux hosts without every required proof fail
+preflight before any MCP mutation. On those hosts, use Kiro's documented manual
+skill and MCP configuration paths; that workflow is outside this automatic CLI
+path. Failure to start ACP
+after a supported preflight may still leave a manual verification action. This
+is activation evidence, not a runtime tool E2E claim.
+Once the ACP process starts, companion-launch failure (including a missing
+`kiro-cli-chat`), EOF, timeout, authentication failure, malformed or partial
+output, contradiction, and non-clean exit are authoritative activation
+failures; the managed package remains committed for explicit repair and is
+never reported active.
+Verification is reported for the exact plugin, client, runtime, and OAuth
+evidence available—not as a claim that every combination has been tested.
+
+`universal-agent-plugins` is an independent community installer, not an official
+OpenAI CLI.
+
+Docs site:
+
+- overview: [plugin-kit-ai documentation](https://777genius.github.io/plugin-kit-ai/docs/en/)
+- fastest start: [Quickstart](https://777genius.github.io/plugin-kit-ai/docs/en/guide/quickstart.html)
+- choose by job first: [Choose What You Are Building](https://777genius.github.io/plugin-kit-ai/docs/en/guide/choose-what-you-are-building.html)
+- one repo, many outputs: [What You Can Build](https://777genius.github.io/plugin-kit-ai/docs/en/guide/what-you-can-build.html)
+- delivery model guide: [Choose A Target](https://777genius.github.io/plugin-kit-ai/docs/en/guide/choose-a-target.html)
+- honest caveat: [Support Boundary](https://777genius.github.io/plugin-kit-ai/docs/en/reference/support-boundary.html)
+
+Project policies:
+
+- support boundary: [docs/SUPPORT.md](docs/SUPPORT.md)
+- contributing: [CONTRIBUTING.md](CONTRIBUTING.md)
+- security: [SECURITY.md](SECURITY.md)
+- code of conduct: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+
+## Choose What You Are Building
+
+### Connect an online service
+
+Use this when the plugin should connect to a hosted service like Notion, Stripe, Cloudflare, or Vercel.
+
+```bash
+plugin-kit-ai init my-plugin --template online-service
+cd my-plugin
+plugin-kit-ai inspect . --authoring
+plugin-kit-ai generate .
+plugin-kit-ai generate --check .
+plugin-kit-ai validate . --platform claude --strict
+```
+
+Real examples:
+
+- [notion](https://github.com/777genius/universal-plugins-for-ai-agents/tree/main/plugins/notion)
+- [stripe](https://github.com/777genius/universal-plugins-for-ai-agents/tree/main/plugins/stripe)
+- [cloudflare](https://github.com/777genius/universal-plugins-for-ai-agents/tree/main/plugins/cloudflare)
+- [vercel](https://github.com/777genius/universal-plugins-for-ai-agents/tree/main/plugins/vercel)
+
+### Connect a local tool
+
+Use this when the plugin should call into a repo-owned tool or CLI like Docker Hub, Chrome DevTools, or HubSpot Developer.
+
+```bash
+plugin-kit-ai init my-plugin --template local-tool
+cd my-plugin
+plugin-kit-ai inspect . --authoring
+plugin-kit-ai generate .
+plugin-kit-ai generate --check .
+plugin-kit-ai validate . --platform claude --strict
+```
+
+Real examples:
+
+- [docker-hub](https://github.com/777genius/universal-plugins-for-ai-agents/tree/main/plugins/docker-hub)
+- [hubspot-developer](https://github.com/777genius/universal-plugins-for-ai-agents/tree/main/plugins/hubspot-developer)
+- [chrome-devtools](https://github.com/777genius/universal-plugins-for-ai-agents/tree/main/plugins/win4r/chrome-devtools-codex-plugin)
+
+### Build custom plugin logic - Advanced
+
+Use this when the product is defined by hooks, runtime behavior, or custom plugin code.
+
+This path is more powerful and more engineering-heavy than the first two starters.
+Plain `plugin-kit-ai init my-plugin` still exists as the legacy compatibility path for the older Codex runtime Go starter.
+
+```bash
+plugin-kit-ai init my-plugin --template custom-logic
+cd my-plugin
+plugin-kit-ai inspect . --authoring
+plugin-kit-ai validate . --platform codex-runtime --strict
+plugin-kit-ai test . --platform codex-runtime --event Notify
+```
+
+Guide:
+
+- [Build Custom Plugin Logic](https://777genius.github.io/plugin-kit-ai/docs/en/guide/build-custom-plugin-logic.html)
+
+## Quick Start
+
+Want to try a real Agent Plugin without installing a CLI permanently?
+
+```bash
+npx universal-agent-plugins add context7
+```
+
+Building a plugin instead? Use `plugin-kit-ai` for authoring and generated
+output delivery. Its older `plugin-kit-ai add` lifecycle is not the default
+installer for portable Agent Plugins 1.0. Start with
+[Choose What You Are Building](#choose-what-you-are-building).
+
+Recommended authoring CLI install path:
+
+```bash
+brew install 777genius/homebrew-plugin-kit-ai/plugin-kit-ai
+plugin-kit-ai version
+```
+
+Then create a repo from the path that matches the job:
+
+```bash
+plugin-kit-ai init my-plugin --template online-service
+plugin-kit-ai init my-plugin --template local-tool
+plugin-kit-ai init my-plugin --template custom-logic
+```
+
+Plain `plugin-kit-ai init my-plugin` still exists for backward compatibility, but it is no longer the recommended first start for new repos.
+Use one of the three job-first templates above unless you are intentionally maintaining the older Codex runtime Go path.
+
+## What You Get
+
+- one plugin repo that stays the source of truth
+- authored files under `plugin/`
+- generated root files that stay managed
+- supported outputs for Claude, Codex, Gemini, Cursor, and OpenCode where the repo shape allows it
+- a clean readiness check through `generate`, `generate --check`, and `validate --strict`
+
+## Works Across Multiple Outputs
+
+- Claude
+- Codex package
+- Codex runtime
+- Gemini
+- OpenCode
+- Cursor
+
+That depth stays available, but you do not need to understand the whole target model before creating the repo.
+
+## What To Do Next
+
+- run `plugin-kit-ai inspect . --authoring`
+- edit the repo under `plugin/`
+- regenerate after changes
+- validate the supported output you actually plan to ship first
+- only then add more outputs when the product really needs them
+
+Other supported CLI install methods:
+
+- npm: `npm i -g plugin-kit-ai` or `npx plugin-kit-ai@latest ...`
+- pipx (`public-beta`, only when that release is published to PyPI): `pipx install plugin-kit-ai`
+- fallback installer: `curl -fsSL https://raw.githubusercontent.com/777genius/plugin-kit-ai/main/scripts/install.sh | sh`
+- fallback one-shot command: `curl -fsSL https://raw.githubusercontent.com/777genius/plugin-kit-ai/main/scripts/install.sh | sh -s -- add notion --dry-run`
+- source build for maintainers of this repo: `go build -o bin/plugin-kit-ai ./cli/plugin-kit-ai/cmd/plugin-kit-ai`
+
+## Keep This Rule In Mind
+
+- start with the job you need today
+- keep authored source under `plugin/` for new repos
+- let generated root files stay managed
+- add deeper target-specific behavior only when you need it
+- use advanced docs when you need exact target and support details
+
+## Deep Product Details
+
+Everything below this point is for people comparing delivery models, import paths, and detailed support boundaries. If you only needed the main promise and first path, you can stop above.
+
+## Go Deeper By Goal
+
+### Fast Local Plugin
+
+Choose this when the plugin stays local to the repo and your team already works in Python or Node.
+
+- Main flow: `init -> doctor -> bootstrap -> generate -> validate --strict`
+- Runtime note: the execution machine still needs Python `3.10+` or Node.js `20+`
+- Delivery options: vendored helper by default, shared `plugin-kit-ai-runtime` when you want a reusable dependency, bundle handoff when the repo must travel
+
+This is a supported non-Go path, not a hidden fallback.
+Use the starter templates for Codex and Claude across Go, Python, and Node/TypeScript when you want the fastest copy-first path into a working repo.
+
+Start here:
+
+- [examples/starters/README.md](examples/starters/README.md)
+- [examples/local/README.md](examples/local/README.md)
+- [docs/CHOOSING_HELPER_DELIVERY_MODE.md](docs/CHOOSING_HELPER_DELIVERY_MODE.md)
+
+### Production-Ready Plugin Repo
+
+Choose this when you want the strongest supported release and distribution story.
+
+- Online service path: `plugin-kit-ai init my-plugin --template online-service`
+- Local tool path: `plugin-kit-ai init my-plugin --template local-tool`
+- Advanced runtime path: `plugin-kit-ai init my-plugin --template custom-logic`
+- Package/config expansion later: `codex-package`, `gemini`, `opencode`, `cursor`
+- Real multi-target MCP-first example: [`context7` in universal-plugins-for-ai-agents](https://github.com/777genius/universal-plugins-for-ai-agents/tree/main/plugins/context7)
+
+### Already Have Native Config
+
+Choose this when you are migrating existing Claude/Codex/Gemini/OpenCode/Cursor native files into the repo-owned workflow.
+
+```bash
+./bin/plugin-kit-ai import ./native-plugin --from codex-runtime
+./bin/plugin-kit-ai normalize ./my-plugin
+./bin/plugin-kit-ai generate ./my-plugin
+./bin/plugin-kit-ai validate ./my-plugin --platform codex-runtime --strict
+```
+
+## Stability Snapshot
+
+Stable by default:
+
+- the main public CLI contract
+- the recommended Go SDK path
+- Go scaffolds for the default Codex and Claude runtime lanes
+- the stable local Python and Node subset on `codex-runtime` and `claude`
+- `doctor`, `bootstrap`, `validate --strict`, `export`, and bundle handoff for that stable local subset
+
+Use carefully:
+
+- `generate`, `import`, and `normalize` are still `public-beta`
+- package and workspace-config targets have different guarantees than runtime targets
+- `shell` remains a bounded `public-beta` escape hatch
+
+For the precise contract:
+
+- [docs/generated/target_support_matrix.md](docs/generated/target_support_matrix.md)
+- [docs/generated/support_matrix.md](docs/generated/support_matrix.md)
+- [docs/SUPPORT.md](docs/SUPPORT.md)
+
+## Path Summary
+
+- Go is the recommended path when you want the strongest production story and the least downstream runtime friction.
+- Node/TypeScript is the main supported non-Go path for repo-local runtime plugins.
+- Python is the supported Python-first repo-local path.
+- Package and workspace-config targets are for packaging and configuration outputs, not for pretending every target behaves like a runtime plugin.
+
+## SDK And CLI
+
+Go SDK packages:
+
+- `github.com/777genius/plugin-kit-ai/sdk`
+- `github.com/777genius/plugin-kit-ai/sdk/claude`
+- `github.com/777genius/plugin-kit-ai/sdk/codex`
+- `github.com/777genius/plugin-kit-ai/sdk/gemini`
+
+Useful starting points:
+
+- [sdk/README.md](sdk/README.md)
+- [docs/generated/support_matrix.md](docs/generated/support_matrix.md)
+- [docs/SUPPORT.md](docs/SUPPORT.md)
+
+Common CLI commands:
+
+```bash
+./bin/plugin-kit-ai init my-plugin
+./bin/plugin-kit-ai doctor ./my-plugin
+./bin/plugin-kit-ai bootstrap ./my-plugin
+./bin/plugin-kit-ai generate ./my-plugin
+./bin/plugin-kit-ai validate ./my-plugin --platform codex-runtime --strict
+./bin/plugin-kit-ai import ./native-plugin --from codex-runtime
+./bin/plugin-kit-ai capabilities --format json
+```
+
+`plugin-kit-ai install` stays intentionally narrow: it installs third-party plugin binaries from GitHub Releases, verifies `checksums.txt`, and does not act as a self-update path for the CLI itself.
+
+For automation, `plugin-kit-ai validate --format json` now emits the versioned `plugin-kit-ai/validate-report` contract with `schema_version: 1` and explicit outcomes `passed`, `failed`, or `failed_strict_warnings`.
+For Codex lane selection, use [docs/CODEX_TARGET_BOUNDARY.md](docs/CODEX_TARGET_BOUNDARY.md). For the validation ABI itself, use [docs/VALIDATE_JSON_CONTRACT.md](docs/VALIDATE_JSON_CONTRACT.md).
+
+## Build And Test
+
+Requirements:
+
+- Go `1.25.13` for this monorepo workspace and its CI lanes
+- generated Go plugin projects created by `plugin-kit-ai init` remain on Go `1.22+`
+
+Common commands from repo root:
+
+```bash
+go run ./cmd/plugin-kit-ai-gen
+go build -o bin/plugin-kit-ai ./cli/plugin-kit-ai/cmd/plugin-kit-ai
+./bin/plugin-kit-ai version
+make test-polyglot-smoke
+go test ./...
+```
+
+## Repository And Docs Map
+
+Main repo areas:
+
+- `sdk`
+- `cli/plugin-kit-ai`
+- `install/plugininstall`
+- `examples/starters`
+- `examples/local`
+- `examples/plugins`
+- `repotests`
+- `docs`
+
+Canonical docs:
+
+- [docs/generated/support_matrix.md](docs/generated/support_matrix.md)
+- [docs/generated/target_support_matrix.md](docs/generated/target_support_matrix.md)
+- [docs/SUPPORT.md](docs/SUPPORT.md)
+- [docs/CODEX_TARGET_BOUNDARY.md](docs/CODEX_TARGET_BOUNDARY.md)
+- [docs/VALIDATE_JSON_CONTRACT.md](docs/VALIDATE_JSON_CONTRACT.md)
+- [docs/PRODUCTION.md](docs/PRODUCTION.md)
+- [docs/INSTALL_COMPATIBILITY.md](docs/INSTALL_COMPATIBILITY.md)
+- [docs/STATUS.md](docs/STATUS.md)
+
+Maintainer-only historical context:
+
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+- [docs/FOUNDATION_REWRITE_VNEXT.md](docs/FOUNDATION_REWRITE_VNEXT.md)
+- [docs/adr/README.md](docs/adr/README.md)

--- a/npm/agentplugins/README.md
+++ b/npm/agentplugins/README.md
@@ -1,9 +1,11 @@
 # Universal Agent Plugins
 
 `universal-agent-plugins` is the public npm package for installing and managing
-portable Agent Plugins 1.0 packages. It installs the `agentplugins` binary;
-`npx universal-agent-plugins` and a globally installed `agentplugins` run the
-same lifecycle manager, not separate engines.
+portable Agent Plugins 1.0 packages. Its product home and npm facade source are
+the [`universal-agent-plugins`](https://github.com/777genius/universal-agent-plugins)
+repository. It installs the `agentplugins` binary; `npx universal-agent-plugins`
+and a globally installed `agentplugins` run the same lifecycle manager, not
+separate engines.
 
 Prerequisite: Node.js 22 or newer.
 
@@ -11,9 +13,10 @@ Prerequisite: Node.js 22 or newer.
 npx universal-agent-plugins add context7
 ```
 
-`universal-agent-plugins` is an independent community CLI built in
-[`plugin-kit-ai`](https://github.com/777genius/plugin-kit-ai). It is not an
-official OpenAI or Agent Plugins project and is not affiliated with
+The npm package is a thin Node.js launcher.
+[`plugin-kit-ai`](https://github.com/777genius/plugin-kit-ai) owns and releases
+the shared Go implementation engine; it is not duplicated here. This is an independent community CLI, not an official
+OpenAI or Agent Plugins project, and is not affiliated with
 `sigilco/agentplugins` or `@agentplugins/cli`. Agent Plugins 1.0 defines the
 portable `plugin.json` package; this CLI supplies installation and lifecycle
 policy.
@@ -23,7 +26,7 @@ binary matching the exact npm version, verifies the SHA-256 embedded in the npm
 tarball, then caches it under XDG Cache or LocalAppData. It never falls back to
 `latest` and never sends `GITHUB_TOKEN` to public downloads.
 
-Release 0.1.15 passed exact native npm bootstrap proofs on all six supported
+Stable publication is gated by exact native npm bootstrap proofs on all six supported
 platforms:
 
 | OS | x64 | arm64 |
@@ -63,10 +66,10 @@ Detection checks installed executables and documented configuration surfaces.
 It does not start an agent, log in, complete OAuth, or prove browser/tool
 runtime behavior.
 
-The following matrix describes the current release source. New client support
-is available through `npx` once a release containing this source is published.
-The exact package, source revisions, commands, and limitations are recorded in
-the [isolated client E2E evidence](https://github.com/777genius/plugin-kit-ai/blob/main/docs/AGENTPLUGINS_CLIENT_E2E.md).
+The following matrix describes historical lifecycle evidence collected for
+installer 0.1.22. It is not evidence for the current npm release. The exact
+package, source revisions, commands, and limitations are recorded in the
+[commit-pinned historical client E2E evidence](https://github.com/777genius/plugin-kit-ai/blob/4b25a45e1574bab7a4f49e48905a3b3b2647e917/docs/AGENTPLUGINS_CLIENT_E2E.md).
 
 | Client | Evidence |
 | --- | --- |

--- a/npm/agentplugins/assets.json
+++ b/npm/agentplugins/assets.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "version": "0.0.0-development",
   "repository": "777genius/plugin-kit-ai",
   "tag": "",

--- a/npm/agentplugins/lib/bootstrap.js
+++ b/npm/agentplugins/lib/bootstrap.js
@@ -15,6 +15,16 @@ const MAX_REDIRECTS = 5;
 const DOWNLOAD_TIMEOUT_MS = 30_000;
 const LOCK_TIMEOUT_MS = 30_000;
 const PROOF_MODE = "local-frozen-release-asset-v1";
+const PRODUCER_REPOSITORY = "777genius/plugin-kit-ai";
+const HISTORICAL_EVIDENCE_COMMIT = "4b25a45e1574bab7a4f49e48905a3b3b2647e917";
+const HISTORICAL_EVIDENCE_DOCUMENT_SHA256 = "df6769bf430a337f116cd9df75bcc3ea26df166a016eacf9bc9fbc6cfbf9b100";
+const HISTORICAL_EVIDENCE_RECORD_SHA256 = "437da1bc7423a85b231be139ff9bfbd7e89c942ef216a61ebde668c08a9c2ee3";
+const COMMIT = /^[0-9a-f]{40}$/;
+
+function exactKeys(value, keys) {
+  return value && typeof value === "object" && !Array.isArray(value) &&
+    Object.keys(value).sort().join(",") === [...keys].sort().join(",");
+}
 
 function loadRelease(packageRoot, platformInfo) {
   const pkg = JSON.parse(fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"));
@@ -23,7 +33,7 @@ function loadRelease(packageRoot, platformInfo) {
   if (!VERSION.test(version) || version === "0.0.0-development") {
     throw new Error("this development npm package has no released binary; use an exact published version");
   }
-  if (manifest.schema_version !== 1 || manifest.version !== version) {
+  if (manifest.schema_version !== 2 || manifest.version !== version) {
     throw new Error("npm version and embedded binary manifest do not match");
   }
   if (manifest.npm_package !== pkg.name) {
@@ -34,6 +44,43 @@ function loadRelease(packageRoot, platformInfo) {
   }
   if (manifest.tag !== `agentplugins-v${version}`) {
     throw new Error("embedded release tag does not match npm version");
+  }
+  const producer = manifest.producer;
+  const releaseManifest = producer && producer.release_manifest;
+  if (!exactKeys(producer, ["repository", "tag", "commit", "release_manifest"]) ||
+      producer.repository !== PRODUCER_REPOSITORY || producer.repository !== manifest.repository ||
+      producer.tag !== manifest.tag || !COMMIT.test(String(producer.commit || "")) ||
+      !exactKeys(releaseManifest, ["schema_version", "sha256", "version"]) ||
+      releaseManifest.schema_version !== 2 || releaseManifest.version !== version ||
+      !DIGEST.test(String(releaseManifest.sha256 || ""))) {
+    throw new Error("embedded producer release identity is invalid or incomplete");
+  }
+  const evidence = manifest.client_evidence;
+  const installer = evidence && evidence.installer;
+  const evidencePackage = evidence && evidence.package;
+  const source = evidence && evidence.source;
+  const claims = evidence && evidence.claim_boundary;
+  const claimKeys = ["lifecycle_e2e", "client_discovery_e2e", "browser_tool_runtime_e2e", "model_turn_e2e", "login_e2e", "oauth_e2e", "windsurf_skill_activation_claimed"];
+  if (!exactKeys(evidence, ["schema_version", "kind", "recorded_at", "document_sha256", "record_sha256", "source", "installer", "package", "claim_boundary"]) ||
+      evidence.schema_version !== 1 || evidence.kind !== "agentplugins_client_lifecycle" ||
+      !/^\d{4}-\d{2}-\d{2}$/.test(String(evidence.recorded_at || "")) ||
+      evidence.document_sha256 !== HISTORICAL_EVIDENCE_DOCUMENT_SHA256 || evidence.record_sha256 !== HISTORICAL_EVIDENCE_RECORD_SHA256 ||
+      !exactKeys(source, ["repository", "commit", "document", "record"]) || source.repository !== PRODUCER_REPOSITORY || source.commit !== HISTORICAL_EVIDENCE_COMMIT ||
+      !exactKeys(source.document, ["path", "sha256"]) || source.document.path !== "docs/AGENTPLUGINS_CLIENT_E2E.md" || source.document.sha256 !== evidence.document_sha256 ||
+      !exactKeys(source.record, ["path", "sha256"]) || source.record.path !== "docs/evidence/agentplugins-client-e2e-2026-08-30.json" || source.record.sha256 !== evidence.record_sha256 ||
+      !exactKeys(installer, ["repository", "commit", "tree", "version", "binary_sha256"]) ||
+      installer.repository !== PRODUCER_REPOSITORY || !COMMIT.test(String(installer.commit || "")) ||
+      !COMMIT.test(String(installer.tree || "")) || !/^\d+\.\d+\.\d+$/.test(String(installer.version || "")) ||
+      !DIGEST.test(String(installer.binary_sha256 || "")) ||
+      !exactKeys(evidencePackage, ["selector", "revision", "tree_digest", "manifest_digest"]) ||
+      !COMMIT.test(String(evidencePackage.revision || "")) ||
+      !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+@[0-9a-f]{40}$/.test(String(evidencePackage.selector || "")) ||
+      !String(evidencePackage.selector).endsWith(`@${evidencePackage.revision}`) ||
+      !/^sha256:[0-9a-f]{64}$/.test(String(evidencePackage.tree_digest || "")) ||
+      !/^sha256:[0-9a-f]{64}$/.test(String(evidencePackage.manifest_digest || "")) ||
+      !exactKeys(claims, claimKeys) || claims.lifecycle_e2e !== true || claims.client_discovery_e2e !== true ||
+      claimKeys.slice(2).some((key) => claims[key] !== false)) {
+    throw new Error("embedded historical client evidence identity is invalid or incomplete");
   }
   const asset = manifest.assets && manifest.assets[platformInfo.key];
   if (!asset || asset.file !== expectedAssetName(version, platformInfo) || !DIGEST.test(String(asset.sha256 || "")) || !Number.isSafeInteger(asset.size) || asset.size <= 0) {
@@ -213,8 +260,19 @@ function delay(milliseconds) {
 }
 
 async function acquireLock(target, options = {}) {
-  const lockRoot = path.join(os.tmpdir(), "agentplugins-npm-locks");
+  const lockRoot = options.lockRoot || path.join(cacheRoot(
+    options.environment || process.env,
+    options.platform || process.platform,
+    options.home || os.homedir()
+  ), ".locks");
   await fsp.mkdir(lockRoot, { recursive: true, mode: 0o700 });
+  const rootStat = await fsp.lstat(lockRoot);
+  const expectedUid = typeof process.geteuid === "function" ? process.geteuid() : null;
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink() ||
+      (expectedUid !== null && rootStat.uid !== expectedUid) ||
+      (process.platform !== "win32" && (rootStat.mode & 0o777) !== 0o700)) {
+    throw new Error("agentplugins cache lock root must be a user-owned mode-0700 real directory");
+  }
   const name = crypto.createHash("sha256").update(target).digest("hex") + ".lock";
   const lockPath = path.join(lockRoot, name);
   const started = Date.now();
@@ -256,8 +314,8 @@ async function acquireLock(target, options = {}) {
   }
 }
 
-async function installVerifiedBinary(downloaded, binaryPath, release, platformInfo) {
-  const releaseLock = await acquireLock(binaryPath);
+async function installVerifiedBinary(downloaded, binaryPath, release, platformInfo, lockRoot) {
+  const releaseLock = await acquireLock(binaryPath, { lockRoot });
   try {
     if (await validCachedBinary(binaryPath, release.asset.sha256)) {
       return binaryPath;
@@ -315,6 +373,7 @@ async function ensureBinary(options = {}) {
   const platformInfo = detectPlatform(options.platform, options.arch);
   const release = loadRelease(packageRoot, platformInfo);
   const root = options.cacheRoot || cacheRoot(options.environment, options.platform);
+  const lockRoot = path.join(root, ".locks");
   const binaryPath = path.join(root, release.version, platformInfo.key, platformInfo.binaryName);
   if (await validCachedBinary(binaryPath, release.asset.sha256)) {
     return { binaryPath, version: release.version, cacheHit: true };
@@ -326,7 +385,7 @@ async function ensureBinary(options = {}) {
         throw new Error("internal proof release asset filename does not match embedded metadata");
       }
       await verifyLocalProofAsset(proofAsset, release.asset);
-      await installVerifiedBinary(proofAsset, binaryPath, release, platformInfo);
+      await installVerifiedBinary(proofAsset, binaryPath, release, platformInfo, lockRoot);
       return { binaryPath, version: release.version, cacheHit: false, source: "local_frozen_asset" };
     } catch (error) {
       const cold = !(await validCachedBinary(binaryPath, release.asset.sha256));
@@ -339,7 +398,7 @@ async function ensureBinary(options = {}) {
   const temporary = path.join(os.tmpdir(), `agentplugins-download-${process.pid}-${crypto.randomBytes(8).toString("hex")}`);
   try {
     await downloadFile(url, temporary, release.asset, options);
-    await installVerifiedBinary(temporary, binaryPath, release, platformInfo);
+    await installVerifiedBinary(temporary, binaryPath, release, platformInfo, lockRoot);
     return { binaryPath, version: release.version, cacheHit: false };
   } catch (error) {
     const cold = !(await validCachedBinary(binaryPath, release.asset.sha256));

--- a/npm/agentplugins/package.json
+++ b/npm/agentplugins/package.json
@@ -3,14 +3,14 @@
   "version": "0.0.0-development",
   "description": "Universal community installer and lifecycle manager for Agent Plugins 1.0",
   "license": "MIT",
-  "homepage": "https://github.com/777genius/plugin-kit-ai#install-agent-plugins-10",
+  "homepage": "https://777genius.github.io/universal-agent-plugins/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/777genius/plugin-kit-ai.git",
+    "url": "git+https://github.com/777genius/universal-agent-plugins.git",
     "directory": "npm/agentplugins"
   },
   "bugs": {
-    "url": "https://github.com/777genius/plugin-kit-ai/issues"
+    "url": "https://github.com/777genius/universal-agent-plugins/issues"
   },
   "keywords": [
     "agent-plugins",

--- a/npm/agentplugins/scripts/npm-public-contract.js
+++ b/npm/agentplugins/scripts/npm-public-contract.js
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+const { isDeepStrictEqual } = require("node:util");
+
+const PACKAGE_NAME = "universal-agent-plugins";
+const UAP_REPOSITORY = "https://github.com/777genius/universal-agent-plugins";
+const UAP_WORKFLOW = ".github/workflows/agentplugins-npm-publish.yml";
+const SLSA_PREDICATE = "https://slsa.dev/provenance/v1";
+const VERSION = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/;
+const INTEGRITY = /^sha512-([A-Za-z0-9+/]{86}==)$/;
+const SHASUM = /^[0-9a-f]{40}$/;
+const COMMIT = /^[0-9a-f]{40}$/;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function exactObject(actual, expected, label) {
+  if (!isDeepStrictEqual(actual, expected)) {
+    fail(`${label} does not match the package contract`);
+  }
+}
+
+function exactKeys(actual, expected, label) {
+  if (!actual || typeof actual !== "object" || Array.isArray(actual) ||
+      !isDeepStrictEqual(Object.keys(actual).sort(), expected.slice().sort())) {
+    fail(`${label} does not have the exact package contract fields`);
+  }
+}
+
+function validateExpected(version, integrity, shasum) {
+  if (!VERSION.test(version)) fail("version must be an exact stable semantic version");
+  const match = integrity.match(INTEGRITY);
+  if (!match || Buffer.from(match[1], "base64").length !== 64) {
+    fail("integrity must be an exact SHA-512 SRI value");
+  }
+  if (!SHASUM.test(shasum)) fail("shasum must be an exact lowercase SHA-1 value");
+}
+
+function validatePackJSON(value, version) {
+  let record;
+  if (Array.isArray(value)) {
+    if (value.length !== 1) fail("npm pack JSON must contain exactly one record");
+    [record] = value;
+  } else if (value && typeof value === "object") {
+    const keys = Object.keys(value);
+    if (keys.length !== 1 || keys[0] !== PACKAGE_NAME) {
+      fail("npm pack JSON must contain exactly one package-named record");
+    }
+    record = value[PACKAGE_NAME];
+  } else {
+    fail("npm pack JSON must contain exactly one record");
+  }
+  if (!record || record.name !== PACKAGE_NAME || record.version !== version ||
+      record.filename !== `${PACKAGE_NAME}-${version}.tgz`) {
+    fail("npm pack JSON package identity does not match the release");
+  }
+  validateExpected(version, record.integrity, record.shasum);
+  return record;
+}
+
+function validatePublicMetadata(metadata, version, integrity, shasum) {
+  validateExpected(version, integrity, shasum);
+  if (!metadata || metadata.name !== PACKAGE_NAME || metadata.version !== version) {
+    fail("public npm name/version does not match the package contract");
+  }
+  exactObject(metadata.repository, {
+    type: "git",
+    url: "git+https://github.com/777genius/universal-agent-plugins.git",
+    directory: "npm/agentplugins"
+  }, "public npm repository");
+  if (metadata.homepage !== "https://777genius.github.io/universal-agent-plugins/") {
+    fail("public npm homepage does not match the UAP Pages contract");
+  }
+  exactObject(metadata.engines, { node: ">=22" }, "public npm engines");
+  exactObject(metadata.bin, { agentplugins: "bin/agentplugins.js" }, "public npm bin");
+  exactObject(metadata.scripts, { test: "node --test" }, "public npm scripts/lifecycle hooks");
+
+  const expectedTarball = `https://registry.npmjs.org/${PACKAGE_NAME}/-/${PACKAGE_NAME}-${version}.tgz`;
+  const expectedAttestation = `https://registry.npmjs.org/-/npm/v1/attestations/${PACKAGE_NAME}@${version}`;
+  if (!metadata.dist || metadata.dist.tarball !== expectedTarball ||
+      metadata.dist.integrity !== integrity || metadata.dist.shasum !== shasum) {
+    fail("public npm dist identity does not match the staged tarball");
+  }
+  exactObject(metadata.dist.attestations, {
+    url: expectedAttestation,
+    provenance: { predicateType: "https://slsa.dev/provenance/v1" }
+  }, "public npm attestation URL and provenance predicate");
+  exactKeys(metadata._npmUser, ["name", "email", "trustedPublisher"], "public npm publisher identity");
+  if (metadata._npmUser.name !== "GitHub Actions" ||
+      metadata._npmUser.email !== "npm-oidc-no-reply@github.com") {
+    fail("public npm publisher identity is not GitHub Actions");
+  }
+  const publisher = metadata._npmUser?.trustedPublisher;
+  exactKeys(publisher, ["id", "oidcConfigId"], "public npm trusted publisher");
+  if (publisher.id !== "github" ||
+      !/^oidc:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(publisher.oidcConfigId)) {
+    fail("public npm trusted publisher is not an exact GitHub Actions OIDC identity");
+  }
+  return metadata;
+}
+
+function decodeBase64JSON(encoded, label) {
+  if (typeof encoded !== "string" || !/^[A-Za-z0-9+/]+={0,2}$/.test(encoded) || encoded.length % 4 !== 0) {
+    fail(`${label} is not canonical base64`);
+  }
+  const decoded = Buffer.from(encoded, "base64");
+  if (decoded.toString("base64") !== encoded) fail(`${label} is not canonical base64`);
+  try {
+    return JSON.parse(decoded.toString("utf8"));
+  } catch (error) {
+    fail(`${label} is not JSON: ${error.message}`);
+  }
+}
+
+function validateSLSAAttestation(response, version, integrity, uapTag, uapCommit) {
+  validateExpected(version, integrity, "0".repeat(40));
+  if (uapTag !== `v${version}`) fail("UAP tag does not match the package version");
+  if (!COMMIT.test(uapCommit)) fail("UAP commit must be an exact lowercase commit");
+  if (!response || !Array.isArray(response.attestations)) fail("npm attestation response is invalid");
+  const provenance = response.attestations.filter((item) => item?.predicateType === SLSA_PREDICATE);
+  if (provenance.length !== 1) fail("npm response must contain exactly one SLSA provenance attestation");
+  const attestation = provenance[0];
+  if (attestation.bundle?.mediaType !== "application/vnd.dev.sigstore.bundle.v0.3+json") {
+    fail("npm SLSA provenance is not a Sigstore bundle v0.3");
+  }
+  const envelope = attestation.bundle.dsseEnvelope;
+  if (!envelope || envelope.payloadType !== "application/vnd.in-toto+json" ||
+      !Array.isArray(envelope.signatures) || envelope.signatures.length !== 1 ||
+      typeof envelope.signatures[0]?.sig !== "string" || envelope.signatures[0].sig.length === 0) {
+    fail("npm SLSA provenance does not contain one signed in-toto DSSE payload");
+  }
+  const statement = decodeBase64JSON(envelope.payload, "npm SLSA DSSE payload");
+  const integrityBytes = Buffer.from(integrity.match(INTEGRITY)[1], "base64");
+  exactObject(statement.subject, [{
+    name: `pkg:npm/${PACKAGE_NAME}@${version}`,
+    digest: { sha512: integrityBytes.toString("hex") }
+  }], "npm SLSA subject and staged SHA-512");
+  if (statement._type !== "https://in-toto.io/Statement/v1" ||
+      statement.predicateType !== SLSA_PREDICATE) {
+    fail("npm SLSA statement type or predicate does not match the contract");
+  }
+  const build = statement.predicate?.buildDefinition;
+  if (build?.buildType !== "https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1") {
+    fail("npm SLSA provenance is not a GitHub Actions workflow build");
+  }
+  exactObject(build.externalParameters?.workflow, {
+    ref: `refs/tags/${uapTag}`,
+    repository: UAP_REPOSITORY,
+    path: UAP_WORKFLOW
+  }, "npm SLSA GitHub Actions workflow identity");
+  exactObject(build.resolvedDependencies, [{
+    uri: `git+${UAP_REPOSITORY}@refs/tags/${uapTag}`,
+    digest: { gitCommit: uapCommit }
+  }], "npm SLSA UAP tag and commit dependency");
+  if (statement.predicate?.runDetails?.builder?.id !==
+      "https://github.com/actions/runner/github-hosted") {
+    fail("npm SLSA publisher did not use a GitHub-hosted Actions runner");
+  }
+  const invocation = statement.predicate?.runDetails?.metadata?.invocationId;
+  if (typeof invocation !== "string" ||
+      !invocation.startsWith(`${UAP_REPOSITORY}/actions/runs/`)) {
+    fail("npm SLSA invocation is not an exact UAP GitHub Actions run");
+  }
+  return statement;
+}
+
+function validateAuditSignatures(audit, response, version) {
+  if (!VERSION.test(version) || !audit || !Array.isArray(audit.invalid) || audit.invalid.length !== 0 ||
+      !Array.isArray(audit.missing) || audit.missing.length !== 0 ||
+      !Array.isArray(audit.verified) || audit.verified.length !== 1) {
+    fail("npm audit signatures did not cryptographically verify exactly one package");
+  }
+  const verified = audit.verified[0];
+  const expectedAttestation = `https://registry.npmjs.org/-/npm/v1/attestations/${PACKAGE_NAME}@${version}`;
+  if (verified.name !== PACKAGE_NAME || verified.version !== version ||
+      verified.location !== `node_modules/${PACKAGE_NAME}` ||
+      verified.registry !== "https://registry.npmjs.org/") {
+    fail("npm audit signatures package identity does not match the public release");
+  }
+  exactObject(verified.attestations, {
+    url: expectedAttestation,
+    provenance: { predicateType: SLSA_PREDICATE }
+  }, "npm audit signatures attestation identity");
+  exactObject(verified.attestationBundles, response?.attestations,
+    "npm audit signatures cryptographically verified bundles");
+  return verified;
+}
+
+function validateDownloadedTarball(packJSON, tarballRoot, version, integrity, shasum) {
+  validateExpected(version, integrity, shasum);
+  const record = validatePackJSON(packJSON, version);
+  if (record.integrity !== integrity || record.shasum !== shasum) {
+    fail("downloaded public npm pack identity does not match the staged tarball");
+  }
+  const root = path.resolve(tarballRoot);
+  const tarball = path.join(root, record.filename);
+  const stat = fs.lstatSync(tarball);
+  if (!stat.isFile() || stat.isSymbolicLink()) fail("downloaded npm tarball is not a regular file");
+  const body = fs.readFileSync(tarball);
+  const actualIntegrity = `sha512-${crypto.createHash("sha512").update(body).digest("base64")}`;
+  const actualShasum = crypto.createHash("sha1").update(body).digest("hex");
+  if (actualIntegrity !== integrity || actualShasum !== shasum) {
+    fail("downloaded public npm tarball bytes do not match the staged integrity and shasum");
+  }
+  return record;
+}
+
+function readJSON(filename) {
+  return JSON.parse(fs.readFileSync(filename, "utf8"));
+}
+
+function main() {
+  const [command, ...args] = process.argv.slice(2);
+  if (command === "stage-outputs" && args.length === 3) {
+    const [packFile, outputFile, version] = args;
+    const record = validatePackJSON(readJSON(packFile), version);
+    fs.appendFileSync(outputFile, `tarball_integrity=${record.integrity}\ntarball_shasum=${record.shasum}\n`);
+  } else if (command === "metadata" && args.length === 4) {
+    validatePublicMetadata(readJSON(args[0]), args[1], args[2], args[3]);
+  } else if (command === "attestation" && args.length === 5) {
+    validateSLSAAttestation(readJSON(args[0]), args[1], args[2], args[3], args[4]);
+  } else if (command === "audit" && args.length === 3) {
+    validateAuditSignatures(readJSON(args[0]), readJSON(args[1]), args[2]);
+  } else if (command === "download" && args.length === 5) {
+    validateDownloadedTarball(readJSON(args[0]), args[1], args[2], args[3], args[4]);
+  } else {
+    fail("usage: npm-public-contract.js stage-outputs <pack-json> <github-output> <version> | metadata <metadata-json> <version> <integrity> <shasum> | attestation <attestation-json> <version> <integrity> <uap-tag> <uap-commit> | audit <npm-audit-json> <attestation-json> <version> | download <pack-json> <tarball-root> <version> <integrity> <shasum>");
+  }
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`npm public contract: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  validateDownloadedTarball,
+  validateAuditSignatures,
+  validatePackJSON,
+  validatePublicMetadata,
+  validateSLSAAttestation
+};

--- a/npm/agentplugins/scripts/platform-proof.js
+++ b/npm/agentplugins/scripts/platform-proof.js
@@ -71,6 +71,19 @@ function npmInvocation(args, platform = process.platform, execPath = process.exe
   return { command: execPath, args: [npmCLI, ...args] };
 }
 
+function installedShimInvocation(project, args, platform = process.platform) {
+  const shim = path.join(project, "node_modules", ".bin", platform === "win32" ? "agentplugins.cmd" : "agentplugins");
+  return { command: shim, args, shell: platform === "win32" };
+}
+
+function assertInstalledShimInvocation(invocation, project, platform = process.platform) {
+  const expected = installedShimInvocation(project, [], platform).command;
+  if (!invocation || path.resolve(invocation.command) !== path.resolve(expected) ||
+      invocation.shell !== (platform === "win32")) {
+    fail("platform proof must execute the installed npm agentplugins shim");
+  }
+}
+
 function parseLifecycle(value) {
   if (value !== "true" && value !== "false") {
     fail("lifecycle must be exactly true or false");
@@ -103,6 +116,21 @@ function frozenReleaseAsset(releaseAssetsRoot, expectedCommit, version, expected
   return file;
 }
 
+function assertAssetManifest(manifest, version, expectedCommit, expectedTarget) {
+  if (!manifest || manifest.schema_version !== 2 || manifest.version !== version ||
+      manifest.npm_package !== "universal-agent-plugins" ||
+      manifest.repository !== "777genius/plugin-kit-ai" ||
+      manifest.tag !== `agentplugins-v${version}` ||
+      manifest.producer?.repository !== "777genius/plugin-kit-ai" ||
+      manifest.producer.tag !== `agentplugins-v${version}` ||
+      manifest.producer.commit !== expectedCommit) {
+    fail("npm asset manifest does not match the exact package, producer tag, and expected commit");
+  }
+  const pinned = manifest.assets?.[expectedTarget];
+  if (!pinned) fail(`tarball has no exact pin for ${expectedTarget}`);
+  return pinned;
+}
+
 function lifecycleCommands(synthetic) {
   return [
     ["add", synthetic, "--target", "cursor"],
@@ -130,6 +158,26 @@ function lifecycleResult(output, command, target) {
     fail(`agentplugins ${command} did not return exactly one successful ${target} lifecycle result`);
   }
   return targets[0].output.result;
+}
+
+function assertContext7Search(output) {
+  if (output?.schema_version !== 1 || output.command !== "search" || output.result !== "success" ||
+      !output.data || typeof output.data !== "object" || !Array.isArray(output.data.results) ||
+      !output.data.results.some((result) => result?.product_id === "context7" &&
+        result.distribution_id === "777genius/context7")) {
+    fail("public catalog search did not contain the expected context7 product and distribution");
+  }
+}
+
+function assertSyntheticInfo(output) {
+  const clients = output?.data?.clients;
+  if (output?.schema_version !== 1 || output.command !== "info" || output.result !== "success" ||
+      !output.data || typeof output.data !== "object" || output.data.name !== "platform-proof-synthetic" ||
+      output.data.version !== "1.0.0" || !Array.isArray(clients) || clients.length !== 1 ||
+      clients[0]?.client_id !== "cursor" || clients[0].activation !== "active" ||
+      clients[0].package_revision?.version !== "1.0.0") {
+    fail("isolated synthetic info did not prove identity, Cursor target, installed version, and active state");
+  }
 }
 
 function main() {
@@ -208,8 +256,7 @@ function main() {
     fail("installed tarball version or no-install-script invariant is invalid");
   }
   const manifest = JSON.parse(fs.readFileSync(path.join(packageRoot, "assets.json"), "utf8"));
-  const pinned = manifest.assets?.[expectedTarget];
-  if (!pinned || manifest.version !== version) fail(`tarball has no exact pin for ${expectedTarget}`);
+  const pinned = assertAssetManifest(manifest, version, expectedCommit, expectedTarget);
   if (fs.existsSync(cache)) fail("binary cache was not cold before the launcher ran");
 
   if (bootstrapMode === "local_frozen_asset") {
@@ -222,14 +269,19 @@ function main() {
     fail("public release bootstrap must not receive a local proof asset directory");
   }
 
-  const shim = path.join(project, "node_modules", ".bin", process.platform === "win32" ? "agentplugins.cmd" : "agentplugins");
+  const shim = installedShimInvocation(project, [], process.platform).command;
   if (!fs.existsSync(shim)) fail("npm did not create the agentplugins executable shim");
-  const launcher = path.join(packageRoot, "bin", "agentplugins.js");
   const commandOptions = { cwd: project, env };
-  const invoke = (args) => run(process.execPath, [launcher, ...args], commandOptions);
+  const invoke = (args) => {
+    const invocation = installedShimInvocation(project, args);
+    assertInstalledShimInvocation(invocation, project);
+    return run(invocation.command, invocation.args, { ...commandOptions, shell: invocation.shell });
+  };
   const privateRoots = [root, process.env.GITHUB_WORKSPACE, process.env.RUNNER_TEMP];
   const invokeJSON = (args) => {
-    const output = jsonCommand(process.execPath, [launcher, ...args, "--format", "json"], commandOptions);
+    const invocation = installedShimInvocation(project, [...args, "--format", "json"]);
+    assertInstalledShimInvocation(invocation, project);
+    const output = jsonCommand(invocation.command, invocation.args, { ...commandOptions, shell: invocation.shell });
     assertPublicJSONPathFree(output, `agentplugins ${args[0]} JSON`, privateRoots);
     return output;
   };
@@ -247,12 +299,14 @@ function main() {
   const firstMtime = stat.mtimeMs;
   const list = invokeJSON(["list"]);
   const doctor = invokeJSON(["doctor"]);
+  const search = invokeJSON(["search", "context7"]);
   if (list.schema_version !== 1 || list.command !== "list" || list.data.installations.length !== 0) {
     fail("clean list contract failed");
   }
   if (doctor.schema_version !== 1 || doctor.command !== "doctor" || doctor.data.read_only !== true) {
     fail("read-only doctor contract failed");
   }
+  assertContext7Search(search);
   const dryRun = invokeJSON(["add", synthetic, "--target", "cursor", "--dry-run"]);
   if (dryRun.schema_version !== 1 || dryRun.command !== "add" || dryRun.data.dry_run !== true) {
     fail("synthetic add dry-run contract failed");
@@ -265,10 +319,12 @@ function main() {
     const [addCommand, completeCommand, updateCommand, removeCommand] = lifecycleCommands(synthetic);
     const add = invokeJSON(addCommand);
     const complete = invokeJSON(completeCommand);
+    const info = invokeJSON(["info", "platform-proof-synthetic", "--target", "cursor"]);
     const update = invokeJSON(updateCommand);
     const remove = invokeJSON(removeCommand);
     const addResult = lifecycleResult(add, "add", "cursor");
     const completeResult = lifecycleResult(complete, "add", "cursor");
+    assertSyntheticInfo(info);
     const updateResult = lifecycleResult(update, "update", "cursor");
     const removeResult = lifecycleResult(remove, "remove", "cursor");
     if (addResult.mutated !== true || addResult.activation.authentication !== "not_checked" ||
@@ -292,6 +348,7 @@ function main() {
     bootstrap_source: bootstrapMode,
     proofs: {
       npm_install_ignore_scripts: true,
+      installed_npm_shim_executed: true,
       launcher_cold_bootstrap: true,
       local_frozen_asset_bootstrap: bootstrapMode === "local_frozen_asset",
       anonymous_public_release_download: bootstrapMode === "public_release_download",
@@ -300,10 +357,11 @@ function main() {
       version: true,
       list: true,
       doctor_read_only: true,
+      public_catalog_search: true,
       synthetic_add_dry_run: true,
       warm_cache: true,
       warm_cache_without_proof_source: true,
-      isolated_add_update_remove: lifecycle
+      isolated_add_info_update_remove: lifecycle
     }
   };
   mkdir(path.dirname(path.resolve(resultArg)));
@@ -321,4 +379,17 @@ if (require.main === module) {
   }
 }
 
-module.exports = { assertPublicJSONPathFree, frozenReleaseAsset, lifecycleCommands, lifecycleResult, npmInvocation, parseBootstrapMode, parseLifecycle };
+module.exports = {
+  assertAssetManifest,
+  assertContext7Search,
+  assertInstalledShimInvocation,
+  assertPublicJSONPathFree,
+  assertSyntheticInfo,
+  frozenReleaseAsset,
+  installedShimInvocation,
+  lifecycleCommands,
+  lifecycleResult,
+  npmInvocation,
+  parseBootstrapMode,
+  parseLifecycle
+};

--- a/npm/agentplugins/scripts/release-assets.js
+++ b/npm/agentplugins/scripts/release-assets.js
@@ -8,6 +8,7 @@ const path = require("node:path");
 const VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 const COMMIT = /^[0-9a-f]{40}$/;
 const DIGEST = /^[0-9a-f]{64}$/;
+const PRODUCER_REPOSITORY = "777genius/plugin-kit-ai";
 const TARGETS = [
   ["darwin-amd64", "darwin", "amd64", ""],
   ["darwin-arm64", "darwin", "arm64", ""],
@@ -19,6 +20,21 @@ const TARGETS = [
 
 function sha256(file) {
   return crypto.createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+}
+
+function regularUnaliasedFile(file, label) {
+  const stat = fs.lstatSync(file);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.size <= 0 || stat.nlink !== 1) {
+    throw new Error(`${label} is not a regular, non-empty, unaliased file`);
+  }
+  return stat;
+}
+
+function validateReleaseRoot(assetRoot) {
+  const stat = fs.lstatSync(assetRoot);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error("release root must be a real directory");
+  }
 }
 
 function releaseIdentity(tag, commit) {
@@ -41,12 +57,13 @@ function expectedAssets(version) {
 
 function assetMetadata(assetRoot, version) {
   const assets = {};
+  const identities = new Set();
   for (const [key, file] of Object.entries(expectedAssets(version))) {
     const filePath = path.join(assetRoot, file);
-    const stat = fs.lstatSync(filePath);
-    if (!stat.isFile() || stat.isSymbolicLink() || stat.size <= 0) {
-      throw new Error(`release asset is not a regular non-empty file: ${file}`);
-    }
+    const stat = regularUnaliasedFile(filePath, `release asset ${file}`);
+    const identity = `${stat.dev}:${stat.ino}`;
+    if (identities.has(identity)) throw new Error(`release asset is aliased: ${file}`);
+    identities.add(identity);
     assets[key] = { file, sha256: sha256(filePath), size: stat.size };
   }
   return assets;
@@ -97,8 +114,11 @@ function verifyChecksums(assetRoot, expectedNames) {
 }
 
 function verifyRelease(assetRoot, tag, commit, options = {}) {
+  validateReleaseRoot(assetRoot);
   const identity = releaseIdentity(tag, commit);
   const manifestPath = path.join(assetRoot, "release-manifest.json");
+  regularUnaliasedFile(manifestPath, "release manifest");
+  regularUnaliasedFile(path.join(assetRoot, "checksums.txt"), "release checksums");
   const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
   if (manifest.tag !== identity.tag || manifest.commit !== identity.commit) {
     throw new Error("release manifest identity does not match the exact tag and commit");
@@ -116,7 +136,14 @@ function verifyRelease(assetRoot, tag, commit, options = {}) {
     if (Object.keys(manifest).sort().join(",") !== "commit,schema_version,tag") {
       throw new Error("legacy release manifest has unexpected fields");
     }
-    return { ...identity, assets: computed, manifest_schema: 1, gate_eligible: false };
+    return {
+      repository: PRODUCER_REPOSITORY,
+      ...identity,
+      assets: computed,
+      manifest_schema: 1,
+      manifest_sha256: sha256(manifestPath),
+      gate_eligible: false
+    };
   }
   if (manifest.schema_version !== 2 || manifest.version !== identity.version) {
     throw new Error("release manifest schema or version does not match");
@@ -137,7 +164,14 @@ function verifyRelease(assetRoot, tag, commit, options = {}) {
       throw new Error(`release manifest asset metadata mismatch: ${key}`);
     }
   }
-  return { ...identity, assets: computed, manifest_schema: 2, gate_eligible: true };
+  return {
+    repository: PRODUCER_REPOSITORY,
+    ...identity,
+    assets: computed,
+    manifest_schema: 2,
+    manifest_sha256: sha256(manifestPath),
+    gate_eligible: true
+  };
 }
 
 function main() {
@@ -163,4 +197,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { expectedAssets, prepareRelease, verifyRelease };
+module.exports = { PRODUCER_REPOSITORY, expectedAssets, prepareRelease, verifyRelease };

--- a/npm/agentplugins/scripts/stage-release.js
+++ b/npm/agentplugins/scripts/stage-release.js
@@ -3,13 +3,16 @@
 
 const crypto = require("node:crypto");
 const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 
 const { detectPlatform, expectedAssetName } = require("../lib/platform");
-const { verifyRelease } = require("./release-assets");
+const { PRODUCER_REPOSITORY, verifyRelease } = require("./release-assets");
 
 const VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 const NPM_PACKAGE_NAME = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/;
+const COMMIT = /^[0-9a-f]{40}$/;
+const DIGEST = /^[0-9a-f]{64}$/;
 const PLATFORMS = [
   ["darwin", "x64"],
   ["darwin", "arm64"],
@@ -22,10 +25,14 @@ const EVIDENCE_FILES = [
   "AGENTPLUGINS_CLIENT_E2E.md",
   path.join("evidence", "agentplugins-client-e2e-2026-08-30.json")
 ];
-
-function sha256(file) {
-  return crypto.createHash("sha256").update(fs.readFileSync(file)).digest("hex");
-}
+const EVIDENCE_SOURCE = {
+  repository: PRODUCER_REPOSITORY,
+  commit: "4b25a45e1574bab7a4f49e48905a3b3b2647e917",
+  document_path: "docs/AGENTPLUGINS_CLIENT_E2E.md",
+  document_sha256: "df6769bf430a337f116cd9df75bcc3ea26df166a016eacf9bc9fbc6cfbf9b100",
+  record_path: "docs/evidence/agentplugins-client-e2e-2026-08-30.json",
+  record_sha256: "437da1bc7423a85b231be139ff9bfbd7e89c942ef216a61ebde668c08a9c2ee3"
+};
 
 function validatePackageMetadata(pkg) {
   if (!pkg || typeof pkg !== "object" || typeof pkg.name !== "string" ||
@@ -39,7 +46,181 @@ function validatePackageMetadata(pkg) {
   return packageName;
 }
 
-function stageEvidence(packageRoot, evidenceRoot) {
+function requireSafeStagingFile(file, label, allowMissing = false) {
+  if (allowMissing && !fs.existsSync(file)) return;
+  const stat = fs.lstatSync(file);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1) {
+    throw new Error(`${label} must be a real, unaliased file`);
+  }
+}
+
+function exactKeys(value, keys) {
+  return value && typeof value === "object" && !Array.isArray(value) &&
+    Object.keys(value).sort().join(",") === [...keys].sort().join(",");
+}
+
+function requireExactKeys(value, keys, label) {
+  if (!exactKeys(value, keys)) throw new Error(`client E2E evidence ${label} keys are invalid`);
+}
+
+function requireStringArray(value, label) {
+  if (!Array.isArray(value) || value.length === 0 || value.some((entry) => typeof entry !== "string" || !entry)) {
+    throw new Error(`client E2E evidence ${label} is invalid`);
+  }
+}
+
+function requireExactArgv(value, expected, label) {
+  requireStringArray(value, label);
+  if (value.join("\0") !== expected.join("\0")) {
+    throw new Error(`client E2E evidence ${label} command identity is invalid`);
+  }
+}
+
+function validateEvidenceRecord(body) {
+  let data;
+  try {
+    data = JSON.parse(body);
+  } catch (error) {
+    throw new Error(`client E2E evidence JSON is malformed: ${error.message}`);
+  }
+  requireExactKeys(data, ["schema_version", "evidence_kind", "recorded_at", "installer", "package", "environment", "transcript", "claim_boundary"], "record");
+  if (data.schema_version !== 1 || data.evidence_kind !== "agentplugins_client_lifecycle" ||
+      !/^\d{4}-\d{2}-\d{2}$/.test(String(data.recorded_at || ""))) {
+    throw new Error("client E2E evidence schema or identity is invalid");
+  }
+  const installer = data.installer;
+  requireExactKeys(installer, ["repository", "commit", "tree", "version", "binary_sha256"], "installer");
+  if (installer.repository !== PRODUCER_REPOSITORY || !COMMIT.test(String(installer.commit || "")) ||
+      !COMMIT.test(String(installer.tree || "")) || !/^\d+\.\d+\.\d+$/.test(String(installer.version || "")) ||
+      !DIGEST.test(String(installer.binary_sha256 || ""))) {
+    throw new Error("client E2E installer identity is invalid");
+  }
+
+  const pkg = data.package;
+  requireExactKeys(pkg, ["selector", "repository", "revision", "name", "version", "tree_digest", "manifest_digest", "acquisition_closure_digest"], "package");
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(String(pkg.repository || "")) ||
+      !COMMIT.test(String(pkg.revision || "")) || pkg.selector !== `${pkg.repository}@${pkg.revision}` ||
+      typeof pkg.name !== "string" || !pkg.name || typeof pkg.version !== "string" || !pkg.version ||
+      !/^sha256:[0-9a-f]{64}$/.test(String(pkg.tree_digest || "")) ||
+      !/^sha256:[0-9a-f]{64}$/.test(String(pkg.manifest_digest || "")) ||
+      !/^sha256:[0-9a-f]{64}$/.test(String(pkg.acquisition_closure_digest || ""))) {
+    throw new Error("client E2E package identity is invalid");
+  }
+
+  const environment = data.environment;
+  requireExactKeys(environment, ["os", "arch", "node", "clients", "isolation"], "environment");
+  if (typeof environment.os !== "string" || !environment.os || !["arm64", "amd64"].includes(environment.arch) ||
+      !/^\d+\.\d+\.\d+$/.test(String(environment.node || ""))) {
+    throw new Error("client E2E environment identity is invalid");
+  }
+  requireExactKeys(environment.clients, ["claude", "gemini", "opencode", "cline", "windsurf"], "client inventory");
+  for (const client of Object.values(environment.clients)) {
+    requireExactKeys(client, ["version", "host_surface_detected"], "client inventory entry");
+    if ((client.version !== null && (typeof client.version !== "string" || !client.version)) || client.host_surface_detected !== true) {
+      throw new Error("client E2E inventory did not detect every claimed host surface");
+    }
+  }
+  const isolationKeys = ["fresh_home", "fresh_xdg_roots", "fresh_claude_config", "fresh_gemini_home", "fresh_cline_data", "fresh_agentplugins_state", "user_project_accessed", "user_client_config_mutated"];
+  requireExactKeys(environment.isolation, isolationKeys, "isolation");
+  if (isolationKeys.slice(0, 6).some((key) => environment.isolation[key] !== true) ||
+      isolationKeys.slice(6).some((key) => environment.isolation[key] !== false)) {
+    throw new Error("client E2E isolation or user-project boundary is invalid");
+  }
+
+  if (!Array.isArray(data.transcript) || data.transcript.length !== 7) {
+    throw new Error("client E2E evidence must contain the exact lifecycle transcript");
+  }
+  const [add, discovery, doctor, preflight, repair, remove, postRemove] = data.transcript;
+  const expectedSteps = ["add", "client_discovery", "doctor", "immutable_update_preflight", "repair", "remove", "post_remove"];
+  if (data.transcript.some((entry, index) => !entry || entry.step !== expectedSteps[index])) {
+    throw new Error("client E2E evidence lifecycle step identities or order are invalid");
+  }
+  requireExactKeys(add, ["step", "argv", "exit_code", "result", "status", "acquisition_count", "source_kind", "fetched", "validated", "targets", "shared_identity"], "add step");
+  requireExactKeys(add.targets, ["claude", "gemini", "opencode", "cline", "windsurf"], "add targets");
+  for (const target of Object.values(add.targets)) {
+    requireExactKeys(target, ["outcome", "activation", "verification"], "add target");
+    if (target.outcome !== "passed" || target.activation !== "active" || target.verification !== "installation_verified") {
+      throw new Error("client E2E add target did not pass");
+    }
+  }
+  requireExactKeys(add.shared_identity, ["installation_count", "physical_artifact_id", "same_tree_digest_for_all_targets", "same_manifest_digest_for_all_targets", "same_closure_digest_for_all_targets"], "shared identity");
+  if (add.exit_code !== 0 || add.result !== "success" || add.status !== "completed" || add.acquisition_count !== 1 ||
+      add.source_kind !== "github" || add.fetched !== true || add.validated !== true ||
+      add.shared_identity.installation_count !== 1 || typeof add.shared_identity.physical_artifact_id !== "string" || !add.shared_identity.physical_artifact_id ||
+      ["same_tree_digest_for_all_targets", "same_manifest_digest_for_all_targets", "same_closure_digest_for_all_targets"].some((key) => add.shared_identity[key] !== true)) {
+    throw new Error("client E2E add step did not prove one validated shared acquisition");
+  }
+
+  requireExactKeys(discovery, ["step", "checks"], "client discovery step");
+  requireExactKeys(discovery.checks, ["claude", "gemini_mcp", "gemini_skills", "opencode", "cline", "windsurf"], "client discovery checks");
+  const discoveryKeys = {
+    claude: ["argv", "exit_code", "plugin_id", "plugin_version", "enabled", "skill_count", "mcp_command"],
+    gemini_mcp: ["argv", "exit_code", "server", "transport", "command", "connection"],
+    gemini_skills: ["argv", "exit_code", "enabled_skill_count"],
+    opencode: ["argv", "exit_code", "server", "type", "command", "cwd_bound_to_managed_package", "plugin_root_bound", "plugin_data_bound"],
+    cline: ["config", "transport", "command", "plugin_root_bound", "plugin_data_bound", "projected_skill_count"],
+    windsurf: ["config", "command", "plugin_root_bound", "plugin_data_bound", "skills"]
+  };
+  for (const [key, keys] of Object.entries(discoveryKeys)) {
+    requireExactKeys(discovery.checks[key], keys, `${key} discovery check`);
+  }
+  requireExactArgv(discovery.checks.claude.argv, ["claude", "plugin", "list", "--json"], "claude discovery argv");
+  requireExactArgv(discovery.checks.gemini_mcp.argv, ["gemini", "mcp", "list"], "gemini_mcp discovery argv");
+  requireExactArgv(discovery.checks.gemini_skills.argv, ["gemini", "skills", "list"], "gemini_skills discovery argv");
+  requireExactArgv(discovery.checks.opencode.argv, ["opencode", "debug", "config"], "opencode discovery argv");
+  for (const key of ["claude", "gemini_mcp", "gemini_skills", "opencode"]) {
+    if (discovery.checks[key].exit_code !== 0) throw new Error(`client E2E discovery check did not pass: ${key}`);
+  }
+  const nonEmptyCommand = (value) => Array.isArray(value) && value.length > 0 &&
+    value.every((entry) => typeof entry === "string" && entry.length > 0);
+  const expectedCommand = ["npx", `chrome-devtools-mcp@${data.package.version}`];
+  const exactCommand = (value) => nonEmptyCommand(value) && value.join("\0") === expectedCommand.join("\0");
+  const { claude, gemini_mcp: geminiMcp, gemini_skills: geminiSkills, opencode, cline, windsurf } = discovery.checks;
+  if (claude.plugin_id !== "chrome-devtools@skills-dir" || claude.plugin_version !== data.package.version || claude.enabled !== true || claude.skill_count !== 6 || !exactCommand(claude.mcp_command) ||
+      geminiMcp.server !== data.package.name || geminiMcp.transport !== "stdio" || !exactCommand(geminiMcp.command) || geminiMcp.connection !== "disconnected" ||
+      geminiSkills.enabled_skill_count !== 6 ||
+      opencode.server !== data.package.name || opencode.type !== "local" || !exactCommand(opencode.command) || opencode.cwd_bound_to_managed_package !== true || opencode.plugin_root_bound !== true || opencode.plugin_data_bound !== true ||
+      cline.config !== `mcpServers.${data.package.name}` || cline.transport !== "stdio" || !exactCommand(cline.command) || cline.plugin_root_bound !== true || cline.plugin_data_bound !== true || cline.projected_skill_count !== 6 ||
+      windsurf.config !== `mcpServers.${data.package.name}` || !exactCommand(windsurf.command) || windsurf.plugin_root_bound !== true || windsurf.plugin_data_bound !== true || windsurf.skills !== "prepared_only") {
+    throw new Error("client E2E discovery semantic outcomes are incomplete");
+  }
+
+  requireExactKeys(doctor, ["step", "argv", "exit_code", "result", "read_only", "installation_count", "projection_drift_findings", "authentication_not_checked_clients"], "doctor step");
+  requireExactKeys(preflight, ["step", "argv", "exit_code", "result", "status", "reason", "succeeded", "failed", "mutated_targets", "postcondition"], "immutable update step");
+  requireExactKeys(repair, ["step", "argv", "exit_code", "result", "status", "succeeded", "failed", "targets"], "repair step");
+  requireExactKeys(remove, ["step", "argv", "exit_code", "result", "status", "succeeded", "failed", "plugin_data_preserved", "targets"], "remove step");
+  requireExactKeys(postRemove, ["step", "checks"], "post-remove step");
+  const targets = "claude,gemini,opencode,cline,windsurf";
+  requireExactArgv(add.argv, ["agentplugins", "add", data.package.selector, "--target", targets, "--format", "json"], "add argv");
+  requireExactArgv(doctor.argv, ["agentplugins", "doctor", "--format", "json"], "doctor argv");
+  requireExactArgv(preflight.argv, ["agentplugins", "update", data.package.name, "--target", targets, "--format", "json"], "immutable_update_preflight argv");
+  requireExactArgv(repair.argv, ["agentplugins", "repair", data.package.name, "--target", targets, "--format", "json"], "repair argv");
+  requireExactArgv(remove.argv, ["agentplugins", "remove", data.package.name, "--target", targets, "--format", "json"], "remove argv");
+  requireExactKeys(repair.targets, ["claude", "gemini", "opencode", "cline", "windsurf"], "repair targets");
+  requireExactKeys(remove.targets, ["claude", "gemini", "opencode", "cline", "windsurf"], "remove targets");
+  requireExactKeys(postRemove.checks, ["agentplugins_installation_count", "claude_plugin_count", "gemini_mcp_count", "gemini_skill_count", "opencode_mcp_count", "cline_mcp_count", "cline_skill_count", "windsurf_mcp_count"], "post-remove checks");
+  requireStringArray(doctor.authentication_not_checked_clients, "doctor authentication boundary");
+  if (doctor.exit_code !== 0 || doctor.result !== "success" || doctor.read_only !== true || doctor.installation_count !== 1 || doctor.projection_drift_findings !== 0 ||
+      doctor.authentication_not_checked_clients.join(",") !== targets ||
+      preflight.exit_code !== 1 || preflight.result !== "failure" || preflight.status !== "preflight_failed" || preflight.reason !== "direct full-SHA installations require explicit switch" || preflight.succeeded !== 0 || preflight.failed !== 5 || preflight.mutated_targets !== 0 || preflight.postcondition !== "the exact installation and all five client projections remained installed and unchanged" ||
+      repair.exit_code !== 0 || repair.result !== "success" || repair.status !== "completed" || repair.succeeded !== 5 || repair.failed !== 0 ||
+      remove.exit_code !== 0 || remove.result !== "success" || remove.status !== "data_retained" || remove.succeeded !== 5 || remove.failed !== 0 || remove.plugin_data_preserved !== true ||
+      Object.values(repair.targets).some((value) => value !== "passed") ||
+      Object.values(remove.targets).some((value) => value !== "external_completed") ||
+      Object.values(postRemove.checks).some((value) => value !== 0)) {
+    throw new Error("client E2E evidence contains an unsuccessful lifecycle result");
+  }
+
+  const claimKeys = ["lifecycle_e2e", "client_discovery_e2e", "browser_tool_runtime_e2e", "model_turn_e2e", "login_e2e", "oauth_e2e", "windsurf_skill_activation_claimed"];
+  requireExactKeys(data.claim_boundary, claimKeys, "claim boundary");
+  if (data.claim_boundary.lifecycle_e2e !== true || data.claim_boundary.client_discovery_e2e !== true ||
+      claimKeys.slice(2).some((key) => data.claim_boundary[key] !== false)) {
+    throw new Error("client E2E claim boundary is invalid");
+  }
+  return data;
+}
+
+function loadEvidence(evidenceRoot) {
   if (!evidenceRoot) {
     throw new Error("release staging requires the checked-in client E2E evidence root");
   }
@@ -51,20 +232,86 @@ function stageEvidence(packageRoot, evidenceRoot) {
     throw new Error("client E2E evidence root must be a real directory");
   }
   const resolvedRoot = fs.realpathSync(evidenceRoot);
-  const destination = path.join(packageRoot, "test", "evidence-root");
-  fs.mkdirSync(destination, { recursive: true });
+  const bodies = {};
+  const digests = {};
   for (const sourceName of EVIDENCE_FILES) {
     const source = path.join(evidenceRoot, sourceName);
     if (!fs.realpathSync(source).startsWith(`${resolvedRoot}${path.sep}`)) {
       throw new Error(`client E2E evidence escapes its exact root: ${sourceName}`);
     }
     const stat = fs.lstatSync(source);
-    if (!stat.isFile() || stat.isSymbolicLink() || stat.size <= 0) {
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size <= 0 || stat.nlink !== 1) {
       throw new Error(`client E2E evidence is not a regular non-empty file: ${sourceName}`);
     }
+    bodies[sourceName] = fs.readFileSync(source);
+    digests[sourceName] = crypto.createHash("sha256").update(bodies[sourceName]).digest("hex");
+  }
+  const recordName = EVIDENCE_FILES[1];
+  const record = validateEvidenceRecord(bodies[recordName].toString("utf8"));
+  const markdown = bodies[EVIDENCE_FILES[0]].toString("utf8");
+  for (const value of [record.recorded_at, record.installer.commit, record.installer.tree, record.installer.version,
+    record.installer.binary_sha256, record.package.selector, record.package.version, record.package.tree_digest,
+    record.package.manifest_digest, recordName.split(path.sep).join("/"), digests[recordName]]) {
+    if (!markdown.includes(value)) throw new Error("client E2E document does not bind the structured evidence identity and digest");
+  }
+  if (digests[EVIDENCE_FILES[0]] !== EVIDENCE_SOURCE.document_sha256 ||
+      digests[recordName] !== EVIDENCE_SOURCE.record_sha256) {
+    throw new Error("client E2E evidence bytes do not match the immutable source locator");
+  }
+  return {
+    bodies,
+    metadata: {
+      schema_version: record.schema_version,
+      kind: record.evidence_kind,
+      recorded_at: record.recorded_at,
+      document_sha256: digests[EVIDENCE_FILES[0]],
+      record_sha256: digests[recordName],
+      source: {
+        repository: EVIDENCE_SOURCE.repository,
+        commit: EVIDENCE_SOURCE.commit,
+        document: { path: EVIDENCE_SOURCE.document_path, sha256: digests[EVIDENCE_FILES[0]] },
+        record: { path: EVIDENCE_SOURCE.record_path, sha256: digests[recordName] }
+      },
+      installer: { ...record.installer },
+      package: {
+        selector: record.package.selector,
+        revision: record.package.revision,
+        tree_digest: record.package.tree_digest,
+        manifest_digest: record.package.manifest_digest
+      },
+      claim_boundary: { ...record.claim_boundary }
+    }
+  };
+}
+
+function writeEvidence(packageRoot, loaded) {
+  const destination = path.join(packageRoot, "test", "evidence-root");
+  for (const sourceName of EVIDENCE_FILES) {
     const target = path.join(destination, sourceName);
     fs.mkdirSync(path.dirname(target), { recursive: true });
-    fs.copyFileSync(source, target, fs.constants.COPYFILE_EXCL);
+    fs.writeFileSync(target, loaded.bodies[sourceName], { flag: "wx" });
+  }
+  return loaded.metadata;
+}
+
+function stageEvidence(packageRoot, evidenceRoot) {
+  return writeEvidence(packageRoot, loadEvidence(evidenceRoot));
+}
+
+function snapshotRelease(assetRoot, release, version, commit, options) {
+  const snapshotRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agentplugins-release-"));
+  try {
+    const names = [
+      ...Object.values(release.assets).map((asset) => asset.file),
+      "release-manifest.json",
+      "checksums.txt"
+    ];
+    for (const name of names) {
+      fs.copyFileSync(path.join(assetRoot, name), path.join(snapshotRoot, name), fs.constants.COPYFILE_EXCL);
+    }
+    return verifyRelease(snapshotRoot, `agentplugins-v${version}`, commit, options);
+  } finally {
+    fs.rmSync(snapshotRoot, { recursive: true, force: true });
   }
 }
 
@@ -72,32 +319,55 @@ function stage(packageRoot, assetRoot, version, commit, options = {}) {
   if (!VERSION.test(version)) {
     throw new Error(`invalid release version: ${version}`);
   }
-  verifyRelease(assetRoot, `agentplugins-v${version}`, commit, options);
+  const initialRelease = verifyRelease(assetRoot, `agentplugins-v${version}`, commit, options);
+  if (!initialRelease.gate_eligible || initialRelease.manifest_schema !== 2) {
+    throw new Error("release staging requires a gate-eligible schema-v2 current producer manifest");
+  }
   const pkgPath = path.join(packageRoot, "package.json");
+  const packageRootStat = fs.lstatSync(packageRoot);
+  if (!packageRootStat.isDirectory() || packageRootStat.isSymbolicLink()) {
+    throw new Error("staged npm package root must be a real directory");
+  }
+  requireSafeStagingFile(pkgPath, "staged npm package.json");
+  requireSafeStagingFile(path.join(packageRoot, "assets.json"), "staged npm assets.json", true);
   const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
   const packageName = validatePackageMetadata(pkg);
-  stageEvidence(packageRoot, options.evidenceRoot);
-  pkg.version = version;
-  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
-  const assets = {};
-  for (const [platform, arch] of PLATFORMS) {
-    const info = detectPlatform(platform, arch);
-    const file = expectedAssetName(version, info);
-    const filePath = path.join(assetRoot, file);
-    const stat = fs.lstatSync(filePath);
-    if (!stat.isFile() || stat.isSymbolicLink() || stat.size <= 0) {
-      throw new Error(`release asset is not a regular non-empty file: ${file}`);
-    }
-    assets[info.key] = { file, sha256: sha256(filePath), size: stat.size };
+  const loadedEvidence = loadEvidence(options.evidenceRoot);
+  if (options.afterInitialReleaseVerification) options.afterInitialReleaseVerification();
+  const release = snapshotRelease(assetRoot, initialRelease, version, commit, options);
+  if (JSON.stringify(release.assets) !== JSON.stringify(initialRelease.assets) ||
+      release.manifest_sha256 !== initialRelease.manifest_sha256) {
+    throw new Error("release directory changed during staging");
   }
+  if (options.afterReleaseSnapshotVerification) options.afterReleaseSnapshotVerification();
+  const assets = Object.fromEntries(PLATFORMS.map(([platform, arch]) => {
+    const info = detectPlatform(platform, arch);
+    const record = release.assets[info.key];
+    if (!record || record.file !== expectedAssetName(version, info)) throw new Error(`verified release asset record is missing: ${info.key}`);
+    return [info.key, { ...record }];
+  }));
   const manifest = {
-    schema_version: 1,
+    schema_version: 2,
     version,
     npm_package: packageName,
     repository: "777genius/plugin-kit-ai",
     tag: `agentplugins-v${version}`,
+    producer: {
+      repository: release.repository,
+      tag: release.tag,
+      commit: release.commit,
+      release_manifest: {
+        schema_version: release.manifest_schema,
+        sha256: release.manifest_sha256,
+        version: release.version
+      }
+    },
+    client_evidence: loadedEvidence.metadata,
     assets
   };
+  pkg.version = version;
+  writeEvidence(packageRoot, loadedEvidence);
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
   fs.writeFileSync(path.join(packageRoot, "assets.json"), JSON.stringify(manifest, null, 2) + "\n");
   return manifest;
 }
@@ -128,4 +398,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { stage, stageEvidence, validatePackageMetadata };
+module.exports = { stage, stageEvidence, validateEvidenceRecord, validatePackageMetadata };

--- a/npm/agentplugins/test/bootstrap.test.js
+++ b/npm/agentplugins/test/bootstrap.test.js
@@ -14,7 +14,9 @@ const { PROOF_MODE, acquireLock, downloadFile, ensureBinary, loadRelease } = req
 const { cacheRoot, detectPlatform, expectedAssetName } = require("../lib/platform");
 
 const VERSION = "0.1.0";
+const COMMIT = "a".repeat(40);
 const BINARY = Buffer.from("#!/bin/sh\necho isolated-agentplugins-test\n");
+const HISTORICAL_COMMIT = "5630ccd92aa91c8ac8cafb37eea8752fd82edce0";
 
 async function fixturePackage(t, binary = BINARY) {
   const root = await fsp.mkdtemp(path.join(os.tmpdir(), "agentplugins-npm-package-"));
@@ -23,11 +25,52 @@ async function fixturePackage(t, binary = BINARY) {
   const file = expectedAssetName(VERSION, platformInfo);
   await fsp.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "universal-agent-plugins", version: VERSION }));
   await fsp.writeFile(path.join(root, "assets.json"), JSON.stringify({
-    schema_version: 1,
+    schema_version: 2,
     version: VERSION,
     npm_package: "universal-agent-plugins",
     repository: "777genius/plugin-kit-ai",
     tag: `agentplugins-v${VERSION}`,
+    producer: {
+      repository: "777genius/plugin-kit-ai",
+      tag: `agentplugins-v${VERSION}`,
+      commit: COMMIT,
+      release_manifest: { schema_version: 2, sha256: "b".repeat(64), version: VERSION }
+    },
+    client_evidence: {
+      schema_version: 1,
+      kind: "agentplugins_client_lifecycle",
+      recorded_at: "2026-08-30",
+      document_sha256: "df6769bf430a337f116cd9df75bcc3ea26df166a016eacf9bc9fbc6cfbf9b100",
+      record_sha256: "437da1bc7423a85b231be139ff9bfbd7e89c942ef216a61ebde668c08a9c2ee3",
+      source: {
+        repository: "777genius/plugin-kit-ai",
+        commit: "4b25a45e1574bab7a4f49e48905a3b3b2647e917",
+        document: { path: "docs/AGENTPLUGINS_CLIENT_E2E.md", sha256: "df6769bf430a337f116cd9df75bcc3ea26df166a016eacf9bc9fbc6cfbf9b100" },
+        record: { path: "docs/evidence/agentplugins-client-e2e-2026-08-30.json", sha256: "437da1bc7423a85b231be139ff9bfbd7e89c942ef216a61ebde668c08a9c2ee3" }
+      },
+      installer: {
+        repository: "777genius/plugin-kit-ai",
+        commit: HISTORICAL_COMMIT,
+        tree: "e".repeat(40),
+        version: "0.1.22",
+        binary_sha256: "f".repeat(64)
+      },
+      package: {
+        selector: `owner/package@${"1".repeat(40)}`,
+        revision: "1".repeat(40),
+        tree_digest: `sha256:${"2".repeat(64)}`,
+        manifest_digest: `sha256:${"3".repeat(64)}`
+      },
+      claim_boundary: {
+        lifecycle_e2e: true,
+        client_discovery_e2e: true,
+        browser_tool_runtime_e2e: false,
+        model_turn_e2e: false,
+        login_e2e: false,
+        oauth_e2e: false,
+        windsurf_skill_activation_claimed: false
+      }
+    },
     assets: {
       [platformInfo.key]: {
         file,
@@ -274,14 +317,64 @@ test("embedded release manifest is pinned to the npm distribution name", async (
   );
 });
 
-test("an old mtime never lets a contender steal a live cache lock", async () => {
+test("historical evidence metadata is independent from the current producer identity", async (t) => {
+  const fixture = await fixturePackage(t);
+  const manifestPath = path.join(fixture.root, "assets.json");
+  const manifest = JSON.parse(await fsp.readFile(manifestPath, "utf8"));
+  assert.notEqual(manifest.client_evidence.installer.version, manifest.version);
+  assert.notEqual(manifest.client_evidence.installer.commit, manifest.producer.commit);
+  assert.notEqual(manifest.client_evidence.installer.binary_sha256, manifest.assets["linux-amd64"].sha256);
+  assert.doesNotThrow(() => loadRelease(fixture.root, detectPlatform("linux", "x64")));
+});
+
+test("runtime rejects missing, malformed, and mismatched current producer identity", async (t) => {
+  for (const mutate of [
+    (manifest) => { delete manifest.producer; },
+    (manifest) => { manifest.producer.commit = "A".repeat(40); },
+    (manifest) => { manifest.producer.repository = "other/repository"; },
+    (manifest) => { manifest.producer.tag = "agentplugins-v9.9.9"; },
+    (manifest) => { manifest.producer.release_manifest.sha256 = "short"; },
+    (manifest) => { manifest.producer.release_manifest.version = "9.9.9"; }
+  ]) {
+    const fixture = await fixturePackage(t);
+    const manifestPath = path.join(fixture.root, "assets.json");
+    const manifest = JSON.parse(await fsp.readFile(manifestPath, "utf8"));
+    mutate(manifest);
+    await fsp.writeFile(manifestPath, JSON.stringify(manifest));
+    assert.throws(() => loadRelease(fixture.root, detectPlatform("linux", "x64")), /producer release identity/);
+  }
+});
+
+test("runtime rejects malformed historical evidence metadata without binding it to the current release", async (t) => {
+  for (const mutate of [
+    (evidence) => { evidence.installer.commit = "A".repeat(40); },
+    (evidence) => { evidence.package.selector = `owner/other@${"9".repeat(40)}`; },
+    (evidence) => { evidence.claim_boundary.oauth_e2e = true; },
+    (evidence) => { evidence.source.commit = "A".repeat(40); },
+    (evidence) => { evidence.source.record.sha256 = "0".repeat(64); },
+    (evidence) => { evidence.document_sha256 = "0".repeat(64); evidence.source.document.sha256 = evidence.document_sha256; },
+    (evidence) => { delete evidence.record_sha256; }
+  ]) {
+    const fixture = await fixturePackage(t);
+    const manifestPath = path.join(fixture.root, "assets.json");
+    const manifest = JSON.parse(await fsp.readFile(manifestPath, "utf8"));
+    mutate(manifest.client_evidence);
+    await fsp.writeFile(manifestPath, JSON.stringify(manifest));
+    assert.throws(() => loadRelease(fixture.root, detectPlatform("linux", "x64")), /historical client evidence/);
+  }
+});
+
+test("an old mtime never lets a contender steal a live cache lock", async (t) => {
   const target = path.join(os.tmpdir(), `agentplugins-live-lock-${crypto.randomBytes(8).toString("hex")}`);
-  const release = await acquireLock(target);
+  const lockRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "agentplugins-live-lock-root-"));
+  await fsp.chmod(lockRoot, 0o700);
+  t.after(() => fsp.rm(lockRoot, { recursive: true, force: true }));
+  const release = await acquireLock(target, { lockRoot });
   const lockName = crypto.createHash("sha256").update(target).digest("hex") + ".lock";
-  const lockPath = path.join(os.tmpdir(), "agentplugins-npm-locks", lockName);
+  const lockPath = path.join(lockRoot, lockName);
   await fsp.utimes(lockPath, new Date(0), new Date(0));
   let firstReleased = false;
-  const contender = acquireLock(target).then((unlock) => {
+  const contender = acquireLock(target, { lockRoot }).then((unlock) => {
     assert.equal(firstReleased, true, "contender stole a lock still held by a live process");
     return unlock;
   });
@@ -294,14 +387,55 @@ test("an old mtime never lets a contender steal a live cache lock", async () => 
 
 test("a stale-looking lock is never auto-removed or stolen", async (t) => {
   const target = path.join(os.tmpdir(), `agentplugins-stale-lock-${crypto.randomBytes(8).toString("hex")}`);
+  const lockRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "agentplugins-stale-lock-root-"));
+  await fsp.chmod(lockRoot, 0o700);
   const lockName = crypto.createHash("sha256").update(target).digest("hex") + ".lock";
-  const lockPath = path.join(os.tmpdir(), "agentplugins-npm-locks", lockName);
+  const lockPath = path.join(lockRoot, lockName);
   await fsp.mkdir(path.dirname(lockPath), { recursive: true });
   const body = JSON.stringify({ pid: 999999, nonce: "0".repeat(32) }) + "\n";
   await fsp.writeFile(lockPath, body, { flag: "wx", mode: 0o600 });
-  t.after(() => fsp.rm(lockPath, { force: true }));
-  await assert.rejects(acquireLock(target, { timeoutMs: 30, pollMs: 5 }), /remove it only after confirming/);
+  t.after(() => fsp.rm(lockRoot, { recursive: true, force: true }));
+  await assert.rejects(acquireLock(target, { lockRoot, timeoutMs: 30, pollMs: 5 }), /remove it only after confirming/);
   assert.equal(await fsp.readFile(lockPath, "utf8"), body);
+});
+
+test("lock roots are isolated inside each user's cache boundary", async (t) => {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "agentplugins-user-locks-"));
+  t.after(() => fsp.rm(root, { recursive: true, force: true }));
+  const target = path.join(root, "shared-target");
+  const environments = [
+    { XDG_CACHE_HOME: path.join(root, "user-a") },
+    { XDG_CACHE_HOME: path.join(root, "user-b") }
+  ];
+  const unlocks = await Promise.all(environments.map((environment) => acquireLock(target, {
+    environment, platform: "linux", home: path.join(root, "unused")
+  })));
+  for (const environment of environments) {
+    const userLockRoot = path.join(environment.XDG_CACHE_HOME, "agentplugins", ".locks");
+    const stat = await fsp.lstat(userLockRoot);
+    assert.equal(stat.isDirectory(), true);
+    assert.equal(stat.mode & 0o777, 0o700);
+  }
+  for (const unlock of unlocks) await unlock();
+  const legacyLock = path.join(os.tmpdir(), "agentplugins-npm-locks",
+    crypto.createHash("sha256").update(target).digest("hex") + ".lock");
+  assert.equal(fs.existsSync(legacyLock), false);
+});
+
+test("lock root rejects symlinks and unsafe modes without touching their contents", async (t) => {
+  if (process.platform === "win32") return;
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "agentplugins-lock-safety-"));
+  t.after(() => fsp.rm(root, { recursive: true, force: true }));
+  const unsafe = path.join(root, "unsafe");
+  await fsp.mkdir(unsafe, { mode: 0o755 });
+  await fsp.chmod(unsafe, 0o755);
+  await assert.rejects(acquireLock("target", { lockRoot: unsafe }), /user-owned mode-0700/);
+  const marker = path.join(unsafe, "keep");
+  await fsp.writeFile(marker, "keep");
+  const link = path.join(root, "link");
+  await fsp.symlink(unsafe, link);
+  await assert.rejects(acquireLock("target", { lockRoot: link }), /user-owned mode-0700/);
+  assert.equal(await fsp.readFile(marker, "utf8"), "keep");
 });
 
 test("download verification closes the destination before rejecting", async (t) => {

--- a/npm/agentplugins/test/documentation-contract.test.js
+++ b/npm/agentplugins/test/documentation-contract.test.js
@@ -1,10 +1,33 @@
 "use strict";
 
 const assert = require("node:assert/strict");
-const crypto = require("node:crypto");
 const fs = require("node:fs");
 const path = require("node:path");
 const test = require("node:test");
+
+test("npm facade metadata exactly names the UAP product endpoints", () => {
+  const pkg = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../package.json"), "utf8"));
+  assert.equal(pkg.homepage, "https://777genius.github.io/universal-agent-plugins/");
+  assert.deepEqual(pkg.repository, {
+    type: "git",
+    url: "git+https://github.com/777genius/universal-agent-plugins.git",
+    directory: "npm/agentplugins"
+  });
+  assert.deepEqual(pkg.bugs, { url: "https://github.com/777genius/universal-agent-plugins/issues" });
+});
+
+test("detached package execution sentinel", (t) => {
+  const expectedRoot = process.env.AGENTPLUGINS_DETACHED_ASSERT_ROOT;
+  if (!expectedRoot) {
+    t.skip("only asserted by the detached staged-package subprocess");
+    return;
+  }
+  assert.equal(
+    fs.realpathSync(path.resolve(__dirname, "..")),
+    fs.realpathSync(path.resolve(expectedRoot))
+  );
+  assert.equal(fs.existsSync(path.resolve(__dirname, "../../../README.md")), false);
+});
 
 const documents = [
   ["root README", path.resolve(__dirname, "../../../README.md")],
@@ -74,76 +97,35 @@ test("public Agentplugins documentation keeps copyable commands within the CLI c
   }
 });
 
-test("public documentation keeps the package, binary, manifest, and safety contracts", () => {
-  for (const [label, filename] of packagedDocuments()) {
-    const markdown = fs.readFileSync(filename, "utf8");
-    assert.match(markdown, /`universal-agent-plugins`[\s\S]{0,160}(?:public )?npm package/i, `${label}: npm package identity missing`);
-    assert.match(markdown, /installs? the `agentplugins` binary/i, `${label}: installed binary identity missing`);
-    assert.match(markdown, /same (?:installer and )?lifecycle manager|not separate engines/i, `${label}: shared engine relationship missing`);
-    assert.match(markdown, /signed\s+(?:\n)?(?:\[[^\]]+\]\([^\n]+\)|Universal Agent Plugins Directory)/i, `${label}: signed Directory contract missing`);
-    assert.doesNotMatch(markdown, /pinned\s+(?:legacy\s+)?catalog|catalog\s+v[12]|first\s+catalog/i, `${label}: stale catalog contract`);
-    assert.match(markdown, /root `plugin\.json` is the install authority/i, `${label}: plugin.json authority missing`);
-    assert.match(markdown, /`plugin\.yaml`[\s\S]{0,100}legacy[\s\S]{0,100}authoring input only/i, `${label}: legacy plugin.yaml boundary missing`);
-    assert.match(markdown, /silently override `plugin\.json`|silent(?:ly)?[^.\n]{0,60}override/i, `${label}: manifest override prohibition missing`);
-    assert.match(markdown, /preflight/i, `${label}: preflight missing`);
-    assert.match(markdown, /`--dry-run`[\s\S]{0,120}(?:read-only|without\s+writing)/i, `${label}: dry-run behavior missing`);
-    assert.match(markdown, /publisher[\s\S]{0,120}source|source[\s\S]{0,120}publisher/i, `${label}: source provenance missing`);
-    assert.match(markdown, /rollback|rolls? (?:the group )?back/i, `${label}: rollback boundary missing`);
-    assert.match(markdown, /manual\s+activation|manual-activation/i, `${label}: manual activation boundary missing`);
-    assert.match(markdown, /OAuth[\s\S]{0,160}(?:prompt|consent)[\s\S]{0,160}user-controlled/i, `${label}: OAuth prompt boundary missing`);
-    assert.match(markdown, /not every|not as a claim that every/i, `${label}: verification scope caveat missing`);
+test("public documentation states the facade and engine ownership boundary", () => {
+  const packaged = fs.readFileSync(documents[1][1], "utf8");
+  const boundaryDocuments = [["npm README", packaged]];
+  if (fs.existsSync(documents[0][1])) {
+    boundaryDocuments.unshift(["root README", fs.readFileSync(documents[0][1], "utf8")]);
   }
+  for (const [label, markdown] of boundaryDocuments) {
+    assert.match(markdown, /product home[\s\S]{0,100}(?:npm facade|facade source)/i, `: facade product ownership missing`);
+    assert.match(markdown, /plugin-kit-ai[\s\S]{0,180}(?:Go implementation engine|implementation engine)/i, `: implementation engine ownership missing`);
+    assert.match(markdown, /not duplicated/i, `: no-duplicate-engine boundary missing`);
+    assert.match(markdown, /installs? the `agentplugins` binary/i, `: installed binary identity missing`);
+  }
+});
+
+test("package documentation labels client evidence historical and commit-pins its source", () => {
+  const markdown = fs.readFileSync(documents[1][1], "utf8");
+  assert.match(markdown, /historical lifecycle evidence collected for[\s\S]{0,80}0\.1\.22/i);
+  assert.match(markdown, /not evidence for the current npm release/i);
+  assert.match(markdown, /https:\/\/github\.com\/777genius\/plugin-kit-ai\/blob\/4b25a45e1574bab7a4f49e48905a3b3b2647e917\/docs\/AGENTPLUGINS_CLIENT_E2E\.md/);
+  assert.doesNotMatch(markdown, /plugin-kit-ai\/blob\/(?:main|master)\/docs\/AGENTPLUGINS_CLIENT_E2E\.md/);
 });
 
 test("copyable direct-source examples use a marked replacement full SHA", () => {
   const placeholder = "0123456789abcdef0123456789abcdef01234567";
-  for (const [label, filename] of packagedDocuments()) {
+  for (const [label, filename] of [documents[1]]) {
     const markdown = fs.readFileSync(filename, "utf8");
     assert.ok(markdown.includes(`owner/repo@${placeholder}//plugins/my-plugin`), `${label}: full-SHA source example missing`);
     assert.ok(markdown.includes("add ./my-plugin --target cursor"), `${label}: local source example missing`);
     assert.match(markdown, new RegExp(`replace[\\s\\S]{0,180}${placeholder}|${placeholder}[\\s\\S]{0,180}replace`, "i"), `${label}: SHA replacement instruction missing`);
     assert.doesNotMatch(markdown, /@commit(?:\/\/|\b)/i, `${label}: literal @commit is not copyable`);
-  }
-});
-
-test("checked-in client E2E evidence remains exact and auditable", () => {
-  const stagedEvidence = path.resolve(__dirname, "evidence-root");
-  const evidenceRoot = fs.existsSync(stagedEvidence)
-    ? stagedEvidence
-    : path.resolve(__dirname, "../../../docs");
-  const evidenceDoc = path.join(evidenceRoot, "AGENTPLUGINS_CLIENT_E2E.md");
-  const transcriptPath = path.join(evidenceRoot, "evidence/agentplugins-client-e2e-2026-08-30.json");
-  const markdown = fs.readFileSync(evidenceDoc, "utf8");
-  const transcriptBytes = fs.readFileSync(transcriptPath);
-  const transcript = JSON.parse(transcriptBytes.toString("utf8"));
-  const digest = crypto.createHash("sha256").update(transcriptBytes).digest("hex");
-
-  assert.equal(transcript.schema_version, 1);
-  assert.match(transcript.installer.commit, /^[0-9a-f]{40}$/);
-  assert.match(transcript.installer.tree, /^[0-9a-f]{40}$/);
-  assert.match(transcript.installer.binary_sha256, /^[0-9a-f]{64}$/);
-  assert.equal(
-    transcript.package.selector,
-    "ChromeDevTools/chrome-devtools-mcp@cb39d1d835c3baa3eff87501cd8c1de020604789"
-  );
-  assert.ok(markdown.includes(transcript.installer.commit), "evidence doc lost tested installer commit");
-  assert.ok(markdown.includes(transcript.installer.tree), "evidence doc lost tested installer tree");
-  assert.ok(markdown.includes(digest), "evidence doc lost exact transcript digest");
-
-  const add = transcript.transcript.find((entry) => entry.step === "add");
-  const repair = transcript.transcript.find((entry) => entry.step === "repair");
-  const remove = transcript.transcript.find((entry) => entry.step === "remove");
-  const postRemove = transcript.transcript.find((entry) => entry.step === "post_remove");
-  const targets = ["claude", "gemini", "opencode", "cline", "windsurf"];
-  assert.equal(add.acquisition_count, 1);
-  for (const target of targets) {
-    assert.equal(add.targets[target].outcome, "passed", `add evidence missing ${target}`);
-    assert.equal(repair.targets[target], "passed", `repair evidence missing ${target}`);
-    assert.equal(remove.targets[target], "external_completed", `remove evidence missing ${target}`);
-  }
-  assert.equal(postRemove.checks.agentplugins_installation_count, 0);
-  assert.equal(transcript.claim_boundary.lifecycle_e2e, true);
-  for (const claim of ["browser_tool_runtime_e2e", "model_turn_e2e", "login_e2e", "oauth_e2e"]) {
-    assert.equal(transcript.claim_boundary[claim], false, `evidence overclaims ${claim}`);
   }
 });

--- a/npm/agentplugins/test/fixtures/historical-evidence/AGENTPLUGINS_CLIENT_E2E.md
+++ b/npm/agentplugins/test/fixtures/historical-evidence/AGENTPLUGINS_CLIENT_E2E.md
@@ -1,0 +1,82 @@
+# Agent Plugins client E2E evidence
+
+This record binds the public client-support claims to one exact, disposable
+macOS run. It is lifecycle and client-discovery evidence, not a browser tool,
+model, OAuth, or login runtime claim.
+
+## Candidate identity
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-30 |
+| Installer source | `5630ccd92aa91c8ac8cafb37eea8752fd82edce0` |
+| Installer tree | `cf13cbe2f64ae09d93ad34bfc6047fe99d5ca845` |
+| Installer version | `0.1.22` |
+| Installer binary SHA-256 | `8f417cea031d42b07badbe1b2a37dcd53deb2e5804f99d668f733309ecb4022b` |
+| Package source | `ChromeDevTools/chrome-devtools-mcp@cb39d1d835c3baa3eff87501cd8c1de020604789` |
+| Package version | `1.8.0` |
+| Package tree digest | `sha256:3bd47ccd3f990a6fdd8d3e2fa3dac48ac460a9043e0ccf0c5e14522fb4c472ea` |
+| Package manifest digest | `sha256:b34a4dcd71cd536a7f5a3a51d76d53ae5af3d0ce0f18783e71c7f01da865b867` |
+| Platform | macOS 15.6.1, arm64, Node.js 24.18.0 |
+| Structured transcript | [`evidence/agentplugins-client-e2e-2026-08-30.json`](evidence/agentplugins-client-e2e-2026-08-30.json) |
+| Transcript SHA-256 | `437da1bc7423a85b231be139ff9bfbd7e89c942ef216a61ebde668c08a9c2ee3` |
+
+The run used fresh temporary `HOME`, XDG, Claude, Gemini, Cline, and
+agentplugins state directories. It did not read or mutate an agent project or
+the user's client configuration. A separate read-only `doctor` inventory
+confirmed that all five selected client families were present on the host.
+
+## Lifecycle proof
+
+The same exact package acquisition was applied to all five clients:
+
+```bash
+agentplugins add ChromeDevTools/chrome-devtools-mcp@cb39d1d835c3baa3eff87501cd8c1de020604789 \
+  --target claude,gemini,opencode,cline,windsurf \
+  --format json
+```
+
+The operation produced one installation ID and reported all five targets as
+installed against the same tree and manifest digests. The following client
+checks were then run inside the disposable profile.
+
+| Client | Exact check and result |
+| --- | --- |
+| Claude Code 2.1.205 | `claude plugin list --json` returned the enabled `chrome-devtools` package, its six skills, and the `chrome-devtools` MCP server. |
+| Gemini CLI 0.36.0 | `gemini mcp list` returned the configured `chrome-devtools` stdio server; `gemini skills list` discovered all six skills. The MCP process was `Disconnected`, so browser/runtime execution is not claimed. |
+| OpenCode 1.18.4 | `opencode debug config` returned the exact managed MCP command, working directory, `PLUGIN_ROOT`, and `PLUGIN_DATA`. Runtime tool execution is not claimed. |
+| Cline | The isolated native MCP settings contained the exact managed server and all six skills were projected. The real host detector found the installed Cursor extension/config surfaces; Cline runtime and login were not started. |
+| Windsurf / Devin | The isolated legacy MCP settings contained the exact managed server. The real host detector found existing Devin/Windsurf configuration surfaces; skills remained prepared-only and runtime/login were not started. |
+
+`doctor --format json` completed read-only and found no projection drift. Its
+only findings were the expected `authentication_not_checked` notices because
+this run intentionally performed no login or OAuth flow.
+
+An immutable full-SHA installation deliberately has no update channel. The
+multi-target update failed during preflight with no mutation and directed the
+user to `switch --to` with a new reviewed SHA. A repair then reacquired the
+exact recorded revision once and completed for every client:
+
+```bash
+agentplugins repair chrome-devtools \
+  --target claude,gemini,opencode,cline,windsurf \
+  --format json
+```
+
+The transcript records the exact update preflight and confirms the installation
+was unchanged. Directory-backed updates are a separate release/publication
+canary and are not inferred from this immutable-source run.
+
+Finally, one multi-target remove succeeded for all five clients. Post-removal
+checks proved:
+
+- `agentplugins list` returned no installations;
+- Claude Code returned an empty plugin list;
+- Gemini CLI reported no MCP servers and no skills;
+- OpenCode returned an empty MCP map;
+- Cline and Windsurf MCP maps were empty;
+- the projected Gemini and Cline skill files were gone.
+
+Plugin data was retained by default, matching the CLI's documented safe-remove
+contract. No browser, model, tool call, consent screen, or OAuth session was
+used in this evidence run.

--- a/npm/agentplugins/test/fixtures/historical-evidence/evidence/agentplugins-client-e2e-2026-08-30.json
+++ b/npm/agentplugins/test/fixtures/historical-evidence/evidence/agentplugins-client-e2e-2026-08-30.json
@@ -1,0 +1,232 @@
+{
+  "schema_version": 1,
+  "evidence_kind": "agentplugins_client_lifecycle",
+  "recorded_at": "2026-08-30",
+  "installer": {
+    "repository": "777genius/plugin-kit-ai",
+    "commit": "5630ccd92aa91c8ac8cafb37eea8752fd82edce0",
+    "tree": "cf13cbe2f64ae09d93ad34bfc6047fe99d5ca845",
+    "version": "0.1.22",
+    "binary_sha256": "8f417cea031d42b07badbe1b2a37dcd53deb2e5804f99d668f733309ecb4022b"
+  },
+  "package": {
+    "selector": "ChromeDevTools/chrome-devtools-mcp@cb39d1d835c3baa3eff87501cd8c1de020604789",
+    "repository": "ChromeDevTools/chrome-devtools-mcp",
+    "revision": "cb39d1d835c3baa3eff87501cd8c1de020604789",
+    "name": "chrome-devtools",
+    "version": "1.8.0",
+    "tree_digest": "sha256:3bd47ccd3f990a6fdd8d3e2fa3dac48ac460a9043e0ccf0c5e14522fb4c472ea",
+    "manifest_digest": "sha256:b34a4dcd71cd536a7f5a3a51d76d53ae5af3d0ce0f18783e71c7f01da865b867",
+    "acquisition_closure_digest": "sha256:d06d41ea4cca87f5731aac72cd9c1bc46e280fd9d84107ed1dcbbbc6e05e02e9"
+  },
+  "environment": {
+    "os": "macOS 15.6.1",
+    "arch": "arm64",
+    "node": "24.18.0",
+    "clients": {
+      "claude": { "version": "2.1.205", "host_surface_detected": true },
+      "gemini": { "version": "0.36.0", "host_surface_detected": true },
+      "opencode": { "version": "1.18.4", "host_surface_detected": true },
+      "cline": { "version": null, "host_surface_detected": true },
+      "windsurf": { "version": null, "host_surface_detected": true }
+    },
+    "isolation": {
+      "fresh_home": true,
+      "fresh_xdg_roots": true,
+      "fresh_claude_config": true,
+      "fresh_gemini_home": true,
+      "fresh_cline_data": true,
+      "fresh_agentplugins_state": true,
+      "user_project_accessed": false,
+      "user_client_config_mutated": false
+    }
+  },
+  "transcript": [
+    {
+      "step": "add",
+      "argv": [
+        "agentplugins",
+        "add",
+        "ChromeDevTools/chrome-devtools-mcp@cb39d1d835c3baa3eff87501cd8c1de020604789",
+        "--target",
+        "claude,gemini,opencode,cline,windsurf",
+        "--format",
+        "json"
+      ],
+      "exit_code": 0,
+      "result": "success",
+      "status": "completed",
+      "acquisition_count": 1,
+      "source_kind": "github",
+      "fetched": true,
+      "validated": true,
+      "targets": {
+        "claude": { "outcome": "passed", "activation": "active", "verification": "installation_verified" },
+        "gemini": { "outcome": "passed", "activation": "active", "verification": "installation_verified" },
+        "opencode": { "outcome": "passed", "activation": "active", "verification": "installation_verified" },
+        "cline": { "outcome": "passed", "activation": "active", "verification": "installation_verified" },
+        "windsurf": { "outcome": "passed", "activation": "active", "verification": "installation_verified" }
+      },
+      "shared_identity": {
+        "installation_count": 1,
+        "physical_artifact_id": "chrome-devtools-f7f684ed8c79",
+        "same_tree_digest_for_all_targets": true,
+        "same_manifest_digest_for_all_targets": true,
+        "same_closure_digest_for_all_targets": true
+      }
+    },
+    {
+      "step": "client_discovery",
+      "checks": {
+        "claude": {
+          "argv": ["claude", "plugin", "list", "--json"],
+          "exit_code": 0,
+          "plugin_id": "chrome-devtools@skills-dir",
+          "plugin_version": "1.8.0",
+          "enabled": true,
+          "skill_count": 6,
+          "mcp_command": ["npx", "chrome-devtools-mcp@1.8.0"]
+        },
+        "gemini_mcp": {
+          "argv": ["gemini", "mcp", "list"],
+          "exit_code": 0,
+          "server": "chrome-devtools",
+          "transport": "stdio",
+          "command": ["npx", "chrome-devtools-mcp@1.8.0"],
+          "connection": "disconnected"
+        },
+        "gemini_skills": {
+          "argv": ["gemini", "skills", "list"],
+          "exit_code": 0,
+          "enabled_skill_count": 6
+        },
+        "opencode": {
+          "argv": ["opencode", "debug", "config"],
+          "exit_code": 0,
+          "server": "chrome-devtools",
+          "type": "local",
+          "command": ["npx", "chrome-devtools-mcp@1.8.0"],
+          "cwd_bound_to_managed_package": true,
+          "plugin_root_bound": true,
+          "plugin_data_bound": true
+        },
+        "cline": {
+          "config": "mcpServers.chrome-devtools",
+          "transport": "stdio",
+          "command": ["npx", "chrome-devtools-mcp@1.8.0"],
+          "plugin_root_bound": true,
+          "plugin_data_bound": true,
+          "projected_skill_count": 6
+        },
+        "windsurf": {
+          "config": "mcpServers.chrome-devtools",
+          "command": ["npx", "chrome-devtools-mcp@1.8.0"],
+          "plugin_root_bound": true,
+          "plugin_data_bound": true,
+          "skills": "prepared_only"
+        }
+      }
+    },
+    {
+      "step": "doctor",
+      "argv": ["agentplugins", "doctor", "--format", "json"],
+      "exit_code": 0,
+      "result": "success",
+      "read_only": true,
+      "installation_count": 1,
+      "projection_drift_findings": 0,
+      "authentication_not_checked_clients": ["claude", "gemini", "opencode", "cline", "windsurf"]
+    },
+    {
+      "step": "immutable_update_preflight",
+      "argv": [
+        "agentplugins",
+        "update",
+        "chrome-devtools",
+        "--target",
+        "claude,gemini,opencode,cline,windsurf",
+        "--format",
+        "json"
+      ],
+      "exit_code": 1,
+      "result": "failure",
+      "status": "preflight_failed",
+      "reason": "direct full-SHA installations require explicit switch",
+      "succeeded": 0,
+      "failed": 5,
+      "mutated_targets": 0,
+      "postcondition": "the exact installation and all five client projections remained installed and unchanged"
+    },
+    {
+      "step": "repair",
+      "argv": [
+        "agentplugins",
+        "repair",
+        "chrome-devtools",
+        "--target",
+        "claude,gemini,opencode,cline,windsurf",
+        "--format",
+        "json"
+      ],
+      "exit_code": 0,
+      "result": "success",
+      "status": "completed",
+      "succeeded": 5,
+      "failed": 0,
+      "targets": {
+        "claude": "passed",
+        "gemini": "passed",
+        "opencode": "passed",
+        "cline": "passed",
+        "windsurf": "passed"
+      }
+    },
+    {
+      "step": "remove",
+      "argv": [
+        "agentplugins",
+        "remove",
+        "chrome-devtools",
+        "--target",
+        "claude,gemini,opencode,cline,windsurf",
+        "--format",
+        "json"
+      ],
+      "exit_code": 0,
+      "result": "success",
+      "status": "data_retained",
+      "succeeded": 5,
+      "failed": 0,
+      "plugin_data_preserved": true,
+      "targets": {
+        "claude": "external_completed",
+        "gemini": "external_completed",
+        "opencode": "external_completed",
+        "cline": "external_completed",
+        "windsurf": "external_completed"
+      }
+    },
+    {
+      "step": "post_remove",
+      "checks": {
+        "agentplugins_installation_count": 0,
+        "claude_plugin_count": 0,
+        "gemini_mcp_count": 0,
+        "gemini_skill_count": 0,
+        "opencode_mcp_count": 0,
+        "cline_mcp_count": 0,
+        "cline_skill_count": 0,
+        "windsurf_mcp_count": 0
+      }
+    }
+  ],
+  "claim_boundary": {
+    "lifecycle_e2e": true,
+    "client_discovery_e2e": true,
+    "browser_tool_runtime_e2e": false,
+    "model_turn_e2e": false,
+    "login_e2e": false,
+    "oauth_e2e": false,
+    "windsurf_skill_activation_claimed": false
+  }
+}

--- a/npm/agentplugins/test/npm-public-contract.test.js
+++ b/npm/agentplugins/test/npm-public-contract.test.js
@@ -1,0 +1,269 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  validateAuditSignatures,
+  validateDownloadedTarball,
+  validatePackJSON,
+  validatePublicMetadata,
+  validateSLSAAttestation
+} = require("../scripts/npm-public-contract");
+
+function fixture(body = Buffer.from("exact tarball bytes")) {
+  const version = "1.2.3";
+  const integrity = `sha512-${crypto.createHash("sha512").update(body).digest("base64")}`;
+  const shasum = crypto.createHash("sha1").update(body).digest("hex");
+  const pack = [{
+    name: "universal-agent-plugins",
+    version,
+    filename: `universal-agent-plugins-${version}.tgz`,
+    integrity,
+    shasum
+  }];
+  const metadata = {
+    name: "universal-agent-plugins",
+    version,
+    homepage: "https://777genius.github.io/universal-agent-plugins/",
+    repository: {
+      type: "git",
+      url: "git+https://github.com/777genius/universal-agent-plugins.git",
+      directory: "npm/agentplugins"
+    },
+    engines: { node: ">=22" },
+    bin: { agentplugins: "bin/agentplugins.js" },
+    scripts: { test: "node --test" },
+    _npmUser: {
+      name: "GitHub Actions",
+      email: "npm-oidc-no-reply@github.com",
+      trustedPublisher: { id: "github", oidcConfigId: "oidc:001caef4-dbce-4b2d-a25d-1d6ee59b68ac" }
+    },
+    dist: {
+      integrity,
+      shasum,
+      tarball: `https://registry.npmjs.org/universal-agent-plugins/-/universal-agent-plugins-${version}.tgz`,
+      attestations: {
+        url: `https://registry.npmjs.org/-/npm/v1/attestations/universal-agent-plugins@${version}`,
+        provenance: { predicateType: "https://slsa.dev/provenance/v1" }
+      }
+    }
+  };
+  const uapTag = `v${version}`;
+  const uapCommit = "a".repeat(40);
+  const statement = {
+    _type: "https://in-toto.io/Statement/v1",
+    subject: [{
+      name: `pkg:npm/universal-agent-plugins@${version}`,
+      digest: { sha512: crypto.createHash("sha512").update(body).digest("hex") }
+    }],
+    predicateType: "https://slsa.dev/provenance/v1",
+    predicate: {
+      buildDefinition: {
+        buildType: "https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1",
+        externalParameters: {
+          workflow: {
+            ref: `refs/tags/${uapTag}`,
+            repository: "https://github.com/777genius/universal-agent-plugins",
+            path: ".github/workflows/agentplugins-npm-publish.yml"
+          }
+        },
+        resolvedDependencies: [{
+          uri: `git+https://github.com/777genius/universal-agent-plugins@refs/tags/${uapTag}`,
+          digest: { gitCommit: uapCommit }
+        }]
+      },
+      runDetails: {
+        builder: { id: "https://github.com/actions/runner/github-hosted" },
+        metadata: {
+          invocationId: "https://github.com/777genius/universal-agent-plugins/actions/runs/123/attempts/1"
+        }
+      }
+    }
+  };
+  const attestations = {
+    attestations: [{ predicateType: "https://github.com/npm/attestation/tree/main/specs/publish/v0.1" }, {
+      predicateType: "https://slsa.dev/provenance/v1",
+      bundle: {
+        mediaType: "application/vnd.dev.sigstore.bundle.v0.3+json",
+        dsseEnvelope: {
+          payload: Buffer.from(JSON.stringify(statement)).toString("base64"),
+          payloadType: "application/vnd.in-toto+json",
+          signatures: [{ sig: "signed", keyid: "" }]
+        }
+      }
+    }]
+  };
+  return { attestations, body, integrity, metadata, pack, shasum, statement, uapCommit, uapTag, version };
+}
+
+test("public npm metadata and downloaded pack bind the staged package identity", (t) => {
+  const value = fixture();
+  assert.equal(validatePackJSON(value.pack, value.version), value.pack[0]);
+  assert.equal(validatePublicMetadata(value.metadata, value.version, value.integrity, value.shasum), value.metadata);
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "npm-public-contract-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  fs.writeFileSync(path.join(root, value.pack[0].filename), value.body);
+  assert.equal(
+    validateDownloadedTarball(value.pack, root, value.version, value.integrity, value.shasum),
+    value.pack[0]
+  );
+});
+
+test("npm 12 object-shaped pack JSON preserves the exact package identity", (t) => {
+  const value = fixture();
+  const npm12 = { "universal-agent-plugins": structuredClone(value.pack[0]) };
+  assert.equal(validatePackJSON(npm12, value.version), npm12["universal-agent-plugins"]);
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "npm-public-contract-npm12-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  fs.writeFileSync(path.join(root, value.pack[0].filename), value.body);
+  assert.equal(
+    validateDownloadedTarball(npm12, root, value.version, value.integrity, value.shasum),
+    npm12["universal-agent-plugins"]
+  );
+  assert.throws(
+    () => validatePackJSON({ ...npm12, lookalike: structuredClone(value.pack[0]) }, value.version),
+    /exactly one package-named record/
+  );
+  assert.throws(
+    () => validatePackJSON({ lookalike: structuredClone(value.pack[0]) }, value.version),
+    /exactly one package-named record/
+  );
+});
+
+test("public npm SLSA DSSE binds staged digest and exact UAP workflow tag commit", () => {
+  const value = fixture();
+  assert.deepEqual(
+    validateSLSAAttestation(
+      value.attestations, value.version, value.integrity, value.uapTag, value.uapCommit
+    ),
+    value.statement
+  );
+});
+
+test("npm audit signatures output binds cryptographic verification to the fetched bundles", () => {
+  const value = fixture();
+  const audit = {
+    invalid: [],
+    missing: [],
+    verified: [{
+      name: "universal-agent-plugins",
+      version: value.version,
+      location: "node_modules/universal-agent-plugins",
+      registry: "https://registry.npmjs.org/",
+      attestations: {
+        url: `https://registry.npmjs.org/-/npm/v1/attestations/universal-agent-plugins@${value.version}`,
+        provenance: { predicateType: "https://slsa.dev/provenance/v1" }
+      },
+      attestationBundles: value.attestations.attestations
+    }]
+  };
+  assert.equal(validateAuditSignatures(audit, value.attestations, value.version), audit.verified[0]);
+  for (const mutate of [
+    (x) => { x.invalid.push({ name: "universal-agent-plugins" }); },
+    (x) => { x.verified[0].name = "lookalike"; },
+    (x) => { x.verified[0].attestationBundles[1].bundle.dsseEnvelope.payload = "e30="; }
+  ]) {
+    const invalid = structuredClone(audit);
+    mutate(invalid);
+    assert.throws(() => validateAuditSignatures(invalid, value.attestations, value.version));
+  }
+});
+
+test("public npm SLSA DSSE fails closed for every reviewed provenance binding", () => {
+  const value = fixture();
+  const mutations = [
+    (x) => { x.attestations[1].predicateType = "https://example.invalid/predicate"; },
+    (x) => { x.attestations.push(structuredClone(x.attestations[1])); },
+    (x) => { x.attestations[1].bundle.mediaType = "application/json"; },
+    (x) => { x.attestations[1].bundle.dsseEnvelope.payloadType = "application/json"; },
+    (x) => { x.attestations[1].bundle.dsseEnvelope.signatures = []; },
+    (x) => mutatePayload(x, (statement) => { statement.subject[0].digest.sha512 = "0".repeat(128); }),
+    (x) => mutatePayload(x, (statement) => { statement.subject[0].name = "pkg:npm/lookalike@1.2.3"; }),
+    (x) => mutatePayload(x, (statement) => { statement.predicateType = "https://example.invalid/predicate"; }),
+    (x) => mutatePayload(x, (statement) => {
+      statement.predicate.buildDefinition.externalParameters.workflow.repository =
+        "https://github.com/lookalike/repository";
+    }),
+    (x) => mutatePayload(x, (statement) => {
+      statement.predicate.buildDefinition.externalParameters.workflow.path = "/.github/workflows/lookalike.yml";
+    }),
+    (x) => mutatePayload(x, (statement) => {
+      statement.predicate.buildDefinition.externalParameters.workflow.path =
+        "/.github/workflows/agentplugins-npm-publish.yml";
+    }),
+    (x) => mutatePayload(x, (statement) => {
+      statement.predicate.buildDefinition.externalParameters.workflow.ref = "refs/heads/main";
+    }),
+    (x) => mutatePayload(x, (statement) => {
+      statement.predicate.buildDefinition.resolvedDependencies[0].digest.gitCommit = "b".repeat(40);
+    }),
+    (x) => mutatePayload(x, (statement) => {
+      statement.predicate.runDetails.builder.id = "https://example.invalid/runner";
+    }),
+    (x) => mutatePayload(x, (statement) => {
+      statement.predicate.runDetails.metadata.invocationId =
+        "https://github.com/lookalike/repository/actions/runs/123/attempts/1";
+    })
+  ];
+  for (const mutate of mutations) {
+    const invalid = structuredClone(value.attestations);
+    mutate(invalid);
+    assert.throws(() => validateSLSAAttestation(
+      invalid, value.version, value.integrity, value.uapTag, value.uapCommit
+    ));
+  }
+});
+
+function mutatePayload(attestations, mutate) {
+  const envelope = attestations.attestations[1].bundle.dsseEnvelope;
+  const statement = JSON.parse(Buffer.from(envelope.payload, "base64").toString("utf8"));
+  mutate(statement);
+  envelope.payload = Buffer.from(JSON.stringify(statement)).toString("base64");
+}
+
+test("public npm metadata fails closed for every reviewed identity field", () => {
+  const value = fixture();
+  const mutations = [
+    (x) => { x.name = "lookalike"; },
+    (x) => { x.version = "1.2.4"; },
+    (x) => { x.repository.url = "git+https://github.com/lookalike/repository.git"; },
+    (x) => { x.homepage = "https://example.invalid/"; },
+    (x) => { x.dist.tarball = "https://example.invalid/package.tgz"; },
+    (x) => { x.dist.integrity = `sha512-${Buffer.alloc(64).toString("base64")}`; },
+    (x) => { x.dist.shasum = "0".repeat(40); },
+    (x) => { x.dist.attestations.url = "https://example.invalid/attestation"; },
+    (x) => { x.dist.attestations.provenance.predicateType = "https://example.invalid/predicate"; },
+    (x) => { x._npmUser.name = "npm user"; },
+    (x) => { x._npmUser.trustedPublisher.id = "other"; },
+    (x) => { x.engines.node = ">=22.23.2"; },
+    (x) => { x.bin.agentplugins = "bin/lookalike.js"; },
+    (x) => { x.scripts.postinstall = "node install.js"; }
+  ];
+  for (const mutate of mutations) {
+    const invalid = structuredClone(value.metadata);
+    mutate(invalid);
+    assert.throws(() => validatePublicMetadata(invalid, value.version, value.integrity, value.shasum));
+  }
+});
+
+test("downloaded public npm bytes and pack JSON reject staged digest mismatches", (t) => {
+  const value = fixture();
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "npm-public-contract-negative-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  fs.writeFileSync(path.join(root, value.pack[0].filename), Buffer.from("tampered"));
+  assert.throws(
+    () => validateDownloadedTarball(value.pack, root, value.version, value.integrity, value.shasum),
+    /bytes do not match/
+  );
+  const wrongPack = structuredClone(value.pack);
+  wrongPack[0].shasum = "0".repeat(40);
+  assert.throws(
+    () => validateDownloadedTarball(wrongPack, root, value.version, value.integrity, value.shasum),
+    /pack identity/
+  );
+});

--- a/npm/agentplugins/test/platform-proof.test.js
+++ b/npm/agentplugins/test/platform-proof.test.js
@@ -9,14 +9,119 @@ const test = require("node:test");
 
 const script = path.resolve(__dirname, "..", "scripts", "platform-proof.js");
 const {
+  assertAssetManifest,
+  assertContext7Search,
+  assertInstalledShimInvocation,
   assertPublicJSONPathFree,
+  assertSyntheticInfo,
   frozenReleaseAsset,
+  installedShimInvocation,
   lifecycleCommands,
   lifecycleResult,
   npmInvocation,
   parseBootstrapMode,
   parseLifecycle
 } = require(script);
+
+test("platform proof binds assets.json producer commit in staged and public modes", () => {
+  const version = "1.2.3";
+  const commit = "a".repeat(40);
+  const manifest = {
+    schema_version: 2,
+    version,
+    npm_package: "universal-agent-plugins",
+    repository: "777genius/plugin-kit-ai",
+    tag: `agentplugins-v${version}`,
+    producer: {
+      repository: "777genius/plugin-kit-ai",
+      tag: `agentplugins-v${version}`,
+      commit
+    },
+    assets: { "linux-amd64": { file: "agentplugins", size: 1, sha256: "0".repeat(64) } }
+  };
+  assert.equal(assertAssetManifest(manifest, version, commit, "linux-amd64"), manifest.assets["linux-amd64"]);
+  for (const mutate of [
+    (value) => { value.producer.commit = "b".repeat(40); },
+    (value) => { value.producer.tag = "agentplugins-v9.9.9"; },
+    (value) => { value.producer.repository = "lookalike/repository"; },
+    (value) => { delete value.producer; }
+  ]) {
+    const invalid = structuredClone(manifest);
+    mutate(invalid);
+    assert.throws(() => assertAssetManifest(invalid, version, commit, "linux-amd64"), /expected commit/);
+  }
+});
+
+test("platform proof invokes the installed npm shim and rejects direct bin bypass", () => {
+  const project = path.join(os.tmpdir(), "proof project");
+  const posix = installedShimInvocation(project, ["version"], "linux");
+  assert.equal(posix.command, path.join(project, "node_modules", ".bin", "agentplugins"));
+  assert.equal(posix.shell, false);
+  assert.doesNotThrow(() => assertInstalledShimInvocation(posix, project, "linux"));
+
+  const windows = installedShimInvocation(project, ["version"], "win32");
+  assert.equal(windows.command, path.join(project, "node_modules", ".bin", "agentplugins.cmd"));
+  assert.equal(windows.shell, true);
+  assert.doesNotThrow(() => assertInstalledShimInvocation(windows, project, "win32"));
+
+  assert.throws(() => assertInstalledShimInvocation({
+    command: process.execPath,
+    args: [path.join(project, "node_modules", "universal-agent-plugins", "bin", "agentplugins.js")],
+    shell: false
+  }, project, process.platform), /must execute the installed npm agentplugins shim/);
+});
+
+test("platform proof requires the expected context7 product and distribution in search results", () => {
+  const valid = {
+    schema_version: 1,
+    command: "search",
+    result: "success",
+    data: {
+      results: [
+        { product_id: "other", distribution_id: "owner/other" },
+        { product_id: "context7", distribution_id: "777genius/context7" }
+      ]
+    }
+  };
+  assert.doesNotThrow(() => assertContext7Search(valid));
+  for (const invalid of [
+    { ...valid, data: { results: [] } },
+    { ...valid, data: { results: [{ product_id: "context7", distribution_id: "upstash/context7" }] } },
+    { ...valid, data: { results: [{ product_id: "other", distribution_id: "777genius/context7" }] } }
+  ]) {
+    assert.throws(() => assertContext7Search(invalid), /expected context7 product and distribution/);
+  }
+});
+
+test("platform proof requires exact synthetic info identity, Cursor version, and active state", () => {
+  const valid = {
+    schema_version: 1,
+    command: "info",
+    result: "success",
+    data: {
+      name: "platform-proof-synthetic",
+      version: "1.0.0",
+      clients: [{
+        client_id: "cursor",
+        activation: "active",
+        package_revision: { version: "1.0.0" }
+      }]
+    }
+  };
+  assert.doesNotThrow(() => assertSyntheticInfo(valid));
+  for (const mutate of [
+    (value) => { value.data.name = "lookalike"; },
+    (value) => { value.data.version = "2.0.0"; },
+    (value) => { value.data.clients[0].client_id = "codex"; },
+    (value) => { value.data.clients[0].activation = "pending"; },
+    (value) => { value.data.clients[0].package_revision.version = "2.0.0"; },
+    (value) => { value.data.clients.push({ ...value.data.clients[0] }); }
+  ]) {
+    const invalid = structuredClone(valid);
+    mutate(invalid);
+    assert.throws(() => assertSyntheticInfo(invalid), /identity, Cursor target, installed version, and active state/);
+  }
+});
 
 test("platform proof rejects absolute paths anywhere in public lifecycle JSON", () => {
   const privateRoot = path.join(os.tmpdir(), "agentplugins-private-root");

--- a/npm/agentplugins/test/stage-release.test.js
+++ b/npm/agentplugins/test/stage-release.test.js
@@ -11,13 +11,123 @@ const test = require("node:test");
 
 const { detectPlatform, expectedAssetName } = require("../lib/platform");
 const { prepareRelease, verifyRelease } = require("../scripts/release-assets");
-const { stage, stageEvidence, validatePackageMetadata } = require("../scripts/stage-release");
+const { stage, stageEvidence, validateEvidenceRecord, validatePackageMetadata } = require("../scripts/stage-release");
 
 const COMMIT = "a".repeat(40);
-const STAGED_EVIDENCE_ROOT = path.resolve(__dirname, "evidence-root");
-const EVIDENCE_ROOT = fs.existsSync(STAGED_EVIDENCE_ROOT)
-  ? STAGED_EVIDENCE_ROOT
-  : path.resolve(__dirname, "../../../docs");
+const HISTORICAL_COMMIT = "5630ccd92aa91c8ac8cafb37eea8752fd82edce0";
+const HISTORICAL_TREE = "cf13cbe2f64ae09d93ad34bfc6047fe99d5ca845";
+
+async function fixtureEvidence(root) {
+  const evidenceRoot = path.join(root, "evidence");
+  await fsp.mkdir(path.join(evidenceRoot, "evidence"), { recursive: true });
+  const record = {
+    schema_version: 1,
+    evidence_kind: "agentplugins_client_lifecycle",
+    recorded_at: "2026-08-30",
+    installer: {
+      repository: "777genius/plugin-kit-ai",
+      commit: HISTORICAL_COMMIT,
+      tree: HISTORICAL_TREE,
+      version: "0.1.22",
+      binary_sha256: "8f417cea031d42b07badbe1b2a37dcd53deb2e5804f99d668f733309ecb4022b"
+    },
+    package: {
+      selector: "ChromeDevTools/chrome-devtools-mcp@cb39d1d835c3baa3eff87501cd8c1de020604789",
+      repository: "ChromeDevTools/chrome-devtools-mcp",
+      revision: "cb39d1d835c3baa3eff87501cd8c1de020604789",
+      name: "chrome-devtools",
+      version: "1.8.0",
+      tree_digest: "sha256:3bd47ccd3f990a6fdd8d3e2fa3dac48ac460a9043e0ccf0c5e14522fb4c472ea",
+      manifest_digest: "sha256:b34a4dcd71cd536a7f5a3a51d76d53ae5af3d0ce0f18783e71c7f01da865b867",
+      acquisition_closure_digest: "sha256:d06d41ea4cca87f5731aac72cd9c1bc46e280fd9d84107ed1dcbbbc6e05e02e9"
+    },
+    environment: {
+      os: "macOS 15.6.1",
+      arch: "arm64",
+      node: "24.18.0",
+      clients: {
+        claude: { version: "2.1.205", host_surface_detected: true },
+        gemini: { version: "0.36.0", host_surface_detected: true },
+        opencode: { version: "1.18.4", host_surface_detected: true },
+        cline: { version: null, host_surface_detected: true },
+        windsurf: { version: null, host_surface_detected: true }
+      },
+      isolation: {
+        fresh_home: true, fresh_xdg_roots: true, fresh_claude_config: true,
+        fresh_gemini_home: true, fresh_cline_data: true, fresh_agentplugins_state: true,
+        user_project_accessed: false, user_client_config_mutated: false
+      }
+    },
+    transcript: [
+      {
+        step: "add", argv: ["agentplugins", "add"], exit_code: 0, result: "success", status: "completed",
+        acquisition_count: 1, source_kind: "github", fetched: true, validated: true,
+        targets: Object.fromEntries(["claude", "gemini", "opencode", "cline", "windsurf"].map((name) => [name,
+          { outcome: "passed", activation: "active", verification: "installation_verified" }])),
+        shared_identity: { installation_count: 1, physical_artifact_id: "chrome-devtools-f7f684ed8c79", same_tree_digest_for_all_targets: true,
+          same_manifest_digest_for_all_targets: true, same_closure_digest_for_all_targets: true }
+      },
+      {
+        step: "client_discovery",
+        checks: {
+          claude: { argv: ["claude", "plugin", "list", "--json"], exit_code: 0, plugin_id: "chrome-devtools@skills-dir", plugin_version: "1.8.0",
+            enabled: true, skill_count: 6, mcp_command: ["npx", "chrome-devtools-mcp@1.8.0"] },
+          gemini_mcp: { argv: ["gemini", "mcp", "list"], exit_code: 0, server: "chrome-devtools", transport: "stdio",
+            command: ["npx", "chrome-devtools-mcp@1.8.0"], connection: "disconnected" },
+          gemini_skills: { argv: ["gemini", "skills", "list"], exit_code: 0, enabled_skill_count: 6 },
+          opencode: { argv: ["opencode", "debug", "config"], exit_code: 0, server: "chrome-devtools", type: "local",
+            command: ["npx", "chrome-devtools-mcp@1.8.0"], cwd_bound_to_managed_package: true, plugin_root_bound: true, plugin_data_bound: true },
+          cline: { config: "mcpServers.chrome-devtools", transport: "stdio", command: ["npx", "chrome-devtools-mcp@1.8.0"], plugin_root_bound: true,
+            plugin_data_bound: true, projected_skill_count: 6 },
+          windsurf: { config: "mcpServers.chrome-devtools", command: ["npx", "chrome-devtools-mcp@1.8.0"], plugin_root_bound: true,
+            plugin_data_bound: true, skills: "prepared_only" }
+        }
+      },
+      { step: "doctor", argv: ["agentplugins", "doctor"], exit_code: 0, result: "success", read_only: true,
+        installation_count: 1, projection_drift_findings: 0, authentication_not_checked_clients: [] },
+      { step: "immutable_update_preflight", argv: ["agentplugins", "update"], exit_code: 1, result: "failure",
+        status: "preflight_failed", reason: "direct full-SHA installations require explicit switch", succeeded: 0, failed: 5, mutated_targets: 0,
+        postcondition: "the exact installation and all five client projections remained installed and unchanged" },
+      { step: "repair", argv: ["agentplugins", "repair"], exit_code: 0, result: "success", status: "completed",
+        succeeded: 5, failed: 0, targets: Object.fromEntries(["claude", "gemini", "opencode", "cline", "windsurf"].map((name) => [name, "passed"])) },
+      { step: "remove", argv: ["agentplugins", "remove"], exit_code: 0, result: "success", status: "data_retained",
+        succeeded: 5, failed: 0, plugin_data_preserved: true,
+        targets: Object.fromEntries(["claude", "gemini", "opencode", "cline", "windsurf"].map((name) => [name, "external_completed"])) },
+      { step: "post_remove", checks: Object.fromEntries(["agentplugins_installation_count", "claude_plugin_count", "gemini_mcp_count",
+        "gemini_skill_count", "opencode_mcp_count", "cline_mcp_count", "cline_skill_count", "windsurf_mcp_count"].map((name) => [name, 0])) }
+    ],
+    claim_boundary: { lifecycle_e2e: true, client_discovery_e2e: true, browser_tool_runtime_e2e: false,
+      model_turn_e2e: false, login_e2e: false, oauth_e2e: false, windsurf_skill_activation_claimed: false }
+  };
+  const targets = "claude,gemini,opencode,cline,windsurf";
+  record.transcript[0].argv = ["agentplugins", "add", record.package.selector, "--target", targets, "--format", "json"];
+  record.transcript[2].argv = ["agentplugins", "doctor", "--format", "json"];
+  record.transcript[2].authentication_not_checked_clients = targets.split(",");
+  record.transcript[3].argv = ["agentplugins", "update", record.package.name, "--target", targets, "--format", "json"];
+  record.transcript[4].argv = ["agentplugins", "repair", record.package.name, "--target", targets, "--format", "json"];
+  record.transcript[5].argv = ["agentplugins", "remove", record.package.name, "--target", targets, "--format", "json"];
+  const recordFixture = path.join(__dirname, "fixtures/historical-evidence/evidence/agentplugins-client-e2e-2026-08-30.json");
+  assert.deepEqual(record, JSON.parse(await fsp.readFile(recordFixture, "utf8")));
+  const recordBody = await fsp.readFile(recordFixture);
+  const recordDigest = crypto.createHash("sha256").update(recordBody).digest("hex");
+  await fsp.writeFile(path.join(evidenceRoot, "evidence/agentplugins-client-e2e-2026-08-30.json"), recordBody);
+  assert.equal(recordDigest, "437da1bc7423a85b231be139ff9bfbd7e89c942ef216a61ebde668c08a9c2ee3");
+  await fsp.copyFile(
+    path.join(__dirname, "fixtures/historical-evidence/AGENTPLUGINS_CLIENT_E2E.md"),
+    path.join(evidenceRoot, "AGENTPLUGINS_CLIENT_E2E.md")
+  );
+  return evidenceRoot;
+}
+
+function childNodeEnvironment(extra = {}) {
+  const environment = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key === "NODE_UNIQUE_ID" || key === "NODE_CHANNEL_FD" ||
+        key === "NODE_CHANNEL_SERIALIZATION_MODE" || key.startsWith("NODE_TEST_")) continue;
+    environment[key] = value;
+  }
+  return { ...environment, ...extra };
+}
 
 test("release staging embeds every exact platform asset hash", async (t) => {
   const root = await fsp.mkdtemp(path.join(os.tmpdir(), "agentplugins-stage-"));
@@ -37,9 +147,29 @@ test("release staging embeds every exact platform asset hash", async (t) => {
     await fsp.writeFile(path.join(assetsRoot, expectedAssetName(version, info)), `${info.key}\n`);
   }
   prepareRelease(assetsRoot, `agentplugins-v${version}`, COMMIT);
-  const manifest = stage(packageRoot, assetsRoot, version, COMMIT, { evidenceRoot: EVIDENCE_ROOT });
+  const release = verifyRelease(assetsRoot, `agentplugins-v${version}`, COMMIT);
+  const evidenceRoot = await fixtureEvidence(root);
+  const manifest = stage(packageRoot, assetsRoot, version, COMMIT, { evidenceRoot });
   assert.equal(manifest.version, version);
   assert.equal(manifest.npm_package, "universal-agent-plugins");
+  assert.equal(manifest.producer.repository, "777genius/plugin-kit-ai");
+  assert.equal(manifest.producer.commit, COMMIT);
+  assert.equal(manifest.producer.release_manifest.sha256, release.manifest_sha256);
+  assert.equal(manifest.client_evidence.installer.commit, HISTORICAL_COMMIT);
+  assert.deepEqual(manifest.client_evidence.source, {
+    repository: "777genius/plugin-kit-ai",
+    commit: "4b25a45e1574bab7a4f49e48905a3b3b2647e917",
+    document: {
+      path: "docs/AGENTPLUGINS_CLIENT_E2E.md",
+      sha256: manifest.client_evidence.document_sha256
+    },
+    record: {
+      path: "docs/evidence/agentplugins-client-e2e-2026-08-30.json",
+      sha256: manifest.client_evidence.record_sha256
+    }
+  });
+  assert.notEqual(manifest.client_evidence.installer.commit, manifest.producer.commit);
+  assert.notEqual(manifest.client_evidence.installer.version, manifest.version);
   assert.equal(Object.keys(manifest.assets).length, 6);
   for (const asset of Object.values(manifest.assets)) {
     assert.match(asset.sha256, /^[0-9a-f]{64}$/);
@@ -49,7 +179,7 @@ test("release staging embeds every exact platform asset hash", async (t) => {
   assert.equal(pkg.version, version);
   assert.equal(
     await fsp.readFile(path.join(packageRoot, "test/evidence-root/AGENTPLUGINS_CLIENT_E2E.md"), "utf8"),
-    await fsp.readFile(path.join(EVIDENCE_ROOT, "AGENTPLUGINS_CLIENT_E2E.md"), "utf8")
+    await fsp.readFile(path.join(evidenceRoot, "AGENTPLUGINS_CLIENT_E2E.md"), "utf8")
   );
 });
 
@@ -72,23 +202,27 @@ test("staged package tests are hermetic to repository layout and caller cwd", {
     await fsp.writeFile(path.join(assetsRoot, expectedAssetName(version, info)), `${info.key}\n`);
   }
   prepareRelease(assetsRoot, `agentplugins-v${version}`, COMMIT);
-  stage(packageRoot, assetsRoot, version, COMMIT, { evidenceRoot: EVIDENCE_ROOT });
+  const evidenceRoot = await fixtureEvidence(root);
+  stage(packageRoot, assetsRoot, version, COMMIT, { evidenceRoot });
 
   const result = childProcess.spawnSync("npm", ["--prefix", packageRoot, "test"], {
     cwd: callerRoot,
     encoding: "utf8",
-    env: {
-      ...process.env,
+    env: childNodeEnvironment({
       AGENTPLUGINS_STAGED_TEST_CHILD: "1",
+      AGENTPLUGINS_DETACHED_ASSERT_ROOT: packageRoot,
       NPM_CONFIG_CACHE: npmCache
-    }
+    })
   });
   assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  assert.match(result.stdout, /[ℹ#] tests [1-9][0-9]*/);
+  assert.match(result.stdout, /[ℹ#] pass [1-9][0-9]*/);
+  assert.match(result.stdout, /detached package execution sentinel/);
 
   const packed = childProcess.spawnSync("npm", ["pack", "--ignore-scripts", "--json"], {
     cwd: packageRoot,
     encoding: "utf8",
-    env: { ...process.env, NPM_CONFIG_CACHE: npmCache }
+    env: childNodeEnvironment({ NPM_CONFIG_CACHE: npmCache })
   });
   assert.equal(packed.status, 0, `${packed.stdout}\n${packed.stderr}`);
   const packResult = JSON.parse(packed.stdout);
@@ -97,6 +231,120 @@ test("staged package tests are hermetic to repository layout and caller cwd", {
   assert.ok(packedFiles.includes("README.md"));
   assert.ok(packedFiles.includes("assets.json"));
   assert.equal(packedFiles.some((filename) => filename.startsWith("test/") || filename.includes("evidence-root")), false);
+});
+
+test("release staging rejects malformed and internally mismatched historical evidence", async (t) => {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "agentplugins-bad-evidence-"));
+  t.after(() => fsp.rm(root, { recursive: true, force: true }));
+  const packageRoot = path.join(root, "package");
+  const assetsRoot = path.join(root, "assets");
+  await fsp.mkdir(packageRoot);
+  await fsp.mkdir(assetsRoot);
+  await fsp.writeFile(path.join(packageRoot, "package.json"), JSON.stringify({
+    name: "universal-agent-plugins", version: "0.0.0-development",
+    bin: { agentplugins: "bin/agentplugins.js" }
+  }));
+  const version = "0.1.9";
+  for (const [platform, arch] of [["darwin", "x64"], ["darwin", "arm64"], ["linux", "x64"], ["linux", "arm64"], ["win32", "x64"], ["win32", "arm64"]]) {
+    const info = detectPlatform(platform, arch);
+    await fsp.writeFile(path.join(assetsRoot, expectedAssetName(version, info)), `${info.key}\n`);
+  }
+  prepareRelease(assetsRoot, `agentplugins-v${version}`, COMMIT);
+  const evidenceRoot = await fixtureEvidence(root);
+  const recordPath = path.join(evidenceRoot, "evidence/agentplugins-client-e2e-2026-08-30.json");
+  await fsp.writeFile(recordPath, "dummy\n");
+  assert.throws(() => stage(packageRoot, assetsRoot, version, COMMIT, { evidenceRoot }), /JSON is malformed/);
+
+  await fsp.rm(path.join(packageRoot, "test"), { recursive: true, force: true });
+  const repairedEvidence = await fixtureEvidence(root);
+  const record = JSON.parse(await fsp.readFile(recordPath, "utf8"));
+  record.package.selector = `ChromeDevTools/chrome-devtools-mcp@${"9".repeat(40)}`;
+  await fsp.writeFile(recordPath, JSON.stringify(record));
+  assert.throws(() => stage(packageRoot, assetsRoot, version, COMMIT, { evidenceRoot: repairedEvidence }), /package identity is invalid/);
+
+  await fixtureEvidence(root);
+  const extraKeyRecord = JSON.parse(await fsp.readFile(recordPath, "utf8"));
+  extraKeyRecord.unexpected = true;
+  await fsp.writeFile(recordPath, JSON.stringify(extraKeyRecord));
+  assert.throws(() => stage(packageRoot, assetsRoot, version, COMMIT, { evidenceRoot }), /record keys are invalid/);
+
+  await fixtureEvidence(root);
+  const markdownPath = path.join(evidenceRoot, "AGENTPLUGINS_CLIENT_E2E.md");
+  const markdown = await fsp.readFile(markdownPath, "utf8");
+  await fsp.writeFile(markdownPath, markdown.replace(
+    "437da1bc7423a85b231be139ff9bfbd7e89c942ef216a61ebde668c08a9c2ee3",
+    "0".repeat(64)
+  ));
+  assert.throws(() => stage(packageRoot, assetsRoot, version, COMMIT, { evidenceRoot }), /does not bind/);
+});
+
+test("historical client discovery and boundary claims reject every semantic bypass", async (t) => {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "agentplugins-evidence-semantics-"));
+  t.after(() => fsp.rm(root, { recursive: true, force: true }));
+  const evidenceRoot = await fixtureEvidence(root);
+  const original = JSON.parse(await fsp.readFile(
+    path.join(evidenceRoot, "evidence/agentplugins-client-e2e-2026-08-30.json"), "utf8"
+  ));
+  const cases = [
+    ["claude enabled", (r) => { r.transcript[1].checks.claude.enabled = false; }],
+    ["claude skill count", (r) => { r.transcript[1].checks.claude.skill_count = 1; }],
+    ["claude command", (r) => { r.transcript[1].checks.claude.mcp_command = ["wrong"]; }],
+    ["Gemini connection", (r) => { r.transcript[1].checks.gemini_mcp.connection = "connected"; }],
+    ["Gemini command", (r) => { r.transcript[1].checks.gemini_mcp.command = ["wrong"]; }],
+    ["Gemini skill count", (r) => { r.transcript[1].checks.gemini_skills.enabled_skill_count = 1; }],
+    ["OpenCode cwd binding", (r) => { r.transcript[1].checks.opencode.cwd_bound_to_managed_package = false; }],
+    ["OpenCode root binding", (r) => { r.transcript[1].checks.opencode.plugin_root_bound = false; }],
+    ["OpenCode data binding", (r) => { r.transcript[1].checks.opencode.plugin_data_bound = false; }],
+    ["OpenCode command", (r) => { r.transcript[1].checks.opencode.command = ["wrong"]; }],
+    ["Cline root binding", (r) => { r.transcript[1].checks.cline.plugin_root_bound = false; }],
+    ["Cline data binding", (r) => { r.transcript[1].checks.cline.plugin_data_bound = false; }],
+    ["Cline skill count", (r) => { r.transcript[1].checks.cline.projected_skill_count = 1; }],
+    ["Cline command", (r) => { r.transcript[1].checks.cline.command = ["wrong"]; }],
+    ["Windsurf root binding", (r) => { r.transcript[1].checks.windsurf.plugin_root_bound = false; }],
+    ["Windsurf data binding", (r) => { r.transcript[1].checks.windsurf.plugin_data_bound = false; }],
+    ["Windsurf activation boundary", (r) => { r.transcript[1].checks.windsurf.skills = "active"; }],
+    ["Windsurf command", (r) => { r.transcript[1].checks.windsurf.command = ["wrong"]; }],
+    ["discovery argv", (r) => { r.transcript[1].checks.claude.argv = ["wrong"]; }],
+    ["doctor argv", (r) => { r.transcript[2].argv = ["agentplugins", "doctor"]; }],
+    ["doctor authentication boundary", (r) => { r.transcript[2].authentication_not_checked_clients = []; }],
+    ["preflight argv", (r) => { r.transcript[3].argv = ["agentplugins", "update"]; }],
+    ["preflight reason", (r) => { r.transcript[3].reason = "wrong but non-empty"; }],
+    ["preflight failed count", (r) => { r.transcript[3].failed = 0; }],
+    ["preflight postcondition", (r) => { r.transcript[3].postcondition = "wrong but non-empty"; }]
+  ];
+  for (const [label, mutate] of cases) {
+    const record = structuredClone(original);
+    mutate(record);
+    assert.throws(() => validateEvidenceRecord(JSON.stringify(record)), /client E2E evidence|client E2E discovery/, label);
+  }
+});
+
+test("identical release bytes at different commits produce distinct fail-closed metadata", async (t) => {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "agentplugins-commit-bound-"));
+  t.after(() => fsp.rm(root, { recursive: true, force: true }));
+  const version = "0.1.10";
+  const results = [];
+  for (const commit of ["1".repeat(40), "2".repeat(40)]) {
+    const caseRoot = path.join(root, commit[0]);
+    const packageRoot = path.join(caseRoot, "package");
+    const assetsRoot = path.join(caseRoot, "assets");
+    await fsp.mkdir(packageRoot, { recursive: true });
+    await fsp.mkdir(assetsRoot);
+    await fsp.writeFile(path.join(packageRoot, "package.json"), JSON.stringify({
+      name: "universal-agent-plugins", version: "0.0.0-development",
+      bin: { agentplugins: "bin/agentplugins.js" }
+    }));
+    for (const [platform, arch] of [["darwin", "x64"], ["darwin", "arm64"], ["linux", "x64"], ["linux", "arm64"], ["win32", "x64"], ["win32", "arm64"]]) {
+      const info = detectPlatform(platform, arch);
+      await fsp.writeFile(path.join(assetsRoot, expectedAssetName(version, info)), `${info.key}\n`);
+    }
+    prepareRelease(assetsRoot, `agentplugins-v${version}`, commit);
+    const evidenceRoot = await fixtureEvidence(caseRoot);
+    results.push(stage(packageRoot, assetsRoot, version, commit, { evidenceRoot }));
+  }
+  assert.notEqual(results[0].producer.commit, results[1].producer.commit);
+  assert.notEqual(results[0].producer.release_manifest.sha256, results[1].producer.release_manifest.sha256);
+  assert.equal(results[0].client_evidence.record_sha256, results[1].client_evidence.record_sha256);
 });
 
 test("release verification fails closed on checksum, size, and manifest mismatch", async (t) => {
@@ -138,6 +386,66 @@ test("release verification fails closed on checksum, size, and manifest mismatch
   assert.throws(() => verifyRelease(root, `agentplugins-v${version}`, COMMIT), /identity does not match/);
 });
 
+test("release staging rejects hardlinked inputs and concurrent release replacement", async (t) => {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "agentplugins-stage-attacks-"));
+  t.after(() => fsp.rm(root, { recursive: true, force: true }));
+  const makeCase = async (name) => {
+    const caseRoot = path.join(root, name);
+    const packageRoot = path.join(caseRoot, "package");
+    const assetsRoot = path.join(caseRoot, "assets");
+    await fsp.mkdir(packageRoot, { recursive: true });
+    await fsp.mkdir(assetsRoot);
+    await fsp.writeFile(path.join(packageRoot, "package.json"), JSON.stringify({
+      name: "universal-agent-plugins", version: "0.0.0-development", bin: { agentplugins: "bin/agentplugins.js" }
+    }));
+    const version = "0.1.11";
+    for (const [platform, arch] of [["darwin", "x64"], ["darwin", "arm64"], ["linux", "x64"], ["linux", "arm64"], ["win32", "x64"], ["win32", "arm64"]]) {
+      const info = detectPlatform(platform, arch);
+      await fsp.writeFile(path.join(assetsRoot, expectedAssetName(version, info)), `${info.key}\n`);
+    }
+    prepareRelease(assetsRoot, `agentplugins-v${version}`, COMMIT);
+    return { packageRoot, assetsRoot, version, evidenceRoot: await fixtureEvidence(caseRoot) };
+  };
+
+  const hardlinkCase = await makeCase("hardlink");
+  const source = path.join(hardlinkCase.assetsRoot, `agentplugins_${hardlinkCase.version}_linux_amd64`);
+  await fsp.link(source, path.join(root, "external-hardlink"));
+  assert.throws(() => stage(hardlinkCase.packageRoot, hardlinkCase.assetsRoot, hardlinkCase.version, COMMIT,
+    { evidenceRoot: hardlinkCase.evidenceRoot }), /unaliased file/);
+  assert.equal(fs.existsSync(path.join(hardlinkCase.packageRoot, "assets.json")), false);
+
+  const mutationCase = await makeCase("mutation");
+  assert.throws(() => stage(mutationCase.packageRoot, mutationCase.assetsRoot, mutationCase.version, COMMIT, {
+    evidenceRoot: mutationCase.evidenceRoot,
+    afterInitialReleaseVerification() {
+      const target = path.join(mutationCase.assetsRoot, `agentplugins_${mutationCase.version}_linux_amd64`);
+      const replacement = path.join(mutationCase.assetsRoot, "replacement-in-flight");
+      fs.writeFileSync(replacement, "concurrent replacement");
+      fs.renameSync(replacement, target);
+    }
+  }), /checksum mismatch/);
+  assert.equal(fs.existsSync(path.join(mutationCase.packageRoot, "assets.json")), false);
+  assert.equal(JSON.parse(await fsp.readFile(path.join(mutationCase.packageRoot, "package.json"))).version, "0.0.0-development");
+
+  const postCheckCase = await makeCase("post-check-replacement");
+  const validated = verifyRelease(postCheckCase.assetsRoot, `agentplugins-v${postCheckCase.version}`, COMMIT);
+  const staged = stage(postCheckCase.packageRoot, postCheckCase.assetsRoot, postCheckCase.version, COMMIT, {
+    evidenceRoot: postCheckCase.evidenceRoot,
+    afterReleaseSnapshotVerification() {
+      for (const [platform, arch] of [["darwin", "x64"], ["darwin", "arm64"], ["linux", "x64"],
+        ["linux", "arm64"], ["win32", "x64"], ["win32", "arm64"]]) {
+        const info = detectPlatform(platform, arch);
+        fs.writeFileSync(path.join(postCheckCase.assetsRoot, expectedAssetName(postCheckCase.version, info)), `replacement-${info.key}\n`);
+      }
+      prepareRelease(postCheckCase.assetsRoot, `agentplugins-v${postCheckCase.version}`, COMMIT);
+    }
+  });
+  const replaced = verifyRelease(postCheckCase.assetsRoot, `agentplugins-v${postCheckCase.version}`, COMMIT);
+  assert.notEqual(replaced.manifest_sha256, validated.manifest_sha256);
+  assert.equal(staged.producer.release_manifest.sha256, validated.manifest_sha256);
+  assert.deepEqual(staged.assets, validated.assets);
+});
+
 test("legacy manifests are audit-only and never gate eligible", async (t) => {
   const root = await fsp.mkdtemp(path.join(os.tmpdir(), "agentplugins-legacy-assets-"));
   t.after(() => fsp.rm(root, { recursive: true, force: true }));
@@ -162,6 +470,16 @@ test("legacy manifests are audit-only and never gate eligible", async (t) => {
   const audited = verifyRelease(root, `agentplugins-v${version}`, COMMIT, { allowLegacyManifest: true });
   assert.equal(audited.manifest_schema, 1);
   assert.equal(audited.gate_eligible, false);
+
+  const stagingRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "agentplugins-legacy-stage-"));
+  t.after(() => fsp.rm(stagingRoot, { recursive: true, force: true }));
+  const packageRoot = path.join(stagingRoot, "package");
+  await fsp.mkdir(packageRoot);
+  await fsp.writeFile(path.join(packageRoot, "package.json"), JSON.stringify({
+    name: "universal-agent-plugins", version: "0.0.0-development", bin: { agentplugins: "bin/agentplugins.js" }
+  }));
+  const evidenceRoot = await fixtureEvidence(stagingRoot);
+  assert.throws(() => stage(packageRoot, root, version, COMMIT, { allowLegacyManifest: true, evidenceRoot }), /gate-eligible schema-v2/);
 });
 
 test("npm distribution name is independent from the agentplugins binary name", () => {


### PR DESCRIPTION
## Summary
- make the root README the user-facing Universal Agent Plugins product guide
- make npm/agentplugins the canonical universal-agent-plugins facade and keep the agentplugins binary identity
- retain plugin-kit-ai authoring documentation and the legacy Go module/packages during the staged repository rename
- carry the hardened npm release, provenance, cache, and documentation contracts into the product repository

## Migration boundary
This is the pre-rename preparation checkpoint described in `docs/E2E_AND_COMPETITIVE_LAUNCH_PLAN.md`. It intentionally keeps `github.com/777genius/plugin-kit-ai` as the producer and Go module identity until the repository rename cutover. The README and npm metadata point at the future product identity so the post-rename release has no duplicate facade.

## Validation
- `npm test` in `npm/agentplugins` (53 pass, 2 skipped)
- `npm pack --dry-run --json`
- `git diff --check`
- `go test ./...` started; the repository integration suite is long-running and remains a separate CI gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a concise guide to installing and managing Agent Plugins with the `universal-agent-plugins` CLI.
  - Added comprehensive authoring documentation covering plugin workflows, supported clients, validation, generation, and supported outputs.
  - Updated npm package documentation and links to reflect the Universal Agent Plugins project.
  - Clarified historical client evidence and its scope.
- **Security & Reliability**
  - Improved release and package verification, including integrity, provenance, and client-evidence checks.
  - Strengthened cache-lock safety and platform installation validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->