### PR TITLE
feat(agentplugins): add native CLI installers

### DIFF
--- a/.github/workflows/agentplugins-native-install.yml
+++ b/.github/workflows/agentplugins-native-install.yml
@@ -1,0 +1,106 @@
+name: Native Installer
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - install.sh
+      - install.ps1
+      - repotests/agentplugins_native_install_integration_test.go
+      - .github/workflows/agentplugins-native-install.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - install.sh
+      - install.ps1
+      - repotests/agentplugins_native_install_integration_test.go
+      - .github/workflows/agentplugins-native-install.yml
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Published Agentplugins version to install
+        required: true
+        default: 0.1.44
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: agentplugins-native-installer-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unix:
+    name: native install (${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: darwin-amd64
+            runner: macos-15-intel
+          - target: darwin-arm64
+            runner: macos-15
+          - target: linux-amd64
+            runner: ubuntu-24.04
+          - target: linux-arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install the published native binary without Node.js
+        env:
+          AGENTPLUGINS_VERSION: ${{ inputs.version || '0.1.44' }}
+          AGENTPLUGINS_BIN_DIR: ${{ runner.temp }}/agentplugins-bin
+          AGENTPLUGINS_OUTPUT_FILE: ${{ runner.temp }}/agentplugins-install.outputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          sh ./install.sh version | tee "${RUNNER_TEMP}/installer-output.txt"
+          expected="${AGENTPLUGINS_VERSION#agentplugins-v}"
+          expected="${expected#v}"
+          test "$("${AGENTPLUGINS_BIN_DIR}/agentplugins" version)" = "agentplugins ${expected}"
+          grep -Fx "version=${expected}" "${AGENTPLUGINS_OUTPUT_FILE}"
+          grep -Fx "path=${AGENTPLUGINS_BIN_DIR}/agentplugins" "${AGENTPLUGINS_OUTPUT_FILE}"
+          grep -Eq '^sha256=[0-9a-f]{64}$' "${AGENTPLUGINS_OUTPUT_FILE}"
+
+  windows:
+    name: native install (${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: windows-amd64
+            runner: windows-2025
+          - target: windows-arm64
+            runner: windows-11-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install the published native binary without Node.js
+        shell: pwsh
+        env:
+          AGENTPLUGINS_OUTPUT_FILE: ${{ runner.temp }}\agentplugins-install.outputs
+        run: |
+          $version = "${{ inputs.version || '0.1.44' }}"
+          $resolvedVersion = $version -replace '^agentplugins-v', '' -replace '^v', ''
+          $binDir = Join-Path "${{ runner.temp }}" "agentplugins-bin"
+          & ./install.ps1 -Version $version -BinDir $binDir -Command "version"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $observed = (& (Join-Path $binDir "agentplugins.exe") version | Out-String).Trim()
+          if ($observed -ne "agentplugins $resolvedVersion") {
+            throw "unexpected installed version: $observed"
+          }
+          $outputs = Get-Content -LiteralPath $env:AGENTPLUGINS_OUTPUT_FILE
+          if ($outputs -notcontains "version=$resolvedVersion") {
+            throw "installer output did not contain the exact version"
+          }
+          if (-not ($outputs | Where-Object { $_ -match '^sha256=[0-9a-f]{64}$' })) {
+            throw "installer output did not contain a valid SHA-256"
+          }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-required test-plugin-manifest-workflow test-install-compat test-extended test-polyglot-smoke test-live test-live-cli test-install-live test-gemini-live test-gemini-runtime test-gemini-runtime-live test-opencode-live test-opencode-cli-live test-opencode-tools-live test-opencode-mcp-live test-opencode-e2e-live test-cursor-live test-portable-mcp-live test-context7-live test-chrome-devtools-live test-atlassian-live test-cloudflare-live test-cloudflare-bindings-live test-cloudflare-docs-live test-cloudflare-observability-live test-cloudflare-radar-live test-heroku-live test-hubspot-crm-live test-hubspot-developer-live test-neon-live test-docker-hub-live test-notion-live test-e2e-live test-govulncheck-local test-security generated-check version-sync-check removed-contract-boundary-check release-gate release-rehearsal build-plugin-kit-ai vet
+.PHONY: test test-required test-agentplugins-native-install test-plugin-manifest-workflow test-install-compat test-extended test-polyglot-smoke test-live test-live-cli test-install-live test-gemini-live test-gemini-runtime test-gemini-runtime-live test-opencode-live test-opencode-cli-live test-opencode-tools-live test-opencode-mcp-live test-opencode-e2e-live test-cursor-live test-portable-mcp-live test-context7-live test-chrome-devtools-live test-atlassian-live test-cloudflare-live test-cloudflare-bindings-live test-cloudflare-docs-live test-cloudflare-observability-live test-cloudflare-radar-live test-heroku-live test-hubspot-crm-live test-hubspot-developer-live test-neon-live test-docker-hub-live test-notion-live test-e2e-live test-govulncheck-local test-security generated-check version-sync-check removed-contract-boundary-check release-gate release-rehearsal build-plugin-kit-ai vet
 
 GOCACHE ?= /tmp/plugin-kit-ai-gocache
 export GOCACHE
@@ -18,6 +18,9 @@ test-required:
 	go test -count=1 -timeout=$(REQUIRED_TEST_TIMEOUT) ./install/plugininstall/...
 	go test -count=1 -timeout=$(REQUIRED_TEST_TIMEOUT) ./sdk/...
 	cd npm/agentplugins && npm test && npm pack --dry-run --ignore-scripts
+
+test-agentplugins-native-install:
+	go test -count=1 -run '^TestAgentpluginsNativeInstaller' ./repotests
 
 test-plugin-manifest-workflow:
 	go test -count=1 -run 'TestPluginKitAI(ValidateWarnsButSucceedsOnExtraPluginYAMLFields|ValidateStrictFailsOnWarningsThenNormalizeFixesThem|ImportPrintsWarningsForIgnoredAssets|MigrationFixtures_RoundTripToStrictValidation)$$' ./repotests

--- a/README.md
+++ b/README.md
@@ -8,17 +8,40 @@
 
 Install and manage Agent Plugins 1.0 across your AI agents with one CLI.
 
+## Quick start
+
+The native Go CLI does not require Node.js. Install it and add Context7 in one
+command on macOS or Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.sh | sh -s -- add context7
+```
+
+On Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.ps1 | iex
+& "$HOME\.local\bin\agentplugins.exe" add context7
+```
+
+The installers select the native binary for your OS and architecture, verify its
+published SHA-256 and reported version, then replace the CLI atomically. They
+install into `$HOME/.local/bin` unless `AGENTPLUGINS_BIN_DIR` is set.
+
+If you already have Node.js 22 or newer, the npm facade remains the quickest
+zero-install alternative. It downloads and verifies the same Go binary:
+
 ```bash
 npx universal-agent-plugins add context7
 ```
 
+Node.js is not a requirement of the native CLI. Individual plugins may declare
+their own runtime requirements; the CLI checks those separately before
+installation.
+
 The CLI finds compatible agents installed on your computer and asks where to
 install the plugin. Choose one or several. The package is downloaded and
 verified once, then prepared for every agent you selected.
-
-## Quick start
-
-You need Node.js 22 or newer.
 
 1. Run the command above.
 2. Select the installed agents you want to use. If only one is found, it is
@@ -107,26 +130,26 @@ Use `--target` in scripts, CI, or whenever you want to name clients explicitly.
 
 ```bash
 # Find and inspect plugins
-npx universal-agent-plugins search docs
-npx universal-agent-plugins info context7
+agentplugins search docs
+agentplugins info context7
 
 # Install in specific agents
-npx universal-agent-plugins add context7 --target codex,cursor,kiro
+agentplugins add context7 --target codex,cursor,kiro
 
 # Manage an installed plugin
-npx universal-agent-plugins update context7 --target codex,cursor
-npx universal-agent-plugins repair context7 --target codex,cursor
-npx universal-agent-plugins remove context7 --target codex,cursor
-npx universal-agent-plugins outdated --all
-npx universal-agent-plugins update --all
-npx universal-agent-plugins doctor
+agentplugins update context7 --target codex,cursor
+agentplugins repair context7 --target codex,cursor
+agentplugins remove context7 --target codex,cursor
+agentplugins outdated --all
+agentplugins update --all
+agentplugins doctor
 
 # Install a local Agent Plugins 1.0 package
-npx universal-agent-plugins validate ./my-plugin
-npx universal-agent-plugins add ./my-plugin
+agentplugins validate ./my-plugin
+agentplugins add ./my-plugin
 
 # Install a GitHub package at an exact commit
-npx universal-agent-plugins add \
+agentplugins add \
   owner/repository@0123456789abcdef0123456789abcdef01234567//path/to/plugin
 ```
 
@@ -220,6 +243,7 @@ make vet
 - Contributing: CONTRIBUTING.md
 - Security policy: SECURITY.md
 - Support boundary: docs/SUPPORT.md
+- Native CLI installation: docs/NATIVE_INSTALL.md
 - Client E2E evidence: docs/AGENTPLUGINS_CLIENT_E2E.md
 - Registry: https://github.com/777genius/universal-agent-plugins-registry
 

--- a/docs/NATIVE_INSTALL.md
+++ b/docs/NATIVE_INSTALL.md
@@ -1,0 +1,87 @@
+# Native CLI installation
+
+`agentplugins` is a Go binary. The native installation path does not require
+Node.js, Python, npm, or pip.
+
+## macOS and Linux
+
+Install the latest published release and immediately run a command:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.sh \
+  | sh -s -- add context7
+```
+
+The default destination is `$HOME/.local/bin/agentplugins`. Set an explicit
+destination or version by downloading the installer first. Environment
+assignments before a pipeline are not portable to every shell, so this form is
+deliberately explicit:
+
+```bash
+curl -fsSLo /tmp/agentplugins-install.sh \
+  https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.sh
+AGENTPLUGINS_VERSION=0.1.44 AGENTPLUGINS_BIN_DIR="$HOME/bin" \
+  sh /tmp/agentplugins-install.sh
+```
+
+## Windows PowerShell
+
+```powershell
+irm https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.ps1 | iex
+& "$HOME\.local\bin\agentplugins.exe" add context7
+```
+
+Use the script directly for an explicit version or destination:
+
+```powershell
+Invoke-WebRequest `
+  https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.ps1 `
+  -OutFile "$env:TEMP\agentplugins-install.ps1"
+& "$env:TEMP\agentplugins-install.ps1" `
+  -Version 0.1.44 `
+  -BinDir "$HOME\bin"
+```
+
+## What the installer verifies
+
+The installer:
+
+1. accepts only stable `agentplugins-vX.Y.Z` release tags;
+2. selects the exact asset for the detected OS and architecture;
+3. requires exactly one matching entry in the release `checksums.txt`;
+4. verifies the downloaded binary's SHA-256;
+5. executes only `agentplugins version` and requires the exact release version;
+6. atomically replaces the destination only after all checks pass.
+
+Published release assets also carry GitHub artifact attestations. The release
+pipeline verifies those attestations independently before publishing the npm
+facade. The lightweight native installer intentionally requires only `curl`
+plus a standard SHA-256 utility on Unix, or PowerShell on Windows.
+
+## Pinning and automation
+
+Use `AGENTPLUGINS_VERSION` to avoid resolving `latest`:
+
+```bash
+AGENTPLUGINS_VERSION=0.1.44 sh ./install.sh
+```
+
+Automation can set `AGENTPLUGINS_OUTPUT_FILE`. The installer appends the exact
+version, tag, path, asset name, and verified SHA-256 as `key=value` records.
+
+Mirrors and GitHub Enterprise can override the repository, API base, and
+release host with `AGENTPLUGINS_REPOSITORY`, `AGENTPLUGINS_API_BASE`, and
+`AGENTPLUGINS_RELEASE_BASE_URL`.
+
+## Runtime requirements belong to plugins
+
+The manager itself has no Node.js dependency when installed natively. A plugin
+may still require Node.js, Python, a browser, or another executable. Those are
+package runtime requirements, not CLI installation requirements, and are
+reported during planning before the plugin is changed on disk.
+
+The npm facade remains available for users who prefer `npx`:
+
+```bash
+npx universal-agent-plugins add context7
+```

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,168 @@
+# Install the native agentplugins CLI from verified GitHub Release assets.
+# The CLI itself does not require Node.js. Individual plugins may.
+
+[CmdletBinding()]
+param(
+    [string]$Version = $(if ($env:AGENTPLUGINS_VERSION) { $env:AGENTPLUGINS_VERSION } else { "latest" }),
+    [string]$BinDir = $(if ($env:AGENTPLUGINS_BIN_DIR) { $env:AGENTPLUGINS_BIN_DIR } else { Join-Path $HOME ".local\bin" }),
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Command
+)
+
+$ErrorActionPreference = "Stop"
+$Repository = if ($env:AGENTPLUGINS_REPOSITORY) { $env:AGENTPLUGINS_REPOSITORY } else { "777genius/universal-agent-plugins" }
+$ApiBase = if ($env:AGENTPLUGINS_API_BASE) { $env:AGENTPLUGINS_API_BASE.TrimEnd("/") } else { "https://api.github.com" }
+$ReleaseHost = if ($env:AGENTPLUGINS_RELEASE_BASE_URL) {
+    $env:AGENTPLUGINS_RELEASE_BASE_URL.TrimEnd("/")
+} elseif ($ApiBase -eq "https://api.github.com") {
+    "https://github.com"
+} else {
+    $ApiBase -replace "/api/v3$", "" -replace "/api$", ""
+}
+
+function Fail([string]$Message) {
+    throw "agentplugins installer: $Message"
+}
+
+function Get-Headers {
+    $headers = @{ Accept = "application/vnd.github+json" }
+    if ($env:GITHUB_TOKEN) {
+        $headers.Authorization = "Bearer $($env:GITHUB_TOKEN)"
+    }
+    return $headers
+}
+
+function Normalize-Tag([string]$InputVersion) {
+    switch -Regex ($InputVersion) {
+        "^(|latest)$" { return "" }
+        "^agentplugins-v" { return $InputVersion }
+        "^v" { return "agentplugins-$InputVersion" }
+        default { return "agentplugins-v$InputVersion" }
+    }
+}
+
+function Assert-StableTag([string]$Tag) {
+    if ($Tag -notmatch '^agentplugins-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$') {
+        Fail "invalid stable version or tag: $Tag"
+    }
+}
+
+function Resolve-Architecture {
+    $architecture = if ($env:PROCESSOR_ARCHITEW6432) {
+        $env:PROCESSOR_ARCHITEW6432
+    } else {
+        $env:PROCESSOR_ARCHITECTURE
+    }
+    switch ($architecture.ToUpperInvariant()) {
+        "AMD64" { return "amd64" }
+        "X86_64" { return "amd64" }
+        "ARM64" { return "arm64" }
+        default { Fail "unsupported architecture: $architecture" }
+    }
+}
+
+function Invoke-Download([string]$Uri, [string]$OutFile) {
+    $parameters = @{
+        Uri = $Uri
+        OutFile = $OutFile
+        Headers = (Get-Headers)
+        MaximumRedirection = 10
+    }
+    if ($PSVersionTable.PSVersion.Major -le 5) {
+        $parameters["UseBasicParsing"] = $true
+    }
+    Invoke-WebRequest @parameters
+}
+
+$Tag = Normalize-Tag $Version
+if (-not $Tag) {
+    $latest = Invoke-RestMethod -Uri "$ApiBase/repos/$Repository/releases/latest" -Headers (Get-Headers)
+    $Tag = [string]$latest.tag_name
+    if (-not $Tag) {
+        Fail "latest release response did not contain tag_name"
+    }
+}
+Assert-StableTag $Tag
+$ResolvedVersion = $Tag.Substring("agentplugins-v".Length)
+$Architecture = Resolve-Architecture
+$AssetName = "agentplugins_${ResolvedVersion}_windows_${Architecture}.exe"
+$DownloadBase = "$ReleaseHost/$Repository/releases/download/$Tag"
+$TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("agentplugins-" + [Guid]::NewGuid().ToString("N"))
+$InstallTemp = $null
+
+New-Item -ItemType Directory -Path $TempRoot | Out-Null
+try {
+    $ChecksumsPath = Join-Path $TempRoot "checksums.txt"
+    $BinaryPath = Join-Path $TempRoot $AssetName
+    Invoke-Download "$DownloadBase/checksums.txt" $ChecksumsPath
+
+    $escapedAsset = [Regex]::Escape($AssetName)
+    $checksumLines = @(Get-Content -LiteralPath $ChecksumsPath | Where-Object { $_ -match "^[0-9a-f]{64}\s+$escapedAsset$" })
+    if ($checksumLines.Count -ne 1) {
+        Fail "checksums.txt must contain exactly one valid entry for $AssetName"
+    }
+    $hashMatch = [Regex]::Match($checksumLines[0], "^(?<hash>[0-9a-f]{64})\s+")
+    if (-not $hashMatch.Success) {
+        Fail "checksums.txt contains an invalid SHA-256 for $AssetName"
+    }
+    $ExpectedHash = $hashMatch.Groups["hash"].Value
+
+    Invoke-Download "$DownloadBase/$AssetName" $BinaryPath
+    if ((Get-Item -LiteralPath $BinaryPath).Length -le 0) {
+        Fail "downloaded binary is empty: $AssetName"
+    }
+    $ActualHash = (Get-FileHash -LiteralPath $BinaryPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($ActualHash -ne $ExpectedHash) {
+        Fail "checksum mismatch for $AssetName"
+    }
+
+    $ObservedVersion = (& $BinaryPath version 2>&1 | Out-String).Trim()
+    if ($LASTEXITCODE -ne 0 -or $ObservedVersion -ne "agentplugins $ResolvedVersion") {
+        Fail "downloaded binary reported unexpected version: $ObservedVersion"
+    }
+
+    New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
+    $Destination = Join-Path $BinDir "agentplugins.exe"
+    if (Test-Path -LiteralPath $Destination -PathType Container) {
+        Fail "install destination is a directory: $Destination"
+    }
+    $InstallTemp = Join-Path $BinDir (".agentplugins-" + [Guid]::NewGuid().ToString("N") + ".exe")
+    Copy-Item -LiteralPath $BinaryPath -Destination $InstallTemp
+    if (Test-Path -LiteralPath $Destination -PathType Leaf) {
+        [System.IO.File]::Replace($InstallTemp, $Destination, $null, $true)
+    } else {
+        [System.IO.File]::Move($InstallTemp, $Destination)
+    }
+    $InstallTemp = $null
+
+    Write-Output "Installed agentplugins $ResolvedVersion"
+    Write-Output "Path: $Destination"
+    Write-Output "SHA-256: $ActualHash"
+    if (($env:PATH -split [IO.Path]::PathSeparator) -notcontains $BinDir) {
+        Write-Output "PATH hint: add $BinDir to PATH"
+    }
+
+    if ($env:AGENTPLUGINS_OUTPUT_FILE) {
+        @(
+            "version=$ResolvedVersion"
+            "tag=$Tag"
+            "path=$Destination"
+            "asset=$AssetName"
+            "sha256=$ActualHash"
+        ) | Add-Content -LiteralPath $env:AGENTPLUGINS_OUTPUT_FILE
+    }
+
+    if ($Command.Count -gt 0) {
+        & $Destination @Command
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
+    }
+} finally {
+    if ($InstallTemp -and (Test-Path -LiteralPath $InstallTemp)) {
+        Remove-Item -LiteralPath $InstallTemp -Force
+    }
+    if (Test-Path -LiteralPath $TempRoot) {
+        Remove-Item -LiteralPath $TempRoot -Recurse -Force
+    }
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env sh
+# Install the native agentplugins CLI from verified GitHub Release assets.
+#
+# The CLI itself does not require Node.js. Individual plugins may declare their
+# own runtime requirements, which agentplugins reports before installation.
+#
+# Optional environment variables:
+#   AGENTPLUGINS_VERSION          version or tag (0.1.44, v0.1.44, or agentplugins-v0.1.44)
+#   AGENTPLUGINS_BIN_DIR          destination directory (default: $HOME/.local/bin)
+#   AGENTPLUGINS_REPOSITORY       owner/repo override for mirrors and tests
+#   AGENTPLUGINS_API_BASE         GitHub API base override
+#   AGENTPLUGINS_RELEASE_BASE_URL release host override
+#   AGENTPLUGINS_OUTPUT_FILE      optional key=value output file for automation
+#   GITHUB_TOKEN                  optional token for API and download rate limits
+#
+# Arguments are passed to the installed binary after installation:
+#   curl -fsSL https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.sh \
+#     | sh -s -- add context7
+
+set -eu
+
+REPOSITORY="${AGENTPLUGINS_REPOSITORY:-777genius/universal-agent-plugins}"
+API_BASE="${AGENTPLUGINS_API_BASE:-https://api.github.com}"
+RELEASE_BASE_URL="${AGENTPLUGINS_RELEASE_BASE_URL:-}"
+BIN_DIR="${AGENTPLUGINS_BIN_DIR:-${HOME:?HOME is required}/.local/bin}"
+VERSION_INPUT="${AGENTPLUGINS_VERSION:-latest}"
+OUTPUT_FILE="${AGENTPLUGINS_OUTPUT_FILE:-}"
+
+fail() {
+  echo "agentplugins installer: $*" >&2
+  exit 1
+}
+
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+http_fetch() {
+  url="$1"
+  output="$2"
+  if [ -n "${GITHUB_TOKEN:-}" ]; then
+    curl -fsSL --retry 3 --retry-delay 1 \
+      -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+      -H "Accept: application/vnd.github+json" \
+      "$url" -o "$output"
+  else
+    curl -fsSL --retry 3 --retry-delay 1 \
+      -H "Accept: application/vnd.github+json" \
+      "$url" -o "$output"
+  fi
+}
+
+http_fetch_stdout() {
+  url="$1"
+  if [ -n "${GITHUB_TOKEN:-}" ]; then
+    curl -fsSL --retry 3 --retry-delay 1 \
+      -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+      -H "Accept: application/vnd.github+json" \
+      "$url"
+  else
+    curl -fsSL --retry 3 --retry-delay 1 \
+      -H "Accept: application/vnd.github+json" \
+      "$url"
+  fi
+}
+
+detect_os() {
+  case "$(uname -s | tr '[:upper:]' '[:lower:]')" in
+    linux*) echo "linux" ;;
+    darwin*) echo "darwin" ;;
+    msys*|mingw*|cygwin*) echo "windows" ;;
+    *) fail "unsupported operating system: $(uname -s)" ;;
+  esac
+}
+
+detect_arch() {
+  case "$(uname -m | tr '[:upper:]' '[:lower:]')" in
+    x86_64|amd64) echo "amd64" ;;
+    arm64|aarch64) echo "arm64" ;;
+    *) fail "unsupported architecture: $(uname -m)" ;;
+  esac
+}
+
+normalize_tag() {
+  raw="$1"
+  case "$raw" in
+    ""|latest) echo "" ;;
+    agentplugins-v*) echo "$raw" ;;
+    v*) echo "agentplugins-$raw" ;;
+    *) echo "agentplugins-v$raw" ;;
+  esac
+}
+
+validate_tag() {
+  tag="$1"
+  printf '%s\n' "$tag" | grep -Eq '^agentplugins-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$' \
+    || fail "invalid stable version or tag: $tag"
+}
+
+latest_tag() {
+  api="$(printf '%s' "$API_BASE" | sed 's#/$##')/repos/${REPOSITORY}/releases/latest"
+  payload="$(http_fetch_stdout "$api")" || fail "failed to resolve the latest release"
+  tag="$(printf '%s' "$payload" | tr -d '\n' | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+  [ -n "$tag" ] || fail "latest release response did not contain tag_name"
+  echo "$tag"
+}
+
+derive_release_host() {
+  if [ -n "$RELEASE_BASE_URL" ]; then
+    printf '%s\n' "$(printf '%s' "$RELEASE_BASE_URL" | sed 's#/$##')"
+    return
+  fi
+  case "$API_BASE" in
+    https://api.github.com|https://api.github.com/) echo "https://github.com" ;;
+    *) printf '%s' "$API_BASE" | sed -E 's#/api/v3/?$##; s#/api/?$##; s#/$##' ;;
+  esac
+}
+
+file_sha256() {
+  file="$1"
+  if command_exists sha256sum; then
+    sha256sum "$file" | awk '{print $1}'
+  elif command_exists shasum; then
+    shasum -a 256 "$file" | awk '{print $1}'
+  elif command_exists openssl; then
+    openssl dgst -sha256 "$file" | awk '{print $NF}'
+  else
+    fail "no SHA-256 utility found; install sha256sum, shasum, or openssl"
+  fi
+}
+
+write_output() {
+  key="$1"
+  value="$2"
+  if [ -n "$OUTPUT_FILE" ]; then
+    printf '%s=%s\n' "$key" "$value" >>"$OUTPUT_FILE"
+  fi
+}
+
+command_exists curl || fail "curl is required"
+
+OS_NAME="$(detect_os)"
+ARCH_NAME="$(detect_arch)"
+TAG="$(normalize_tag "$VERSION_INPUT")"
+if [ -z "$TAG" ]; then
+  TAG="$(latest_tag)"
+fi
+validate_tag "$TAG"
+VERSION="${TAG#agentplugins-v}"
+
+SUFFIX=""
+if [ "$OS_NAME" = "windows" ]; then
+  SUFFIX=".exe"
+fi
+ASSET_NAME="agentplugins_${VERSION}_${OS_NAME}_${ARCH_NAME}${SUFFIX}"
+DOWNLOAD_BASE="$(derive_release_host)/${REPOSITORY}/releases/download/${TAG}"
+
+TEMP_ROOT="$(mktemp -d)"
+INSTALL_TEMP=""
+cleanup() {
+  if [ -n "$INSTALL_TEMP" ] && [ -e "$INSTALL_TEMP" ]; then
+    rm -f "$INSTALL_TEMP"
+  fi
+  rm -rf "$TEMP_ROOT"
+}
+trap cleanup EXIT HUP INT TERM
+
+CHECKSUMS_PATH="$TEMP_ROOT/checksums.txt"
+BINARY_PATH="$TEMP_ROOT/$ASSET_NAME"
+http_fetch "$DOWNLOAD_BASE/checksums.txt" "$CHECKSUMS_PATH" \
+  || fail "failed to download checksums.txt for ${REPOSITORY}@${TAG}"
+
+MATCHES="$(awk -v asset="$ASSET_NAME" '$2 == asset { print $1 }' "$CHECKSUMS_PATH")"
+MATCH_COUNT="$(printf '%s\n' "$MATCHES" | sed '/^$/d' | wc -l | tr -d ' ')"
+[ "$MATCH_COUNT" -eq 1 ] || fail "checksums.txt must contain exactly one entry for $ASSET_NAME"
+EXPECTED_SUM="$(printf '%s\n' "$MATCHES" | sed -n '1p')"
+printf '%s\n' "$EXPECTED_SUM" | grep -Eq '^[0-9a-f]{64}$' \
+  || fail "checksums.txt contains an invalid SHA-256 for $ASSET_NAME"
+
+http_fetch "$DOWNLOAD_BASE/$ASSET_NAME" "$BINARY_PATH" \
+  || fail "failed to download $ASSET_NAME"
+[ -s "$BINARY_PATH" ] || fail "downloaded binary is empty: $ASSET_NAME"
+ACTUAL_SUM="$(file_sha256 "$BINARY_PATH")"
+[ "$ACTUAL_SUM" = "$EXPECTED_SUM" ] || fail "checksum mismatch for $ASSET_NAME"
+chmod 0755 "$BINARY_PATH" 2>/dev/null || true
+
+OBSERVED_VERSION="$($BINARY_PATH version 2>&1)" \
+  || fail "downloaded binary failed its version check"
+[ "$OBSERVED_VERSION" = "agentplugins $VERSION" ] \
+  || fail "downloaded binary reported unexpected version: $OBSERVED_VERSION"
+
+mkdir -p "$BIN_DIR"
+DEST_NAME="agentplugins${SUFFIX}"
+DEST_PATH="$BIN_DIR/$DEST_NAME"
+[ ! -d "$DEST_PATH" ] || fail "install destination is a directory: $DEST_PATH"
+INSTALL_TEMP="$(mktemp "$BIN_DIR/.agentplugins.XXXXXX")"
+cp "$BINARY_PATH" "$INSTALL_TEMP"
+chmod 0755 "$INSTALL_TEMP" 2>/dev/null || true
+mv -f "$INSTALL_TEMP" "$DEST_PATH"
+INSTALL_TEMP=""
+
+echo "Installed agentplugins $VERSION"
+echo "Path: $DEST_PATH"
+echo "SHA-256: $ACTUAL_SUM"
+case ":${PATH:-}:" in
+  *":${BIN_DIR}:"*) ;;
+  *) echo "PATH hint: add $BIN_DIR to PATH" ;;
+esac
+
+write_output "version" "$VERSION"
+write_output "tag" "$TAG"
+write_output "path" "$DEST_PATH"
+write_output "asset" "$ASSET_NAME"
+write_output "sha256" "$ACTUAL_SUM"
+
+if [ "$#" -gt 0 ]; then
+  "$DEST_PATH" "$@"
+fi

--- a/npm/agentplugins/README.md
+++ b/npm/agentplugins/README.md
@@ -12,6 +12,9 @@ verified once, then prepared for every agent you selected.
 
 You need Node.js 22 or newer.
 
+To use the same native Go CLI without Node.js, run the verified installer from
+the [project README](https://github.com/777genius/universal-agent-plugins#quick-start).
+
 ## Quick start
 
 1. Run the command above.

--- a/npm/agentplugins/test/documentation-contract.test.js
+++ b/npm/agentplugins/test/documentation-contract.test.js
@@ -66,7 +66,9 @@ function commandArgument(command, flag) {
 test("public Agentplugins documentation keeps copyable commands within the CLI contract", () => {
   for (const [label, filename] of packagedDocuments()) {
     const markdown = fs.readFileSync(filename, "utf8");
-    const commands = bashCommands(markdown).filter((command) => command.startsWith("npx universal-agent-plugins "));
+    const commands = bashCommands(markdown).filter(
+      (command) => command.startsWith("npx universal-agent-plugins ") || command.startsWith("agentplugins ")
+    );
     assert.ok(commands.length > 0, `${label} has no copyable universal-agent-plugins commands`);
     assert.equal(
       commands[0],
@@ -92,10 +94,35 @@ test("public Agentplugins documentation keeps copyable commands within the CLI c
     }
 
     for (const verb of ["add", "update", "repair", "remove"]) {
-      assert.ok(commands.some((command) => command.startsWith(`npx universal-agent-plugins ${verb} `)), `${label}: missing ${verb} example`);
+      assert.ok(
+        commands.some(
+          (command) =>
+            command.startsWith(`npx universal-agent-plugins ${verb} `) ||
+            command.startsWith(`agentplugins ${verb} `)
+        ),
+        `${label}: missing ${verb} example`
+      );
     }
     assert.ok(commands.some((command) => command.includes("--target codex,cursor,kiro")), `${label}: missing explicit three-target example`);
   }
+});
+
+test("root documentation recommends the native Go installer without hiding npm", (t) => {
+  if (!fs.existsSync(documents[0][1])) {
+    t.skip("root README is intentionally absent from the detached npm package");
+    return;
+  }
+  const markdown = fs.readFileSync(documents[0][1], "utf8");
+  assert.match(markdown, /native Go CLI does not require Node\.js/i);
+  assert.match(
+    markdown,
+    /https:\/\/raw\.githubusercontent\.com\/777genius\/universal-agent-plugins\/main\/install\.sh/
+  );
+  assert.match(
+    markdown,
+    /https:\/\/raw\.githubusercontent\.com\/777genius\/universal-agent-plugins\/main\/install\.ps1/
+  );
+  assert.match(markdown, /npx universal-agent-plugins add context7/);
 });
 
 test("public package documentation points to the authoritative product source", () => {

--- a/repotests/agentplugins_native_install_integration_test.go
+++ b/repotests/agentplugins_native_install_integration_test.go
@@ -1,0 +1,235 @@
+package pluginkitairepo_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const nativeInstallerTestVersion = "9.8.7"
+
+type nativeInstallerRelease struct {
+	tag        string
+	assetName  string
+	asset      []byte
+	checksums  string
+	repository string
+}
+
+func TestAgentpluginsNativeInstallerInstallsLatestAndRunsCommand(t *testing.T) {
+	t.Parallel()
+	requireBindTests(t)
+	requireShellBootstrap(t)
+	if runtime.GOOS == "windows" {
+		t.Skip("the POSIX installer is covered by the cross-platform workflow on Windows")
+	}
+
+	assetName := nativeInstallerAssetName(nativeInstallerTestVersion)
+	asset := []byte(`#!/usr/bin/env sh
+if [ "${1:-}" = version ]; then
+  echo "agentplugins 9.8.7"
+  exit 0
+fi
+printf 'native test args:'
+for arg in "$@"; do printf ' [%s]' "$arg"; done
+printf '\n'
+`)
+	digest := sha256.Sum256(asset)
+	release := nativeInstallerRelease{
+		tag:        "agentplugins-v" + nativeInstallerTestVersion,
+		assetName:  assetName,
+		asset:      asset,
+		checksums:  fmt.Sprintf("%s  %s\n", hex.EncodeToString(digest[:]), assetName),
+		repository: "example/agentplugins",
+	}
+	server := newNativeInstallerReleaseServer(t, release)
+	t.Cleanup(server.Close)
+
+	root := t.TempDir()
+	binDir := filepath.Join(root, "bin")
+	outputFile := filepath.Join(root, "installer.outputs")
+	output := runNativeInstaller(t, server.URL, map[string]string{
+		"AGENTPLUGINS_BIN_DIR":     binDir,
+		"AGENTPLUGINS_OUTPUT_FILE": outputFile,
+	}, "add", "context7", "--dry-run")
+
+	installedPath := filepath.Join(binDir, "agentplugins")
+	installed, err := os.ReadFile(installedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(installed) != string(asset) {
+		t.Fatal("installed binary bytes differ from the verified release asset")
+	}
+	for _, expected := range []string{
+		"Installed agentplugins " + nativeInstallerTestVersion,
+		"Path: " + installedPath,
+		"SHA-256: " + hex.EncodeToString(digest[:]),
+		"native test args: [add] [context7] [--dry-run]",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("installer output missing %q:\n%s", expected, output)
+		}
+	}
+
+	outputs, err := os.ReadFile(outputFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []string{
+		"version=" + nativeInstallerTestVersion,
+		"tag=agentplugins-v" + nativeInstallerTestVersion,
+		"path=" + installedPath,
+		"asset=" + assetName,
+		"sha256=" + hex.EncodeToString(digest[:]),
+	} {
+		if !strings.Contains(string(outputs), expected) {
+			t.Fatalf("installer output file missing %q:\n%s", expected, outputs)
+		}
+	}
+}
+
+func TestAgentpluginsNativeInstallerAcceptsExplicitVersion(t *testing.T) {
+	t.Parallel()
+	requireBindTests(t)
+	requireShellBootstrap(t)
+	if runtime.GOOS == "windows" {
+		t.Skip("the POSIX installer is covered by the cross-platform workflow on Windows")
+	}
+
+	release := validNativeInstallerRelease(t)
+	server := newNativeInstallerReleaseServer(t, release)
+	t.Cleanup(server.Close)
+	output := runNativeInstaller(t, server.URL, map[string]string{
+		"AGENTPLUGINS_VERSION": release.tag,
+		"AGENTPLUGINS_BIN_DIR": filepath.Join(t.TempDir(), "bin"),
+	})
+	if !strings.Contains(output, "Installed agentplugins "+nativeInstallerTestVersion) {
+		t.Fatalf("explicit version was not installed:\n%s", output)
+	}
+}
+
+func TestAgentpluginsNativeInstallerRejectsChecksumMismatchWithoutMutation(t *testing.T) {
+	t.Parallel()
+	requireBindTests(t)
+	requireShellBootstrap(t)
+	if runtime.GOOS == "windows" {
+		t.Skip("the POSIX installer is covered by the cross-platform workflow on Windows")
+	}
+
+	release := validNativeInstallerRelease(t)
+	release.checksums = strings.Repeat("0", 64) + "  " + release.assetName + "\n"
+	server := newNativeInstallerReleaseServer(t, release)
+	t.Cleanup(server.Close)
+	binDir := filepath.Join(t.TempDir(), "bin")
+
+	root := RepoRoot(t)
+	cmd := exec.Command(shellPath(t), filepath.Join(root, "install.sh"))
+	cmd.Env = nativeInstallerEnvironment(server.URL, map[string]string{
+		"AGENTPLUGINS_VERSION": release.tag,
+		"AGENTPLUGINS_BIN_DIR": binDir,
+	})
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected checksum mismatch failure:\n%s", output)
+	}
+	if !strings.Contains(string(output), "checksum mismatch") {
+		t.Fatalf("unexpected checksum mismatch output:\n%s", output)
+	}
+	if _, statErr := os.Stat(filepath.Join(binDir, "agentplugins")); !os.IsNotExist(statErr) {
+		t.Fatalf("failed verification must not create the destination, stat error: %v", statErr)
+	}
+}
+
+func TestAgentpluginsNativeInstallerRejectsInvalidVersionBeforeNetwork(t *testing.T) {
+	t.Parallel()
+	requireShellBootstrap(t)
+	if runtime.GOOS == "windows" {
+		t.Skip("the POSIX installer is covered by the cross-platform workflow on Windows")
+	}
+
+	root := RepoRoot(t)
+	cmd := exec.Command(shellPath(t), filepath.Join(root, "install.sh"))
+	cmd.Env = append(os.Environ(),
+		"AGENTPLUGINS_VERSION=../../main",
+		"AGENTPLUGINS_RELEASE_BASE_URL=http://127.0.0.1:1",
+		"AGENTPLUGINS_BIN_DIR="+filepath.Join(t.TempDir(), "bin"),
+	)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected invalid version failure:\n%s", output)
+	}
+	if !strings.Contains(string(output), "invalid stable version or tag") {
+		t.Fatalf("invalid version was not rejected before download:\n%s", output)
+	}
+}
+
+func validNativeInstallerRelease(t *testing.T) nativeInstallerRelease {
+	t.Helper()
+	assetName := nativeInstallerAssetName(nativeInstallerTestVersion)
+	asset := []byte("#!/usr/bin/env sh\necho 'agentplugins 9.8.7'\n")
+	digest := sha256.Sum256(asset)
+	return nativeInstallerRelease{
+		tag:        "agentplugins-v" + nativeInstallerTestVersion,
+		assetName:  assetName,
+		asset:      asset,
+		checksums:  fmt.Sprintf("%s  %s\n", hex.EncodeToString(digest[:]), assetName),
+		repository: "example/agentplugins",
+	}
+}
+
+func nativeInstallerAssetName(version string) string {
+	return fmt.Sprintf("agentplugins_%s_%s_%s", version, runtimeGOOSForScript(), runtimeGOARCHForScript())
+}
+
+func newNativeInstallerReleaseServer(t *testing.T, release nativeInstallerRelease) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case fmt.Sprintf("/repos/%s/releases/latest", release.repository):
+			writer.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(writer).Encode(map[string]string{"tag_name": release.tag})
+		case fmt.Sprintf("/%s/releases/download/%s/checksums.txt", release.repository, release.tag):
+			_, _ = writer.Write([]byte(release.checksums))
+		case fmt.Sprintf("/%s/releases/download/%s/%s", release.repository, release.tag, release.assetName):
+			_, _ = writer.Write(release.asset)
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+}
+
+func runNativeInstaller(t *testing.T, serverURL string, environment map[string]string, command ...string) string {
+	t.Helper()
+	root := RepoRoot(t)
+	arguments := []string{filepath.Join(root, "install.sh")}
+	arguments = append(arguments, command...)
+	cmd := exec.Command(shellPath(t), arguments...)
+	cmd.Env = nativeInstallerEnvironment(serverURL, environment)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("native installer failed: %v\n%s", err, output)
+	}
+	return string(output)
+}
+
+func nativeInstallerEnvironment(serverURL string, overrides map[string]string) []string {
+	environment := append(os.Environ(),
+		"AGENTPLUGINS_REPOSITORY=example/agentplugins",
+		"AGENTPLUGINS_API_BASE="+serverURL,
+		"AGENTPLUGINS_RELEASE_BASE_URL="+serverURL,
+	)
+	for key, value := range overrides {
+		environment = append(environment, key+"="+value)
+	}
+	return environment
+}

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -279,6 +279,47 @@ func TestAgentpluginsReadmesUseUnversionedNpxExamples(t *testing.T) {
 	}
 }
 
+func TestAgentpluginsNativeInstallSurfaceIsChecksumAndVersionBound(t *testing.T) {
+	root := RepoRoot(t)
+	unixInstaller := readRepoFile(t, root, "install.sh")
+	windowsInstaller := readRepoFile(t, root, "install.ps1")
+	workflow := readRepoFile(t, root, ".github", "workflows", "agentplugins-native-install.yml")
+	guide := readRepoFile(t, root, "docs", "NATIVE_INSTALL.md")
+
+	for _, want := range []string{
+		"checksums.txt must contain exactly one entry",
+		"checksum mismatch",
+		"OBSERVED_VERSION",
+		"agentplugins $VERSION",
+		"mktemp \"$BIN_DIR/.agentplugins.XXXXXX\"",
+		"mv -f \"$INSTALL_TEMP\" \"$DEST_PATH\"",
+	} {
+		mustContain(t, unixInstaller, want)
+	}
+	for _, want := range []string{
+		"Get-FileHash",
+		"checksums.txt must contain exactly one valid entry",
+		"ObservedVersion",
+		"[System.IO.File]::Replace($InstallTemp, $Destination, $null, $true)",
+		"[System.IO.File]::Move($InstallTemp, $Destination)",
+	} {
+		mustContain(t, windowsInstaller, want)
+	}
+	for _, target := range []string{
+		"darwin-amd64",
+		"darwin-arm64",
+		"linux-amd64",
+		"linux-arm64",
+		"windows-amd64",
+		"windows-arm64",
+	} {
+		mustContain(t, workflow, target)
+	}
+	mustContain(t, workflow, "Install the published native binary without Node.js")
+	mustContain(t, guide, "The native installation path does not require")
+	mustContain(t, guide, "atomically replaces the destination only after all checks pass")
+}
+
 func mustAppearBefore(t *testing.T, text, first, second string) {
 	t.Helper()
 	firstIndex := strings.Index(text, first)


### PR DESCRIPTION
## Summary

- add checksum and version verified native installers for macOS, Linux, and Windows
- prove all six published OS and architecture combinations without Node.js
- make the native Go CLI the recommended README path while keeping npx available
- fix the public repository license text to match Apache 2.0

## Verification

- focused Go installer and release contract tests pass
- npm facade tests and detached package tests pass
- real macOS arm64 install of public agentplugins 0.1.44 passes checksum, version, and execution checks
- shell syntax, workflow YAML, and diff checks pass

The full local suite reached an unrelated existing Node bundle bootstrap wait. Cross-platform installer proof runs in the dedicated GitHub workflow on Linux, macOS, and Windows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native Go CLI installers for macOS, Linux, and Windows.
  * Installers verify release checksums and versions before atomic installation.
  * Added configurable installation destinations, versions, and metadata output.
  * Native CLI commands can run without Node.js.

* **Documentation**
  * Updated quick-start instructions to prioritize native installation.
  * Added comprehensive native installation guidance.

* **Tests**
  * Added cross-platform installer validation and integration coverage.
  * Added a Make target for running native installer tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->