### PR TITLE
feat(agentplugins): publish native Homebrew formula

### DIFF
--- a/.github/workflows/agentplugins-homebrew-tap.yml
+++ b/.github/workflows/agentplugins-homebrew-tap.yml
@@ -1,0 +1,70 @@
+name: Agentplugins Homebrew Tap
+
+on:
+  workflow_run:
+    workflows: [Agentplugins Release Assets]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Exact published Agentplugins tag
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  attestations: read
+
+concurrency:
+  group: agentplugins-homebrew-tap
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          package-manager-cache: false
+      - name: Resolve the exact successful release tag
+        id: release
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          RELEASE_COMMIT: ${{ github.event.workflow_run.head_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == workflow_dispatch ]]; then
+            tag="$INPUT_TAG"
+          else
+            matches=()
+            while IFS= read -r candidate; do
+              [[ -z "$candidate" ]] && continue
+              if [[ "$(git rev-list -n 1 "$candidate")" == "$RELEASE_COMMIT" ]]; then
+                matches+=("$candidate")
+              fi
+            done < <(git tag --list 'agentplugins-v*')
+            if [[ "${#matches[@]}" -ne 1 ]]; then
+              echo "expected exactly one Agentplugins release tag at $RELEASE_COMMIT, found ${#matches[@]}" >&2
+              exit 1
+            fi
+            tag="${matches[0]}"
+          fi
+          [[ "$tag" =~ ^agentplugins-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
+          echo "tag=$tag" >>"$GITHUB_OUTPUT"
+      - name: Publish the attested formula
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+          SOURCE_GITHUB_TOKEN: ${{ github.token }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          HOMEBREW_TAP_REPOSITORY: 777genius/homebrew-agentplugins
+        run: ./scripts/update-agentplugins-homebrew-tap.sh

--- a/README.md
+++ b/README.md
@@ -10,8 +10,14 @@ Install and manage Agent Plugins 1.0 across your AI agents with one CLI.
 
 ## Quick start
 
-The native Go CLI does not require Node.js. Install it and add Context7 in one
-command on macOS or Linux:
+The native Go CLI does not require Node.js. On macOS or Linux with Homebrew:
+
+```bash
+brew install 777genius/agentplugins/agentplugins
+agentplugins add context7
+```
+
+Or install the same verified native release and add Context7 in one command:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.sh | sh -s -- add context7
@@ -24,9 +30,10 @@ irm https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/ins
 & "$HOME\.local\bin\agentplugins.exe" add context7
 ```
 
-The installers select the native binary for your OS and architecture, verify its
-published SHA-256 and reported version, then replace the CLI atomically. They
-install into `$HOME/.local/bin` unless `AGENTPLUGINS_BIN_DIR` is set.
+Homebrew and the installers select the native binary for your OS and
+architecture. The scripts verify its published SHA-256 and reported version,
+then replace the CLI atomically. They install into `$HOME/.local/bin` unless
+`AGENTPLUGINS_BIN_DIR` is set.
 
 If you already have Node.js 22 or newer, the npm facade remains the quickest
 zero-install alternative. It downloads and verifies the same Go binary:

--- a/docs/NATIVE_INSTALL.md
+++ b/docs/NATIVE_INSTALL.md
@@ -3,6 +3,17 @@
 `agentplugins` is a Go binary. The native installation path does not require
 Node.js, Python, npm, or pip.
 
+## Homebrew on macOS and Linux
+
+```bash
+brew install 777genius/agentplugins/agentplugins
+agentplugins add context7
+```
+
+The tap installs the same platform-specific binary published in the signed
+GitHub release. Its formula pins the release URL and SHA-256 for every supported
+macOS and Linux architecture.
+
 ## macOS and Linux
 
 Install the latest published release and immediately run a command:

--- a/docs/agentplugins-release.md
+++ b/docs/agentplugins-release.md
@@ -71,6 +71,23 @@ Proof` with `--ref <exact-tag>` and `allow_legacy_manifest=true`. The workflow
 must already exist at that tag, and its source SHA must equal the audited tag
 commit; current `main` is never allowed to impersonate a historical harness.
 
+## Homebrew tap
+
+A successful `Agentplugins Release Assets` run triggers
+`.github/workflows/agentplugins-homebrew-tap.yml`. The publisher downloads only
+the exact public `release-manifest.json`, requires its stable tag to resolve to
+the embedded source commit, verifies the GitHub artifact attestation, and
+generates `777genius/homebrew-agentplugins/Formula/agentplugins.rb` from the six
+closed-set asset identities. The formula exposes the four macOS and Linux
+assets and pins every URL to its release tag and SHA-256.
+
+`HOMEBREW_TAP_TOKEN` must have contents-write access to the tap repository and
+does not need write access to this source repository. The publisher is
+idempotent: an identical formula is a no-op. If automatic publication fails,
+fix the publisher or token and manually dispatch the workflow with the same
+immutable release tag. Do not edit a released formula by hand or repoint it to
+different bytes under the same version.
+
 ## Bootstrap publication record
 
 `universal-agent-plugins@0.1.1` completed the one-time bootstrap publication.

--- a/npm/agentplugins/README.md
+++ b/npm/agentplugins/README.md
@@ -12,8 +12,8 @@ verified once, then prepared for every agent you selected.
 
 You need Node.js 22 or newer.
 
-To use the same native Go CLI without Node.js, run the verified installer from
-the [project README](https://github.com/777genius/universal-agent-plugins#quick-start).
+To use the same native Go CLI without Node.js, install it with Homebrew or the
+verified scripts in the [project README](https://github.com/777genius/universal-agent-plugins#quick-start).
 
 ## Quick start
 

--- a/npm/agentplugins/scripts/homebrew-formula.js
+++ b/npm/agentplugins/scripts/homebrew-formula.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const COMMIT = /^[0-9a-f]{40}$/;
+const DIGEST = /^[0-9a-f]{64}$/;
+const REPOSITORY = /^[A-Za-z0-9][A-Za-z0-9-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const TARGETS = [
+  ["darwin-amd64", "darwin", "amd64", ""],
+  ["darwin-arm64", "darwin", "arm64", ""],
+  ["linux-amd64", "linux", "amd64", ""],
+  ["linux-arm64", "linux", "arm64", ""],
+  ["windows-amd64", "windows", "amd64", ".exe"],
+  ["windows-arm64", "windows", "arm64", ".exe"]
+];
+
+function exactKeys(value, expected, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (actual.join("\n") !== wanted.join("\n")) {
+    throw new Error(`${label} has unexpected or missing fields`);
+  }
+}
+
+function validateManifest(manifest) {
+  exactKeys(manifest, ["schema_version", "tag", "version", "commit", "assets"], "release manifest");
+  if (manifest.schema_version !== 2 || !VERSION.test(String(manifest.version))) {
+    throw new Error("release manifest schema or version is invalid");
+  }
+  if (manifest.tag !== `agentplugins-v${manifest.version}` || !COMMIT.test(String(manifest.commit))) {
+    throw new Error("release manifest tag or commit is invalid");
+  }
+
+  const expectedKeys = TARGETS.map(([key]) => key);
+  exactKeys(manifest.assets, expectedKeys, "release manifest assets");
+  for (const [key, osName, archName, suffix] of TARGETS) {
+    const asset = manifest.assets[key];
+    exactKeys(asset, ["file", "sha256", "size"], `release asset ${key}`);
+    const expectedFile = `agentplugins_${manifest.version}_${osName}_${archName}${suffix}`;
+    if (asset.file !== expectedFile || !DIGEST.test(String(asset.sha256)) ||
+        !Number.isSafeInteger(asset.size) || asset.size <= 0) {
+      throw new Error(`release asset metadata is invalid: ${key}`);
+    }
+  }
+  return manifest;
+}
+
+function assetBlock(repository, manifest, key, indent) {
+  const asset = manifest.assets[key];
+  const url = `https://github.com/${repository}/releases/download/${manifest.tag}/${asset.file}`;
+  return [
+    `${indent}url "${url}", using: :nounzip`,
+    `${indent}sha256 "${asset.sha256}"`
+  ].join("\n");
+}
+
+function renderFormula(manifestInput, repository = "777genius/universal-agent-plugins") {
+  if (!REPOSITORY.test(repository)) throw new Error(`invalid repository: ${repository}`);
+  const manifest = validateManifest(manifestInput);
+  return `class Agentplugins < Formula
+  desc "Universal installer and lifecycle manager for Agent Plugins 1.0"
+  homepage "https://github.com/${repository}"
+  version "${manifest.version}"
+  license "Apache-2.0"
+
+  on_macos do
+    if Hardware::CPU.arm?
+${assetBlock(repository, manifest, "darwin-arm64", "      ")}
+    else
+${assetBlock(repository, manifest, "darwin-amd64", "      ")}
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+${assetBlock(repository, manifest, "linux-arm64", "      ")}
+    else
+${assetBlock(repository, manifest, "linux-amd64", "      ")}
+    end
+  end
+
+  def install
+    asset = Dir["agentplugins_*"].fetch(0)
+    bin.install asset => "agentplugins"
+    chmod 0755, bin/"agentplugins"
+  end
+
+  test do
+    assert_equal "agentplugins #{version}", shell_output("#{bin}/agentplugins version").strip
+  end
+end
+`;
+}
+
+function main() {
+  const [manifestPath, outputPath, repository = "777genius/universal-agent-plugins"] = process.argv.slice(2);
+  if (!manifestPath || !outputPath) {
+    throw new Error("usage: homebrew-formula.js <release-manifest.json> <output.rb> [owner/repo]");
+  }
+  const manifest = JSON.parse(fs.readFileSync(path.resolve(manifestPath), "utf8"));
+  const output = path.resolve(outputPath);
+  fs.mkdirSync(path.dirname(output), { recursive: true });
+  fs.writeFileSync(output, renderFormula(manifest, repository), { mode: 0o644 });
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`agentplugins Homebrew formula: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = { renderFormula, validateManifest };

--- a/npm/agentplugins/test/documentation-contract.test.js
+++ b/npm/agentplugins/test/documentation-contract.test.js
@@ -70,9 +70,12 @@ test("public Agentplugins documentation keeps copyable commands within the CLI c
       (command) => command.startsWith("npx universal-agent-plugins ") || command.startsWith("agentplugins ")
     );
     assert.ok(commands.length > 0, `${label} has no copyable universal-agent-plugins commands`);
+    const expectedFirstCommand = label === "root README"
+      ? "agentplugins add context7"
+      : "npx universal-agent-plugins add context7";
     assert.equal(
       commands[0],
-      "npx universal-agent-plugins add context7",
+      expectedFirstCommand,
       `${label}: the first command must keep the no-target interactive quick start`
     );
 
@@ -114,6 +117,7 @@ test("root documentation recommends the native Go installer without hiding npm",
   }
   const markdown = fs.readFileSync(documents[0][1], "utf8");
   assert.match(markdown, /native Go CLI does not require Node\.js/i);
+  assert.match(markdown, /brew install 777genius\/agentplugins\/agentplugins/);
   assert.match(
     markdown,
     /https:\/\/raw\.githubusercontent\.com\/777genius\/universal-agent-plugins\/main\/install\.sh/

--- a/npm/agentplugins/test/homebrew-formula.test.js
+++ b/npm/agentplugins/test/homebrew-formula.test.js
@@ -1,0 +1,64 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { renderFormula, validateManifest } = require("../scripts/homebrew-formula");
+
+const targets = [
+  ["darwin-amd64", "darwin", "amd64", ""],
+  ["darwin-arm64", "darwin", "arm64", ""],
+  ["linux-amd64", "linux", "amd64", ""],
+  ["linux-arm64", "linux", "arm64", ""],
+  ["windows-amd64", "windows", "amd64", ".exe"],
+  ["windows-arm64", "windows", "arm64", ".exe"]
+];
+
+function manifest() {
+  const version = "1.2.3";
+  return {
+    schema_version: 2,
+    tag: `agentplugins-v${version}`,
+    version,
+    commit: "1".repeat(40),
+    assets: Object.fromEntries(targets.map(([key, osName, archName, suffix], index) => [
+      key,
+      {
+        file: `agentplugins_${version}_${osName}_${archName}${suffix}`,
+        sha256: String(index + 1).repeat(64),
+        size: 1000 + index
+      }
+    ]))
+  };
+}
+
+test("renders a native macOS and Linux formula from exact release identities", () => {
+  const formula = renderFormula(manifest());
+  for (const [key, osName, archName] of targets.filter(([key]) => !key.startsWith("windows"))) {
+    assert.match(formula, new RegExp(`agentplugins_1\\.2\\.3_${osName}_${archName}`), key);
+  }
+  assert.match(formula, /using: :nounzip/);
+  assert.match(formula, /license "Apache-2\.0"/);
+  assert.match(formula, /bin\.install asset => "agentplugins"/);
+  assert.match(formula, /assert_equal "agentplugins #\{version\}"/);
+  assert.doesNotMatch(formula, /windows_(?:amd64|arm64)/);
+});
+
+test("fails closed on every release identity used by the formula", () => {
+  const mutations = [
+    (value) => { value.schema_version = 1; },
+    (value) => { value.tag = "v1.2.3"; },
+    (value) => { value.version = "01.2.3"; },
+    (value) => { value.commit = "main"; },
+    (value) => { value.assets["darwin-arm64"].file = "agentplugins"; },
+    (value) => { value.assets["linux-amd64"].sha256 = "0"; },
+    (value) => { value.assets["linux-arm64"].size = 0; },
+    (value) => { value.assets.extra = value.assets["linux-arm64"]; }
+  ];
+  for (const mutate of mutations) {
+    const value = structuredClone(manifest());
+    mutate(value);
+    assert.throws(() => validateManifest(value));
+  }
+  assert.throws(() => renderFormula(manifest(), "https://example.com/repo"), /invalid repository/);
+});

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -320,6 +320,41 @@ func TestAgentpluginsNativeInstallSurfaceIsChecksumAndVersionBound(t *testing.T)
 	mustContain(t, guide, "atomically replaces the destination only after all checks pass")
 }
 
+func TestAgentpluginsHomebrewTapIsReleaseAndAttestationBound(t *testing.T) {
+	root := RepoRoot(t)
+	publisher := readRepoFile(t, root, "scripts", "update-agentplugins-homebrew-tap.sh")
+	workflow := readRepoFile(t, root, ".github", "workflows", "agentplugins-homebrew-tap.yml")
+	guide := readRepoFile(t, root, "docs", "NATIVE_INSTALL.md")
+	runbook := readRepoFile(t, root, "docs", "agentplugins-release.md")
+
+	for _, want := range []string{
+		"TAG must be an exact stable agentplugins-vX.Y.Z tag",
+		"release-manifest.json",
+		"release tag does not match the attested source commit",
+		"gh attestation verify",
+		"agentplugins-release.yml",
+		"--source-digest \"$COMMIT\"",
+		"ruby -c \"$FORMULA\"",
+		"GIT_ASKPASS",
+		"git -C \"$TEMP_ROOT/tap\" diff --cached --quiet",
+		"chore: update agentplugins to",
+	} {
+		mustContain(t, publisher, want)
+	}
+	for _, want := range []string{
+		"workflows: [Agentplugins Release Assets]",
+		"github.event.workflow_run.conclusion == 'success'",
+		"persist-credentials: false",
+		"HOMEBREW_TAP_TOKEN",
+		"777genius/homebrew-agentplugins",
+	} {
+		mustContain(t, workflow, want)
+	}
+	mustContain(t, guide, "brew install 777genius/agentplugins/agentplugins")
+	mustContain(t, runbook, "verifies the GitHub artifact attestation")
+	mustContain(t, runbook, "Do not edit a released formula by hand")
+}
+
 func mustAppearBefore(t *testing.T, text, first, second string) {
 	t.Helper()
 	firstIndex := strings.Index(text, first)

--- a/scripts/update-agentplugins-homebrew-tap.sh
+++ b/scripts/update-agentplugins-homebrew-tap.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+TAG="${TAG:-}"
+SOURCE_REPOSITORY="${AGENTPLUGINS_REPOSITORY:-777genius/universal-agent-plugins}"
+TAP_REPOSITORY="${HOMEBREW_TAP_REPOSITORY:-777genius/homebrew-agentplugins}"
+SOURCE_TOKEN="$(printf '%s' "${SOURCE_GITHUB_TOKEN:-${GITHUB_TOKEN:-}}" | tr -d '\r\n')"
+TAP_TOKEN="$(printf '%s' "${HOMEBREW_TAP_TOKEN:-}" | tr -d '\r\n')"
+
+fail() {
+  echo "agentplugins Homebrew publisher: $*" >&2
+  exit 1
+}
+
+[[ "$TAG" =~ ^agentplugins-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] \
+  || fail "TAG must be an exact stable agentplugins-vX.Y.Z tag"
+[[ "$SOURCE_REPOSITORY" =~ ^[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9][A-Za-z0-9._-]*$ ]] \
+  || fail "invalid source repository"
+[[ "$TAP_REPOSITORY" =~ ^[A-Za-z0-9][A-Za-z0-9-]*/homebrew-[A-Za-z0-9][A-Za-z0-9._-]*$ ]] \
+  || fail "tap repository must use an owner/homebrew-name identity"
+[[ -n "$SOURCE_TOKEN" ]] || fail "SOURCE_GITHUB_TOKEN or GITHUB_TOKEN is required"
+[[ -n "$TAP_TOKEN" ]] || fail "HOMEBREW_TAP_TOKEN is required"
+command -v gh >/dev/null 2>&1 || fail "gh is required"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+command -v node >/dev/null 2>&1 || fail "node is required"
+command -v ruby >/dev/null 2>&1 || fail "ruby is required"
+
+TEMP_ROOT="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TEMP_ROOT"
+}
+trap cleanup EXIT HUP INT TERM
+
+release_json="$(GH_TOKEN="$SOURCE_TOKEN" gh release view "$TAG" \
+  --repo "$SOURCE_REPOSITORY" \
+  --json isDraft,isPrerelease,tagName,assets)"
+jq -e --arg tag "$TAG" \
+  '.isDraft == false and .isPrerelease == false and .tagName == $tag and
+   ([.assets[].name | select(. == "release-manifest.json")] | length) == 1' \
+  <<<"$release_json" >/dev/null \
+  || fail "source release is not an exact published Agentplugins release"
+
+mkdir -p "$TEMP_ROOT/release"
+GH_TOKEN="$SOURCE_TOKEN" gh release download "$TAG" \
+  --repo "$SOURCE_REPOSITORY" \
+  --pattern release-manifest.json \
+  --dir "$TEMP_ROOT/release"
+
+MANIFEST="$TEMP_ROOT/release/release-manifest.json"
+COMMIT="$(node -e '
+const fs = require("node:fs");
+const value = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+if (!/^[0-9a-f]{40}$/.test(String(value.commit))) process.exit(1);
+process.stdout.write(value.commit);
+' "$MANIFEST")" || fail "release manifest does not contain a valid source commit"
+TAG_COMMIT="$(GH_TOKEN="$SOURCE_TOKEN" gh api \
+  "repos/${SOURCE_REPOSITORY}/commits/${TAG}" --jq .sha)"
+[[ "$TAG_COMMIT" == "$COMMIT" ]] || fail "release tag does not match the attested source commit"
+
+GH_TOKEN="$SOURCE_TOKEN" gh attestation verify "$MANIFEST" \
+  --repo "$SOURCE_REPOSITORY" \
+  --signer-workflow "github.com/${SOURCE_REPOSITORY}/.github/workflows/agentplugins-release.yml" \
+  --source-digest "$COMMIT" >/dev/null \
+  || fail "release manifest attestation verification failed"
+
+FORMULA="$TEMP_ROOT/agentplugins.rb"
+node npm/agentplugins/scripts/homebrew-formula.js \
+  "$MANIFEST" "$FORMULA" "$SOURCE_REPOSITORY"
+ruby -c "$FORMULA" >/dev/null
+
+ASKPASS="$TEMP_ROOT/git-askpass.sh"
+cat >"$ASKPASS" <<'EOF'
+#!/usr/bin/env sh
+case "$1" in
+  *Username*) printf '%s\n' 'x-access-token' ;;
+  *Password*) printf '%s\n' "$HOMEBREW_TAP_TOKEN" ;;
+  *) exit 1 ;;
+esac
+EOF
+chmod 0700 "$ASKPASS"
+
+export HOMEBREW_TAP_TOKEN="$TAP_TOKEN"
+export GIT_ASKPASS="$ASKPASS"
+export GIT_TERMINAL_PROMPT=0
+git clone --depth 1 "https://github.com/${TAP_REPOSITORY}.git" "$TEMP_ROOT/tap"
+mkdir -p "$TEMP_ROOT/tap/Formula"
+cp "$FORMULA" "$TEMP_ROOT/tap/Formula/agentplugins.rb"
+
+git -C "$TEMP_ROOT/tap" config user.name "agentplugins-release"
+git -C "$TEMP_ROOT/tap" config user.email "actions@users.noreply.github.com"
+git -C "$TEMP_ROOT/tap" add Formula/agentplugins.rb
+if git -C "$TEMP_ROOT/tap" diff --cached --quiet; then
+  echo "Homebrew formula already matches $TAG"
+  exit 0
+fi
+
+git -C "$TEMP_ROOT/tap" commit -m "chore: update agentplugins to ${TAG#agentplugins-v}"
+git -C "$TEMP_ROOT/tap" push origin HEAD:main
+echo "Published ${TAP_REPOSITORY}/Formula/agentplugins.rb for $TAG"


### PR DESCRIPTION
## What

- adds a strict formula generator for the existing signed Agentplugins release manifest
- publishes future releases to `777genius/homebrew-agentplugins` only after exact tag, source commit, and GitHub attestation verification
- makes Homebrew the recommended persistent no-Node install while keeping `npx` available
- documents the token boundary and idempotent recovery path

## Evidence

- npm package suite: 56 passed, 2 expected skips
- focused Go release contracts: passed
- ShellCheck and bash syntax: passed
- generated 0.1.44 formula: Ruby syntax and `brew style` passed
- real public `brew tap`, install, exact `agentplugins 0.1.44` version check, uninstall, and untap: passed
- publisher rerun against 0.1.44: attestation verification passed and produced a no-op

Supersedes automatically closed stacked PR #107 after #105 merged and its temporary base branch was removed.
