### PR TITLE
fix(release): validate native lifecycle proof field

### DIFF
--- a/.github/workflows/agentplugins-platform-proof.yml
+++ b/.github/workflows/agentplugins-platform-proof.yml
@@ -383,6 +383,6 @@ jobs:
                .proofs.synthetic_add_dry_run == true and
                .proofs.warm_cache == true and
                .proofs.warm_cache_without_proof_source == true and
-               .proofs.isolated_add_update_remove == $lifecycle' \
+               .proofs.isolated_add_info_update_remove == $lifecycle' \
               "${matches[0]}" >/dev/null
           done

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -225,7 +225,7 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 		"expected exactly one machine-readable proof for ${target}",
 		".schema_version == 1",
 		".release_version == $version",
-		".proofs.isolated_add_update_remove == $lifecycle",
+		".proofs.isolated_add_info_update_remove == $lifecycle",
 		`.bootstrap_source == $bootstrap_mode`,
 		`.proofs.local_frozen_asset_bootstrap == ($bootstrap_mode == "local_frozen_asset")`,
 		`.proofs.anonymous_public_release_download == ($bootstrap_mode == "public_release_download")`,


### PR DESCRIPTION
The native platform proof producer emits isolated_add_info_update_remove, but the aggregate gate still checked the old field name. Align the gate and its contract test so successful six-platform lifecycle proofs can promote.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated platform proof validation to use the `isolated_add_info_update_remove` lifecycle key.
  - Updated release-contract checks to verify the revised aggregated proof bundle key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->