### PR TITLE
fix(mirror): preserve signed snapshot paths

### DIFF
--- a/cmd/agentplugins-registry-mirror/main.go
+++ b/cmd/agentplugins-registry-mirror/main.go
@@ -120,20 +120,7 @@ func run(registry, origin, output, previous string) error {
 	if err := os.MkdirAll(stage, 0o755); err != nil {
 		return fmt.Errorf("create staging directory: %w", err)
 	}
-	files := []struct {
-		rel  string
-		body []byte
-	}{
-		{"registry/schemas/1/latest.json", directory.pointerBytes},
-		{"registry/schemas/1/" + directory.stem + ".json", directory.snapshotBytes},
-		{"registry/schemas/1/" + directory.stem + ".envelope.json", directory.envelopeBytes},
-		{"registry/publication/trusted-keys.json", directory.trustBytes},
-		{"discovery/latest.json", discovery.pointerBytes},
-		{"discovery/" + discovery.stem + ".json", discovery.snapshotBytes},
-		{"discovery/" + discovery.stem + ".envelope.json", discovery.envelopeBytes},
-		{"discovery/search/" + discovery.stem + ".json", discovery.searchBytes},
-		{"discovery/trusted-keys.json", discovery.trustBytes},
-	}
+	files := stagedFiles(directory, discovery)
 	for _, file := range files {
 		if err := writeStaged(stage, file.rel, file.body); err != nil {
 			return err
@@ -158,6 +145,25 @@ func run(registry, origin, output, previous string) error {
 	}
 	fmt.Printf("verified Directory seq %d and Discovery seq %d; mirrored %d files to %s\n", metadata.DirectorySequence, metadata.DiscoverySequence, metadata.GeneratedFiles, output)
 	return nil
+}
+
+type mirrorFile struct {
+	rel  string
+	body []byte
+}
+
+func stagedFiles(directory directoryResult, discovery discoveryResult) []mirrorFile {
+	return []mirrorFile{
+		{rel: "registry/schemas/1/latest.json", body: directory.pointerBytes},
+		{rel: "registry/schemas/1/snapshots/" + directory.stem + ".json", body: directory.snapshotBytes},
+		{rel: "registry/schemas/1/snapshots/" + directory.stem + ".envelope.json", body: directory.envelopeBytes},
+		{rel: "registry/publication/trusted-keys.json", body: directory.trustBytes},
+		{rel: "discovery/latest.json", body: discovery.pointerBytes},
+		{rel: "discovery/snapshots/" + discovery.stem + ".json", body: discovery.snapshotBytes},
+		{rel: "discovery/snapshots/" + discovery.stem + ".envelope.json", body: discovery.envelopeBytes},
+		{rel: "discovery/search/" + discovery.stem + ".json", body: discovery.searchBytes},
+		{rel: "discovery/trusted-keys.json", body: discovery.trustBytes},
+	}
 }
 
 type directoryResult struct {

--- a/cmd/agentplugins-registry-mirror/main_test.go
+++ b/cmd/agentplugins-registry-mirror/main_test.go
@@ -90,3 +90,35 @@ func TestWriteStagedRejectsTraversal(t *testing.T) {
 		}
 	}
 }
+
+func TestStagedFilesFollowSignedPointerPaths(t *testing.T) {
+	const stem = "00000000000000000027"
+	files := stagedFiles(directoryResult{stem: stem}, discoveryResult{stem: stem})
+	paths := make(map[string]bool, len(files))
+	for _, file := range files {
+		paths[file.rel] = true
+	}
+	for _, expected := range []string{
+		"registry/schemas/1/latest.json",
+		"registry/schemas/1/snapshots/" + stem + ".json",
+		"registry/schemas/1/snapshots/" + stem + ".envelope.json",
+		"discovery/latest.json",
+		"discovery/snapshots/" + stem + ".json",
+		"discovery/snapshots/" + stem + ".envelope.json",
+		"discovery/search/" + stem + ".json",
+	} {
+		if !paths[expected] {
+			t.Fatalf("signed pointer artifact path is missing: %s", expected)
+		}
+	}
+	for _, unexpected := range []string{
+		"registry/schemas/1/" + stem + ".json",
+		"registry/schemas/1/" + stem + ".envelope.json",
+		"discovery/" + stem + ".json",
+		"discovery/" + stem + ".envelope.json",
+	} {
+		if paths[unexpected] {
+			t.Fatalf("legacy root artifact path must not be emitted: %s", unexpected)
+		}
+	}
+}


### PR DESCRIPTION
The mirror consumed pointers whose snapshot_path values are snapshots/<stem>.json but emitted files at the parent directory, causing 404s on the old Pages origin. Emit the exact signed pointer paths and add a regression test; no feed bytes or signatures change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Snapshot and envelope artifacts are now stored under dedicated `snapshots/` directories for Directory and Discovery feeds.
  * Signed pointer paths remain available for latest, snapshot, envelope, and search artifacts.
  * Legacy root-level artifact paths are no longer emitted.
* **Tests**
  * Added coverage verifying that staged files follow the signed pointer paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->