### PR TITLE
fix(npm): tolerate registry metadata propagation

### DIFF
--- a/.github/workflows/agentplugins-npm-publish.yml
+++ b/.github/workflows/agentplugins-npm-publish.yml
@@ -188,10 +188,19 @@ jobs:
           export HOME="${root}/home" USERPROFILE="${root}/home" XDG_CONFIG_HOME="${root}/config" XDG_CACHE_HOME="${root}/cache" AGENTPLUGINS_HOME="${root}/state" AGENTPLUGINS_CACHE_DIR="${root}/binary-cache" NPM_CONFIG_CACHE="${root}/npm-cache" NPM_CONFIG_USERCONFIG="${root}/home/.npmrc" TMPDIR="${root}/tmp" GIT_CONFIG_GLOBAL="${root}/home/.gitconfig" GIT_CONFIG_NOSYSTEM=1 GIT_TERMINAL_PROMPT=0
           printf '%s\n' 'registry=https://registry.npmjs.org/' > "${NPM_CONFIG_USERCONFIG}"
           cd "${root}/project"
-          npm install --ignore-scripts --no-audit --no-fund --save-exact "${PACKAGE_NAME}@${VERSION}"
+          for attempt in 1 2 3 4 5; do
+            if npm install --ignore-scripts --no-audit --no-fund --save-exact "${PACKAGE_NAME}@${VERSION}"; then
+              break
+            fi
+            if [[ "${attempt}" == 5 ]]; then
+              echo "published npm version was not readable after bounded retries" >&2
+              exit 1
+            fi
+            sleep "$((attempt * 2))"
+          done
           npm view "${PACKAGE_NAME}@${VERSION}" --json > "${root}/metadata.json"
-          integrity="$(jq -er '.dist.integrity' "${root}/metadata.json")"
-          shasum="$(jq -er '.dist.shasum' "${root}/metadata.json")"
+          integrity="$(jq -er 'if type == "array" and length == 1 then .[0].dist.integrity elif type == "object" then .dist.integrity else error("expected one metadata record") end' "${root}/metadata.json")"
+          shasum="$(jq -er 'if type == "array" and length == 1 then .[0].dist.shasum elif type == "object" then .dist.shasum else error("expected one metadata record") end' "${root}/metadata.json")"
           test "${integrity}" = "${TARBALL_INTEGRITY}"; test "${shasum}" = "${TARBALL_SHASUM}"
           node "${GITHUB_WORKSPACE}/npm/agentplugins/scripts/npm-public-contract.js" metadata "${root}/metadata.json" "${VERSION}" "${integrity}" "${shasum}"
           npm audit signatures --json --include-attestations > "${root}/audit.json"

--- a/npm/agentplugins/scripts/npm-public-contract.js
+++ b/npm/agentplugins/scripts/npm-public-contract.js
@@ -65,6 +65,12 @@ function validatePackJSON(value, version) {
 
 function validatePublicMetadata(metadata, version, integrity, shasum) {
   validateExpected(version, integrity, shasum);
+  if (Array.isArray(metadata)) {
+    if (metadata.length !== 1) {
+      fail("public npm metadata must contain exactly one release record");
+    }
+    [metadata] = metadata;
+  }
   if (!metadata || metadata.name !== PACKAGE_NAME || metadata.version !== version) {
     fail("public npm name/version does not match the package contract");
   }

--- a/npm/agentplugins/test/npm-public-contract.test.js
+++ b/npm/agentplugins/test/npm-public-contract.test.js
@@ -105,6 +105,18 @@ test("public npm metadata and downloaded pack bind the staged package identity",
   const value = fixture();
   assert.equal(validatePackJSON(value.pack, value.version), value.pack[0]);
   assert.equal(validatePublicMetadata(value.metadata, value.version, value.integrity, value.shasum), value.metadata);
+  assert.equal(
+    validatePublicMetadata([value.metadata], value.version, value.integrity, value.shasum),
+    value.metadata
+  );
+  assert.throws(
+    () => validatePublicMetadata([], value.version, value.integrity, value.shasum),
+    /exactly one release record/
+  );
+  assert.throws(
+    () => validatePublicMetadata([value.metadata, value.metadata], value.version, value.integrity, value.shasum),
+    /exactly one release record/
+  );
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "npm-public-contract-"));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
   fs.writeFileSync(path.join(root, value.pack[0].filename), value.body);


### PR DESCRIPTION
## What changed

- accept npm 12's one-record array response for exact-version metadata
- keep the public metadata contract fail-closed for zero or multiple records
- retry the exact public install for a bounded 20 seconds while npm CDN metadata propagates

## Why

The `0.1.41` package was successfully published through npm Trusted Publisher with provenance, but the post-publish job first saw the normal registry propagation delay and then npm 12 returned exact-version metadata as a one-element array. The package and provenance were valid; the verifier rejected the response shape.

## Verification

- `git diff --check`
- `npm --prefix npm/agentplugins test` (53 passed, 2 platform skips, 0 failed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package verification reliability by retrying installations when published packages are temporarily unavailable.
  * Added support for multiple valid npm metadata response formats.
  * Improved validation for metadata returned as a single-record array, while rejecting empty or multi-record arrays.

* **Tests**
  * Expanded coverage for npm metadata formats and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->