### PR TITLE
fix(release): let npm trusted publishing reach OIDC

### DIFF
--- a/.github/workflows/agentplugins-npm-publish.yml
+++ b/.github/workflows/agentplugins-npm-publish.yml
@@ -118,8 +118,16 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.23.2"
-          registry-url: https://registry.npmjs.org
           package-manager-cache: false
+      - name: Use an empty npm config for OIDC publish
+        run: |
+          set -euo pipefail
+          config="${RUNNER_TEMP}/agentplugins-publish.npmrc"
+          : > "${config}"
+          chmod 600 "${config}"
+          echo "NPM_CONFIG_USERCONFIG=${config}" >> "${GITHUB_ENV}"
+          # Do not inherit a runner/global registry while exchanging the OIDC token.
+          echo "NPM_CONFIG_REGISTRY=https://registry.npmjs.org" >> "${GITHUB_ENV}"
       - name: Install the pinned npm trusted-publisher client
         run: |
           set -euo pipefail
@@ -138,6 +146,8 @@ jobs:
           set -euo pipefail
           test -z "${NPM_TOKEN:-}"
           test -z "${NODE_AUTH_TOKEN:-}"
+          test ! -s "${NPM_CONFIG_USERCONFIG}"
+          test "${NPM_CONFIG_REGISTRY}" = "https://registry.npmjs.org"
           if npm view "${PACKAGE_NAME}@${VERSION}" version >/dev/null 2>&1; then
             echo "npm version already exists and is immutable: ${PACKAGE_NAME}@${VERSION}" >&2
             exit 1


### PR DESCRIPTION
## What changed
- stop setup-node from writing an empty `_authToken` entry in the publish job
- provide an explicitly empty npm config so npm 11/12 can perform its OIDC exchange
- keep the exact package, provenance, and no-token checks unchanged

## Why
The previous run reached Sigstore but npm returned a masked E404. npm skips trusted publishing when setup-node leaves an empty `NODE_AUTH_TOKEN` entry in `.npmrc`.

## Safety
This changes only the publish job configuration; no package bytes or release identity are changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package publishing safeguards to use a temporary, restricted npm configuration file.
  * Added checks to prevent publishing when authentication tokens or unexpected npm configuration are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->