### PR TITLE
docs(e2e): record signed discovery closure

### DIFF
--- a/docs/E2E_AND_COMPETITIVE_LAUNCH_PLAN.md
+++ b/docs/E2E_AND_COMPETITIVE_LAUNCH_PLAN.md
@@ -14,6 +14,8 @@ one place.
 | npm release | npm workflow `33792693406` | Prepare, OIDC publish, and public verification passed |
 | Public package | `universal-agent-plugins@0.1.44` | `latest` points to `0.1.44` |
 | Lifecycle | Isolated synthetic package in release CI | `add`, `info`, `update`, and `remove` passed for Codex, Cursor, and Kiro |
+| Discovery | Signed production snapshot, sequence 30 | `2,875` records; exact production verification passed |
+| Directory site | GitHub Pages production URL | HTTP 200 and the search UI loaded successfully |
 | Documentation | Root and npm READMEs | Target-free one-command quick start is published |
 
 The npm package is published by GitHub Actions with npm Trusted Publisher
@@ -36,6 +38,8 @@ The exact CI evidence is available from the repository's Actions history:
 - [native release run 33791852212](https://github.com/777genius/universal-agent-plugins/actions/runs/33791852212)
 - [npm publish run 33792693406](https://github.com/777genius/universal-agent-plugins/actions/runs/33792693406)
 - [release `agentplugins-v0.1.44`](https://github.com/777genius/universal-agent-plugins/releases/tag/agentplugins-v0.1.44)
+- [signed Discovery run 33791156432](https://github.com/777genius/universal-agent-plugins-registry/actions/runs/33791156432)
+- [public Directory](https://777genius.github.io/universal-agent-plugins-registry/)
 
 ## Scope and honest limits
 


### PR DESCRIPTION
## Summary\n- record signed Discovery sequence 30 and its 2,875 production records\n- link the production Pages smoke and signed Discovery run\n\n## Validation\n- git diff --check\n- read-only HTTP 200 Pages smoke\n- public CLI search returned signed Discovery results\n\nDocumentation-only; no runtime, package, or release workflow changes.