### PR TITLE
fix(mirror): follow renamed registry identity

### DIFF
--- a/.github/workflows/registry-compatibility-mirror.yml
+++ b/.github/workflows/registry-compatibility-mirror.yml
@@ -8,11 +8,11 @@ on:
       registry_repository:
         description: Registry owner/repository to mirror
         required: false
-        default: 777genius/universal-agent-plugins
+        default: 777genius/universal-agent-plugins-registry
       pages_origin:
         description: Published registry Pages origin
         required: false
-        default: https://777genius.github.io/universal-agent-plugins/
+        default: https://777genius.github.io/universal-agent-plugins-registry/
 
 permissions:
   contents: read
@@ -24,8 +24,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DEFAULT_REGISTRY_REPOSITORY: 777genius/universal-agent-plugins
-  DEFAULT_PAGES_ORIGIN: https://777genius.github.io/universal-agent-plugins/
+  DEFAULT_REGISTRY_REPOSITORY: 777genius/universal-agent-plugins-registry
+  DEFAULT_PAGES_ORIGIN: https://777genius.github.io/universal-agent-plugins-registry/
 
 jobs:
   build:
@@ -91,13 +91,13 @@ jobs:
 
       - name: Build landing
         env:
-          NUXT_APP_BASE_URL: /plugin-kit-ai/
+          NUXT_APP_BASE_URL: /universal-agent-plugins/
         working-directory: landing
         run: pnpm generate
 
       - name: Build public docs under /docs
         env:
-          DOCS_BASE_PATH: /plugin-kit-ai/docs/
+          DOCS_BASE_PATH: /universal-agent-plugins/docs/
           DOCS_HOSTNAME: https://777genius.github.io
         working-directory: website
         run: pnpm run docs:build

--- a/cmd/agentplugins-registry-mirror/main.go
+++ b/cmd/agentplugins-registry-mirror/main.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	defaultPagesOrigin = "https://777genius.github.io/universal-agent-plugins/"
-	defaultRegistry    = "777genius/universal-agent-plugins"
+	defaultPagesOrigin = "https://777genius.github.io/universal-agent-plugins-registry/"
+	defaultRegistry    = "777genius/universal-agent-plugins-registry"
 	maxTrustBytes      = 64 << 10
 	directoryKeyID     = "uap-directory-2026-01"
 	directoryPublicKey = "HalXARjat+v3ylTPLMAnvuavRo4ZfrF+DbWwsjlp2bI="

--- a/cmd/agentplugins-registry-mirror/main_test.go
+++ b/cmd/agentplugins-registry-mirror/main_test.go
@@ -19,7 +19,7 @@ func TestEnforceMonotonicAllowsAdvanceAndRejectsRollback(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "MIRROR_METADATA.json")
 	body := []byte(`{
   "schema_version": 1,
-  "registry_repository": "777genius/universal-agent-plugins",
+  "registry_repository": "777genius/universal-agent-plugins-registry",
   "directory_sequence": 10,
   "directory_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   "directory_source_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -58,7 +58,7 @@ func TestEnforceMonotonicRejectsSameSequenceConflict(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "MIRROR_METADATA.json")
 	if err := os.WriteFile(path, []byte(`{
   "schema_version": 1,
-  "registry_repository": "777genius/universal-agent-plugins",
+  "registry_repository": "777genius/universal-agent-plugins-registry",
   "directory_sequence": 10,
   "directory_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   "directory_source_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",

--- a/docs/REGISTRY_COMPATIBILITY_MIRROR.md
+++ b/docs/REGISTRY_COMPATIBILITY_MIRROR.md
@@ -44,10 +44,10 @@ Pages artifact, and deploys only the resulting artifact. A failed fetch,
 signature, trust-anchor, rollback, or build leaves the previous deployment
 untouched.
 
-The workflow currently points at the existing registry repository and Pages
-origin. During the approved repository cutover, update those two defaults in
-one reviewed commit and re-run the workflow once; do not silently mix the old
-and new registry identities.
+The workflow defaults to the renamed catalog repository
+`777genius/universal-agent-plugins-registry` and its Pages origin. Event and
+manual inputs may override these values for a reviewed compatibility test, but
+the source identity is always re-read and verified before deployment.
 
 The mirror has no signing key, no GitHub write token, and no package execution
 path. Direct local or Git installs continue to work when the Directory is


### PR DESCRIPTION
## Summary
- point the compatibility mirror at `universal-agent-plugins-registry`
- update the build-time mirror defaults and Pages paths for the renamed catalog
- keep signed feed bytes and monotonic marker verification unchanged

## Validation
- `go test ./cmd/agentplugins-registry-mirror`
- `git diff --check`

This is the post-registry-rename preparation checkpoint. The CLI repository rename and release remain a separate cutover step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated registry mirroring and GitHub Pages defaults to use the `universal-agent-plugins-registry` repository.
  - Adjusted landing page and documentation paths to the `/universal-agent-plugins/` location.
  - Updated compatibility-mirror documentation to reflect the new repository and Pages origin.
  - Preserved support for reviewed event and manual overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->