### PR TITLE
docs(readme): simplify plugin onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,56 +9,31 @@
 Install and manage Agent Plugins 1.0 across your AI agents with one CLI.
 
 ```bash
-npx universal-agent-plugins add context7 --target cursor
+npx universal-agent-plugins add context7
 ```
 
-The command downloads a package once, verifies it, prepares the native format for
-the selected client or clients, and tells you about any remaining activation or
-OAuth step.
-
-This repository is the product home and npm facade source. The facade installs the `agentplugins` binary; `plugin-kit-ai` is the shared Go implementation engine
-during the repository rename and is not duplicated here.
+The CLI finds compatible agents installed on your computer and asks where to
+install the plugin. Choose one or several. The package is downloaded and
+verified once, then prepared for every agent you selected.
 
 ## Quick start
 
 You need Node.js 22 or newer.
 
-1. Pick a plugin from the Universal Agent Plugins Registry:
-   https://777genius.github.io/universal-agent-plugins-registry/
-2. Choose one or several clients explicitly:
+1. Run the command above.
+2. Select the installed agents you want to use. If only one is found, it is
+   selected automatically; if several are found, the CLI shows a multi-select.
+3. Follow any activation or sign-in instruction printed by the CLI.
+4. Start a new agent session and use the plugin.
 
