### PR TITLE
feat(landing): recommend installs by OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,22 +10,35 @@ Install and manage Agent Plugins 1.0 across your AI agents with one CLI.
 
 ## Quick start
 
-The native Go CLI does not require Node.js. On macOS or Linux with Homebrew:
+Choose the shortest path for your computer. Every option runs the same verified
+Go CLI; the difference is whether it stays installed.
+
+| Your setup                      | Best option               | What happens                                                         |
+| ------------------------------- | ------------------------- | -------------------------------------------------------------------- |
+| macOS                           | Homebrew                  | Installs `agentplugins` and keeps it upgradeable                     |
+| Linux                           | Verified native installer | Installs the matching Linux binary                                   |
+| Windows                         | PowerShell installer      | Installs the matching Windows binary                                 |
+| Any desktop OS with Node.js 22+ | `npx`                     | Runs the plugin command immediately, without a permanent CLI install |
+
+macOS with Homebrew (also supported on Linux with Homebrew):
 
 ```bash
+# macOS · Homebrew
 brew install 777genius/agentplugins/agentplugins
 agentplugins add context7
 ```
 
-Or install the same verified native release and add Context7 in one command:
+macOS or Linux without a package manager:
 
 ```bash
+# macOS / Linux · verified native installer
 curl -fsSL https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.sh | sh -s -- add context7
 ```
 
-On Windows PowerShell:
+Windows PowerShell:
 
 ```powershell
+# Windows · PowerShell
 irm https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.ps1 | iex
 & "$HOME\.local\bin\agentplugins.exe" add context7
 ```
@@ -35,10 +48,11 @@ architecture. The scripts verify its published SHA-256 and reported version,
 then replace the CLI atomically. They install into `$HOME/.local/bin` unless
 `AGENTPLUGINS_BIN_DIR` is set.
 
-If you already have Node.js 22 or newer, the npm facade remains the quickest
-zero-install alternative. It downloads and verifies the same Go binary:
+Already have Node.js 22 or newer? `npx` is the fastest zero-install path: it
+downloads the verified Go binary and immediately runs the plugin command.
 
 ```bash
+# macOS / Linux / Windows · Node.js 22+
 npx universal-agent-plugins add context7
 ```
 

--- a/landing/components/plugins/PluginInstallSection.vue
+++ b/landing/components/plugins/PluginInstallSection.vue
@@ -30,7 +30,6 @@ const localePath = useLocalePath();
 const selectedTargetIds = ref<
   Array<(typeof props.installSpec.supportedTargets)[number]['targetId']>
 >([]);
