### PR TITLE
test(npm): provision synthetic client surfaces

### DIFF
--- a/.github/workflows/agentplugins-npm-publish.yml
+++ b/.github/workflows/agentplugins-npm-publish.yml
@@ -182,17 +182,17 @@ jobs:
           npm install --global npm@12.0.2
           test "$(npm --version)" = "12.0.2"
           root="${RUNNER_TEMP}/agentplugins-public-e2e"
-          mkdir -p "${root}/project" "${root}/home" "${root}/tmp" "${root}/synthetic" "${root}/packed"
+          mkdir -p "${root}/project" "${root}/home" "${root}/home/.codex" "${root}/home/.cursor" "${root}/home/.kiro" "${root}/tmp" "${root}/synthetic" "${root}/packed"
           printf '%s\n' '{' '  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",' '  "name": "npm-public-proof",' '  "version": "1.0.0",' '  "description": "Synthetic package used only by isolated npm release CI"' '}' > "${root}/synthetic/plugin.json"
           printf '%s\n' '{"name":"npm-public-proof-project","version":"1.0.0","private":true}' > "${root}/project/package.json"
           export HOME="${root}/home" USERPROFILE="${root}/home" XDG_CONFIG_HOME="${root}/config" XDG_CACHE_HOME="${root}/cache" AGENTPLUGINS_HOME="${root}/state" AGENTPLUGINS_CACHE_DIR="${root}/binary-cache" NPM_CONFIG_CACHE="${root}/npm-cache" NPM_CONFIG_USERCONFIG="${root}/home/.npmrc" TMPDIR="${root}/tmp" GIT_CONFIG_GLOBAL="${root}/home/.gitconfig" GIT_CONFIG_NOSYSTEM=1 GIT_TERMINAL_PROMPT=0
           printf '%s\n' 'registry=https://registry.npmjs.org/' > "${NPM_CONFIG_USERCONFIG}"
           cd "${root}/project"
-          for attempt in 1 2 3 4 5; do
+          for attempt in 1 2 3 4 5 6 7 8; do
             if npm install --ignore-scripts --no-audit --no-fund --save-exact "${PACKAGE_NAME}@${VERSION}"; then
               break
             fi
-            if [[ "${attempt}" == 5 ]]; then
+            if [[ "${attempt}" == 8 ]]; then
               echo "published npm version was not readable after bounded retries" >&2
               exit 1
             fi


### PR DESCRIPTION
## Summary\n- create isolated Codex, Cursor, and Kiro config roots before the public lifecycle proof\n- extend the bounded npm CDN propagation retry window\n\n## Verification\n- npm --prefix npm/agentplugins test\n- git diff --check