### PR TITLE
fix(landing): polish mobile navigation and discovery UX

### DIFF
--- a/landing/assets/styles/registry.scss
+++ b/landing/assets/styles/registry.scss
@@ -1027,7 +1027,36 @@ img {
   pointer-events: none;
 }
 .search-field input {
-  padding: 0 12px 0 42px;
+  padding: 0 42px;
+}
+.search-field__clear {
+  position: absolute;
+  z-index: 2;
+  top: 50%;
+  right: 8px;
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  translate: 0 -50%;
+  border: 0;
+  border-radius: 8px;
+  color: var(--subtle);
+  background: transparent;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+}
+.search-field__clear:hover,
+.search-field__clear:focus-visible {
+  color: var(--text);
+  background: var(--surface-raised);
+}
+.catalog-advanced-filters {
+  display: contents;
+}
+.catalog-filter-toggle {
+  display: none;
 }
 .app-select__trigger {
   width: 100%;
@@ -1616,16 +1645,20 @@ img {
 }
 .catalog-add-button {
   position: relative;
-  width: 44px;
+  width: auto;
   height: 44px;
   flex: 0 0 auto;
-  display: grid;
-  place-items: center;
+  padding: 0 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
   border: 1px solid color-mix(in srgb, var(--primary) 48%, var(--line));
   border-radius: 13px;
   color: var(--text);
   background: color-mix(in srgb, var(--primary) 10%, var(--surface));
-  font-size: 1.45rem;
+  font-size: 0.76rem;
+  font-weight: 750;
   line-height: 1;
   text-decoration: none;
   transition:
@@ -1633,37 +1666,15 @@ img {
     border-color 0.16s ease,
     background 0.16s ease;
 }
+.catalog-add-button > span:first-child {
+  font-size: 1.25rem;
+  font-weight: 500;
+}
 .catalog-add-button:hover,
 .catalog-add-button:focus-visible {
   transform: translateY(-2px);
   border-color: var(--primary);
   background: color-mix(in srgb, var(--primary) 18%, var(--surface));
-}
-.catalog-add-button__tooltip {
-  position: absolute;
-  right: 0;
-  bottom: calc(100% + 9px);
-  z-index: 5;
-  width: max-content;
-  padding: 6px 8px;
-  border: 1px solid var(--line-strong);
-  border-radius: 7px;
-  color: var(--text);
-  background: var(--surface-solid);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.22);
-  font-size: 0.64rem;
-  font-weight: 700;
-  pointer-events: none;
-  opacity: 0;
-  translate: 0 4px;
-  transition:
-    opacity 0.14s ease,
-    translate 0.14s ease;
-}
-.catalog-add-button:hover .catalog-add-button__tooltip,
-.catalog-add-button:focus-visible .catalog-add-button__tooltip {
-  opacity: 1;
-  translate: 0;
 }
 .catalog-meta {
   margin: 15px 2px 18px;
@@ -2676,6 +2687,43 @@ img {
   }
   .search-field {
     grid-column: auto;
+  }
+  .catalog-filter-toggle {
+    min-height: 44px;
+    padding: 0 12px;
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    color: var(--text);
+    background: var(--surface-solid);
+    font-size: 0.82rem;
+    font-weight: 680;
+    cursor: pointer;
+  }
+  .catalog-filter-toggle__count {
+    margin-left: auto;
+    color: var(--primary-bright);
+    font-size: 0.68rem;
+  }
+  .catalog-filter-toggle__chevron {
+    margin-left: auto;
+    color: var(--subtle);
+    font-size: 1rem;
+    transition: rotate 0.16s ease;
+  }
+  .catalog-filter-toggle__count + .catalog-filter-toggle__chevron {
+    margin-left: 0;
+  }
+  .catalog-filter-toggle[aria-expanded='true'] .catalog-filter-toggle__chevron {
+    rotate: 180deg;
+  }
+  .catalog-advanced-filters {
+    display: none;
+  }
+  .catalog-advanced-filters--open {
+    display: contents;
   }
   .catalog-meta {
     align-items: stretch;

--- a/landing/components/layout/AppHeader.vue
+++ b/landing/components/layout/AppHeader.vue
@@ -1,5 +1,15 @@
 <script setup lang="ts">
 import { mdiClose, mdiGithub, mdiMenu } from '@mdi/js';
+import {
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogOverlay,
+  DialogPortal,
+  DialogRoot,
+  DialogTitle,
+  DialogTrigger,
+} from 'reka-ui';
 
 const { t } = useI18n();
 const route = useRoute();
@@ -58,52 +68,60 @@ onMounted(() => {
         <div v-else class="app-header__control-fallback" aria-hidden="true" />
       </div>
       <div class="app-header__mobile-actions">
-        <v-btn :icon="mdiMenu" variant="text" @click="menuOpen = true" />
-        <Teleport to="body">
-          <Transition name="mobile-menu-fade">
-            <div v-if="menuOpen" class="mobile-menu-overlay" @click.self="menuOpen = false">
-              <div class="mobile-menu">
-                <div class="mobile-menu__header">
-                  <div @click="menuOpen = false">
-                    <AppLogo />
-                  </div>
-                  <div style="flex: 1" />
-                  <v-btn :icon="mdiClose" variant="text" @click="menuOpen = false" />
+        <DialogRoot v-model:open="menuOpen">
+          <DialogTrigger as-child>
+            <v-btn :icon="mdiMenu" variant="text" aria-label="Open navigation menu" />
+          </DialogTrigger>
+          <DialogPortal>
+            <DialogOverlay class="mobile-menu-overlay" />
+            <DialogContent class="mobile-menu">
+              <DialogTitle class="sr-only">Navigation menu</DialogTitle>
+              <DialogDescription class="sr-only">
+                Jump to plugins, product details, frequently asked questions, or GitHub.
+              </DialogDescription>
+              <div class="mobile-menu__header">
+                <div @click="menuOpen = false">
+                  <AppLogo />
                 </div>
-                <hr class="mobile-menu__divider" >
-                <nav class="mobile-menu__list">
-                  <a
-                    v-for="item in navItems"
-                    :key="item.id"
-                    :href="sectionHref(item.id)"
-                    class="mobile-menu__link"
-                    @click="menuOpen = false"
-                  >
-                    {{ item.label }}
-                  </a>
-                  <a
-                    :href="githubUrl"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="mobile-menu__link"
-                    @click="menuOpen = false"
-                  >
-                    {{ t('nav.viewOnGithub') }}
-                  </a>
-                </nav>
-                <hr class="mobile-menu__divider" >
-                <div class="mobile-menu__actions">
-                  <template v-if="interactiveReady">
-                    <ThemeToggle />
-                  </template>
-                  <template v-else>
-                    <div class="app-header__control-fallback" aria-hidden="true" />
-                  </template>
-                </div>
+                <div style="flex: 1" />
+                <DialogClose as-child>
+                  <v-btn :icon="mdiClose" variant="text" aria-label="Close navigation menu" />
+                </DialogClose>
               </div>
-            </div>
-          </Transition>
-        </Teleport>
+              <hr class="mobile-menu__divider" >
+              <nav class="mobile-menu__list">
+                <a
+                  v-for="item in navItems"
+                  :key="item.id"
+                  :href="sectionHref(item.id)"
+                  class="mobile-menu__link"
+                  @click="menuOpen = false"
+                >
+                  {{ item.label }}
+                </a>
+                <a
+                  :href="githubUrl"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="mobile-menu__link"
+                  @click="menuOpen = false"
+                >
+                  {{ t('nav.viewOnGithub') }}
+                </a>
+              </nav>
+              <hr class="mobile-menu__divider" >
+              <div class="mobile-menu__actions">
+                <span>Appearance</span>
+                <template v-if="interactiveReady">
+                  <ThemeToggle />
+                </template>
+                <template v-else>
+                  <div class="app-header__control-fallback" aria-hidden="true" />
+                </template>
+              </div>
+            </DialogContent>
+          </DialogPortal>
+        </DialogRoot>
       </div>
     </v-container>
   </header>
@@ -209,21 +227,22 @@ onMounted(() => {
   position: fixed;
   inset: 0;
   z-index: 9999;
-  background: rgba(6, 8, 16, 0.94);
+  background: color-mix(in srgb, var(--surface-solid) 94%, transparent);
   backdrop-filter: blur(18px);
   -webkit-backdrop-filter: blur(18px);
 }
 
-.v-theme--light .mobile-menu-overlay {
-  background: rgba(248, 250, 252, 0.96);
-}
-
 .mobile-menu {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
   padding: 16px 16px 24px;
   height: 100%;
   overflow-y: auto;
+  color: var(--text);
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.015), rgba(255, 255, 255, 0)), transparent;
+    linear-gradient(180deg, color-mix(in srgb, var(--cyan) 3%, transparent), transparent 32%),
+    var(--surface-solid);
 }
 
 .mobile-menu__header {
@@ -264,17 +283,30 @@ onMounted(() => {
   flex-direction: row;
   gap: 8px;
   align-items: center;
-  justify-content: center;
-  padding-top: 16px;
+  justify-content: space-between;
+  padding: 12px 16px 0;
+  color: var(--muted);
+  font-size: 0.9rem;
 }
 
-.mobile-menu-fade-enter-active,
-.mobile-menu-fade-leave-active {
-  transition: opacity 0.2s ease;
+.mobile-menu-overlay[data-state='open'] {
+  animation: mobile-menu-overlay-in 0.18s ease-out;
 }
 
-.mobile-menu-fade-enter-from,
-.mobile-menu-fade-leave-to {
-  opacity: 0;
+.mobile-menu[data-state='open'] {
+  animation: mobile-menu-content-in 0.2s ease-out;
+}
+
+@keyframes mobile-menu-overlay-in {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes mobile-menu-content-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
 }
 </style>

--- a/landing/components/registry/PluginCatalog.vue
+++ b/landing/components/registry/PluginCatalog.vue
@@ -18,6 +18,7 @@ const trust = ref('all');
 const client = ref('all');
 const authentication = ref('all');
 const owner = ref('all');
+const mobileFiltersOpen = ref(false);
 const pageSize = 48;
 const displayLimit = ref(pageSize);
 const discovery = useDiscoveryStatus();
@@ -96,6 +97,33 @@ const visible = computed(() =>
 );
 const displayed = computed(() => visible.value.slice(0, displayLimit.value));
 const remaining = computed(() => Math.max(0, visible.value.length - displayed.value.length));
+const activeFilterCount = computed(
+  () =>
+    [category, component, source, trust, client, authentication, owner].filter(
+      (filter) => filter.value !== 'all',
+    ).length,
+);
+const catalogSummary = computed(() => {
+  const total = props.plugins.length;
+  if (!visible.value.length) return `No matches · ${total} total`;
+  if (visible.value.length === total) return `${displayed.value.length} shown · ${total} plugins`;
+  if (displayed.value.length < visible.value.length)
+    return `${displayed.value.length} shown · ${visible.value.length} matching · ${total} total`;
+  return `${visible.value.length} matching · ${total} total`;
+});
+
+function clearFilters() {
+  query.value = '';
+  category.value = 'all';
+  component.value = 'all';
+  source.value = 'all';
+  trust.value = 'all';
+  client.value = 'all';
+  authentication.value = 'all';
+  owner.value = 'all';
+  mobileFiltersOpen.value = false;
+}
+
 watch([query, category, component, source, trust, client, authentication, owner], () => {
   displayLimit.value = pageSize;
 });
@@ -113,12 +141,8 @@ watch([query, category, component, source, trust, client, authentication, owner]
           target="_blank"
           rel="noreferrer"
           aria-label="Add a plugin"
-          aria-describedby="catalog-add-tooltip"
         >
-          <span aria-hidden="true">＋</span>
-          <span id="catalog-add-tooltip" class="catalog-add-button__tooltip" role="tooltip"
-            >Add a plugin</span
-          >
+          <span aria-hidden="true">＋</span><span>Add plugin</span>
         </a>
       </div>
       <p>{{ intro }}</p>
@@ -130,59 +154,90 @@ watch([query, category, component, source, trust, client, authentication, owner]
           <circle cx="11" cy="11" r="6.5" />
           <path d="m16 16 4 4" />
         </svg>
-        <input v-model="query" type="search" placeholder="Search by name, author, or capability…" >
+        <input
+          v-model="query"
+          type="search"
+          aria-label="Search plugins"
+          placeholder="Search by name, author, or capability…"
+        >
+        <button
+          v-if="query"
+          class="search-field__clear"
+          type="button"
+          aria-label="Clear plugin search"
+          @click="query = ''"
+        >
+          <span aria-hidden="true">×</span>
+        </button>
       </label>
-      <AppCombobox
-        v-model="category"
-        leading-icon="category"
-        label="Filter by category"
-        search-placeholder="Search categories…"
-        :options="stableCategoryOptions"
-      />
-      <AppSelect
-        v-model="component"
-        leading-icon="component"
-        label="Filter by component"
-        :options="stableComponentOptions"
-      />
-      <AppSelect
-        v-model="source"
-        leading-icon="source"
-        label="Filter by source"
-        :options="sourceOptions"
-      />
-      <AppSelect
-        v-model="trust"
-        leading-icon="trust"
-        label="Filter by trust level"
-        :options="trustOptions"
-      />
-      <AppSelect
-        v-model="client"
-        leading-icon="agent"
-        label="Filter by agent"
-        :options="clientOptions"
-      />
-      <AppSelect
-        v-model="authentication"
-        leading-icon="authentication"
-        label="Filter by authentication"
-        :options="authenticationOptions"
-      />
-      <AppCombobox
-        v-model="owner"
-        leading-icon="owner"
-        label="Filter by owner"
-        search-placeholder="Search owners…"
-        :options="ownerOptions"
-      />
+      <button
+        class="catalog-filter-toggle"
+        type="button"
+        :aria-expanded="mobileFiltersOpen"
+        aria-controls="catalog-advanced-filters"
+        @click="mobileFiltersOpen = !mobileFiltersOpen"
+      >
+        <FilterIcon name="category" />
+        <span>{{ mobileFiltersOpen ? 'Hide filters' : 'More filters' }}</span>
+        <span v-if="activeFilterCount" class="catalog-filter-toggle__count"
+          >{{ activeFilterCount }} active</span
+        >
+        <span class="catalog-filter-toggle__chevron" aria-hidden="true">⌄</span>
+      </button>
+      <div
+        id="catalog-advanced-filters"
+        class="catalog-advanced-filters"
+        :class="{ 'catalog-advanced-filters--open': mobileFiltersOpen }"
+      >
+        <AppCombobox
+          v-model="category"
+          leading-icon="category"
+          label="Filter by category"
+          search-placeholder="Search categories…"
+          :options="stableCategoryOptions"
+        />
+        <AppSelect
+          v-model="component"
+          leading-icon="component"
+          label="Filter by component"
+          :options="stableComponentOptions"
+        />
+        <AppSelect
+          v-model="source"
+          leading-icon="source"
+          label="Filter by source"
+          :options="sourceOptions"
+        />
+        <AppSelect
+          v-model="trust"
+          leading-icon="trust"
+          label="Filter by trust level"
+          :options="trustOptions"
+        />
+        <AppSelect
+          v-model="client"
+          leading-icon="agent"
+          label="Filter by agent"
+          :options="clientOptions"
+        />
+        <AppSelect
+          v-model="authentication"
+          leading-icon="authentication"
+          label="Filter by authentication"
+          :options="authenticationOptions"
+        />
+        <AppCombobox
+          v-model="owner"
+          leading-icon="owner"
+          label="Filter by owner"
+          search-placeholder="Search owners…"
+          :options="ownerOptions"
+        />
+      </div>
     </div>
     <div class="catalog-meta">
       <div>
-        <div class="catalog-count" aria-live="polite">
-          Showing {{ displayed.length }} of {{ visible.length }} matching plugins ·
-          {{ plugins.length }} total
-        </div>
+        <div class="catalog-count" aria-live="polite">{{ catalogSummary }}</div>
         <p
           v-if="['loading', 'stale', 'unavailable'].includes(discovery.state)"
           class="discovery-status"
@@ -211,20 +266,7 @@ watch([query, category, component, source, trust, client, authentication, owner]
     <div v-else class="empty-state">
       <h3>No matching plugins</h3>
       <p>Try a broader search or clear one of the filters.</p>
-      <button
-        class="button button--secondary"
-        type="button"
-        @click="
-          query = '';
-          category = 'all';
-          component = 'all';
-          source = 'all';
-          trust = 'all';
-          client = 'all';
-          authentication = 'all';
-          owner = 'all';
-        "
-      >
+      <button class="button button--secondary" type="button" @click="clearFilters">
         Clear filters
       </button>
     </div>

--- a/landing/components/registry/RegistryHero.vue
+++ b/landing/components/registry/RegistryHero.vue
@@ -159,7 +159,7 @@ function updateTargets(values: string[]) {
       </div>
     </div>
 
-    <footer class="client-section" aria-labelledby="supported-clients-title">
+    <div class="client-section" aria-labelledby="supported-clients-title">
       <div class="client-section__inner container">
         <p id="supported-clients-title">Supported clients</p>
         <ClientStrip />
@@ -168,6 +168,6 @@ function updateTargets(values: string[]) {
           you to finish activation or sign in.
         </p>
       </div>
-    </footer>
+    </div>
   </section>
 </template>

--- a/landing/tests/browser/landing.spec.ts
+++ b/landing/tests/browser/landing.spec.ts
@@ -22,13 +22,59 @@ test('homepage installs with auto-detection and exposes the full directory', asy
   await expect(page.locator('.command-snippet').first()).not.toContainText('--target');
   await expect(page.getByText('Supported clients')).toBeVisible();
   await expect(page.locator('.client-strip li')).toHaveCount(11);
+  await expect(page.getByRole('contentinfo')).toHaveCount(1);
   await expect(page.locator('.plugin-card').first()).toBeVisible();
-  await expect(page.locator('.catalog-count')).toContainText(/[2-9]\d{3} total/, {
+  await expect(page.locator('.catalog-count')).toContainText(/[2-9]\d{3} plugins/, {
     timeout: 15_000,
   });
   await expect(page.getByRole('link', { name: /Explore [\d,]+ plugins/ })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Add a plugin', exact: true })).toContainText(
+    'Add plugin',
+  );
   await expect(page.getByText(/recently found community packages/i)).toHaveCount(0);
   expect(errors).toEqual([]);
+});
+
+test.describe('mobile navigation and catalog', () => {
+  test.use({ viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true });
+
+  test('navigation is labeled, modal, keyboard-safe, and restores focus', async ({ page }) => {
+    await page.goto('./');
+    const trigger = page.getByRole('button', { name: 'Open navigation menu' });
+
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await trigger.click();
+    const dialog = page.getByRole('dialog', { name: 'Navigation menu' });
+    await expect(dialog).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Close navigation menu' })).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(dialog).toBeHidden();
+    await expect(trigger).toBeFocused();
+  });
+
+  test('keeps advanced filters compact and makes search easy to clear', async ({ page }) => {
+    await page.goto('./');
+    await page.locator('.catalog .section-heading').scrollIntoViewIfNeeded();
+
+    const toggle = page.locator('.catalog-filter-toggle');
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toContainText('More filters');
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    const componentFilter = page.locator('.app-select__trigger[aria-label="Filter by component"]');
+    await expect(componentFilter).toBeHidden();
+
+    const search = page.getByRole('searchbox', { name: 'Search plugins' });
+    await search.fill('gitlab');
+    await expect(page.getByRole('button', { name: 'Clear plugin search' })).toBeVisible();
+    await page.getByRole('button', { name: 'Clear plugin search' }).click();
+    await expect(search).toHaveValue('');
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(toggle).toContainText('Hide filters');
+    await expect(componentFilter).toBeVisible();
+  });
 });
 
 test('community plugin titles open an installable plugin page instead of GitHub', async ({


### PR DESCRIPTION
## What changed

- make the mobile menu an accessible modal with focus trapping, Escape handling, scroll locking, and focus restoration
- keep the mobile catalog compact by hiding advanced filters behind one clear control
- add an explicit search reset and simplify the plugin count
- make Add plugin visible instead of relying on an icon tooltip
- keep only the real page footer as a contentinfo landmark

## Verification

- production Nuxt generate with the signed Directory and Discovery mirror
- landing lint and registry tests
- 6 Playwright browser tests, including new 390x844 navigation and filter coverage
- manual Chromium QA at 1600x900 and 390x844
- no console errors, failed responses, or horizontal overflow
- command copy, explicit target selection, mobile menu, theme toggle, catalog filters, plugin install expansion, and plugin detail flow exercised