### PR TITLE
feat(landing): make native CLI the default

### DIFF
--- a/landing/assets/styles/registry.scss
+++ b/landing/assets/styles/registry.scss
@@ -2218,14 +2218,19 @@ img {
   margin-bottom: 0;
   font-size: 1.35rem;
 }
-.install-panel__heading > span {
+.install-panel__cli-link {
   padding: 5px 8px;
   border: 1px solid var(--line);
   border-radius: 7px;
   color: var(--subtle);
+  text-decoration: none;
   font:
     0.61rem 'SFMono-Regular',
     monospace;
+}
+.install-panel__cli-link:hover {
+  border-color: var(--violet);
+  color: var(--ink);
 }
 .install-command-row {
   display: grid;

--- a/landing/components/plugins/PluginInstallSection.vue
+++ b/landing/components/plugins/PluginInstallSection.vue
@@ -47,7 +47,9 @@ const selectedTargets = computed(() =>
 );
 
 const installChannels = computed<InstallChannel[]>(() =>
-  content.value.installChannels.filter((channel) => channel.command && channel.id === 'npm'),
+  content.value.installChannels.filter(
+    (channel) => channel.command && ['brew', 'script', 'npm'].includes(channel.id),
+  ),
 );
 
 watchEffect(() => {

--- a/landing/components/registry/CommandSnippet.vue
+++ b/landing/components/registry/CommandSnippet.vue
@@ -25,7 +25,7 @@ const visibleCommand = computed(() => {
   if (!props.compact) return props.command;
   if (props.command.includes(' --target '))
     return props.command.replace(' --target ', '\n--target ');
-  return props.command.replace(/^(npx universal-agent-plugins\s+\S+)\s+/, '$1\n');
+  return props.command.replace(/^(agentplugins\s+\S+)\s+/, '$1\n');
 });
 let timer: ReturnType<typeof setTimeout> | undefined;
 

--- a/landing/components/registry/InstallPanel.vue
+++ b/landing/components/registry/InstallPanel.vue
@@ -80,7 +80,13 @@ watch(availableClients, (next) => {
         <p class="eyebrow">Installer</p>
         <h2 id="install-title">Use with your agent</h2>
       </div>
-      <span>Node.js 22+</span>
+      <a
+        class="install-panel__cli-link"
+        href="https://github.com/777genius/universal-agent-plugins#quick-start"
+        target="_blank"
+        rel="noreferrer"
+        >Native Go CLI · no Node.js</a
+      >
     </div>
     <div v-if="commands" class="command-stack">
       <div class="install-command-row">

--- a/landing/components/sections/DownloadSection.vue
+++ b/landing/components/sections/DownloadSection.vue
@@ -21,7 +21,7 @@ const supportAccent = ['#39ff14', '#00f0ff', '#ffb703', '#f472b6', '#94a3b8'];
 
 const installChannels = computed(() =>
   content.value.installChannels
-    .filter((channel) => channel.id === 'npm')
+    .filter((channel) => ['brew', 'script', 'npm'].includes(channel.id))
     .map((channel) =>
       channel.id === 'docs' ? { ...channel, href: quickstartUrl.value } : channel,
     ),

--- a/landing/content/en.json
+++ b/landing/content/en.json
@@ -985,7 +985,7 @@
     {
       "id": "fastestStart",
       "question": "What is the fastest way to start?",
-      "answer": "Run <code>npx universal-agent-plugins add context7 --target codex,cursor</code>. Choose one or more targets explicitly, then follow any client activation step."
+      "answer": "Install the native Go CLI, then run <code>agentplugins add context7 --target codex,cursor</code>. Choose one or more targets explicitly, then follow any client activation step."
     },
     {
       "id": "whichPathFirst",
@@ -1001,20 +1001,21 @@
     {
       "id": "brew",
       "title": "Homebrew",
-      "description": "Recommended permanent install for machines that already use Homebrew.",
-      "href": "https://github.com/777genius/homebrew-plugin-kit-ai",
-      "note": "Best when you plan to use plugin-kit-ai every day.",
-      "command": "brew install 777genius/homebrew-plugin-kit-ai/plugin-kit-ai"
+      "description": "Native Go CLI for macOS and Linux. Node.js is not required.",
+      "href": "https://github.com/777genius/homebrew-agentplugins",
+      "note": "Recommended for a permanent install with automatic Homebrew upgrades.",
+      "command": "brew install 777genius/agentplugins/agentplugins",
+      "invocation": "agentplugins",
+      "recommended": true
     },
     {
       "id": "npm",
       "title": "npx",
       "description": "Run the installer without a permanent install.",
       "href": "https://www.npmjs.com/package/universal-agent-plugins",
-      "note": "Fastest path to your first multi-agent plugin install.",
+      "note": "Zero-install alternative when Node.js 22 or newer is already available.",
       "command": "npx universal-agent-plugins version",
-      "invocation": "npx universal-agent-plugins",
-      "recommended": true
+      "invocation": "npx universal-agent-plugins"
     },
     {
       "id": "pipx",
@@ -1027,10 +1028,11 @@
     {
       "id": "script",
       "title": "Verified install script",
-      "description": "Fallback bootstrap path that resolves the latest published stable release and verifies checksums.",
-      "href": "https://raw.githubusercontent.com/777genius/plugin-kit-ai/main/scripts/install.sh",
-      "note": "Good when package-manager setup is not what you want first.",
-      "command": "curl -fsSL https://raw.githubusercontent.com/777genius/plugin-kit-ai/main/scripts/install.sh | sh"
+      "description": "Native install without a package manager. Node.js is not required.",
+      "href": "https://github.com/777genius/universal-agent-plugins/blob/main/docs/NATIVE_INSTALL.md",
+      "note": "Downloads the correct release binary and verifies its SHA-256 and version.",
+      "command": "curl -fsSL https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.sh | sh",
+      "invocation": "$HOME/.local/bin/agentplugins"
     },
     {
       "id": "releases",

--- a/landing/content/es.json
+++ b/landing/content/es.json
@@ -985,7 +985,7 @@
     {
       "id": "fastestStart",
       "question": "¿Cuál es la forma más rápida de empezar?",
-      "answer": "Ejecuta <code>npx universal-agent-plugins add context7 --target codex,cursor</code>. Elige uno o varios agentes y sigue cualquier paso de activación que muestre el cliente."
+      "answer": "Instala la CLI nativa de Go y ejecuta <code>agentplugins add context7 --target codex,cursor</code>. Elige uno o varios agentes y sigue cualquier paso de activación que muestre el cliente."
     },
     {
       "id": "whichPathFirst",
@@ -1001,20 +1001,21 @@
     {
       "id": "brew",
       "title": "Homebrew",
-      "description": "Instalación permanente recomendada para máquinas que ya usan Homebrew.",
-      "href": "https://github.com/777genius/homebrew-plugin-kit-ai",
-      "note": "La mejor opción cuando planea usar plugin-kit-ai todos los días.",
-      "command": "brew install 777genius/homebrew-plugin-kit-ai/plugin-kit-ai"
+      "description": "CLI nativa de Go para macOS y Linux. No requiere Node.js.",
+      "href": "https://github.com/777genius/homebrew-agentplugins",
+      "note": "Recomendado para una instalación permanente con actualizaciones de Homebrew.",
+      "command": "brew install 777genius/agentplugins/agentplugins",
+      "invocation": "agentplugins",
+      "recommended": true
     },
     {
       "id": "npm",
       "title": "npx",
-      "description": "Ejecute plugin-kit-ai sin una instalación permanente cuando quiera añadir un plugin real lo más rápido posible.",
-      "href": "https://www.npmjs.com/package/plugin-kit-ai",
-      "note": "La ruta más rápida cuando primero quiere una instalación de plugin con un solo comando.",
-      "command": "npx plugin-kit-ai@latest version",
-      "invocation": "npx plugin-kit-ai@latest",
-      "recommended": true
+      "description": "Ejecuta el instalador sin una instalación permanente.",
+      "href": "https://www.npmjs.com/package/universal-agent-plugins",
+      "note": "Alternativa sin instalación si ya tienes Node.js 22 o posterior.",
+      "command": "npx universal-agent-plugins version",
+      "invocation": "npx universal-agent-plugins"
     },
     {
       "id": "pipx",
@@ -1027,10 +1028,11 @@
     {
       "id": "script",
       "title": "Script de instalación verificado",
-      "description": "Ruta de arranque alternativa que resuelve la última versión estable publicada y verifica las sumas de comprobación.",
-      "href": "https://raw.githubusercontent.com/777genius/plugin-kit-ai/main/scripts/install.sh",
-      "note": "Good cuando la configuración del administrador de paquetes no es lo que desea primero.",
-      "command": "curl -fsSL https://raw.githubusercontent.com/777genius/plugin-kit-ai/main/scripts/install.sh | sh"
+      "description": "Instalación nativa sin gestor de paquetes. No requiere Node.js.",
+      "href": "https://github.com/777genius/universal-agent-plugins/blob/main/docs/NATIVE_INSTALL.md",
+      "note": "Descarga el binario correcto y verifica su SHA-256 y versión.",
+      "command": "curl -fsSL https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.sh | sh",
+      "invocation": "$HOME/.local/bin/agentplugins"
     },
     {
       "id": "releases",

--- a/landing/content/fr.json
+++ b/landing/content/fr.json
@@ -985,7 +985,7 @@
     {
       "id": "fastestStart",
       "question": "Quelle est la manière la plus rapide de commencer ?",
-      "answer": "Exécutez <code>npx universal-agent-plugins add context7 --target codex,cursor</code>. Choisissez un ou plusieurs agents et suivez l'étape d'activation indiquée par le client."
+      "answer": "Installez le CLI Go natif, puis exécutez <code>agentplugins add context7 --target codex,cursor</code>. Choisissez un ou plusieurs agents et suivez l'étape d'activation indiquée par le client."
     },
     {
       "id": "whichPathFirst",
@@ -1001,20 +1001,21 @@
     {
       "id": "brew",
       "title": "Homebrew",
-      "description": "Installation permanente recommandée pour les machines qui utilisent déjà Homebrew.",
-      "href": "https://github.com/777genius/homebrew-plugin-kit-ai",
-      "note": "Le meilleur choix lorsque vous prévoyez d'utiliser plugin-kit-ai tous les jours.",
-      "command": "brew install 777genius/homebrew-plugin-kit-ai/plugin-kit-ai"
+      "description": "CLI Go natif pour macOS et Linux. Node.js n'est pas requis.",
+      "href": "https://github.com/777genius/homebrew-agentplugins",
+      "note": "Recommandé pour une installation permanente avec les mises à jour Homebrew.",
+      "command": "brew install 777genius/agentplugins/agentplugins",
+      "invocation": "agentplugins",
+      "recommended": true
     },
     {
       "id": "npm",
       "title": "npx",
-      "description": "Exécutez plugin-kit-ai sans installation permanente lorsque vous voulez ajouter un vrai plugin le plus vite possible.",
-      "href": "https://www.npmjs.com/package/plugin-kit-ai",
-      "note": "Le chemin le plus rapide lorsque vous voulez d'abord une installation de plugin en une seule commande.",
-      "command": "npx plugin-kit-ai@latest version",
-      "invocation": "npx plugin-kit-ai@latest",
-      "recommended": true
+      "description": "Exécutez l'installateur sans installation permanente.",
+      "href": "https://www.npmjs.com/package/universal-agent-plugins",
+      "note": "Alternative sans installation si Node.js 22 ou plus récent est déjà disponible.",
+      "command": "npx universal-agent-plugins version",
+      "invocation": "npx universal-agent-plugins"
     },
     {
       "id": "pipx",
@@ -1027,10 +1028,11 @@
     {
       "id": "script",
       "title": "Script d'installation vérifié",
-      "description": "Chemin d’amorçage de secours qui résout la dernière version stable publiée et vérifie les sommes de contrôle.",
-      "href": "https://raw.githubusercontent.com/777genius/plugin-kit-ai/main/scripts/install.sh",
-      "note": "Good lorsque la configuration du gestionnaire de packages n'est pas celle que vous souhaitez en premier.",
-      "command": "curl -fsSL https://raw.githubusercontent.com/777genius/plugin-kit-ai/main/scripts/install.sh | sh"
+      "description": "Installation native sans gestionnaire de paquets. Node.js n'est pas requis.",
+      "href": "https://github.com/777genius/universal-agent-plugins/blob/main/docs/NATIVE_INSTALL.md",
+      "note": "Télécharge le bon binaire et vérifie son SHA-256 et sa version.",
+      "command": "curl -fsSL https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.sh | sh",
+      "invocation": "$HOME/.local/bin/agentplugins"
     },
     {
       "id": "releases",

--- a/landing/content/ru.json
+++ b/landing/content/ru.json
@@ -985,7 +985,7 @@
     {
       "id": "fastestStart",
       "question": "Как начать быстрее всего?",
-      "answer": "Запустите <code>npx universal-agent-plugins add context7 --target codex,cursor</code>. Выберите одного или нескольких агентов и выполните показанный шаг активации."
+      "answer": "Установите нативный Go CLI, затем запустите <code>agentplugins add context7 --target codex,cursor</code>. Выберите одного или нескольких агентов и выполните показанный шаг активации."
     },
     {
       "id": "whichPathFirst",
@@ -1001,20 +1001,21 @@
     {
       "id": "brew",
       "title": "Homebrew",
-      "description": "Рекомендуемый постоянный способ установки для машин, где уже используется Homebrew.",
-      "href": "https://github.com/777genius/homebrew-plugin-kit-ai",
-      "note": "Лучший вариант, если вы планируете пользоваться plugin-kit-ai каждый день.",
-      "command": "brew install 777genius/homebrew-plugin-kit-ai/plugin-kit-ai"
+      "description": "Нативный Go CLI для macOS и Linux. Node.js не требуется.",
+      "href": "https://github.com/777genius/homebrew-agentplugins",
+      "note": "Рекомендуется для постоянной установки и обновлений через Homebrew.",
+      "command": "brew install 777genius/agentplugins/agentplugins",
+      "invocation": "agentplugins",
+      "recommended": true
     },
     {
       "id": "npm",
       "title": "npx",
       "description": "Запускайте установщик без постоянной установки.",
       "href": "https://www.npmjs.com/package/universal-agent-plugins",
-      "note": "Самый быстрый путь к первой установке плагина в несколько агентов.",
+      "note": "Вариант без установки, если Node.js 22 или новее уже доступен.",
       "command": "npx universal-agent-plugins version",
-      "invocation": "npx universal-agent-plugins",
-      "recommended": true
+      "invocation": "npx universal-agent-plugins"
     },
     {
       "id": "pipx",
@@ -1027,10 +1028,11 @@
     {
       "id": "script",
       "title": "Проверяемый установочный скрипт",
-      "description": "Резервный путь установки, который находит последний опубликованный стабильный релиз и проверяет контрольные суммы.",
-      "href": "https://raw.githubusercontent.com/777genius/plugin-kit-ai/main/scripts/install.sh",
-      "note": "Подходит, когда не хочется начинать с пакетного менеджера.",
-      "command": "curl -fsSL https://raw.githubusercontent.com/777genius/plugin-kit-ai/main/scripts/install.sh | sh"
+      "description": "Нативная установка без пакетного менеджера. Node.js не требуется.",
+      "href": "https://github.com/777genius/universal-agent-plugins/blob/main/docs/NATIVE_INSTALL.md",
+      "note": "Скачивает нужный бинарник релиза и проверяет его SHA-256 и версию.",
+      "command": "curl -fsSL https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.sh | sh",
+      "invocation": "$HOME/.local/bin/agentplugins"
     },
     {
       "id": "releases",

--- a/landing/content/zh.json
+++ b/landing/content/zh.json
@@ -985,7 +985,7 @@
     {
       "id": "fastestStart",
       "question": "最快的开始方式是什么？",
-      "answer": "运行 <code>npx universal-agent-plugins add context7 --target codex,cursor</code>。选择一个或多个代理，然后按客户端提示完成激活。"
+      "answer": "安装原生 Go CLI，然后运行 <code>agentplugins add context7 --target codex,cursor</code>。选择一个或多个代理，然后按客户端提示完成激活。"
     },
     {
       "id": "whichPathFirst",
@@ -1001,20 +1001,21 @@
     {
       "id": "brew",
       "title": "Homebrew",
-      "description": "建议已经使用 Homebrew 的机器进行长期安装。",
-      "href": "https://github.com/777genius/homebrew-plugin-kit-ai",
-      "note": "当您计划每天使用 plugin-kit-ai 时，这是更好的选择。",
-      "command": "brew install 777genius/homebrew-plugin-kit-ai/plugin-kit-ai"
+      "description": "适用于 macOS 和 Linux 的原生 Go CLI，无需 Node.js。",
+      "href": "https://github.com/777genius/homebrew-agentplugins",
+      "note": "建议用于长期安装，并通过 Homebrew 自动升级。",
+      "command": "brew install 777genius/agentplugins/agentplugins",
+      "invocation": "agentplugins",
+      "recommended": true
     },
     {
       "id": "npm",
       "title": "npx",
-      "description": "当您想最快添加一个真实插件时，无需永久安装即可运行 plugin-kit-ai。",
-      "href": "https://www.npmjs.com/package/plugin-kit-ai",
-      "note": "当您首先想要一次性插件安装时，这是最快的路径。",
-      "command": "npx plugin-kit-ai@latest version",
-      "invocation": "npx plugin-kit-ai@latest",
-      "recommended": true
+      "description": "无需永久安装即可运行安装器。",
+      "href": "https://www.npmjs.com/package/universal-agent-plugins",
+      "note": "如果已有 Node.js 22 或更高版本，可使用此免安装方案。",
+      "command": "npx universal-agent-plugins version",
+      "invocation": "npx universal-agent-plugins"
     },
     {
       "id": "pipx",
@@ -1027,10 +1028,11 @@
     {
       "id": "script",
       "title": "已验证的安装脚本",
-      "description": "后备引导路径，用于解析最新发布的稳定版本并验证校验和。",
-      "href": "https://raw.githubusercontent.com/777genius/plugin-kit-ai/main/scripts/install.sh",
-      "note": "Good 当包管理器设置不是您首先想要的时。",
-      "command": "curl -fsSL https://raw.githubusercontent.com/777genius/plugin-kit-ai/main/scripts/install.sh | sh"
+      "description": "无需包管理器的原生安装，无需 Node.js。",
+      "href": "https://github.com/777genius/universal-agent-plugins/blob/main/docs/NATIVE_INSTALL.md",
+      "note": "下载正确的发布二进制文件，并验证 SHA-256 和版本。",
+      "command": "curl -fsSL https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.sh | sh",
+      "invocation": "$HOME/.local/bin/agentplugins"
     },
     {
       "id": "releases",

--- a/landing/nuxt.config.ts
+++ b/landing/nuxt.config.ts
@@ -104,6 +104,7 @@ export default defineNuxtConfig({
       routes: [
         '/',
         '/create-plugin',
+        '/download',
         '/plugins',
         '/plugins/community',
         ...registryIndex.plugins.map((plugin) => `/plugins/${plugin.name}`),

--- a/landing/tests/browser/landing.spec.ts
+++ b/landing/tests/browser/landing.spec.ts
@@ -18,6 +18,7 @@ test('homepage installs with auto-detection and exposes the full directory', asy
   await expect(page.locator('.hero-agent-field__hub img')).toHaveAttribute('src', /icon\.svg$/);
   await expect(page.getByRole('heading', { name: /One plugin/ })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'One plugin All your agents' })).toBeVisible();
+  await expect(page.locator('.command-snippet').first()).toContainText('agentplugins add');
   await expect(page.locator('.command-snippet').first()).not.toContainText('--target');
   await expect(page.getByText('Supported clients')).toBeVisible();
   await expect(page.locator('.client-strip li')).toHaveCount(11);
@@ -62,5 +63,24 @@ test('directory filters and reviewed detail keep automatic detection as the defa
   ]);
   await expect(page.getByRole('heading', { name: 'GitLab', exact: true })).toBeVisible();
   await expect(page.getByText('All installed agents')).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Native Go CLI · no Node.js' })).toBeVisible();
+  await expect(page.locator('.command-snippet').first()).toContainText('agentplugins add');
   await expect(page.locator('.command-snippet').first()).not.toContainText('--target');
+});
+
+test('download page recommends native Homebrew and preserves the npx alternative', async ({
+  page,
+}) => {
+  await page.goto('./download');
+  const tabs = page.locator('.download-section__install-tab');
+  const homebrew = tabs.filter({ hasText: 'Homebrew' });
+  await expect(homebrew).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.getByText('brew install 777genius/agentplugins/agentplugins')).toBeVisible();
+  await expect(page.getByText('agentplugins add context7 --target codex,cursor')).toBeVisible();
+
+  await tabs.filter({ hasText: 'npx' }).click();
+  await expect(page.getByText('npx universal-agent-plugins version')).toBeVisible();
+  await expect(
+    page.getByText('npx universal-agent-plugins add context7 --target codex,cursor'),
+  ).toBeVisible();
 });

--- a/landing/tests/native-install.test.ts
+++ b/landing/tests/native-install.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { applyCliInvocation, getCliInvocation } from '../utils/cliInvocation.ts';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const locales = ['en', 'es', 'fr', 'ru', 'zh'];
+
+describe('native-first installation', () => {
+  it('keeps the native Go CLI as the default command invocation', () => {
+    assert.equal(getCliInvocation(), 'agentplugins');
+    assert.equal(
+      applyCliInvocation('universal-agent-plugins add context7'),
+      'agentplugins add context7',
+    );
+    assert.equal(
+      applyCliInvocation('universal-agent-plugins add context7', 'npx universal-agent-plugins'),
+      'npx universal-agent-plugins add context7',
+    );
+  });
+
+  it('publishes the same native and zero-install channels in every locale', () => {
+    for (const locale of locales) {
+      const content = JSON.parse(
+        readFileSync(resolve(root, 'content', `${locale}.json`), 'utf8'),
+      ) as {
+        installChannels: Array<{
+          id: string;
+          command?: string;
+          invocation?: string;
+          recommended?: boolean;
+        }>;
+      };
+      const selected = content.installChannels.filter((channel) =>
+        ['brew', 'script', 'npm'].includes(channel.id),
+      );
+      assert.deepEqual(
+        selected.map((channel) => channel.id),
+        ['brew', 'npm', 'script'],
+        locale,
+      );
+      assert.equal(selected.filter((channel) => channel.recommended).length, 1, locale);
+      assert.equal(selected[0]?.recommended, true, locale);
+      assert.equal(selected[0]?.command, 'brew install 777genius/agentplugins/agentplugins');
+      assert.equal(selected[0]?.invocation, 'agentplugins');
+      assert.equal(selected[1]?.invocation, 'npx universal-agent-plugins');
+      assert.equal(selected[2]?.invocation, '$HOME/.local/bin/agentplugins');
+      assert.ok(
+        selected.every((channel) => !channel.command?.includes('plugin-kit-ai')),
+        locale,
+      );
+    }
+  });
+});

--- a/landing/tests/registry.test.ts
+++ b/landing/tests/registry.test.ts
@@ -26,6 +26,7 @@ describe('unified registry landing', () => {
     const plugin = registry.plugins.find((item) => item.installable);
     assert.ok(plugin);
     assert.equal(pluginCommands(plugin).add.includes('--target'), false);
+    assert.match(pluginCommands(plugin).add, /^agentplugins add /);
   });
 
   it('uses one comma-separated target flag for explicit multi-agent installation', () => {

--- a/landing/utils/cliInvocation.ts
+++ b/landing/utils/cliInvocation.ts
@@ -1,4 +1,4 @@
-const DEFAULT_CLI_INVOCATION = 'universal-agent-plugins';
+const DEFAULT_CLI_INVOCATION = 'agentplugins';
 
 export function applyCliInvocation(command: string, invocation?: string | null): string {
   const normalizedInvocation = invocation?.trim() || DEFAULT_CLI_INVOCATION;

--- a/landing/utils/commands.ts
+++ b/landing/utils/commands.ts
@@ -7,10 +7,10 @@ export function pluginCommands(plugin: RegistryPlugin, targets?: string | readon
   if (targets !== undefined && !values.length) throw new Error('At least one target is required');
   const targetFlag = values.length ? ` --target ${values.join(',')}` : '';
   return {
-    add: `npx universal-agent-plugins add ${plugin.install_source}${targetFlag}`,
-    update: `npx universal-agent-plugins update ${plugin.name}${targetFlag}`,
-    repair: `npx universal-agent-plugins repair ${plugin.name}${targetFlag}`,
-    switch: `npx universal-agent-plugins switch ${plugin.name} --to <distribution-id>`,
-    remove: `npx universal-agent-plugins remove ${plugin.name}${targetFlag}`,
+    add: `agentplugins add ${plugin.install_source}${targetFlag}`,
+    update: `agentplugins update ${plugin.name}${targetFlag}`,
+    repair: `agentplugins repair ${plugin.name}${targetFlag}`,
+    switch: `agentplugins switch ${plugin.name} --to <distribution-id>`,
+    remove: `agentplugins remove ${plugin.name}${targetFlag}`,
   };
 }


### PR DESCRIPTION
## What

- makes `agentplugins` the default command shown by the directory and plugin pages
- recommends the native Homebrew channel, while keeping verified script and `npx` tabs
- replaces the misleading global `Node.js 22+` badge with `Native Go CLI - no Node.js`
- updates all five localized installation surfaces
- explicitly prerenders `/download`, which was previously a production 404

Plugin runtimes may still declare Node.js or other requirements; this changes only the manager installation surface.

## Evidence

- exact head rebased onto the merged native installer and Homebrew publisher
- signed registry mirror: Directory seq 29, Discovery seq 30
- landing unit/contract tests: 6 passed
- ESLint: passed
- Nuxt static generation: 67 routes, including `/download`
- Playwright: 4 passed, covering native commands, Homebrew default, npx fallback, automatic agent detection, community detail, and reviewed plugin detail
- generated HTML contains native commands and no global Node.js requirement badge