### PR TITLE
fix(npm): accept public publisher metadata shape

### DIFF
--- a/npm/agentplugins/scripts/npm-public-contract.js
+++ b/npm/agentplugins/scripts/npm-public-contract.js
@@ -96,16 +96,25 @@ function validatePublicMetadata(metadata, version, integrity, shasum) {
     url: expectedAttestation,
     provenance: { predicateType: "https://slsa.dev/provenance/v1" }
   }, "public npm attestation URL and provenance predicate");
-  exactKeys(metadata._npmUser, ["name", "email", "trustedPublisher"], "public npm publisher identity");
-  if (metadata._npmUser.name !== "GitHub Actions" ||
-      metadata._npmUser.email !== "npm-oidc-no-reply@github.com") {
-    fail("public npm publisher identity is not GitHub Actions");
-  }
-  const publisher = metadata._npmUser?.trustedPublisher;
-  exactKeys(publisher, ["id", "oidcConfigId"], "public npm trusted publisher");
-  if (publisher.id !== "github" ||
-      !/^oidc:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(publisher.oidcConfigId)) {
-    fail("public npm trusted publisher is not an exact GitHub Actions OIDC identity");
+  if (typeof metadata._npmUser === "string") {
+    // The public npm registry currently flattens the publisher object to this
+    // exact display string. OIDC/workflow identity is verified by the signed
+    // provenance checks below, not by fields the registry does not expose.
+    if (metadata._npmUser !== "GitHub Actions <npm-oidc-no-reply@github.com>") {
+      fail("public npm publisher identity is not GitHub Actions");
+    }
+  } else {
+    exactKeys(metadata._npmUser, ["name", "email", "trustedPublisher"], "public npm publisher identity");
+    if (metadata._npmUser.name !== "GitHub Actions" ||
+        metadata._npmUser.email !== "npm-oidc-no-reply@github.com") {
+      fail("public npm publisher identity is not GitHub Actions");
+    }
+    const publisher = metadata._npmUser?.trustedPublisher;
+    exactKeys(publisher, ["id", "oidcConfigId"], "public npm trusted publisher");
+    if (publisher.id !== "github" ||
+        !/^oidc:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(publisher.oidcConfigId)) {
+      fail("public npm trusted publisher is not an exact GitHub Actions OIDC identity");
+    }
   }
   return metadata;
 }

--- a/npm/agentplugins/test/npm-public-contract.test.js
+++ b/npm/agentplugins/test/npm-public-contract.test.js
@@ -109,6 +109,12 @@ test("public npm metadata and downloaded pack bind the staged package identity",
     validatePublicMetadata([value.metadata], value.version, value.integrity, value.shasum),
     value.metadata
   );
+  const publicStringPublisher = JSON.parse(JSON.stringify(value.metadata));
+  publicStringPublisher._npmUser = "GitHub Actions <npm-oidc-no-reply@github.com>";
+  assert.equal(
+    validatePublicMetadata(publicStringPublisher, value.version, value.integrity, value.shasum),
+    publicStringPublisher
+  );
   assert.throws(
     () => validatePublicMetadata([], value.version, value.integrity, value.shasum),
     /exactly one release record/
@@ -116,6 +122,10 @@ test("public npm metadata and downloaded pack bind the staged package identity",
   assert.throws(
     () => validatePublicMetadata([value.metadata, value.metadata], value.version, value.integrity, value.shasum),
     /exactly one release record/
+  );
+  assert.throws(
+    () => validatePublicMetadata({ ...publicStringPublisher, _npmUser: "Unknown <unknown@example.com>" }, value.version, value.integrity, value.shasum),
+    /publisher identity is not GitHub Actions/
   );
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "npm-public-contract-"));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));


### PR DESCRIPTION
## What changed

- accept npm's public `_npmUser` display string while retaining the exact GitHub Actions identity check
- keep the richer object-shaped contract for registries that expose trusted publisher fields
- add positive and negative coverage for both public shapes

## Why

The exact `0.1.42` package and OIDC provenance published successfully, but npm's public metadata exposes `_npmUser` as `GitHub Actions <npm-oidc-no-reply@github.com>`, not the internal object used by the original fixture. The verifier therefore failed before lifecycle checks.

## Verification

- `git diff --check`
- `npm --prefix npm/agentplugins test` (53 passed, 2 platform skips, 0 failed)
