### PR TITLE
feat(landing): brand the installer as Universal Agent Plugins

### DIFF
--- a/landing/components/common/AppLogo.vue
+++ b/landing/components/common/AppLogo.vue
@@ -7,8 +7,8 @@ const homePath = computed(() => localePath("/"));
   <NuxtLink :to="homePath" class="app-logo">
     <span class="app-logo__mark">P</span>
     <span class="app-logo__copy">
-      <span class="app-logo__text">plugin-kit-ai</span>
-      <span class="app-logo__subtext">multi-agent</span>
+      <span class="app-logo__text">Universal Agent Plugins</span>
+      <span class="app-logo__subtext">multi-agent CLI</span>
     </span>
   </NuxtLink>
 </template>

--- a/landing/composables/usePageSeo.ts
+++ b/landing/composables/usePageSeo.ts
@@ -30,7 +30,7 @@ export const usePageSeo = (
   const switchLocale = useSwitchLocalePath();
   const { docsUrl } = useDocsLinks();
   const siteUrl = config.public.siteUrl || 'https://777genius.github.io/plugin-kit-ai';
-  const siteName = 'plugin-kit-ai';
+  const siteName = 'Universal Agent Plugins';
   const githubUrl = `https://github.com/${config.public.githubRepo}`;
 
   const shouldTranslate = options.translate !== false;
@@ -51,7 +51,7 @@ export const usePageSeo = (
       width: 1200,
       height: 630,
       type: 'image/png',
-      alt: 'plugin-kit-ai - build a plugin once and ship it to many AI agents',
+      alt: 'Universal Agent Plugins - install plugins across AI agents with one CLI',
     };
   });
 
