### PR TITLE
test(landing): accept static route slash

### DIFF
--- a/landing/tests/browser/landing.spec.ts
+++ b/landing/tests/browser/landing.spec.ts
@@ -58,7 +58,7 @@ test('directory filters and reviewed detail keep automatic detection as the defa
     .filter({ has: page.getByRole('heading', { name: 'GitLab', exact: true }) });
   await expect(gitlabCard).toHaveCount(1);
   await Promise.all([
-    page.waitForURL(/\/plugins\/gitlab$/),
+    page.waitForURL(/\/plugins\/gitlab\/?$/),
     gitlabCard.getByRole('link', { name: 'GitLab', exact: true }).click(),
   ]);
   await expect(page.getByRole('heading', { name: 'GitLab', exact: true })).toBeVisible();


### PR DESCRIPTION
## What

- accepts both equivalent static route forms for the reviewed plugin detail URL
- fixes the GitHub Pages base-path browser test without changing production behavior

## Evidence

- mirrored signed Directory seq 29 and Discovery seq 31
- registry tests: 6 passed
- Nuxt generated 67 production routes
- production-like base path Playwright: 4 passed