### PR TITLE
fix(cli): use standalone registry feed by default

### DIFF
--- a/cli/plugin-kit-ai/cmd/agentplugins/directory_configuration_test.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins/directory_configuration_test.go
@@ -53,6 +53,12 @@ func TestProductionDirectoryIgnoresCallerSuppliedConformanceData(t *testing.T) {
 	}
 }
 
+func TestProductionDefaultsUseTheStandaloneRegistry(t *testing.T) {
+	if want := "https://777genius.github.io/universal-agent-plugins-registry/"; !strings.HasPrefix(defaultDirectoryOrigin, want) || !strings.HasPrefix(defaultDiscoveryOrigin, want) {
+		t.Fatalf("production feed defaults must use the standalone registry: directory=%q discovery=%q", defaultDirectoryOrigin, defaultDiscoveryOrigin)
+	}
+}
+
 func TestTestOnlyDependencyInjectionPreservesExactLaunchConformance(t *testing.T) {
 	clearDirectoryEnvironment(t)
 	root := t.TempDir()

--- a/cli/plugin-kit-ai/cmd/agentplugins/main.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins/main.go
@@ -38,10 +38,10 @@ import (
 
 var (
 	version                   = "0.1.0-development"
-	defaultDirectoryOrigin    = "https://777genius.github.io/universal-agent-plugins/registry/schemas/1/"
+	defaultDirectoryOrigin    = "https://777genius.github.io/universal-agent-plugins-registry/registry/schemas/1/"
 	defaultDirectoryKeyID     = "uap-directory-2026-01"
 	defaultDirectoryPublicKey = "HalXARjat+v3ylTPLMAnvuavRo4ZfrF+DbWwsjlp2bI="
-	defaultDiscoveryOrigin    = "https://777genius.github.io/universal-agent-plugins/discovery/"
+	defaultDiscoveryOrigin    = "https://777genius.github.io/universal-agent-plugins-registry/discovery/"
 	defaultDiscoveryKeyID     = "uap-discovery-2026-01"
 	defaultDiscoveryPublicKey = "IxWvGuscXR9crlCrGyBQZNqroYNVPbBA1B3pnjSffhc="
 	directoryClientFactory    = newDirectoryClient


### PR DESCRIPTION
The registry now lives at 777genius/universal-agent-plugins-registry, but the released CLI still defaulted to the old Pages origin. Point Directory and Discovery defaults at the standalone registry and add a regression test. This keeps short-name search aligned with production sequence 29 while preserving explicit origin overrides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the default plugin directory and discovery feed locations to use the standalone universal agent plugins registry.
  * Production configurations now reference the registry’s dedicated directory and discovery paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->