@@ -139,7 +139,7 @@ export const usePageSeo = (
       jsonLd.push({
         '@context': 'https://schema.org',
         '@type': 'SoftwareApplication',
-        name: 'plugin-kit-ai',
+        name: 'Universal Agent Plugins',
         applicationCategory: 'DeveloperApplication',
         operatingSystem: 'macOS, Linux, Windows',
         description: description.value,
@@ -173,7 +173,7 @@ export const usePageSeo = (
       },
       link: links,
       meta: [
-        { name: 'author', content: 'plugin-kit-ai' },
+        { name: 'author', content: 'Universal Agent Plugins' },
         { name: 'application-name', content: siteName },
         { name: 'apple-mobile-web-app-title', content: siteName },
         { name: 'format-detection', content: 'telephone=no' },
@@ -181,7 +181,7 @@ export const usePageSeo = (
         {
           name: 'keywords',
           content:
-            'plugin-kit-ai, AI plugins, Claude plugins, Codex plugins, Gemini plugins, multi-agent plugins, plugin repo, validate strict',
+            'Universal Agent Plugins, AI plugins, Claude plugins, Codex plugins, Gemini plugins, multi-agent plugins, plugin repo, validate strict',
         },
       ],
       script: jsonLd.map((item) => ({

--- a/landing/composables/useReleaseDownloads.ts
+++ b/landing/composables/useReleaseDownloads.ts
@@ -9,7 +9,10 @@ import type { Ref } from "vue"
 
 type ResolveResult = { url: string; version: string | null } | null
 
-const CACHE_KEY = "universal-agent-plugins_release_meta"
+// Keep the storage key stable across the product rename so existing browser
+// sessions retain their cached release metadata and do not trigger a burst of
+// duplicate API requests during rollout.
+const CACHE_KEY = "plugin-kit-ai_release_meta"
 const CACHE_TTL = 10 * 60 * 1000
 let clientRefreshPromise: Promise<DownloadsApiResponse | null> | null = null
 

--- a/landing/composables/useReleaseDownloads.ts
+++ b/landing/composables/useReleaseDownloads.ts
@@ -9,7 +9,7 @@ import type { Ref } from "vue"
 
 type ResolveResult = { url: string; version: string | null } | null
 
-const CACHE_KEY = "plugin-kit-ai_release_meta"
+const CACHE_KEY = "universal-agent-plugins_release_meta"
 const CACHE_TTL = 10 * 60 * 1000
 let clientRefreshPromise: Promise<DownloadsApiResponse | null> | null = null
 
@@ -104,7 +104,7 @@ export const useReleaseDownloads = () => {
     config.public.githubReleasesUrl || `https://github.com/${githubRepo}/releases`
 
   const { data, pending, error } = useAsyncData<DownloadsApiResponse>(
-    "plugin-kit-ai-releases",
+    "universal-agent-plugins-releases",
     async () => {
       const cached = readCache()
       if (cached) {

--- a/landing/data/pluginInstall.ts
+++ b/landing/data/pluginInstall.ts
@@ -110,7 +110,7 @@ const buildInstallCommand = (
   scope?: PluginInstallScope,
   includeTargets = true,
 ): string => {
-  const args = ['plugin-kit-ai', 'add', cliSource];
+  const args = ['universal-agent-plugins', 'add', cliSource];
 
   if (includeTargets) {
     for (const targetId of targetIds) {
@@ -126,9 +126,9 @@ const buildInstallCommand = (
 };
 
 const buildManageCommands = (integrationName: string): PluginManageCommands => ({
-  update: `plugin-kit-ai update ${integrationName}`,
-  repair: `plugin-kit-ai repair ${integrationName}`,
-  remove: `plugin-kit-ai remove ${integrationName}`,
+  update: `universal-agent-plugins update ${integrationName}`,
+  repair: `universal-agent-plugins repair ${integrationName}`,
+  remove: `universal-agent-plugins remove ${integrationName}`,
 });
 
 const buildCommandSet = (
@@ -137,9 +137,9 @@ const buildCommandSet = (
   lane: PluginTargetInstallLane,
 ): PluginInstallCommandSet => ({
   install: buildInstallCommand(cliSource, [lane.targetId], lane.scope, true),
-  update: `plugin-kit-ai update ${integrationName}`,
-  repair: `plugin-kit-ai repair ${integrationName} --target ${lane.targetId}`,
-  remove: `plugin-kit-ai remove ${integrationName}`,
+  update: `universal-agent-plugins update ${integrationName}`,
+  repair: `universal-agent-plugins repair ${integrationName} --target ${lane.targetId}`,
+  remove: `universal-agent-plugins remove ${integrationName}`,
 });
 
 const resolveSupportedTargets = (spec: PluginInstallSpec): PluginResolvedInstallLane[] =>

--- a/landing/nuxt.config.ts
+++ b/landing/nuxt.config.ts
@@ -6,6 +6,7 @@ declare const process: any;
 
 const siteUrl = process.env.NUXT_PUBLIC_SITE_URL || "https://777genius.github.io/plugin-kit-ai";
 const githubRepo = process.env.NUXT_PUBLIC_GITHUB_REPO || "777genius/plugin-kit-ai";
+const productName = process.env.NUXT_PUBLIC_PRODUCT_NAME || "Universal Agent Plugins";
 const githubReleasesUrl = `https://github.com/${githubRepo}/releases`;
 const docsUrl = process.env.NUXT_PUBLIC_DOCS_URL || "https://777genius.github.io/plugin-kit-ai/docs/en/";
 const quickstartUrl =
@@ -96,7 +97,7 @@ export default defineNuxtConfig({
   // @ts-expect-error - field provided by nuxt modules
   site: {
     url: siteUrl,
-    name: "plugin-kit-ai"
+    name: productName
   },
   runtimeConfig: {
     github: {
@@ -105,6 +106,7 @@ export default defineNuxtConfig({
     public: {
       siteUrl,
       githubRepo,
+      productName,
       githubReleasesUrl,
       docsUrl,
       quickstartUrl,

--- a/landing/utils/cliInvocation.ts
+++ b/landing/utils/cliInvocation.ts
@@ -1,4 +1,4 @@
-const DEFAULT_CLI_INVOCATION = 'plugin-kit-ai';
+const DEFAULT_CLI_INVOCATION = 'universal-agent-plugins';
 
 export function applyCliInvocation(command: string, invocation?: string | null): string {
   const normalizedInvocation = invocation?.trim() || DEFAULT_CLI_INVOCATION;

--- a/repotests/landing_contract_integration_test.go
+++ b/repotests/landing_contract_integration_test.go
@@ -206,7 +206,8 @@ func TestLandingSurface_LocalesLinksAndBrandingStayAligned(t *testing.T) {
 	logo := string(logoBody)
 	mustContain(t, logo, `const localePath = useLocalePath();`)
 	mustContain(t, logo, `<NuxtLink :to="homePath" class="app-logo">`)
-	mustContain(t, logo, `plugin-kit-ai`)
+	mustContain(t, logo, `Universal Agent Plugins`)
+	mustNotContain(t, logo, `plugin-kit-ai`)
 	mustNotContain(t, logo, `Hookplex`)
 
 	heroBody, err := os.ReadFile(filepath.Join(landingRoot, "components", "sections", "HeroSection.vue"))


### PR DESCRIPTION
## Summary
- make the landing site's visible brand and SEO identity Universal Agent Plugins
- use the public `universal-agent-plugins` command in generated install/lifecycle snippets
- expose a product-name runtime setting for the post-rename Pages deployment
- keep legacy plugin-kit-ai URLs as explicit compatibility fallbacks until the approved repository cutover

## Verification
- `pnpm exec nuxt prepare`
- `pnpm run lint`
- `pnpm exec prettier --check` (baseline reports existing formatting drift outside this focused change)
- `git diff --check`