-const selectedInstallChannelId = ref<string | null>(null);
 const isExpanded = computed({
   get: () => props.expanded,
   set: (value: boolean) => emit('update:expanded', value),
@@ -48,23 +47,12 @@ const selectedTargets = computed(() =>
 
 const installChannels = computed<InstallChannel[]>(() =>
   content.value.installChannels.filter(
-    (channel) => channel.command && ['brew', 'script', 'npm'].includes(channel.id),
+    (channel) => channel.command && ['brew', 'script', 'powershell', 'npm'].includes(channel.id),
   ),
 );
 
-watchEffect(() => {
-  if (
-    selectedInstallChannelId.value &&
-    installChannels.value.some((channel) => channel.id === selectedInstallChannelId.value)
-  ) {
-    return;
-  }
-
-  selectedInstallChannelId.value =
-    installChannels.value.find((channel) => channel.recommended)?.id ??
-    installChannels.value[0]?.id ??
-    null;
-});
+const { recommendedChannelId, selectedInstallChannelId, selectInstallChannel } =
+  useInstallChannelSelection(installChannels);
 
 const selectedInstallChannel = computed(
   () =>
@@ -312,10 +300,13 @@ function toggleExpanded() {
                   'plugin-install__channel-tab--active': channel.id === selectedInstallChannelId,
                 }"
                 :aria-pressed="channel.id === selectedInstallChannelId"
-                @click="selectedInstallChannelId = channel.id"
+                @click="selectInstallChannel(channel.id)"
               >
                 <span>{{ channel.title }}</span>
-                <span v-if="channel.recommended" class="plugin-install__channel-tab-badge">
+                <span
+                  v-if="channel.id === recommendedChannelId"
+                  class="plugin-install__channel-tab-badge"
+                >
                   {{ t('plugins.install.recommended') }}
                 </span>
               </button>

--- a/landing/components/sections/DownloadSection.vue
+++ b/landing/components/sections/DownloadSection.vue
@@ -6,7 +6,6 @@ const { content } = useLandingContent();
 const { t, locale } = useI18n();
 const { data: releaseData, fallbackUrl } = useReleaseDownloads();
 const { quickstartUrl, supportBoundaryUrl } = useDocsLinks();
-const selectedInstallId = ref<string | null>(null);
 
 const releaseVersion = computed(() => releaseData.value?.version || null);
 const releaseDate = computed(() => {
@@ -21,7 +20,7 @@ const supportAccent = ['#39ff14', '#00f0ff', '#ffb703', '#f472b6', '#94a3b8'];
 
 const installChannels = computed(() =>
   content.value.installChannels
-    .filter((channel) => ['brew', 'script', 'npm'].includes(channel.id))
+    .filter((channel) => ['brew', 'script', 'powershell', 'npm'].includes(channel.id))
     .map((channel) =>
       channel.id === 'docs' ? { ...channel, href: quickstartUrl.value } : channel,
     ),
@@ -33,19 +32,12 @@ const quickstartInstallChannels = computed(() =>
   ),
 );
 
-watchEffect(() => {
-  if (
-    selectedInstallId.value &&
-    quickstartInstallChannels.value.some((channel) => channel.id === selectedInstallId.value)
-  ) {
-    return;
-  }
-
-  selectedInstallId.value =
-    quickstartInstallChannels.value.find((channel) => channel.recommended)?.id ||
-    quickstartInstallChannels.value[0]?.id ||
-    null;
-});
+const {
+  detectedInstallPlatform,
+  recommendedChannelId,
+  selectedInstallChannelId: selectedInstallId,
+  selectInstallChannel,
+} = useInstallChannelSelection(quickstartInstallChannels);
 
 const selectedInstallChannel = computed(
   () =>
@@ -58,8 +50,13 @@ const selectedCliInvocation = computed(() =>
   getCliInvocation(selectedInstallChannel.value?.invocation),
 );
 
-const quickstartSteps = computed(() =>
-  content.value.quickstartSteps.map((step) => {
+const quickstartSteps = computed(() => {
+  const steps =
+    selectedInstallChannel.value?.id === 'npm'
+      ? content.value.quickstartSteps.filter((step) => step.id !== 'install-cli')
+      : content.value.quickstartSteps;
+
+  return steps.map((step) => {
     if (step.id === 'install-cli' && selectedInstallChannel.value?.command) {
       const command =
         selectedInstallChannel.value.id === 'npm'
@@ -87,8 +84,8 @@ const quickstartSteps = computed(() =>
     }
 
     return step;
-  }),
-);
+  });
+});
 </script>
 
 <template>
@@ -131,14 +128,27 @@ const quickstartSteps = computed(() =>
                   'download-section__install-tab--active': channel.id === selectedInstallId,
                 }"
                 :aria-pressed="channel.id === selectedInstallId"
-                @click="selectedInstallId = channel.id"
+                @click="selectInstallChannel(channel.id)"
               >
                 <span>{{ channel.title }}</span>
-                <span v-if="channel.recommended" class="download-section__install-tab-badge">
+                <span
+                  v-if="channel.id === recommendedChannelId"
+                  class="download-section__install-tab-badge"
+                >
                   {{ t('download.recommended') }}
                 </span>
               </button>
             </div>
+            <p
+              v-if="detectedInstallPlatform && detectedInstallPlatform !== 'other'"
+              class="download-section__platform-note"
+            >
+              {{
+                t('download.detectedRecommendation', {
+                  platform: t(`download.platforms.${detectedInstallPlatform}`),
+                })
+              }}
+            </p>
             <p v-if="selectedInstallChannel" class="download-section__install-tabs-note">
               {{ selectedInstallChannel.description }}
             </p>
@@ -371,6 +381,13 @@ const quickstartSteps = computed(() =>
   color: #a8b3d1;
   font-size: 0.88rem;
   line-height: 1.55;
+}
+
+.download-section__platform-note {
+  margin: 0;
+  color: #00f0ff;
+  font-size: 0.8rem;
+  font-family: 'JetBrains Mono', monospace;
 }
 
 .download-section__steps {

--- a/landing/composables/useInstallChannelSelection.ts
+++ b/landing/composables/useInstallChannelSelection.ts
@@ -1,0 +1,64 @@
+import type { ComputedRef } from 'vue';
+import type { InstallChannel } from '~/types/content';
+import {
+  normalizeInstallPlatform,
+  recommendedInstallChannelId,
+  type InstallPlatform,
+} from '~/utils/installPlatform';
+
+export function useInstallChannelSelection(channels: ComputedRef<InstallChannel[]>) {
+  const selectedInstallChannelId = ref<string | null>(null);
+  const detectedInstallPlatform = ref<InstallPlatform | null>(null);
+  const manuallySelected = ref(false);
+
+  const recommendedChannelId = computed(() => {
+    const detectedRecommendation = detectedInstallPlatform.value
+      ? recommendedInstallChannelId(detectedInstallPlatform.value)
+      : null;
+    if (
+      detectedRecommendation &&
+      channels.value.some((channel) => channel.id === detectedRecommendation)
+    ) {
+      return detectedRecommendation;
+    }
+
+    return (
+      channels.value.find((channel) => channel.recommended)?.id ?? channels.value[0]?.id ?? null
+    );
+  });
+
+  watchEffect(() => {
+    const selectionStillExists = channels.value.some(
+      (channel) => channel.id === selectedInstallChannelId.value,
+    );
+    if (!selectionStillExists || !manuallySelected.value) {
+      selectedInstallChannelId.value = recommendedChannelId.value;
+    }
+  });
+
+  onMounted(async () => {
+    try {
+      const { default: Bowser } = await import('bowser');
+      detectedInstallPlatform.value = normalizeInstallPlatform(
+        Bowser.getParser(window.navigator.userAgent).getOSName(true),
+      );
+    } catch {
+      detectedInstallPlatform.value = null;
+    }
+  });
+
+  function selectInstallChannel(channelId: string) {
+    if (!channels.value.some((channel) => channel.id === channelId)) {
+      return;
+    }
+    manuallySelected.value = true;
+    selectedInstallChannelId.value = channelId;
+  }
+
+  return {
+    detectedInstallPlatform,
+    recommendedChannelId,
+    selectedInstallChannelId,
+    selectInstallChannel,
+  };
+}

--- a/landing/content/en.json
+++ b/landing/content/en.json
@@ -1010,10 +1010,10 @@
     },
     {
       "id": "npm",
-      "title": "npx",
-      "description": "Run the installer without a permanent install.",
+      "title": "npx · Node.js 22+",
+      "description": "Fastest when Node.js 22+ is already installed: run the plugin command immediately.",
       "href": "https://www.npmjs.com/package/universal-agent-plugins",
-      "note": "Zero-install alternative when Node.js 22 or newer is already available.",
+      "note": "Zero-install: npx downloads the verified CLI and runs the plugin command in one step.",
       "command": "npx universal-agent-plugins version",
       "invocation": "npx universal-agent-plugins"
     },
@@ -1033,6 +1033,15 @@
       "note": "Downloads the correct release binary and verifies its SHA-256 and version.",
       "command": "curl -fsSL https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.sh | sh",
       "invocation": "$HOME/.local/bin/agentplugins"
+    },
+    {
+      "id": "powershell",
+      "title": "Windows PowerShell",
+      "description": "Native Go CLI for Windows. Node.js is not required.",
+      "href": "https://github.com/777genius/universal-agent-plugins/blob/main/docs/NATIVE_INSTALL.md#windows-powershell",
+      "note": "Downloads the Windows binary and verifies its SHA-256 and version.",
+      "command": "irm https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.ps1 | iex",
+      "invocation": "& \"$HOME\\.local\\bin\\agentplugins.exe\""
     },
     {
       "id": "releases",

--- a/landing/content/es.json
+++ b/landing/content/es.json
@@ -1010,10 +1010,10 @@
     },
     {
       "id": "npm",
-      "title": "npx",
-      "description": "Ejecuta el instalador sin una instalación permanente.",
+      "title": "npx · Node.js 22+",
+      "description": "La opción más rápida si ya tiene Node.js 22+: ejecute el comando del plugin inmediatamente.",
       "href": "https://www.npmjs.com/package/universal-agent-plugins",
-      "note": "Alternativa sin instalación si ya tienes Node.js 22 o posterior.",
+      "note": "Sin instalación permanente: npx descarga la CLI verificada y ejecuta el comando en un solo paso.",
       "command": "npx universal-agent-plugins version",
       "invocation": "npx universal-agent-plugins"
     },
@@ -1033,6 +1033,15 @@
       "note": "Descarga el binario correcto y verifica su SHA-256 y versión.",
       "command": "curl -fsSL https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.sh | sh",
       "invocation": "$HOME/.local/bin/agentplugins"
+    },
+    {
+      "id": "powershell",
+      "title": "Windows PowerShell",
+      "description": "CLI nativa de Go para Windows. No requiere Node.js.",
+      "href": "https://github.com/777genius/universal-agent-plugins/blob/main/docs/NATIVE_INSTALL.md#windows-powershell",
+      "note": "Descarga el binario de Windows y verifica su SHA-256 y versión.",
+      "command": "irm https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.ps1 | iex",
+      "invocation": "& \"$HOME\\.local\\bin\\agentplugins.exe\""
     },
     {
       "id": "releases",

--- a/landing/content/fr.json
+++ b/landing/content/fr.json
@@ -1010,10 +1010,10 @@
     },
     {
       "id": "npm",
-      "title": "npx",
-      "description": "Exécutez l'installateur sans installation permanente.",
+      "title": "npx · Node.js 22+",
+      "description": "Le choix le plus rapide si Node.js 22+ est déjà installé : lancez immédiatement la commande du plugin.",
       "href": "https://www.npmjs.com/package/universal-agent-plugins",
-      "note": "Alternative sans installation si Node.js 22 ou plus récent est déjà disponible.",
+      "note": "Sans installation permanente : npx télécharge le CLI vérifié et exécute la commande en une étape.",
       "command": "npx universal-agent-plugins version",
       "invocation": "npx universal-agent-plugins"
     },
@@ -1033,6 +1033,15 @@
       "note": "Télécharge le bon binaire et vérifie son SHA-256 et sa version.",
       "command": "curl -fsSL https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.sh | sh",
       "invocation": "$HOME/.local/bin/agentplugins"
+    },
+    {
+      "id": "powershell",
+      "title": "Windows PowerShell",
+      "description": "CLI Go natif pour Windows. Node.js n'est pas requis.",
+      "href": "https://github.com/777genius/universal-agent-plugins/blob/main/docs/NATIVE_INSTALL.md#windows-powershell",
+      "note": "Télécharge le binaire Windows et vérifie son SHA-256 et sa version.",
+      "command": "irm https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.ps1 | iex",
+      "invocation": "& \"$HOME\\.local\\bin\\agentplugins.exe\""
     },
     {
       "id": "releases",

--- a/landing/content/ru.json
+++ b/landing/content/ru.json
@@ -1010,10 +1010,10 @@
     },
     {
       "id": "npm",
-      "title": "npx",
-      "description": "Запускайте установщик без постоянной установки.",
+      "title": "npx · Node.js 22+",
+      "description": "Самый быстрый вариант, если Node.js 22+ уже установлен: команда плагина запускается сразу.",
       "href": "https://www.npmjs.com/package/universal-agent-plugins",
-      "note": "Вариант без установки, если Node.js 22 или новее уже доступен.",
+      "note": "Без постоянной установки: npx скачивает проверенный CLI и запускает команду плагина за один шаг.",
       "command": "npx universal-agent-plugins version",
       "invocation": "npx universal-agent-plugins"
     },
@@ -1033,6 +1033,15 @@
       "note": "Скачивает нужный бинарник релиза и проверяет его SHA-256 и версию.",
       "command": "curl -fsSL https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.sh | sh",
       "invocation": "$HOME/.local/bin/agentplugins"
+    },
+    {
+      "id": "powershell",
+      "title": "Windows PowerShell",
+      "description": "Нативный Go CLI для Windows. Node.js не требуется.",
+      "href": "https://github.com/777genius/universal-agent-plugins/blob/main/docs/NATIVE_INSTALL.md#windows-powershell",
+      "note": "Скачивает Windows-бинарник и проверяет его SHA-256 и версию.",
+      "command": "irm https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.ps1 | iex",
+      "invocation": "& \"$HOME\\.local\\bin\\agentplugins.exe\""
     },
     {
       "id": "releases",

--- a/landing/content/zh.json
+++ b/landing/content/zh.json
@@ -1010,10 +1010,10 @@
     },
     {
       "id": "npm",
-      "title": "npx",
-      "description": "无需永久安装即可运行安装器。",
+      "title": "npx · Node.js 22+",
+      "description": "如果已安装 Node.js 22+，这是最快的方式：直接运行插件命令。",
       "href": "https://www.npmjs.com/package/universal-agent-plugins",
-      "note": "如果已有 Node.js 22 或更高版本，可使用此免安装方案。",
+      "note": "无需永久安装：npx 下载已验证的 CLI，并一步运行插件命令。",
       "command": "npx universal-agent-plugins version",
       "invocation": "npx universal-agent-plugins"
     },
@@ -1033,6 +1033,15 @@
       "note": "下载正确的发布二进制文件，并验证 SHA-256 和版本。",
       "command": "curl -fsSL https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.sh | sh",
       "invocation": "$HOME/.local/bin/agentplugins"
+    },
+    {
+      "id": "powershell",
+      "title": "Windows PowerShell",
+      "description": "适用于 Windows 的原生 Go CLI，无需 Node.js。",
+      "href": "https://github.com/777genius/universal-agent-plugins/blob/main/docs/NATIVE_INSTALL.md#windows-powershell",
+      "note": "下载 Windows 二进制文件并验证其 SHA-256 和版本。",
+      "command": "irm https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.ps1 | iex",
+      "invocation": "& \"$HOME\\.local\\bin\\agentplugins.exe\""
     },
     {
       "id": "releases",

--- a/landing/locales/en.json
+++ b/landing/locales/en.json
@@ -77,6 +77,13 @@
     "quickstartTitle": "Fastest start",
     "quickstartSubtitle": "This is the fastest path to a real plugin install or a validated repo.",
     "installTabsLabel": "Choose how to run Universal Agent Plugins",
+    "detectedRecommendation": "Best option for {platform} selected",
+    "platforms": {
+      "macos": "macOS",
+      "windows": "Windows",
+      "linux": "Linux",
+      "other": "your device"
+    },
     "supportTitle": "Support snapshot",
     "supportSubtitle": "Real support depth today, based on the current support policy and target matrix.",
     "supportLink": "Read the support boundary"

--- a/landing/locales/es.json
+++ b/landing/locales/es.json
@@ -77,6 +77,13 @@
     "quickstartTitle": "Inicio más rápido",
     "quickstartSubtitle": "Esta es la ruta más rápida hacia una instalación real de plugin o un repositorio validado.",
     "installTabsLabel": "Elija cómo ejecutar Universal Agent Plugins",
+    "detectedRecommendation": "Seleccionada la mejor opción para {platform}",
+    "platforms": {
+      "macos": "macOS",
+      "windows": "Windows",
+      "linux": "Linux",
+      "other": "su dispositivo"
+    },
     "supportTitle": "Instantánea de soporte",
     "supportSubtitle": "Profundidad de soporte real hoy, según la política de soporte actual y la matriz de objetivos.",
     "supportLink": "Leer el límite de soporte"

--- a/landing/locales/fr.json
+++ b/landing/locales/fr.json
@@ -77,6 +77,13 @@
     "quickstartTitle": "Démarrage le plus rapide",
     "quickstartSubtitle": "C'est le chemin le plus rapide vers une vraie installation de plugin ou un dépôt validé.",
     "installTabsLabel": "Choisissez comment exécuter Universal Agent Plugins",
+    "detectedRecommendation": "Meilleure option sélectionnée pour {platform}",
+    "platforms": {
+      "macos": "macOS",
+      "windows": "Windows",
+      "linux": "Linux",
+      "other": "votre appareil"
+    },
     "supportTitle": "Instantané de prise en charge",
     "supportSubtitle": "Véritable profondeur de support aujourd'hui, basée sur la politique de support actuelle et la matrice cible.",
     "supportLink": "Lire la limite du support"

--- a/landing/locales/ru.json
+++ b/landing/locales/ru.json
@@ -77,6 +77,13 @@
     "quickstartTitle": "Самый быстрый старт",
     "quickstartSubtitle": "Это самый быстрый путь к реальной установке плагина или к валидному репозиторию.",
     "installTabsLabel": "Выберите, как запускать Universal Agent Plugins",
+    "detectedRecommendation": "Выбран лучший вариант для {platform}",
+    "platforms": {
+      "macos": "macOS",
+      "windows": "Windows",
+      "linux": "Linux",
+      "other": "вашего устройства"
+    },
     "supportTitle": "Снимок поддержки",
     "supportSubtitle": "Текущая глубина поддержки по реальной политике поддержки и матрице поддерживаемых путей.",
     "supportLink": "Открыть границу поддержки"

--- a/landing/locales/zh.json
+++ b/landing/locales/zh.json
@@ -77,6 +77,13 @@
     "quickstartTitle": "最快开始方式",
     "quickstartSubtitle": "这是通往真实插件安装或已验证仓库的最快路径。",
     "installTabsLabel": "选择如何运行 Universal Agent Plugins",
+    "detectedRecommendation": "已为 {platform} 选择最佳方式",
+    "platforms": {
+      "macos": "macOS",
+      "windows": "Windows",
+      "linux": "Linux",
+      "other": "您的设备"
+    },
     "supportTitle": "支持快照",
     "supportSubtitle": "今天的实际支持深度基于当前的支持政策和目标矩阵。",
     "supportLink": "读取支撑边界"

--- a/landing/package.json
+++ b/landing/package.json
@@ -31,6 +31,7 @@
     "@nuxtjs/i18n": "^9.5.6",
     "@pinia/nuxt": "^0.11.3",
     "@vueuse/nuxt": "^10.11.1",
+    "bowser": "2.14.1",
     "nuxt": "^3.21.10",
     "nuxt-icon": "^0.6.10",
     "pinia": "^3.0.4",

--- a/landing/pnpm-lock.yaml
+++ b/landing/pnpm-lock.yaml
@@ -22,6 +22,9 @@ dependencies:
   '@vueuse/nuxt':
     specifier: ^10.11.1
     version: 10.11.1(nuxt@3.21.11)(vue@3.5.40)
+  bowser:
+    specifier: 2.14.1
+    version: 2.14.1
   nuxt:
     specifier: ^3.21.10
     version: 3.21.11(@vue/compiler-sfc@3.5.40)(eslint@9.39.5)(rollup@4.62.3)(sass@1.102.0)(typescript@6.0.3)(vite@7.3.6)(vue-tsc@3.3.9)
@@ -4429,6 +4432,10 @@ packages:
 
   /boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  /bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+    dev: false
 
   /boxen@7.0.0:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}

--- a/landing/tests/browser/landing.spec.ts
+++ b/landing/tests/browser/landing.spec.ts
@@ -68,19 +68,57 @@ test('directory filters and reviewed detail keep automatic detection as the defa
   await expect(page.locator('.command-snippet').first()).not.toContainText('--target');
 });
 
-test('download page recommends native Homebrew and preserves the npx alternative', async ({
-  page,
+test('download page recommends the detected OS path and preserves the npx alternative', async ({
+  browser,
+  baseURL,
 }) => {
-  await page.goto('./download');
+  const context = await browser.newContext({
+    userAgent:
+      'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 ' +
+      '(KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36',
+  });
+  const page = await context.newPage();
+
+  await page.goto(new URL('download', baseURL).href);
   const tabs = page.locator('.download-section__install-tab');
-  const homebrew = tabs.filter({ hasText: 'Homebrew' });
-  await expect(homebrew).toHaveAttribute('aria-pressed', 'true');
-  await expect(page.getByText('brew install 777genius/agentplugins/agentplugins')).toBeVisible();
-  await expect(page.getByText('agentplugins add context7 --target codex,cursor')).toBeVisible();
+  const script = tabs.filter({ hasText: 'Verified install script' });
+  await expect(script).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.getByText('Best option for Linux selected')).toBeVisible();
+  await expect(page.getByText(/install\.sh \| sh/)).toBeVisible();
+  await expect(
+    page.getByText('$HOME/.local/bin/agentplugins add context7 --target codex,cursor'),
+  ).toBeVisible();
 
   await tabs.filter({ hasText: 'npx' }).click();
-  await expect(page.getByText('npx universal-agent-plugins version')).toBeVisible();
   await expect(
     page.getByText('npx universal-agent-plugins add context7 --target codex,cursor'),
   ).toBeVisible();
+  await expect(page.getByText('npx universal-agent-plugins version')).toHaveCount(0);
+
+  await context.close();
+});
+
+test('Windows visitors receive the PowerShell installer and invocation', async ({
+  browser,
+  baseURL,
+}) => {
+  const context = await browser.newContext({
+    userAgent:
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' +
+      '(KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36',
+  });
+  const page = await context.newPage();
+
+  await page.goto(new URL('download', baseURL).href);
+  const powershell = page
+    .locator('.download-section__install-tab')
+    .filter({ hasText: 'PowerShell' });
+  await expect(powershell).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.getByText('Best option for Windows selected')).toBeVisible();
+  await expect(page.getByText(/install\.ps1 \| iex/)).toBeVisible();
+  await expect(
+    page.getByText('& "$HOME\\.local\\bin\\agentplugins.exe" add context7 --target codex,cursor'),
+  ).toBeVisible();
+
+  await context.close();
 });

--- a/landing/tests/native-install.test.ts
+++ b/landing/tests/native-install.test.ts
@@ -3,7 +3,9 @@ import { readFileSync } from 'node:fs';
 import { describe, it } from 'node:test';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import Bowser from 'bowser';
 import { applyCliInvocation, getCliInvocation } from '../utils/cliInvocation.ts';
+import { normalizeInstallPlatform, recommendedInstallChannelId } from '../utils/installPlatform.ts';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const locales = ['en', 'es', 'fr', 'ru', 'zh'];
@@ -34,11 +36,11 @@ describe('native-first installation', () => {
         }>;
       };
       const selected = content.installChannels.filter((channel) =>
-        ['brew', 'script', 'npm'].includes(channel.id),
+        ['brew', 'script', 'powershell', 'npm'].includes(channel.id),
       );
       assert.deepEqual(
         selected.map((channel) => channel.id),
-        ['brew', 'npm', 'script'],
+        ['brew', 'npm', 'script', 'powershell'],
         locale,
       );
       assert.equal(selected.filter((channel) => channel.recommended).length, 1, locale);
@@ -47,10 +49,31 @@ describe('native-first installation', () => {
       assert.equal(selected[0]?.invocation, 'agentplugins');
       assert.equal(selected[1]?.invocation, 'npx universal-agent-plugins');
       assert.equal(selected[2]?.invocation, '$HOME/.local/bin/agentplugins');
+      assert.equal(selected[3]?.invocation, '& "$HOME\\.local\\bin\\agentplugins.exe"');
       assert.ok(
         selected.every((channel) => !channel.command?.includes('plugin-kit-ai')),
         locale,
       );
     }
+  });
+
+  it('maps current browser OS names to the safest default channel', () => {
+    const userAgents = {
+      macos:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/140.0.0.0 Safari/537.36',
+      windows:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/140.0.0.0 Safari/537.36',
+      linux: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/140.0.0.0 Safari/537.36',
+    };
+
+    for (const [expectedPlatform, userAgent] of Object.entries(userAgents)) {
+      const platform = normalizeInstallPlatform(Bowser.getParser(userAgent).getOSName(true));
+      assert.equal(platform, expectedPlatform);
+    }
+
+    assert.equal(recommendedInstallChannelId('macos'), 'brew');
+    assert.equal(recommendedInstallChannelId('linux'), 'script');
+    assert.equal(recommendedInstallChannelId('windows'), 'powershell');
+    assert.equal(recommendedInstallChannelId('other'), 'npm');
   });
 });