-   ```bash
-   npx universal-agent-plugins add context7 --target codex,cursor
-   ```
+[Browse 2,500+ plugins](https://777genius.github.io/universal-agent-plugins-registry/)
 
-3. Open a new session in the client and follow the printed activation hint.
-4. Ask the agent to use the plugin. A real tool call is the useful runtime check.
+## What the CLI does
 
-The same package is acquired once and planned for every selected target. The CLI
-does not silently modify every detected client.
-
-For an interactive terminal, omit --target to detect compatible installed
-clients and choose them in a multi-select. Scripts and CI should always pass
---target.
-
-## Everyday commands
-
-```bash
-npx universal-agent-plugins search docs
-npx universal-agent-plugins info context7
-npx universal-agent-plugins add context7 --target codex,cursor,kiro
-npx universal-agent-plugins update context7 --target codex,cursor
-npx universal-agent-plugins repair context7 --target codex,cursor
-npx universal-agent-plugins switch context7 --to 777genius/context7
-npx universal-agent-plugins outdated --all
-npx universal-agent-plugins update --all
-npx universal-agent-plugins remove context7 --target codex,cursor
-npx universal-agent-plugins doctor
-```
-
-update keeps the recorded source. repair reapplies that source. switch is the
-explicit way to move to another reviewed distribution or exact source. remove
-changes only files owned by the CLI.
+- installs one plugin in one or several supported agents;
+- updates, repairs, and removes only files it manages;
+- converts the same Agent Plugins 1.0 package into each agent's native format;
+- keeps activation and OAuth prompts visible to you.
 
 ## Any Agent Plugins 1.0 package
 
@@ -71,19 +46,9 @@ plugin.json
 └── hooks/        optional client-supported hooks
 ```
 
-Use a local package or a pinned GitHub source without submitting it to the
-registry:
-
-```bash
-npx universal-agent-plugins validate ./my-plugin
-npx universal-agent-plugins add ./my-plugin --target cursor
-npx universal-agent-plugins add \
-  owner/repository@0123456789abcdef0123456789abcdef01234567//path/to/plugin \
-  --target codex,cursor
-```
-
-Use a full 40-character commit SHA. Branches, tags, and abbreviated SHAs are
-rejected for remote installs.
+You can also install a local package or a pinned GitHub package without adding
+it to the registry. Direct-install examples are collected near the end of this
+README.
 
 plugin.yaml is the legacy plugin-kit-ai authoring format. It is not merged with
 or allowed to override plugin.json.
@@ -134,6 +99,40 @@ by you. No install telemetry is sent.
 
 The CLI is an independent community project. It is not affiliated with OpenAI,
 Agent Plugins, or the vendors shown above.
+
+## More commands
+
+For normal interactive use, omit `--target` and choose agents in the prompt.
+Use `--target` in scripts, CI, or whenever you want to name clients explicitly.
+
+```bash
+# Find and inspect plugins
+npx universal-agent-plugins search docs
+npx universal-agent-plugins info context7
+
+# Install in specific agents
+npx universal-agent-plugins add context7 --target codex,cursor,kiro
+
+# Manage an installed plugin
+npx universal-agent-plugins update context7 --target codex,cursor
+npx universal-agent-plugins repair context7 --target codex,cursor
+npx universal-agent-plugins remove context7 --target codex,cursor
+npx universal-agent-plugins outdated --all
+npx universal-agent-plugins update --all
+npx universal-agent-plugins doctor
+
+# Install a local Agent Plugins 1.0 package
+npx universal-agent-plugins validate ./my-plugin
+npx universal-agent-plugins add ./my-plugin
+
+# Install a GitHub package at an exact commit
+npx universal-agent-plugins add \
+  owner/repository@0123456789abcdef0123456789abcdef01234567//path/to/plugin
+```
+
+Remote installs require a full 40-character commit SHA. Branches, tags, and
+abbreviated SHAs are rejected. `update` keeps the recorded source, `repair`
+reapplies it, and `remove` changes only files owned by the CLI.
 
 ## Authoring and development
 

--- a/npm/agentplugins/README.md
+++ b/npm/agentplugins/README.md
@@ -1,172 +1,98 @@
 # Universal Agent Plugins
 
-`universal-agent-plugins` is the public npm package for installing and managing
-portable Agent Plugins 1.0 packages. Its product home and npm facade source are
-the [`universal-agent-plugins`](https://github.com/777genius/universal-agent-plugins)
-repository. It installs the `agentplugins` binary; `npx universal-agent-plugins`
-and a globally installed `agentplugins` run the same lifecycle manager, not
-separate engines.
-
-Prerequisite: Node.js 22 or newer.
+Install and manage Agent Plugins 1.0 across your AI agents with one CLI.
 
 ```bash
 npx universal-agent-plugins add context7
 ```
 
-The npm package is a thin Node.js launcher.
-[`plugin-kit-ai`](https://github.com/777genius/plugin-kit-ai) owns and releases
-the shared Go implementation engine; it is not duplicated here. This is an independent community CLI, not an official
-OpenAI or Agent Plugins project, and is not affiliated with
-`sigilco/agentplugins` or `@agentplugins/cli`. Agent Plugins 1.0 defines the
-portable `plugin.json` package; this CLI supplies installation and lifecycle
-policy.
+The CLI finds compatible agents installed on your computer and asks where to
+install the plugin. Choose one or several. The package is downloaded and
+verified once, then prepared for every agent you selected.
 
-The npm package has no `postinstall`. On first execution it downloads only the
-binary matching the exact npm version, verifies the SHA-256 embedded in the npm
-tarball, then caches it under XDG Cache or LocalAppData. It never falls back to
-`latest` and never sends `GITHUB_TOKEN` to public downloads.
+You need Node.js 22 or newer.
 
-Stable publication is gated by exact native npm bootstrap proofs on all six supported
-platforms:
+## Quick start
 
-| OS | x64 | arm64 |
-| --- | --- | --- |
-| macOS | Tested | Tested |
-| Linux | Tested | Tested |
-| Windows | Tested | Tested |
+1. Run the command above.
+2. Select the agents you want to use. One detected agent is selected
+   automatically; with several agents, the CLI shows a multi-select.
+3. Follow any activation or sign-in instruction printed by the CLI.
+4. Start a new agent session and use the plugin.
 
-Other operating systems and CPU architectures are unsupported and fail before
-the binary runs.
+[Browse 2,500+ plugins](https://777genius.github.io/universal-agent-plugins-registry/)
+
+## What it does
+
+- installs one plugin in one or several supported agents;
+- updates, repairs, and removes only files it manages;
+- converts the same Agent Plugins 1.0 package into each agent's native format;
+- keeps activation and OAuth prompts visible to you.
+
+Supported clients include Codex, ChatGPT, Cursor, GitHub Copilot CLI, VS Code,
+Kiro, Claude Code, Gemini CLI, OpenCode, Cline, and Windsurf. Compatibility is
+package-specific, and the CLI tells you what is installed automatically and
+what still needs an activation step.
+
+## Install any Agent Plugins 1.0 package
+
+Short names come from the signed Universal Agent Plugins Registry. You can also
+install a valid package directly from a local directory or a pinned GitHub
+source without submitting it to the registry.
+
+The standard `plugin.json` is the installation authority. `plugin.yaml` remains
+legacy authoring input and cannot override `plugin.json`.
+
+## More commands
+
+For normal interactive use, omit `--target` and choose agents in the prompt.
+Use `--target` in scripts, CI, or whenever you want to name clients explicitly.
 
 ```bash
-npx universal-agent-plugins doctor
-npx universal-agent-plugins list
+# Find and inspect plugins
 npx universal-agent-plugins search docs
-npx universal-agent-plugins validate ./my-plugin
-npx universal-agent-plugins add context7 --dry-run --target cursor
+npx universal-agent-plugins info context7
+
+# Install in specific agents
 npx universal-agent-plugins add context7 --target codex,cursor,kiro
+
+# Manage installed plugins
+npx universal-agent-plugins update context7 --target codex,cursor
+npx universal-agent-plugins repair context7 --target codex,cursor
+npx universal-agent-plugins remove context7 --target codex,cursor
 npx universal-agent-plugins outdated --all
 npx universal-agent-plugins update --all
-npx universal-agent-plugins update context7 --target codex,cursor,kiro
-npx universal-agent-plugins repair context7 --target codex,cursor,kiro
-npx universal-agent-plugins remove context7 --target codex,cursor,kiro
-npx universal-agent-plugins switch context7 --to upstash/context7
+npx universal-agent-plugins doctor
+
+# Install a local package
+npx universal-agent-plugins validate ./my-plugin
+npx universal-agent-plugins add ./my-plugin
+
+# Install a GitHub package at an exact commit
+npx universal-agent-plugins add \
+  owner/repository@0123456789abcdef0123456789abcdef01234567//path/to/plugin
 ```
 
-## Choose clients
+Remote installs require a full 40-character commit SHA. Branches, tags, and
+abbreviated SHAs are rejected. `update` keeps the recorded source, `repair`
+reapplies it, and `remove` changes only files owned by the CLI.
 
-In an interactive terminal, `add` without `--target` detects supported clients.
-One detected client is selected automatically. With several clients, the CLI
-shows a multi-select with all detected clients selected by default; press Enter
-to keep all of them. Scripts and CI must choose explicitly, for example
-`--target claude,gemini,opencode`. `add`, `update`, `repair`, and `remove` accept
-the same comma-separated syntax.
+## Safety and verification
 
-Detection checks installed executables and documented configuration surfaces.
-It does not start an agent, log in, complete OAuth, or prove browser/tool
-runtime behavior.
+Every operation validates the package and preflights all selected agents before
+changing managed files. Multi-agent failures roll back the CLI-owned changes or
+stop with a repair instruction. `--dry-run` prints the plan without writing.
+The CLI does not execute packages during search and sends no installation
+telemetry.
 
-The following matrix describes historical lifecycle evidence collected for
-installer 0.1.22. It is not evidence for the current npm release. The exact
-package, source revisions, commands, and limitations are recorded in the
-[commit-pinned historical client E2E evidence](https://github.com/777genius/plugin-kit-ai/blob/4b25a45e1574bab7a4f49e48905a3b3b2647e917/docs/AGENTPLUGINS_CLIENT_E2E.md).
+The npm package has no `postinstall`. On first execution it downloads the exact
+versioned Go binary for macOS, Linux, or Windows, verifies its embedded SHA-256,
+and caches it locally. Native release tests cover x64 and arm64 on all three
+operating systems.
 
-| Client | Evidence |
-| --- | --- |
-| Claude Code | Claude Code 2.1.205: real isolated exact-SHA `add`, native list, `repair`, safe update preflight, and `remove` lifecycle |
-| Gemini CLI | Gemini CLI 0.36.0: real isolated configuration and the same exact-source lifecycle |
-| OpenCode | OpenCode 1.18.4: real isolated configuration and the same exact-source lifecycle |
-| Cline | Real locally detected client; isolated native configuration and exact-source lifecycle; no client runtime or login |
-| Windsurf | Real locally detected configuration and exact-source lifecycle; no client runtime or login |
+- [Source and documentation](https://github.com/777genius/universal-agent-plugins)
+- [Browse the registry](https://777genius.github.io/universal-agent-plugins-registry/)
+- [Client E2E evidence](https://github.com/777genius/universal-agent-plugins/blob/main/docs/AGENTPLUGINS_CLIENT_E2E.md)
 
-`repair` reapplies or reactivates the recorded revision; it does not update or
-change source. `switch` moves the complete installation to a qualified
-Directory distribution or exact source, so it uses `--to` instead of
-`--target`.
-
-`search` combines reviewed Directory releases with a separately signed
-Discovery Index. Discovery results remain visibly unreviewed and use an exact,
-publisher-qualified selector such as `discovery:owner/repo//path`. Before any
-mutation, the CLI reacquires the indexed commit and validates the package. The
-index signature authenticates discovery metadata; it does not endorse package
-code or runtime behavior. `outdated` is read-only. `update --all` preserves each
-installation's recorded source and targets and performs a complete batch
-preflight before applying updates.
-
-A successful non-dry-run, multi-target `add --format json` includes one
-`data.acquisition` proof and a `data.target_outcomes` object keyed by every
-requested target. The acquisition count is exactly one and every passed target
-binds the same acquisition ID, validated tree digest, manifest digest, and
-closure digest. `fetched` is true only for a remote GitHub or Directory source;
-`source_kind` distinguishes `github`, `directory`, and `local` acquisitions.
-The closure digest is SHA-256 over the length-prefixed tuple of source kind,
-repository, package subpath, resolved revision, tree digest, and manifest
-digest, prefixed by the domain `agentplugins/grouped-acquisition-closure/v1`.
-The domain is itself the first length-prefixed field. The digest excludes
-requested and canonical source strings so local paths and
-host-specific data never enter the public proof. Dry runs omit this completed
-proof, and failed or partial group outcomes never label every target `passed`.
-
-Short names resolve through the signed
-[Universal Agent Plugins Directory](https://github.com/777genius/universal-agent-plugins).
-The CLI shows the selected immutable release, publisher, source, and verification
-status before installation. A community bridge remains clearly attributed and
-is not presented as its upstream publisher. You can also install a valid package
-directly from a local directory or exact GitHub source without Directory
-submission:
-
-```bash
-npx universal-agent-plugins add ./my-plugin --target cursor
-npx universal-agent-plugins add owner/repo@0123456789abcdef0123456789abcdef01234567//plugins/my-plugin --target cursor
-```
-
-Replace `0123456789abcdef0123456789abcdef01234567` with the full lowercase
-40-character commit SHA you reviewed. A branch, tag, abbreviated SHA, or the
-word `commit` is not accepted.
-
-For Agent Plugins 1.0, the root `plugin.json` is the install authority and may
-reference standard components such as `mcp.json` and `skills/`. `plugin.yaml`
-is legacy authoring input only. It cannot be merged with or silently override a
-`plugin.json`; changing a legacy package format is a separate explicit action.
-
-Every operation validates the source and preflights all affected targets before
-changing managed files or state. `--dry-run` prints the same plan without
-writing. Managed changes are staged and committed together; on failure the CLI
-rolls back what it can prove it owns, or preserves the safe state and prints a
-repair action. Observed unowned entries fail closed before mutation. Portable
-filesystems cannot provide a linearizable content compare-and-swap against a
-non-cooperating client that writes in the final syscall-sized window, so the CLI
-rechecks and reports identity conflicts instead of promising impossible
-concurrency isolation.
-
-Activation is reported per client. The CLI completes supported automatic steps;
-when a client requires its UI, it reports `prepared` or manual activation and
-prints the next action. OAuth and consent prompts remain visible and
-user-controlled. Cancelling keeps the package and reports authentication as
-pending or cancelled rather than runtime success. Directory badges and status
-describe only the exact schema, materialization, discovery, runtime, or OAuth
-evidence collected—not every plugin/client/environment combination.
-
-Kiro skills are installed directly into the documented global skills path.
-For packages with MCP servers, agentplugins atomically merges only its owned
-entries into Kiro's global `mcp.json`, preserves unrelated configuration, and
-uses a complete supported Kiro CLI distribution for a bounded structured ACP
-v1 initialize/session handshake. The handshake supplies no MCP definitions and
-sends no prompt, model turn, tool call, or permission response: Kiro must load
-the installed native configuration and report each planned server connected
-with enabled tools. The verifier keeps ACP stdin open while it drains a bounded
-quiet settlement window, and rejects EOF, partial, contradictory, or malformed
-protocol evidence before supervised containment stops and reaps the long-lived
-child. Automatic Kiro ACP verification is available only on Linux after
-capability preflight proves delegated cgroup v2 creation, atomic
-CLONE_INTO_CGROUP placement, and cgroup.kill. macOS, Windows, and Linux hosts
-without every required proof fail preflight before any MCP mutation. On those
-hosts, use Kiro's documented manual skill and MCP configuration paths; that
-workflow is outside this
-automatic CLI path. Failure to start ACP after a supported preflight may still
-leave a manual verification action. This proves session loading, not runtime
-tool end-to-end behavior. Once ACP starts, companion-launch
-failure (including a missing `kiro-cli-chat`), EOF, timeout, authentication
-failure, malformed or partial output, contradiction, and non-clean exit are
-authoritative activation failures; managed state stays committed for explicit
-repair and is never reported active.
+Universal Agent Plugins is an independent community project. It is not
+affiliated with OpenAI, Agent Plugins, or the supported client vendors.

--- a/npm/agentplugins/test/documentation-contract.test.js
+++ b/npm/agentplugins/test/documentation-contract.test.js
@@ -68,6 +68,11 @@ test("public Agentplugins documentation keeps copyable commands within the CLI c
     const markdown = fs.readFileSync(filename, "utf8");
     const commands = bashCommands(markdown).filter((command) => command.startsWith("npx universal-agent-plugins "));
     assert.ok(commands.length > 0, `${label} has no copyable universal-agent-plugins commands`);
+    assert.equal(
+      commands[0],
+      "npx universal-agent-plugins add context7",
+      `${label}: the first command must keep the no-target interactive quick start`
+    );
 
     for (const command of commands) {
       assert.doesNotMatch(command, /(?:^|\s)--yes(?:\s|$)/, `${label}: --yes is not a public option`);
@@ -86,46 +91,38 @@ test("public Agentplugins documentation keeps copyable commands within the CLI c
       }
     }
 
-    for (const verb of ["add", "update", "repair", "remove", "switch"]) {
+    for (const verb of ["add", "update", "repair", "remove"]) {
       assert.ok(commands.some((command) => command.startsWith(`npx universal-agent-plugins ${verb} `)), `${label}: missing ${verb} example`);
-    }
-    for (const command of commands.filter((value) => value.startsWith("npx universal-agent-plugins switch "))) {
-      assert.ok(commandArgument(command, "--to"), `${label}: switch example requires --to`);
-      assert.equal(commandArgument(command, "--target"), "", `${label}: switch must not use --target`);
     }
     assert.ok(commands.some((command) => command.includes("--target codex,cursor,kiro")), `${label}: missing explicit three-target example`);
   }
 });
 
-test("public documentation states the facade and engine ownership boundary", () => {
-  const packaged = fs.readFileSync(documents[1][1], "utf8");
-  const boundaryDocuments = [["npm README", packaged]];
-  if (fs.existsSync(documents[0][1])) {
-    boundaryDocuments.unshift(["root README", fs.readFileSync(documents[0][1], "utf8")]);
-  }
-  for (const [label, markdown] of boundaryDocuments) {
-    assert.match(markdown, /product home[\s\S]{0,100}(?:npm facade|facade source)/i, `: facade product ownership missing`);
-    assert.match(markdown, /plugin-kit-ai[\s\S]{0,180}(?:Go implementation engine|implementation engine)/i, `: implementation engine ownership missing`);
-    assert.match(markdown, /not duplicated/i, `: no-duplicate-engine boundary missing`);
-    assert.match(markdown, /installs? the `agentplugins` binary/i, `: installed binary identity missing`);
-  }
+test("public package documentation points to the authoritative product source", () => {
+  const markdown = fs.readFileSync(documents[1][1], "utf8");
+  assert.match(markdown, /https:\/\/github\.com\/777genius\/universal-agent-plugins(?:\)|\b)/i);
+  assert.match(markdown, /versioned Go binary/i);
+  assert.doesNotMatch(markdown, /product home[\s\S]{0,100}(?:npm facade|facade source)/i);
 });
 
-test("package documentation labels client evidence historical and commit-pins its source", () => {
+test("package documentation links current client evidence without stale release claims", () => {
   const markdown = fs.readFileSync(documents[1][1], "utf8");
-  assert.match(markdown, /historical lifecycle evidence collected for[\s\S]{0,80}0\.1\.22/i);
-  assert.match(markdown, /not evidence for the current npm release/i);
-  assert.match(markdown, /https:\/\/github\.com\/777genius\/plugin-kit-ai\/blob\/4b25a45e1574bab7a4f49e48905a3b3b2647e917\/docs\/AGENTPLUGINS_CLIENT_E2E\.md/);
-  assert.doesNotMatch(markdown, /plugin-kit-ai\/blob\/(?:main|master)\/docs\/AGENTPLUGINS_CLIENT_E2E\.md/);
+  assert.match(markdown, /https:\/\/github\.com\/777genius\/universal-agent-plugins\/blob\/main\/docs\/AGENTPLUGINS_CLIENT_E2E\.md/);
+  assert.doesNotMatch(markdown, /historical lifecycle evidence collected for/i);
+  assert.doesNotMatch(markdown, /0\.1\.22/);
 });
 
 test("copyable direct-source examples use a marked replacement full SHA", () => {
   const placeholder = "0123456789abcdef0123456789abcdef01234567";
   for (const [label, filename] of [documents[1]]) {
     const markdown = fs.readFileSync(filename, "utf8");
-    assert.ok(markdown.includes(`owner/repo@${placeholder}//plugins/my-plugin`), `${label}: full-SHA source example missing`);
-    assert.ok(markdown.includes("add ./my-plugin --target cursor"), `${label}: local source example missing`);
-    assert.match(markdown, new RegExp(`replace[\\s\\S]{0,180}${placeholder}|${placeholder}[\\s\\S]{0,180}replace`, "i"), `${label}: SHA replacement instruction missing`);
+    assert.match(
+      markdown,
+      new RegExp(`[A-Za-z0-9-]+/[A-Za-z0-9._-]+@${placeholder}//[A-Za-z0-9._/-]+`),
+      `${label}: full-SHA source example missing`
+    );
+    assert.ok(markdown.includes("add ./my-plugin"), `${label}: local source example missing`);
+    assert.match(markdown, /full 40-character commit SHA/i, `${label}: full-SHA replacement instruction missing`);
     assert.doesNotMatch(markdown, /@commit(?:\/\/|\b)/i, `${label}: literal @commit is not copyable`);
   }
 });


### PR DESCRIPTION
## Summary

- make the first install command interactive and target-free
- explain agent detection and multi-selection in plain language
- move advanced lifecycle and direct-source commands below the onboarding flow
- keep documentation contract tests aligned with the public UX

## Verification

- npm --prefix npm/agentplugins test
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the CLI quick start to use interactive installation without requiring a target.
  - Documented automatic agent detection, per-agent installation, download verification, and available commands.
  - Added guidance for local packages and remote installations using full 40-character commit SHAs.
  - Clarified that `plugin.json` determines installation and that installation telemetry is not sent.
  - Added a link to browse more than 2,500 plugins and refreshed client evidence references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->