### PR TITLE
feat(release): restore trusted npm publisher

### DIFF
--- a/.github/workflows/agentplugins-npm-publish.yml
+++ b/.github/workflows/agentplugins-npm-publish.yml
@@ -1,243 +1,204 @@
-name: Agentplugins NPM Historical Audit
+name: Agentplugins NPM Publish
 
 on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing immutable stable release tag
+        description: Exact public Agentplugins release tag (agentplugins-vX.Y.Z)
         required: true
-      verify_only:
-        description: Required retired-publisher guard; only historical verification is supported
-        required: false
-        default: true
+        type: string
+      publish:
+        description: Publish the verified package to npm with trusted provenance
+        required: true
+        default: false
         type: boolean
 
 permissions:
   contents: read
+  attestations: read
+
+concurrency:
+  group: agentplugins-npm-${{ inputs.tag }}
+  cancel-in-progress: false
 
 jobs:
-  audit-mode:
+  prepare:
+    name: Verify release and stage npm package
     runs-on: ubuntu-24.04
-    steps:
-      - name: Enforce retired publisher boundary
-        env:
-          VERIFY_ONLY: ${{ inputs.verify_only }}
-        run: |
-          if [[ "${VERIFY_ONLY}" != "true" ]]; then
-            echo "npm publication is retired in plugin-kit-ai; dispatch with verify_only=true to audit a historical version" >&2
-            exit 1
-          fi
-
-  verify:
-    needs: audit-mode
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
+    timeout-minutes: 20
+    outputs:
+      version: ${{ steps.stage.outputs.version }}
+      commit: ${{ steps.stage.outputs.commit }}
+      package_name: ${{ steps.stage.outputs.package_name }}
+      tarball_file: ${{ steps.stage.outputs.tarball_file }}
+      tarball_integrity: ${{ steps.stage.outputs.tarball_integrity }}
+      tarball_shasum: ${{ steps.stage.outputs.tarball_shasum }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false
           ref: ${{ inputs.tag }}
+          fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: "22.23.2"
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
-      - name: Resolve immutable verification target
-        id: verify-target
+      - name: Verify exact public release identity and attestations
         env:
+          GH_TOKEN: ${{ github.token }}
           TAG: ${{ inputs.tag }}
         run: |
-          if [[ ! "${TAG}" =~ ^agentplugins-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "invalid agentplugins stable tag: ${TAG}" >&2
-            exit 1
-          fi
-          git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
-          test "$(git rev-parse HEAD)" = "$(git rev-list -n 1 "refs/tags/${TAG}")"
-          package_name="$(node -p 'require("./npm/agentplugins/package.json").name')"
-          package_name_length="$(printf '%s' "${package_name}" | wc -c | tr -d ' ')"
-          if [[ ! "${package_name}" =~ ^(@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$ ]] || [[ "${package_name_length}" -gt 214 ]]; then
-            echo "invalid npm package name in npm/agentplugins/package.json" >&2
-            exit 1
-          fi
-          echo "package_name=${package_name}" >> "${GITHUB_OUTPUT}"
-      - name: Install pinned npm with provenance verification support
-        run: npm install --global npm@12.0.2
-      - name: Verify exact published stable lifecycle from a clean project
-        env:
-          TAG: ${{ inputs.tag }}
-          NPM_PACKAGE: ${{ steps.verify-target.outputs.package_name }}
-        run: |
+          set -euo pipefail
+          [[ "${TAG}" =~ ^agentplugins-v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          test "${GITHUB_REF}" = "refs/tags/${TAG}"
+          commit="$(git rev-parse HEAD)"
+          test "${commit}" = "$(git rev-list -n 1 "refs/tags/${TAG}")"
+          git fetch --no-tags --force origin main:refs/remotes/origin/main
+          git merge-base --is-ancestor "${commit}" refs/remotes/origin/main
+          release_json="$(gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" --json isDraft,isPrerelease,tagName,assets)"
           version="${TAG#agentplugins-v}"
-          project="${RUNNER_TEMP}/agentplugins-registry-smoke"
-          test_home="${project}/home"
-          mkdir -p "${project}" "${test_home}/.codex" "${test_home}/.cursor" "${project}/tmp"
-          synthetic="${project}/synthetic-plugin"
-          mkdir -p "${synthetic}"
-          printf '%s\n' \
-            '{' \
-            '  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",' \
-            '  "name": "registry-proof-synthetic",' \
-            '  "version": "1.0.0",' \
-            '  "description": "Synthetic package used only by isolated registry CI"' \
-            '}' > "${synthetic}/plugin.json"
-          cd "${project}" || exit 1
-          npm init -y >/dev/null
-          export HOME="${test_home}"
-          export USERPROFILE="${test_home}"
-          export XDG_CONFIG_HOME="${project}/config"
-          export XDG_CACHE_HOME="${project}/cache"
-          export AGENTPLUGINS_HOME="${project}/state"
-          export AGENTPLUGINS_CACHE_DIR="${RUNNER_TEMP}/agentplugins-registry-cache"
-          export NPM_CONFIG_CACHE="${project}/npm-cache"
-          export NPM_CONFIG_USERCONFIG="${test_home}/.npmrc"
-          export TMPDIR="${project}/tmp"
-          export GIT_CONFIG_GLOBAL="${test_home}/.gitconfig"
-          export GIT_CONFIG_NOSYSTEM=1
-          export GIT_TERMINAL_PROMPT=0
-          printf '%s\n' 'registry=https://registry.npmjs.org/' > "${NPM_CONFIG_USERCONFIG}"
-          available=false
-          max_attempts=30
-          for attempt in $(seq 1 "${max_attempts}"); do
-            published_version="$(npm view --prefer-online "${NPM_PACKAGE}@${version}" version 2>/dev/null || true)"
-            if [[ "${published_version}" = "${version}" ]]; then
-              available=true
-              break
-            fi
-            echo "waiting for ${NPM_PACKAGE}@${version} registry propagation (${attempt}/${max_attempts})" >&2
-            sleep 10
+          expected_names="agentplugins_${version}_darwin_amd64 agentplugins_${version}_darwin_arm64 agentplugins_${version}_linux_amd64 agentplugins_${version}_linux_arm64 agentplugins_${version}_windows_amd64.exe agentplugins_${version}_windows_arm64.exe checksums.txt release-manifest.json"
+          actual_names="$(jq -r '.assets[].name' <<<"${release_json}" | sort | tr '\n' ' ' | sed 's/ $//')"
+          expected_sorted="$(printf '%s\n' ${expected_names} | sort | tr '\n' ' ' | sed 's/ $//')"
+          jq -e --arg tag "${TAG}" '.isDraft == false and .isPrerelease == false and .tagName == $tag' <<<"${release_json}" >/dev/null
+          test "${actual_names}" = "${expected_sorted}"
+          mkdir -p "${RUNNER_TEMP}/release-assets"
+          gh release download "${TAG}" --repo "${GITHUB_REPOSITORY}" --dir "${RUNNER_TEMP}/release-assets"
+          node npm/agentplugins/scripts/release-assets.js verify "${RUNNER_TEMP}/release-assets" "${TAG}" "${commit}" > "${RUNNER_TEMP}/verified-release.json"
+          for asset in "${RUNNER_TEMP}"/release-assets/agentplugins_* "${RUNNER_TEMP}/release-assets/checksums.txt" "${RUNNER_TEMP}/release-assets/release-manifest.json"; do
+            gh attestation verify "${asset}" --repo "${GITHUB_REPOSITORY}" --signer-workflow "github.com/${GITHUB_REPOSITORY}/.github/workflows/agentplugins-release.yml" --source-digest "${commit}"
           done
-          test "${available}" = true
-          latest_version="$(npm view --prefer-online "${NPM_PACKAGE}@latest" version 2>/dev/null || true)"
-          if [[ -n "${latest_version}" ]]; then
-            echo "informational: ${NPM_PACKAGE}@latest is ${latest_version}; auditing exact historical version ${version}"
-          else
-            echo "warning: ${NPM_PACKAGE}@latest could not be resolved; exact historical version ${version} is available" >&2
-          fi
-          npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"
-          npm audit signatures --json --include-attestations > audit-signatures.json
-          jq -e --arg package "${NPM_PACKAGE}" --arg version "${version}" '
-            (.invalid | length) == 0 and
-            (.missing | length) == 0 and
-            ([.verified[] | select(
-              .name == $package and
-              .version == $version and
-              .attestations.provenance.predicateType == "https://slsa.dev/provenance/v1"
-            )] | length) == 1
-          ' audit-signatures.json
-          run_agentplugins() {
-            npm exec --yes --package="${NPM_PACKAGE}@${version}" -- agentplugins "$@"
-          }
-          run_agentplugins version | grep -Fx "agentplugins ${version}"
-          lifecycle_targets="codex,cursor"
-          run_agentplugins add "${synthetic}" --target "${lifecycle_targets}" --format json > add.json
-          jq -e '
-            .data.operation_id as $operation_id |
-            .data.tree_digest as $tree_digest |
-            .data.manifest_digest as $manifest_digest |
-            .schema_version == 1 and .command == "add" and .result == "success" and
-            .data.batch == true and .data.succeeded == 2 and .data.failed == 0 and
-            ([.data.targets[].target] == ["codex", "cursor"]) and
-            (.data.operation_id | type == "string" and length > 0) and
-            (.data.tree_digest | type == "string" and startswith("sha256:")) and
-            (.data.manifest_digest | type == "string" and startswith("sha256:")) and
-            ([.data.targets[] | select(
-              .status == "external_completed" and
-              .output.operation_id == $operation_id and
-              .output.tree_digest == $tree_digest and
-              .output.manifest_digest == $manifest_digest and
-              (.output.result.installation_id | type == "string" and length > 0) and
-              .output.result.mutated == true and
-              .output.result.activation.authentication == "not_checked"
-            )] | length) == 2 and
-            ([.data.targets[].output.result.installation_id] | unique | length) == 1
-          ' add.json
-          installation_id="$(jq -er '.data.targets[0].output.result.installation_id' add.json)"
-          tree_digest="$(jq -er '.data.tree_digest' add.json)"
-          manifest_digest="$(jq -er '.data.manifest_digest' add.json)"
-          run_agentplugins add "${synthetic}" --target "${lifecycle_targets}" --activation-complete --auth-complete --format json > complete.json
-          jq -e --arg installation_id "${installation_id}" --arg tree_digest "${tree_digest}" --arg manifest_digest "${manifest_digest}" '
-            .data.operation_id as $operation_id |
-            .schema_version == 1 and .command == "add" and .result == "success" and
-            .data.batch == true and .data.succeeded == 2 and .data.failed == 0 and
-            ([.data.targets[].target] == ["codex", "cursor"]) and
-            (.data.operation_id | type == "string" and length > 0) and
-            .data.tree_digest == $tree_digest and .data.manifest_digest == $manifest_digest and
-            ([.data.targets[] | select(
-              .status == "external_completed" and
-              .output.operation_id == $operation_id and
-              .output.tree_digest == $tree_digest and
-              .output.manifest_digest == $manifest_digest and
-              .output.result.installation_id == $installation_id and
-              .output.result.mutated == true and
-              .output.result.activation.activation_attested == true and
-              .output.result.activation.authentication_attested == true
-            )] | length) == 2
-          ' complete.json
-          run_agentplugins info registry-proof-synthetic --format json > info.json
-          jq -e --arg installation_id "${installation_id}" --arg tree_digest "${tree_digest}" --arg manifest_digest "${manifest_digest}" '
-            .schema_version == 1 and .command == "info" and
-            .data.name == "registry-proof-synthetic" and .data.installation_id == $installation_id and
-            ([.data.clients[].client_id] == ["codex", "cursor"]) and
-            ([.data.clients[] | select(.package_revision.tree_digest == $tree_digest and .package_revision.manifest_digest == $manifest_digest)] | length) == 2
-          ' info.json
-          state_before_doctor="$(sha256sum "${AGENTPLUGINS_HOME}/state-v2.json")"
-          run_agentplugins doctor registry-proof-synthetic --format json > doctor.json
-          state_after_doctor="$(sha256sum "${AGENTPLUGINS_HOME}/state-v2.json")"
-          test "${state_before_doctor}" = "${state_after_doctor}"
-          jq -e '.schema_version == 1 and .command == "doctor" and .data.read_only == true' doctor.json
-          run_agentplugins update registry-proof-synthetic --target "${lifecycle_targets}" --format json > update.json
-          jq -e --arg installation_id "${installation_id}" --arg tree_digest "${tree_digest}" --arg manifest_digest "${manifest_digest}" '
-            .data.operation_id as $operation_id |
-            .schema_version == 1 and .command == "update" and .result == "success" and
-            .data.batch == true and .data.succeeded == 2 and .data.failed == 0 and
-            ([.data.targets[].target] == ["codex", "cursor"]) and
-            (.data.operation_id | type == "string" and length > 0) and
-            .data.tree_digest == $tree_digest and
-            ([.data.targets[] | select(
-              .selected == true and .status == "external_completed" and
-              .output.operation_id == $operation_id and
-              .output.tree_digest == $tree_digest and
-              .output.manifest_digest == $manifest_digest and
-              .output.result.installation_id == $installation_id and
-              .output.result.no_change == true and .output.result.mutated == false
-            )] | length) == 2
-          ' update.json
-          run_agentplugins remove registry-proof-synthetic --target "${lifecycle_targets}" --external-uninstalled --format json > remove.json
-          jq -e --arg installation_id "${installation_id}" --arg tree_digest "${tree_digest}" --arg manifest_digest "${manifest_digest}" '
-            .data.operation_id as $operation_id |
-            .schema_version == 1 and .command == "remove" and .result == "success" and
-            .data.batch == true and .data.status == "data_retained" and
-            .data.succeeded == 2 and .data.failed == 0 and .data.data_retained == true and
-            .data.plugin_data_preserved == true and
-            ([.data.targets[].target] == ["codex", "cursor"]) and
-            (.data.operation_id | type == "string" and length > 0) and
-            ([.data.targets[] | select(
-              .status == "external_completed" and
-              .output.operation_id == $operation_id and
-              .output.tree_digest == $tree_digest and
-              .output.manifest_digest == $manifest_digest and
-              .output.result.installation_id == $installation_id and
-              .output.result.mutated == true
-            )] | length) == 2 and
-            (.data.retained_data | length) > 0 and
-            ([.data.retained_data[] | select(
-              (.data_receipt_id | type == "string" and length > 0) and
-              (.physical_backend_id | type == "string" and length > 0) and
-              .scope == "user" and .state == "owned" and
-              (keys | sort) == ["data_receipt_id", "physical_backend_id", "scope", "state"]
-            )] | length) == (.data.retained_data | length) and
-            (.data.retained_data_action | contains("agentplugins remove " + $installation_id + " --purge-data")) and
-            ([paths(scalars) as $path | getpath($path) | select(type == "string" and startswith("/"))] | length) == 0
-          ' remove.json
-          run_agentplugins info registry-proof-synthetic --format json > removed.json
-          jq -e --arg installation_id "${installation_id}" '
-            .schema_version == 1 and .command == "info" and
-            .data.installation_id == $installation_id and .data.name == "registry-proof-synthetic" and
-            (.data.clients | length) == 0
-          ' removed.json
-          if grep -F "${RUNNER_TEMP}" add.json complete.json info.json doctor.json update.json remove.json removed.json; then
-            echo "agentplugins JSON output leaked an absolute runner path" >&2
+      - name: Stage and pack the exact npm facade
+        id: stage
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          version="${TAG#agentplugins-v}"
+          stage="${RUNNER_TEMP}/agentplugins-npm-stage"
+          mkdir -p "${stage}"
+          cp -R npm/agentplugins/. "${stage}/"
+          node "${stage}/scripts/stage-release.js" "${stage}" "${RUNNER_TEMP}/release-assets" "${version}" "$(git rev-parse HEAD)" --evidence-root "${GITHUB_WORKSPACE}/docs"
+          (cd "${stage}" && npm test)
+          mkdir -p "${RUNNER_TEMP}/npm-tarball"
+          (cd "${stage}" && npm pack --ignore-scripts --json --pack-destination "${RUNNER_TEMP}/npm-tarball" > "${RUNNER_TEMP}/npm-tarball/pack.json")
+          tarball_file="$(jq -er 'if length == 1 then .[0].filename else error("expected one tarball") end' "${RUNNER_TEMP}/npm-tarball/pack.json")"
+          integrity="$(jq -er '.[0].integrity' "${RUNNER_TEMP}/npm-tarball/pack.json")"
+          shasum="$(jq -er '.[0].shasum' "${RUNNER_TEMP}/npm-tarball/pack.json")"
+          node npm/agentplugins/scripts/npm-public-contract.js stage-outputs "${RUNNER_TEMP}/npm-tarball/pack.json" "${GITHUB_OUTPUT}" "${version}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "commit=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+          echo "package_name=$(node -p 'require(process.argv[1]).name' "${stage}/package.json")" >> "${GITHUB_OUTPUT}"
+          echo "tarball_file=${tarball_file}" >> "${GITHUB_OUTPUT}"
+          echo "tarball_integrity=${integrity}" >> "${GITHUB_OUTPUT}"
+          echo "tarball_shasum=${shasum}" >> "${GITHUB_OUTPUT}"
+          if tar -tzf "${RUNNER_TEMP}/npm-tarball/${tarball_file}" | grep -Eq '(^/|(^|/)\.\.(\/|$))'; then
+            echo "unsafe tarball path" >&2
             exit 1
           fi
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: agentplugins-npm-${{ steps.stage.outputs.version }}
+          path: ${{ runner.temp }}/npm-tarball/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish npm package with trusted provenance
+    if: ${{ inputs.publish == true }}
+    needs: prepare
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment: npm-agentplugins
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22.23.2"
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Install the pinned npm trusted-publisher client
+        run: |
+          set -euo pipefail
+          npm install --global npm@12.0.2
+          test "$(npm --version)" = "12.0.2"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: agentplugins-npm-${{ needs.prepare.outputs.version }}
+          path: ${{ runner.temp }}/npm-tarball
+      - name: Refuse overwrite and publish the exact staged bytes
+        env:
+          PACKAGE_NAME: ${{ needs.prepare.outputs.package_name }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          TARBALL: ${{ needs.prepare.outputs.tarball_file }}
+        run: |
+          set -euo pipefail
+          test -z "${NPM_TOKEN:-}"
+          test -z "${NODE_AUTH_TOKEN:-}"
+          if npm view "${PACKAGE_NAME}@${VERSION}" version >/dev/null 2>&1; then
+            echo "npm version already exists and is immutable: ${PACKAGE_NAME}@${VERSION}" >&2
+            exit 1
+          fi
+          test "$(find "${RUNNER_TEMP}/npm-tarball" -maxdepth 1 -name '*.tgz' -type f | wc -l | tr -d ' ')" = 1
+          npm publish "${RUNNER_TEMP}/npm-tarball/${TARBALL}" --access public --provenance --tag latest
+
+  verify-public:
+    name: Verify public npm provenance and lifecycle
+    if: ${{ inputs.publish == true }}
+    needs: [prepare, publish]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.tag }}
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22.23.2"
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Verify metadata, signatures, provenance, and isolated lifecycle
+        env:
+          PACKAGE_NAME: ${{ needs.prepare.outputs.package_name }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          COMMIT: ${{ needs.prepare.outputs.commit }}
+          TARBALL_INTEGRITY: ${{ needs.prepare.outputs.tarball_integrity }}
+          TARBALL_SHASUM: ${{ needs.prepare.outputs.tarball_shasum }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --global npm@12.0.2
+          test "$(npm --version)" = "12.0.2"
+          root="${RUNNER_TEMP}/agentplugins-public-e2e"
+          mkdir -p "${root}/project" "${root}/home" "${root}/tmp" "${root}/synthetic" "${root}/packed"
+          printf '%s\n' '{' '  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",' '  "name": "npm-public-proof",' '  "version": "1.0.0",' '  "description": "Synthetic package used only by isolated npm release CI"' '}' > "${root}/synthetic/plugin.json"
+          printf '%s\n' '{"name":"npm-public-proof-project","version":"1.0.0","private":true}' > "${root}/project/package.json"
+          export HOME="${root}/home" USERPROFILE="${root}/home" XDG_CONFIG_HOME="${root}/config" XDG_CACHE_HOME="${root}/cache" AGENTPLUGINS_HOME="${root}/state" AGENTPLUGINS_CACHE_DIR="${root}/binary-cache" NPM_CONFIG_CACHE="${root}/npm-cache" NPM_CONFIG_USERCONFIG="${root}/home/.npmrc" TMPDIR="${root}/tmp" GIT_CONFIG_GLOBAL="${root}/home/.gitconfig" GIT_CONFIG_NOSYSTEM=1 GIT_TERMINAL_PROMPT=0
+          printf '%s\n' 'registry=https://registry.npmjs.org/' > "${NPM_CONFIG_USERCONFIG}"
+          cd "${root}/project"
+          npm install --ignore-scripts --no-audit --no-fund --save-exact "${PACKAGE_NAME}@${VERSION}"
+          npm view "${PACKAGE_NAME}@${VERSION}" --json > "${root}/metadata.json"
+          integrity="$(jq -er '.dist.integrity' "${root}/metadata.json")"
+          shasum="$(jq -er '.dist.shasum' "${root}/metadata.json")"
+          test "${integrity}" = "${TARBALL_INTEGRITY}"; test "${shasum}" = "${TARBALL_SHASUM}"
+          node "${GITHUB_WORKSPACE}/npm/agentplugins/scripts/npm-public-contract.js" metadata "${root}/metadata.json" "${VERSION}" "${integrity}" "${shasum}"
+          npm audit signatures --json --include-attestations > "${root}/audit.json"
+          jq -e --arg package "${PACKAGE_NAME}" --arg version "${VERSION}" '(.invalid | length) == 0 and (.missing | length) == 0 and ([.verified[] | select(.name == $package and .version == $version)] | length) == 1' "${root}/audit.json" >/dev/null
+          jq '{attestations: .verified[0].attestationBundles}' "${root}/audit.json" > "${root}/attestation.json"
+          node "${GITHUB_WORKSPACE}/npm/agentplugins/scripts/npm-public-contract.js" audit "${root}/audit.json" "${root}/attestation.json" "${VERSION}"
+          node "${GITHUB_WORKSPACE}/npm/agentplugins/scripts/npm-public-contract.js" attestation "${root}/attestation.json" "${VERSION}" "${integrity}" "agentplugins-v${VERSION}" "${COMMIT}"
+          npm pack --ignore-scripts --json --pack-destination "${root}/packed" "${PACKAGE_NAME}@${VERSION}" > "${root}/pack.json"
+          node "${GITHUB_WORKSPACE}/npm/agentplugins/scripts/npm-public-contract.js" download "${root}/pack.json" "${root}/packed" "${VERSION}" "${integrity}" "${shasum}"
+          run_agentplugins() { npm exec --yes --package="${PACKAGE_NAME}@${VERSION}" -- agentplugins "$@"; }
+          run_agentplugins version | grep -Fx "agentplugins ${VERSION}"
+          run_agentplugins search context7 --format json | jq -e '.result == "success" and ([.data.results[] | select(.product_id == "context7" and .distribution_id == "upstash/context7" and .distribution_kind == "upstream")] | length) == 1' >/dev/null
+          run_agentplugins add "${root}/synthetic" --target codex,cursor,kiro --format json > "${root}/add.json"
+          jq -e '.result == "success" and .data.batch == true and .data.succeeded == 3 and .data.failed == 0 and ([.data.targets[].target] == ["codex","cursor","kiro"])' "${root}/add.json" >/dev/null
+          run_agentplugins info npm-public-proof --format json | jq -e '.result == "success" and ([.data.clients[].client_id] == ["codex","cursor","kiro"])' >/dev/null
+          run_agentplugins update npm-public-proof --target codex,cursor,kiro --format json | jq -e '.result == "success" and .data.batch == true and .data.succeeded == 3 and .data.failed == 0' >/dev/null
+          run_agentplugins remove npm-public-proof --target codex,cursor,kiro --external-uninstalled --format json | jq -e '.result == "success" and .data.batch == true and .data.succeeded == 3 and .data.failed == 0 and .data.data_retained == true' >/dev/null
+          run_agentplugins info npm-public-proof --format json | jq -e '.result == "success" and (.data.clients | length) == 0' >/dev/null

--- a/docs/agentplugins-release.md
+++ b/docs/agentplugins-release.md
@@ -83,30 +83,27 @@ Do not add a bootstrap token back to the workflow. If the package disappears
 from npm, the registry preflight must fail closed instead of attempting to
 recreate it.
 
-## Producer cutover and historical npm audits
+## Producer cutover and npm publication
 
-For this and later cutover releases, plugin-kit-ai remains the binary producer.
-The release workflow still builds, attests, draft-proves, and promotes the same
-six assets plus `checksums.txt` and `release-manifest.json`; it does not publish
-an npm package. The npm tarball created inside the platform proof is an ephemeral
-test input only and is never a release asset or registry publication artifact.
+For this and later releases, plugin-kit-ai remains the binary producer. The
+release workflow builds, attests, draft-proves, and promotes the same six assets
+plus `checksums.txt` and `release-manifest.json`. The npm facade is staged from
+that exact public release and never embeds the binaries in its tarball.
 
-`.github/workflows/agentplugins-npm-publish.yml` is retained at its historical
-path as a read-only audit workflow. It has no npm publishing job, protected npm
-environment, OIDC write permission, token, or publish-ready gate. Its
-`verify_only` input defaults to `true`; explicitly setting it to `false` fails
-closed. Dispatch it with `verify_only=true` and an existing historical tag to
-verify the public registry version, signature, provenance, and isolated
-lifecycle. Historical audit mode does not require the tag to point to current
-`main` and does not rerun the schema-v2 six-platform release proof. The audit
-waits only for the exact `package@version` named by the historical tag. The
-current `latest` dist-tag is logged for context but is non-blocking, so a newer
-UAP publication does not invalidate or delay an older immutable-version audit.
+`.github/workflows/agentplugins-npm-publish.yml` is the manual trusted publisher.
+Dispatch it from the exact `agentplugins-vX.Y.Z` tag with `publish=true`. The
+prepare job requires a public, immutable GitHub release, verifies every asset
+and GitHub attestation, stages the checked-in evidence, and uploads one exact
+tarball. The publish job runs in the protected `npm-agentplugins` environment,
+requires GitHub OIDC (`id-token: write`), refuses `NPM_TOKEN` and
+`NODE_AUTH_TOKEN`, and publishes with npm provenance. The final job verifies
+public metadata, SLSA provenance, npm audit signatures, the tarball digest, and
+an isolated `codex,cursor,kiro` add/info/update/remove lifecycle.
 
-The UAP facade publisher must consume an exact public tag and verify the release
-manifest version, source commit, six filenames, byte sizes, SHA-256 digests, and
-GitHub artifact attestations before publication. Publisher implementation and
-npm authority are intentionally outside this repository.
+With `publish=false`, only the immutable prepare checks run; no npm state is
+changed. A published version is never overwritten and a stable tag is never
+reused. If the package disappears from npm, rerun only with a new release tag;
+the workflow never recreates an old version or uses a bootstrap token.
 
 Never publish an empty placeholder, reuse a tag, overwrite release assets, or
 resolve a binary through an unpinned GitHub `latest` release.

--- a/npm/agentplugins/scripts/npm-public-contract.js
+++ b/npm/agentplugins/scripts/npm-public-contract.js
@@ -119,7 +119,7 @@ function decodeBase64JSON(encoded, label) {
 
 function validateSLSAAttestation(response, version, integrity, uapTag, uapCommit) {
   validateExpected(version, integrity, "0".repeat(40));
-  if (uapTag !== `v${version}`) fail("UAP tag does not match the package version");
+  if (uapTag !== `agentplugins-v${version}`) fail("UAP tag does not match the package version");
   if (!COMMIT.test(uapCommit)) fail("UAP commit must be an exact lowercase commit");
   if (!response || !Array.isArray(response.attestations)) fail("npm attestation response is invalid");
   const provenance = response.attestations.filter((item) => item?.predicateType === SLSA_PREDICATE);

--- a/npm/agentplugins/test/npm-public-contract.test.js
+++ b/npm/agentplugins/test/npm-public-contract.test.js
@@ -53,7 +53,7 @@ function fixture(body = Buffer.from("exact tarball bytes")) {
       }
     }
   };
-  const uapTag = `v${version}`;
+  const uapTag = `agentplugins-v${version}`;
   const uapCommit = "a".repeat(40);
   const statement = {
     _type: "https://in-toto.io/Statement/v1",

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -17,8 +17,9 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	releaseDraftJob := yamlJob(t, releaseWorkflow, "stage-draft")
 	releaseProofJob := yamlJob(t, releaseWorkflow, "platform-proof")
 	releasePromoteJob := yamlJob(t, releaseWorkflow, "promote-release")
-	npmAuditModeJob := yamlJob(t, npmWorkflow, "audit-mode")
-	npmVerifyJob := yamlJob(t, npmWorkflow, "verify")
+	npmPrepareJob := yamlJob(t, npmWorkflow, "prepare")
+	npmPublishJob := yamlJob(t, npmWorkflow, "publish")
+	npmPublicVerifyJob := yamlJob(t, npmWorkflow, "verify-public")
 	removedBoundaryScript := readRepoFile(t, root, "scripts", "check-removed-contract-boundary.sh")
 	runbook := readRepoFile(t, root, "docs", "agentplugins-release.md")
 
@@ -96,95 +97,69 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	}
 
 	for _, want := range []string{
-		"name: Agentplugins NPM Historical Audit",
-		"verify_only:",
-		"default: true",
-		"only historical verification is supported",
+		"name: Agentplugins NPM Publish",
+		"tag:",
+		"publish:",
+		"default: false",
+		"ref: ${{ inputs.tag }}",
+		"agentplugins-v[0-9]+",
+		"Verify exact public release identity and attestations",
+		"release-assets.js verify",
+		"stage-release.js",
+		"npm-public-contract.js stage-outputs",
+		"agentplugins-npm-${{ steps.stage.outputs.version }}",
 	} {
 		mustContain(t, npmWorkflow, want)
 	}
 	for _, want := range []string{
-		"Enforce retired publisher boundary",
-		"VERIFY_ONLY: ${{ inputs.verify_only }}",
-		"npm publication is retired in plugin-kit-ai",
-		"dispatch with verify_only=true",
+		"Verify exact public release identity and attestations",
+		"release-assets.js verify",
+		"stage-release.js",
+		"npm-public-contract.js stage-outputs",
 	} {
-		mustContain(t, npmAuditModeJob, want)
-	}
-	for _, unwanted := range []string{
-		"release-identity:",
-		"prepublish-conformance:",
-		"publish:",
-		"npm publish",
-		"environment: npm-agentplugins",
-		"id-token: write",
-		"NPM_AGENTPLUGINS_PUBLISH_READY",
-		"uses: ./.github/workflows/agentplugins-platform-proof.yml",
-	} {
-		mustNotContain(t, npmWorkflow, unwanted)
+		mustContain(t, npmPrepareJob, want)
 	}
 	for _, want := range []string{
-		"needs: audit-mode",
-		`ref: ${{ inputs.tag }}`,
-		"Resolve immutable verification target",
-		`NPM_PACKAGE: ${{ steps.verify-target.outputs.package_name }}`,
-		`npm view --prefer-online "${NPM_PACKAGE}@${version}" version`,
-		`npm view --prefer-online "${NPM_PACKAGE}@latest" version`,
-		`if [[ "${published_version}" = "${version}" ]]; then`,
-		"informational: ${NPM_PACKAGE}@latest is ${latest_version}; auditing exact historical version ${version}",
-		"warning: ${NPM_PACKAGE}@latest could not be resolved; exact historical version ${version} is available",
-		"max_attempts=30",
-		`npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`,
-		"npm audit signatures --json --include-attestations",
-		`.attestations.provenance.predicateType == "https://slsa.dev/provenance/v1"`,
-		`lifecycle_targets="codex,cursor"`,
-		`run_agentplugins add "${synthetic}" --target "${lifecycle_targets}" --format json > add.json`,
-		`run_agentplugins add "${synthetic}" --target "${lifecycle_targets}" --activation-complete --auth-complete --format json > complete.json`,
-		`.data.batch == true and .data.succeeded == 2 and .data.failed == 0`,
-		`([.data.targets[].target] == ["codex", "cursor"])`,
-		`.output.operation_id == $operation_id`,
-		`.output.result.installation_id == $installation_id`,
-		`.output.result.activation.activation_attested == true`,
-		`.output.result.activation.authentication_attested == true`,
-		`.output.result.no_change == true and .output.result.mutated == false`,
-		`.data.status == "data_retained"`,
-		`.data.plugin_data_preserved == true`,
-		`(.data.retained_data | length) > 0`,
-		`(keys | sort) == ["data_receipt_id", "physical_backend_id", "scope", "state"]`,
-		`contains("agentplugins remove " + $installation_id + " --purge-data")`,
-		`select(type == "string" and startswith("/"))`,
+		"needs: prepare",
+		"environment: npm-agentplugins",
+		"id-token: write",
+		"npm publish",
+		"--provenance",
+		"Refuse overwrite",
+		"test -z \"${NPM_TOKEN:-}\"",
+		"test -z \"${NODE_AUTH_TOKEN:-}\"",
 	} {
-		mustContain(t, npmVerifyJob, want)
+		mustContain(t, npmPublishJob, want)
 	}
-	mustContain(t, npmWorkflow, "verify_only:")
-	mustContain(t, npmWorkflow, "only historical verification is supported")
+	for _, want := range []string{
+		"needs: [prepare, publish]",
+		"npm audit signatures --json --include-attestations",
+		"npm/agentplugins/scripts/npm-public-contract.js\" metadata",
+		"npm/agentplugins/scripts/npm-public-contract.js\" audit",
+		"npm/agentplugins/scripts/npm-public-contract.js\" attestation",
+		"npm/agentplugins/scripts/npm-public-contract.js\" download",
+		"run_agentplugins()",
+		"--target codex,cursor,kiro",
+		"run_agentplugins add",
+		"run_agentplugins update",
+		"run_agentplugins remove",
+		"data.succeeded == 3",
+	} {
+		mustContain(t, npmPublicVerifyJob, want)
+	}
 	for _, unwanted := range []string{
-		"npm view agentplugins versions --json",
-		"npm view agentplugins version >/dev/null",
+		"verify_only",
+		"only historical verification is supported",
 		"--tag beta",
 		"bootstrap_publish",
-		"NPM_TOKEN",
-		"NODE_AUTH_TOKEN",
+		"NPM_AGENTPLUGINS_PUBLISH_READY",
 	} {
 		mustNotContain(t, npmWorkflow, unwanted)
 	}
-	mustNotContain(t, npmVerifyJob, "npm publish --access public --tag latest --provenance")
-	mustNotContain(t, npmVerifyJob, "environment: npm-agentplugins")
-	mustNotContain(t, npmVerifyJob, "id-token: write")
-	mustNotContain(t, npmVerifyJob, "platform-proof")
-	mustNotContain(t, npmVerifyJob, "--target cursor --yes")
-	mustNotContain(t, npmVerifyJob, `[[ "${latest_version}" = "${version}" ]]`)
-	mustAppearBefore(t, npmVerifyJob, "Resolve immutable verification target", `npm view --prefer-online "${NPM_PACKAGE}@${version}" version`)
-	mustAppearBefore(t, npmVerifyJob, `npm view --prefer-online "${NPM_PACKAGE}@${version}" version`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
-	mustAppearBefore(t, npmVerifyJob, `test "${available}" = true`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
-	mustAppearBefore(t, npmVerifyJob, `test "${available}" = true`, `npm view --prefer-online "${NPM_PACKAGE}@latest" version`)
-	mustAppearBefore(t, npmVerifyJob, `npm view --prefer-online "${NPM_PACKAGE}@latest" version`, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`)
-	mustAppearBefore(t, npmVerifyJob, `npm install --ignore-scripts --save-exact "${NPM_PACKAGE}@${version}"`, "npm audit signatures --json --include-attestations")
-	mustAppearBefore(t, npmVerifyJob, "npm audit signatures --json --include-attestations", "run_agentplugins version")
-	mustNotContain(t, npmVerifyJob, `.data.result.`)
-	mustAppearBefore(t, npmVerifyJob, `run_agentplugins add "${synthetic}" --target "${lifecycle_targets}" --format json > add.json`, `run_agentplugins add "${synthetic}" --target "${lifecycle_targets}" --activation-complete --auth-complete --format json > complete.json`)
-	mustAppearBefore(t, npmVerifyJob, `run_agentplugins add "${synthetic}" --target "${lifecycle_targets}" --activation-complete --auth-complete --format json > complete.json`, `run_agentplugins update registry-proof-synthetic --target "${lifecycle_targets}" --format json > update.json`)
-	mustAppearBefore(t, npmVerifyJob, `run_agentplugins update registry-proof-synthetic --target "${lifecycle_targets}" --format json > update.json`, `run_agentplugins remove registry-proof-synthetic --target "${lifecycle_targets}" --external-uninstalled --format json > remove.json`)
+	mustAppearBefore(t, npmWorkflow, "release-assets.js verify", "stage-release.js")
+	mustAppearBefore(t, npmWorkflow, "npm publish", "Verify metadata, signatures, provenance, and isolated lifecycle")
+	mustNotContain(t, npmPublicVerifyJob, "NPM_TOKEN")
+	mustNotContain(t, npmPublicVerifyJob, "NODE_AUTH_TOKEN")
 
 	for _, want := range []string{
 		"workflow_call:",
@@ -277,33 +252,19 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		"disallow bypass-2FA tokens",
 		"Do not add a bootstrap token back",
 		"required `binary-only` producer mode",
-		"six assets plus `checksums.txt` and `release-manifest.json`",
-		"test input only and is never a release asset",
-		"retained at its historical",
-		"read-only audit workflow",
-		"`verify_only` input defaults to `true`",
-		"explicitly setting it to `false` fails",
-		"does not require the tag to point to current",
-		"does not rerun the schema-v2 six-platform release proof",
-		"manifest version, source commit, six filenames, byte sizes, SHA-256 digests",
-		"same-run frozen",
-		"anonymous GitHub release download",
+		"same six assets",
+		"npm facade is staged from",
+		"manual trusted publisher",
+		"publish=true",
+		"protected `npm-agentplugins` environment",
+		"requires GitHub OIDC",
+		"npm audit signatures",
+		"add/info/update/remove lifecycle",
+		"With `publish=false`",
+		"never recreates an old version",
 	} {
 		mustContain(t, runbook, want)
 	}
-}
-
-func TestAgentpluginsHistoricalAuditAllowsLatestToBeNewer(t *testing.T) {
-	root := RepoRoot(t)
-	npmWorkflow := readRepoFile(t, root, ".github", "workflows", "agentplugins-npm-publish.yml")
-	npmVerifyJob := yamlJob(t, npmWorkflow, "verify")
-
-	// A historical version remains auditable after a later owner advances the
-	// latest dist-tag. Only exact package@version existence may open the gate.
-	mustContain(t, npmVerifyJob, `if [[ "${published_version}" = "${version}" ]]; then`)
-	mustContain(t, npmVerifyJob, `test "${available}" = true`)
-	mustNotContain(t, npmVerifyJob, `[[ "${latest_version}" = "${version}" ]]`)
-	mustAppearBefore(t, npmVerifyJob, `test "${available}" = true`, `latest_version="$(npm view --prefer-online "${NPM_PACKAGE}@latest" version 2>/dev/null || true)"`)
 }
 
 func TestAgentpluginsReadmesUseUnversionedNpxExamples(t *testing.T) {


### PR DESCRIPTION
## Summary
- replace the retired npm audit workflow with an OIDC trusted publisher
- verify exact public Agentplugins release assets and attestations before staging
- verify public npm provenance, signatures, tarball bytes, and isolated codex/cursor/kiro lifecycle
- align release docs and contracts with the renamed CLI repository and agentplugins tags

## Verification
- node --test npm/agentplugins/test/*.test.js
- go test ./repotests -run 'TestAgentpluginsReleaseContractsStayFailClosed|TestAgentpluginsReadmesUseUnversionedNpxExamples' -count=1
- git diff --check