--- a/landing/utils/installPlatform.ts
+++ b/landing/utils/installPlatform.ts
@@ -1,0 +1,30 @@
+export type InstallPlatform = 'macos' | 'windows' | 'linux' | 'other';
+
+export function normalizeInstallPlatform(osName?: string | null): InstallPlatform {
+  const normalized = osName?.trim().toLowerCase() ?? '';
+
+  if (normalized.includes('mac') || normalized.includes('os x')) {
+    return 'macos';
+  }
+  if (normalized.includes('windows')) {
+    return 'windows';
+  }
+  if (normalized.includes('linux')) {
+    return 'linux';
+  }
+
+  return 'other';
+}
+
+export function recommendedInstallChannelId(platform: InstallPlatform): string {
+  switch (platform) {
+    case 'macos':
+      return 'brew';
+    case 'windows':
+      return 'powershell';
+    case 'linux':
+      return 'script';
+    default:
+      return 'npm';
+  }
+}


### PR DESCRIPTION
## What changed
- recommend Homebrew on macOS, the verified native script on Linux, and PowerShell on Windows
- keep every install channel visible so visitors can override the detected recommendation
- make npx a true zero-install path that runs the plugin command immediately when Node.js 22+ is available
- document all four setup paths in the README with explicit OS comments

## Evidence
- `pnpm run test:registry` - 7 passed
- `pnpm run lint` - passed
- production `pnpm run generate` - passed
- GitHub Pages-base Playwright E2E - 5 passed, including explicit Linux and Windows user agents
- `pnpm install --frozen-lockfile` - passed
