### PR TITLE
fix(codex): compare managed paths by filesystem identity

### DIFF
--- a/install/integrationctl/agentplugins/providers/codex_marketplace_cleanup.go
+++ b/install/integrationctl/agentplugins/providers/codex_marketplace_cleanup.go
@@ -49,8 +49,30 @@ func managedCodexMarketplaceRegistered(configRoot, marketplace, managedArtifactP
 	if sourceType, present := entry["source_type"]; present && sourceType != "local" {
 		return false, fmt.Errorf("refuse managed Codex marketplace cleanup because %s is not a local source", marketplace)
 	}
-	if filepath.Clean(source) != filepath.Clean(managedArtifactPath) {
+	if !equivalentLocalPath(source, managedArtifactPath) {
 		return false, fmt.Errorf("refuse managed Codex marketplace cleanup because %s no longer points at the managed artifact", marketplace)
 	}
 	return true, nil
+}
+
+// equivalentLocalPath compares the filesystem identity rather than only the
+// spelling of a path. macOS commonly exposes /tmp through /private/tmp, and
+// the same aliasing can occur in containerized or symlinked test homes. Both
+// paths must resolve successfully before an alias is accepted; an unreadable
+// or missing source remains fail-closed.
+func equivalentLocalPath(left, right string) bool {
+	left = filepath.Clean(left)
+	right = filepath.Clean(right)
+	if left == right {
+		return true
+	}
+	resolvedLeft, err := filepath.EvalSymlinks(left)
+	if err != nil {
+		return false
+	}
+	resolvedRight, err := filepath.EvalSymlinks(right)
+	if err != nil {
+		return false
+	}
+	return filepath.Clean(resolvedLeft) == filepath.Clean(resolvedRight)
 }

--- a/install/integrationctl/agentplugins/providers/codex_marketplace_cleanup_test.go
+++ b/install/integrationctl/agentplugins/providers/codex_marketplace_cleanup_test.go
@@ -1,0 +1,58 @@
+package providers
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestManagedCodexMarketplaceRegisteredAcceptsFilesystemAlias(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating directory symlinks requires elevated Windows privileges")
+	}
+	root := t.TempDir()
+	configRoot := filepath.Join(root, "config")
+	managed := filepath.Join(root, "managed")
+	aliasRoot := filepath.Join(root, "alias")
+	if err := os.MkdirAll(configRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(managed, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(root, aliasRoot); err != nil {
+		t.Fatal(err)
+	}
+	config := "[marketplaces.agentplugins-test]\nsource_type = \"local\"\nsource = \"" + filepath.Join(aliasRoot, "managed") + "\"\n"
+	if err := os.WriteFile(filepath.Join(configRoot, "config.toml"), []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	registered, err := managedCodexMarketplaceRegistered(configRoot, "agentplugins-test", managed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !registered {
+		t.Fatal("filesystem aliases should identify the same managed artifact")
+	}
+}
+
+func TestManagedCodexMarketplaceRegisteredRejectsDifferentResolvedPath(t *testing.T) {
+	root := t.TempDir()
+	configRoot := filepath.Join(root, "config")
+	managed := filepath.Join(root, "managed")
+	other := filepath.Join(root, "other")
+	for _, directory := range []string{configRoot, managed, other} {
+		if err := os.MkdirAll(directory, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	config := "[marketplaces.agentplugins-test]\nsource_type = \"local\"\nsource = \"" + other + "\"\n"
+	if err := os.WriteFile(filepath.Join(configRoot, "config.toml"), []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	registered, err := managedCodexMarketplaceRegistered(configRoot, "agentplugins-test", managed)
+	if err == nil || registered {
+		t.Fatalf("different resolved path must fail closed: registered=%v err=%v", registered, err)
+	}
+}


### PR DESCRIPTION
On macOS, /tmp and /private/tmp can name the same directory. Compare Codex marketplace sources by resolved filesystem identity so cleanup recognizes the manager-owned artifact while still failing closed for missing or different paths. Add alias and negative regression coverage.