### PR TITLE
fix(release): verify upstream Context7 distribution

### DIFF
--- a/npm/agentplugins/scripts/platform-proof.js
+++ b/npm/agentplugins/scripts/platform-proof.js
@@ -164,8 +164,12 @@ function assertContext7Search(output) {
   if (output?.schema_version !== 1 || output.command !== "search" || output.result !== "success" ||
       !output.data || typeof output.data !== "object" || !Array.isArray(output.data.results) ||
       !output.data.results.some((result) => result?.product_id === "context7" &&
-        result.distribution_id === "777genius/context7")) {
-    fail("public catalog search did not contain the expected context7 product and distribution");
+        result.install_selector === "upstash/context7" &&
+        result.distribution_id === "upstash/context7" &&
+        result.distribution_kind === "upstream" &&
+        result.trust_state === "reviewed" &&
+        result.status === "available")) {
+    fail("public catalog search did not contain the reviewed upstream context7 distribution");
   }
 }
 

--- a/npm/agentplugins/test/platform-proof.test.js
+++ b/npm/agentplugins/test/platform-proof.test.js
@@ -71,7 +71,7 @@ test("platform proof invokes the installed npm shim and rejects direct bin bypas
   }, project, process.platform), /must execute the installed npm agentplugins shim/);
 });
 
-test("platform proof requires the expected context7 product and distribution in search results", () => {
+test("platform proof requires the reviewed upstream context7 distribution in search results", () => {
   const valid = {
     schema_version: 1,
     command: "search",
@@ -79,17 +79,27 @@ test("platform proof requires the expected context7 product and distribution in 
     data: {
       results: [
         { product_id: "other", distribution_id: "owner/other" },
-        { product_id: "context7", distribution_id: "777genius/context7" }
+        {
+          product_id: "context7",
+          install_selector: "upstash/context7",
+          distribution_id: "upstash/context7",
+          distribution_kind: "upstream",
+          trust_state: "reviewed",
+          status: "available"
+        }
       ]
     }
   };
   assert.doesNotThrow(() => assertContext7Search(valid));
   for (const invalid of [
     { ...valid, data: { results: [] } },
-    { ...valid, data: { results: [{ product_id: "context7", distribution_id: "upstash/context7" }] } },
-    { ...valid, data: { results: [{ product_id: "other", distribution_id: "777genius/context7" }] } }
+    { ...valid, data: { results: [{ ...valid.data.results[1], distribution_id: "777genius/context7" }] } },
+    { ...valid, data: { results: [{ ...valid.data.results[1], distribution_kind: "community_bridge" }] } },
+    { ...valid, data: { results: [{ ...valid.data.results[1], trust_state: "discovered" }] } },
+    { ...valid, data: { results: [{ ...valid.data.results[1], status: "superseded" }] } },
+    { ...valid, data: { results: [{ ...valid.data.results[1], product_id: "other" }] } }
   ]) {
-    assert.throws(() => assertContext7Search(invalid), /expected context7 product and distribution/);
+    assert.throws(() => assertContext7Search(invalid), /reviewed upstream context7 distribution/);
   }
 });
 


### PR DESCRIPTION
## Summary
- update native release proof to require the reviewed upstream Context7 distribution
- reject community, unreviewed, unavailable, and mismatched search results
- add focused regression coverage

## Verification
- node --test npm/agentplugins/test/platform-proof.test.js
- go test ./repotests -run TestAgentpluginsReleaseContractsStayFailClosed -count=1
- git diff --check