### PR TITLE
feat(landing): improve search metadata and indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ verified once, then prepared for every agent you selected.
 3. Follow any activation or sign-in instruction printed by the CLI.
 4. Start a new agent session and use the plugin.
 
-[Browse 2,500+ plugins](https://777genius.github.io/universal-agent-plugins-registry/)
+[Browse 2,500+ plugins](https://777genius.github.io/universal-agent-plugins/plugins/)
 
 ## What the CLI does
 
@@ -130,7 +130,7 @@ publisher-qualified exact-SHA selector and are validated again before mutation.
 The registry is optional for direct installs, but it makes reviewed short names,
 provenance, compatibility notes, and safe discovery convenient:
 
-[Browse the registry](https://777genius.github.io/universal-agent-plugins-registry/) ·
+[Browse the registry](https://777genius.github.io/universal-agent-plugins/plugins/) ·
 [Submit a package](https://github.com/777genius/universal-agent-plugins-registry/blob/main/CONTRIBUTING.md)
 
 ## Lifecycle safety

--- a/landing/components/registry/RegistryFaq.vue
+++ b/landing/components/registry/RegistryFaq.vue
@@ -1,26 +1,5 @@
 <script setup lang="ts">
-const items = [
-  [
-    'Does one command install into every agent?',
-    'By default the CLI detects installed compatible agents and asks you to confirm. You can also select one or many agents explicitly.',
-  ],
-  [
-    'What happens when an agent needs sign-in?',
-    'The CLI prepares the package and shows the exact activation or sign-in step. It never receives your OAuth password.',
-  ],
-  [
-    'Can I install a plugin outside this directory?',
-    'Yes. Use a pinned GitHub source that contains a valid Agent Plugins 1.0 plugin.json package.',
-  ],
-  [
-    'Are all discovered plugins reviewed?',
-    'No. Reviewed entries and automatically discovered community packages are labeled separately so you can choose the trust level you need.',
-  ],
-  [
-    'Can I undo an installation?',
-    'Yes. The same CLI records managed state and supports inspect, update, repair, source switching, and removal.',
-  ],
-] as const;
+import { registryFaqItems } from '~/data/registryFaq';
 </script>
 
 <template>
@@ -30,9 +9,9 @@ const items = [
       <h2 id="faq-title">Common questions</h2>
     </div>
     <div class="registry-faq__list">
-      <details v-for="item in items" :key="item[0]">
-        <summary>{{ item[0] }}<span aria-hidden="true">+</span></summary>
-        <p>{{ item[1] }}</p>
+      <details v-for="item in registryFaqItems" :key="item.question">
+        <summary>{{ item.question }}<span aria-hidden="true">+</span></summary>
+        <p>{{ item.answer }}</p>
       </details>
     </div>
   </section>

--- a/landing/composables/useLocation.ts
+++ b/landing/composables/useLocation.ts
@@ -16,27 +16,12 @@ export const useLocation = () => {
   };
 
   const initLocale = () => {
-    // Sync store with actual i18n locale (already resolved from route by nuxt-i18n)
+    // Localized routes are not published yet. Keep the locale resolved from the
+    // current route instead of sending first-time visitors to a browser-derived
+    // path that GitHub Pages cannot serve.
     const currentLocale = i18n?.locale?.value || "en";
-
-    if (cookie.value) {
-      // Cookie exists — sync store, but don't override route-based locale
-      localeStore.setLocale(currentLocale, false);
-      if (cookie.value !== currentLocale) {
-        cookie.value = currentLocale;
-      }
-      return;
-    }
-
-    // No cookie — detect from browser and set
-    const detected = getBrowserLocale();
-    localeStore.setLocale(detected, false);
-    if (i18n?.setLocale) {
-      i18n.setLocale(detected);
-    } else if (i18n?.locale?.value) {
-      i18n.locale.value = detected;
-    }
-    cookie.value = detected;
+    localeStore.setLocale(currentLocale, false);
+    cookie.value = currentLocale;
   };
 
   return { initLocale, getBrowserLocale };

--- a/landing/composables/usePageSeo.ts
+++ b/landing/composables/usePageSeo.ts
@@ -1,7 +1,5 @@
 import { computed, toValue } from 'vue';
-import { defaultLocale, supportedLocales } from '~/data/i18n';
-import { getContent } from '~/data/content';
-import type { LocaleCode } from '~/data/i18n';
+import { canonicalPath } from '~/utils/seo';
 import type { MaybeRefOrGetter } from 'vue';
 
 type PageSeoImage = {
@@ -17,6 +15,13 @@ type PageSeoOptions = {
   robots?: string;
   image?: PageSeoImage;
   translate?: boolean;
+  canonical?: boolean;
+  canonicalPath?: MaybeRefOrGetter<string>;
+  includeWebPage?: boolean;
+  pageType?: 'WebPage' | 'CollectionPage';
+  pageProperties?: MaybeRefOrGetter<Record<string, unknown>>;
+  siteIdentity?: boolean;
+  structuredData?: MaybeRefOrGetter<readonly Record<string, unknown>[]>;
 };
 
 export const usePageSeo = (
@@ -27,9 +32,9 @@ export const usePageSeo = (
   const { t, locale } = useI18n();
   const route = useRoute();
   const config = useRuntimeConfig();
-  const switchLocale = useSwitchLocalePath();
-  const { docsUrl } = useDocsLinks();
-  const siteUrl = config.public.siteUrl || 'https://777genius.github.io/universal-agent-plugins';
+  const siteUrl = String(
+    config.public.siteUrl || 'https://777genius.github.io/universal-agent-plugins',
+  ).replace(/\/+$/, '');
   const siteName = 'Universal Agent Plugins';
   const githubUrl = `https://github.com/${config.public.githubRepo}`;
 
@@ -38,8 +43,10 @@ export const usePageSeo = (
   const description = computed(() =>
     shouldTranslate ? t(toValue(descriptionSource)) : toValue(descriptionSource),
   );
-  const canonicalPath = computed(() => route.path);
-  const canonicalUrl = computed(() => `${siteUrl}${canonicalPath.value}`);
+  const resolvedCanonicalPath = computed(() =>
+    canonicalPath(options.canonicalPath ? toValue(options.canonicalPath) : route.path),
+  );
+  const canonicalUrl = computed(() => `${siteUrl}${resolvedCanonicalPath.value}`);
 
   const resolvedImage = computed<PageSeoImage>(() => {
     if (options.image) {
@@ -72,6 +79,7 @@ export const usePageSeo = (
     ogDescription: description,
     ogType: options.type || 'website',
     ogSiteName: siteName,
+    ogLocale: 'en_US',
     ogUrl: canonicalUrl,
     ogImage: resolvedImageUrl,
     ogImageType: computed(() => resolvedImage.value.type) as never,
@@ -93,100 +101,73 @@ export const usePageSeo = (
   });
 
   useHead(() => {
-    const links: { rel: string; hreflang?: string; href: string }[] = supportedLocales.map(
-      (item) => {
-        const path = switchLocale(item.code) || canonicalPath.value;
-        return {
-          rel: 'alternate',
-          hreflang: item.code,
-          href: `${siteUrl}${path}`,
-        };
-      },
-    );
+    const webSiteId = `${siteUrl}/#website`;
+    const organizationId = `${siteUrl}/#organization`;
+    const pageId = `${canonicalUrl.value}#webpage`;
+    const jsonLd: Record<string, unknown>[] = [];
 
-    const defaultPath = switchLocale(defaultLocale) || canonicalPath.value;
-    links.push({
-      rel: 'alternate',
-      hreflang: 'x-default',
-      href: `${siteUrl}${defaultPath}`,
-    });
-    links.push({ rel: 'canonical', href: canonicalUrl.value });
-
-    const jsonLd: Record<string, unknown>[] = [
-      {
-        '@context': 'https://schema.org',
-        '@type': 'WebSite',
-        name: siteName,
-        url: siteUrl,
-        inLanguage: supportedLocales.map((item) => item.code),
-        description: description.value,
-      },
-      {
-        '@context': 'https://schema.org',
-        '@type': 'Organization',
-        name: siteName,
-        url: siteUrl,
-        logo: `${siteUrl}/icon.svg`,
-        sameAs: [githubUrl],
-      },
-    ];
-
-    const isDownload = canonicalPath.value.endsWith('/download');
-    const isHome = canonicalPath.value === '/' || /^\/(ru|es|fr|zh)$/.test(canonicalPath.value);
-
-    if (isHome || isDownload) {
+    if (options.includeWebPage !== false) {
       jsonLd.push({
-        '@context': 'https://schema.org',
-        '@type': 'SoftwareApplication',
-        name: 'Universal Agent Plugins',
-        applicationCategory: 'DeveloperApplication',
-        operatingSystem: 'macOS, Linux, Windows',
-        description: description.value,
+        '@type': options.pageType || 'WebPage',
+        '@id': pageId,
         url: canonicalUrl.value,
-        downloadUrl: config.public.githubReleasesUrl || `${githubUrl}/releases`,
-        softwareHelp: docsUrl.value,
+        name: title.value,
+        description: description.value,
+        inLanguage: locale.value || 'en',
+        isPartOf: { '@id': webSiteId },
+        ...(options.pageProperties ? toValue(options.pageProperties) : {}),
       });
     }
 
-    if (isHome) {
-      const content = getContent(locale.value as LocaleCode);
-      if (content.faq.length > 0) {
-        jsonLd.push({
-          '@context': 'https://schema.org',
-          '@type': 'FAQPage',
-          mainEntity: content.faq.map((item) => ({
-            '@type': 'Question',
-            name: item.question,
-            acceptedAnswer: {
-              '@type': 'Answer',
-              text: item.answer.replace(/<[^>]*>/g, ''),
-            },
-          })),
-        });
-      }
+    if (options.siteIdentity) {
+      jsonLd.push({
+        '@type': 'WebSite',
+        '@id': webSiteId,
+        name: siteName,
+        alternateName: 'UAP',
+        url: `${siteUrl}/`,
+        inLanguage: 'en',
+        description: description.value,
+        publisher: { '@id': organizationId },
+      });
+      jsonLd.push({
+        '@type': 'Organization',
+        '@id': organizationId,
+        name: siteName,
+        url: `${siteUrl}/`,
+        logo: {
+          '@type': 'ImageObject',
+          url: `${siteUrl}/logo-192.png`,
+          width: 192,
+          height: 192,
+        },
+        sameAs: [githubUrl],
+      });
     }
+
+    if (options.structuredData) jsonLd.push(...toValue(options.structuredData));
 
     return {
       htmlAttrs: {
         lang: locale.value || 'en',
       },
-      link: links,
+      link: options.canonical === false ? [] : [{ rel: 'canonical', href: canonicalUrl.value }],
       meta: [
         { name: 'author', content: 'Universal Agent Plugins' },
         { name: 'application-name', content: siteName },
         { name: 'apple-mobile-web-app-title', content: siteName },
         { name: 'format-detection', content: 'telephone=no' },
         { name: 'theme-color', content: '#00f0ff' },
-        {
-          name: 'keywords',
-          content:
-            'Universal Agent Plugins, AI plugins, Claude plugins, Codex plugins, Gemini plugins, multi-agent plugins, plugin repo, validate strict',
-        },
       ],
-      script: jsonLd.map((item) => ({
-        type: 'application/ld+json',
-        children: JSON.stringify(item),
-      })),
+      script: jsonLd.length
+        ? [
+            {
+              key: 'seo-jsonld',
+              type: 'application/ld+json',
+              children: JSON.stringify({ '@context': 'https://schema.org', '@graph': jsonLd }),
+            },
+          ]
+        : [],
     };
   });
 };

--- a/landing/data/i18n.ts
+++ b/landing/data/i18n.ts
@@ -1,5 +1,3 @@
-import enContent from '../content/en.json';
-
 export type LocaleCode = 'en' | 'ru' | 'es' | 'fr' | 'zh';
 
 export const supportedLocales = [
@@ -11,31 +9,3 @@ export const supportedLocales = [
 ] as const;
 
 export const defaultLocale: LocaleCode = 'en';
-
-const pluginDetailPages = (enContent.plugins as Array<{ id: string; slug?: string }>).map(
-  (plugin) => `/plugins/${plugin.slug ?? plugin.id}`,
-);
-
-export const pages = ['/', '/download', '/plugins', ...pluginDetailPages];
-
-/** Pages for sitemap */
-export const sitemapPages = ['/', '/download', '/plugins', ...pluginDetailPages];
-
-/** Generates i18n routes for a given list of pages */
-const buildI18nRoutes = (source: readonly string[]): string[] => {
-  const routes: string[] = [];
-  for (const page of source) {
-    routes.push(page);
-    for (const locale of supportedLocales) {
-      if (locale.code === defaultLocale) continue;
-      routes.push(page === '/' ? `/${locale.code}` : `/${locale.code}${page}`);
-    }
-  }
-  return routes;
-};
-
-/** All i18n routes (for prerender) */
-export const generateI18nRoutes = (): string[] => buildI18nRoutes(pages);
-
-/** i18n routes for sitemap only */
-export const generateSitemapRoutes = (): string[] => buildI18nRoutes(sitemapPages);

--- a/landing/data/registryFaq.ts
+++ b/landing/data/registryFaq.ts
@@ -1,0 +1,27 @@
+export const registryFaqItems = [
+  {
+    question: 'Does one command install into every agent?',
+    answer:
+      'By default the CLI detects installed compatible agents and asks you to confirm. You can also select one or many agents explicitly.',
+  },
+  {
+    question: 'What happens when an agent needs sign-in?',
+    answer:
+      'The CLI prepares the package and shows the exact activation or sign-in step. It never receives your OAuth password.',
+  },
+  {
+    question: 'Can I install a plugin outside this directory?',
+    answer:
+      'Yes. Use a pinned GitHub source that contains a valid Agent Plugins 1.0 plugin.json package.',
+  },
+  {
+    question: 'Are all discovered plugins reviewed?',
+    answer:
+      'No. Reviewed entries and automatically discovered community packages are labeled separately so you can choose the trust level you need.',
+  },
+  {
+    question: 'Can I undo an installation?',
+    answer:
+      'Yes. The same CLI records managed state and supports inspect, update, repair, source switching, and removal.',
+  },
+] as const;

--- a/landing/error.vue
+++ b/landing/error.vue
@@ -11,6 +11,11 @@ const { t } = useI18n();
 const statusCode = computed(() => props.error?.statusCode || 404);
 const isNotFound = computed(() => statusCode.value === 404);
 
+useSeoMeta({
+  title: () => `${statusCode.value} | Universal Agent Plugins`,
+  robots: 'noindex, nofollow',
+});
+
 const handleGoHome = () => clearError({ redirect: "/" });
 </script>
 

--- a/landing/nuxt.config.ts
+++ b/landing/nuxt.config.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { supportedLocales } from './data/i18n';
 import { loadRegistryIndex } from './build/load-registry';
+import { canonicalPath } from './utils/seo';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const process: any;
@@ -47,6 +48,12 @@ function resolveRegistrySnapshot(): string {
 }
 
 const registryIndex = loadRegistryIndex(resolveRegistrySnapshot(), 'published_snapshot');
+const sitemapRoutes = [
+  '/',
+  '/download',
+  '/plugins',
+  ...registryIndex.plugins.map((plugin) => `/plugins/${plugin.name}`),
+].map(canonicalPath);
 
 export default defineNuxtConfig({
   compatibilityDate: '2026-01-19',
@@ -129,13 +136,9 @@ export default defineNuxtConfig({
     bundle: {
       optimizeTranslationDirective: false,
     },
-    detectBrowserLanguage: {
-      useCookie: true,
-      cookieKey: 'i18n_redirected',
-      redirectOn: 'root',
-      alwaysRedirect: false,
-      fallbackLocale: 'en',
-    },
+    // Localized landing routes are not published yet. Avoid redirecting users
+    // and crawlers to locale URLs that GitHub Pages correctly serves as 404.
+    detectBrowserLanguage: false,
   },
   // @ts-expect-error - field provided by nuxt modules
   site: {
@@ -143,6 +146,9 @@ export default defineNuxtConfig({
     name: productName,
   },
   runtimeConfig: {
+    seo: {
+      sitemapRoutes,
+    },
     github: {
       token: process.env.GITHUB_TOKEN,
     },

--- a/landing/pages/create-plugin.vue
+++ b/landing/pages/create-plugin.vue
@@ -1,5 +1,14 @@
 <script setup lang="ts">
-usePageSeo('meta.homeTitle', 'meta.homeDescription');
+// Keep the legacy authoring page out of search until its plugin.yaml workflow
+// is replaced by the approved plugin.json-first Agent Plugins 1.0 flow.
+usePageSeo(
+  'Create an Agent Plugin 1.0 Package | Universal Agent Plugins',
+  'A future guide for creating portable Agent Plugins 1.0 packages for multiple AI agents.',
+  {
+    translate: false,
+    robots: 'noindex, follow',
+  },
+);
 useTrackSections();
 const { containerRef } = useParallaxSections();
 </script>

--- a/landing/pages/download.vue
+++ b/landing/pages/download.vue
@@ -1,7 +1,26 @@
 <script setup lang="ts">
-const { content } = useLandingContent();
+import { productSoftwareSchema } from '~/utils/seo';
 
-usePageSeo("meta.downloadTitle", "meta.downloadDescription");
+const { content } = useLandingContent();
+const config = useRuntimeConfig();
+const description =
+  'Install the Universal Agent Plugins CLI on macOS, Linux, or Windows and manage Agent Plugins 1.0 from one command.';
+const siteUrl = String(config.public.siteUrl).replace(/\/+$/, '');
+const githubUrl = `https://github.com/${config.public.githubRepo}`;
+
+usePageSeo('Download Universal Agent Plugins CLI', description, {
+  translate: false,
+  pageProperties: { mainEntity: { '@id': `${siteUrl}/#software` } },
+  structuredData: [
+    productSoftwareSchema({
+      siteUrl,
+      githubUrl,
+      releasesUrl: String(config.public.githubReleasesUrl),
+      docsUrl: String(config.public.docsUrl),
+      description,
+    }),
+  ],
+});
 </script>
 
 <template>

--- a/landing/pages/index.vue
+++ b/landing/pages/index.vue
@@ -1,15 +1,40 @@
 <script setup lang="ts">
+import { registryFaqItems } from '~/data/registryFaq';
+import { productSoftwareSchema } from '~/utils/seo';
+
 const registry = useRegistry();
+const config = useRuntimeConfig();
 const description =
   'Install, update, repair, and remove Agent Plugins 1.0 across supported AI agents with one CLI.';
+const siteUrl = String(config.public.siteUrl).replace(/\/+$/, '');
+const githubUrl = `https://github.com/${config.public.githubRepo}`;
+const softwareId = `${siteUrl}/#software`;
 
-useSeoMeta({
-  title: 'Universal Agent Plugins',
-  description,
-  ogTitle: 'Universal Agent Plugins',
-  ogDescription: description,
-  ogType: 'website',
-  twitterCard: 'summary',
+usePageSeo('Universal Agent Plugins - Install Plugins Across AI Agents', description, {
+  translate: false,
+  siteIdentity: true,
+  pageProperties: { about: { '@id': softwareId } },
+  structuredData: [
+    productSoftwareSchema({
+      siteUrl,
+      githubUrl,
+      releasesUrl: String(config.public.githubReleasesUrl),
+      docsUrl: String(config.public.docsUrl),
+      description,
+    }),
+    {
+      '@type': 'FAQPage',
+      '@id': `${siteUrl}/#faq`,
+      mainEntity: registryFaqItems.map((item) => ({
+        '@type': 'Question',
+        name: item.question,
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: item.answer,
+        },
+      })),
+    },
+  ],
 });
 </script>
 

--- a/landing/pages/plugins/[slug].vue
+++ b/landing/pages/plugins/[slug].vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { mdiArrowLeft, mdiDownload, mdiOpenInNew } from '@mdi/js';
+import { seoDescription, spdxLicenseUrl } from '~/utils/seo';
 import type { ClientID } from '~/types/registry';
 
 const route = useRoute();
 const registry = useRegistry();
+const config = useRuntimeConfig();
 const { asset, pluginIcon, sourceUrl } = useSite();
 const plugin = registry.plugins.find((item) => item.name === String(route.params.slug));
 
@@ -20,18 +22,66 @@ const initialTarget =
   supportedClients.find((client) => client.id === 'cursor')?.id ?? supportedClients[0]?.id;
 const targets = ref<ClientID[]>(initialTarget ? [initialTarget] : []);
 const autoDetect = ref(true);
-const trustLabel =
-  plugin.trust_state === 'conformant_unreviewed' ? 'Community package' : 'Reviewed package';
+const trustLabel = 'Reviewed package';
+const siteUrl = String(config.public.siteUrl).replace(/\/+$/, '');
+const pluginUrl = `${siteUrl}/plugins/${plugin.name}/`;
+const pluginSchemaId = `${pluginUrl}#plugin`;
+const breadcrumbId = `${pluginUrl}#breadcrumb`;
+const clientNames = supportedClients.map((client) => client.name);
+const description = seoDescription([
+  `Install the ${plugin.display_name} Agent Plugin for ${clientNames.join(', ')}.`,
+  plugin.description,
+]);
+const licenseUrl = spdxLicenseUrl(plugin.license);
 
 function openInstallSection() {
   document.getElementById('plugin-install')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 
-useSeoMeta({
-  title: `${plugin.display_name} · Universal Agent Plugins`,
-  description: plugin.description,
-  ogTitle: `${plugin.display_name} · Universal Agent Plugins`,
-  ogDescription: plugin.description,
+usePageSeo(`${plugin.display_name} Agent Plugin | Universal Agent Plugins`, description, {
+  translate: false,
+  pageProperties: {
+    breadcrumb: { '@id': breadcrumbId },
+    mainEntity: { '@id': pluginSchemaId },
+  },
+  structuredData: [
+    {
+      '@type': 'SoftwareSourceCode',
+      '@id': pluginSchemaId,
+      name: `${plugin.display_name} Agent Plugin`,
+      description: plugin.description,
+      url: pluginUrl,
+      codeRepository: sourceUrl(plugin),
+      softwareVersion: plugin.version,
+      runtimePlatform: clientNames,
+      keywords: plugin.keywords.join(', '),
+      author: {
+        '@type': 'Organization',
+        name: plugin.author.name,
+        ...(plugin.author.url ? { url: plugin.author.url } : {}),
+      },
+      ...(licenseUrl ? { license: licenseUrl } : {}),
+      isPartOf: { '@id': `${siteUrl}/plugins/#webpage` },
+    },
+    {
+      '@type': 'BreadcrumbList',
+      '@id': breadcrumbId,
+      itemListElement: [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          name: 'Plugin directory',
+          item: `${siteUrl}/plugins/`,
+        },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: plugin.display_name,
+          item: pluginUrl,
+        },
+      ],
+    },
+  ],
 });
 </script>
 
@@ -50,6 +100,10 @@ useSeoMeta({
           >
             <v-icon :icon="mdiArrowLeft" size="22" />
           </v-btn>
+          <nav class="breadcrumbs" aria-label="Breadcrumb">
+            <NuxtLink to="/plugins">Plugins</NuxtLink><span aria-hidden="true">/</span
+            ><span>{{ plugin.display_name }}</span>
+          </nav>
         </div>
 
         <div class="plugin-detail__hero-shell">
@@ -108,12 +162,7 @@ useSeoMeta({
                   :key="client.id"
                   class="plugin-detail__client"
                 >
-                  <img
-                    :src="asset(`client-icons/${client.icon}`)"
-                    alt=""
-                    width="22"
-                    height="22"
-                  >
+                  <img :src="asset(`client-icons/${client.icon}`)" alt="" width="22" height="22" >
                   {{ client.name }}
                 </span>
               </div>
@@ -166,6 +215,7 @@ useSeoMeta({
 .plugin-detail__hero-topbar {
   display: flex;
   align-items: center;
+  gap: 8px;
   margin-bottom: 10px;
   padding-left: 4px;
 }

--- a/landing/pages/plugins/community.vue
+++ b/landing/pages/plugins/community.vue
@@ -31,20 +31,19 @@ watch(
   { immediate: true },
 );
 
-useSeoMeta({
-  title: () =>
+usePageSeo(
+  () =>
     plugin.value
-      ? `${plugin.value.display_name} · Universal Agent Plugins`
-      : 'Community plugin · Universal Agent Plugins',
-  description: () =>
-    plugin.value?.description ?? 'Install a community Agent Plugin across supported AI agents.',
-  ogTitle: () =>
-    plugin.value
-      ? `${plugin.value.display_name} · Universal Agent Plugins`
-      : 'Community plugin · Universal Agent Plugins',
-  ogDescription: () =>
-    plugin.value?.description ?? 'Install a community Agent Plugin across supported AI agents.',
-});
+      ? `${plugin.value.display_name} Agent Plugin | Universal Agent Plugins`
+      : 'Community Agent Plugin | Universal Agent Plugins',
+  () => plugin.value?.description ?? 'Install a community Agent Plugin across supported AI agents.',
+  {
+    translate: false,
+    robots: 'noindex, follow',
+    canonical: false,
+    includeWebPage: false,
+  },
+);
 </script>
 
 <template>

--- a/landing/pages/plugins/index.vue
+++ b/landing/pages/plugins/index.vue
@@ -1,12 +1,32 @@
 <script setup lang="ts">
 const registry = useRegistry();
-const description = 'Browse reviewed and automatically discovered Agent Plugins 1.0 packages.';
+const config = useRuntimeConfig();
+const description =
+  'Search reviewed and community Agent Plugins 1.0 for Codex, Claude Code, Cursor, Gemini CLI, OpenCode, and more.';
+const siteUrl = String(config.public.siteUrl).replace(/\/+$/, '');
+const listId = `${siteUrl}/plugins/#plugin-list`;
+const reviewedPlugins = registry.plugins.filter(
+  (plugin) => plugin.trust_state !== 'conformant_unreviewed',
+);
 
-useSeoMeta({
-  title: 'Plugin directory · Universal Agent Plugins',
-  description,
-  ogTitle: 'Plugin directory · Universal Agent Plugins',
-  ogDescription: description,
+usePageSeo('Agent Plugins Directory | Universal Agent Plugins', description, {
+  translate: false,
+  pageType: 'CollectionPage',
+  pageProperties: { mainEntity: { '@id': listId } },
+  structuredData: [
+    {
+      '@type': 'ItemList',
+      '@id': listId,
+      name: 'Reviewed Agent Plugins 1.0 packages',
+      numberOfItems: reviewedPlugins.length,
+      itemListElement: reviewedPlugins.map((plugin, index) => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        name: plugin.display_name,
+        url: `${siteUrl}/plugins/${plugin.name}/`,
+      })),
+    },
+  ],
 });
 </script>
 

--- a/landing/server/routes/robots.txt.ts
+++ b/landing/server/routes/robots.txt.ts
@@ -1,7 +1,8 @@
 export default defineEventHandler((event) => {
   const config = useRuntimeConfig();
-  const siteUrl =
-    (config.public.siteUrl as string) || 'https://777genius.github.io/universal-agent-plugins';
+  const siteUrl = String(
+    config.public.siteUrl || 'https://777genius.github.io/universal-agent-plugins',
+  ).replace(/\/+$/, '');
   const docsSitemapUrl =
     (config.public.docsSitemapUrl as string) ||
     'https://777genius.github.io/universal-agent-plugins/docs/sitemap.xml';

--- a/landing/server/routes/sitemap.xml.ts
+++ b/landing/server/routes/sitemap.xml.ts
@@ -1,5 +1,3 @@
-import { generateSitemapRoutes } from '~/data/i18n';
-
 const escapeXml = (value: string) =>
   value
     .replaceAll('&', '&amp;')
@@ -8,23 +6,21 @@ const escapeXml = (value: string) =>
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&apos;');
 
-const buildDate = new Date().toISOString().split('T')[0];
-
 export default defineEventHandler((event) => {
   const config = useRuntimeConfig();
-  const siteUrl =
-    (config.public.siteUrl as string) || 'https://777genius.github.io/universal-agent-plugins';
+  const siteUrl = String(
+    config.public.siteUrl || 'https://777genius.github.io/universal-agent-plugins',
+  ).replace(/\/+$/, '');
 
   setHeader(event, 'content-type', 'application/xml; charset=utf-8');
 
-  const routes = generateSitemapRoutes();
+  const routes = Array.isArray(config.seo.sitemapRoutes)
+    ? (config.seo.sitemapRoutes as string[])
+    : ['/'];
   const body = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 ${routes
-  .map(
-    (path) =>
-      `  <url>\n    <loc>${escapeXml(`${siteUrl}${path}`)}</loc>\n    <lastmod>${buildDate}</lastmod>\n  </url>`,
-  )
+  .map((path) => `  <url>\n    <loc>${escapeXml(`${siteUrl}${path}`)}</loc>\n  </url>`)
   .join('\n')}
 </urlset>
 `;

--- a/landing/tests/browser/landing.spec.ts
+++ b/landing/tests/browser/landing.spec.ts
@@ -1,5 +1,13 @@
 import { expect, test } from '@playwright/test';
 
+const parseJsonLd = async (page: import('@playwright/test').Page) => {
+  const values = await page.locator('script[type="application/ld+json"]').allTextContents();
+  return values.flatMap((value) => {
+    const parsed = JSON.parse(value) as { '@graph'?: Array<Record<string, unknown>> };
+    return parsed['@graph'] ?? [];
+  });
+};
+
 test('homepage installs with auto-detection and exposes the full directory', async ({ page }) => {
   const errors: string[] = [];
   page.on('console', (message) => {
@@ -33,6 +41,47 @@ test('homepage installs with auto-detection and exposes the full directory', asy
   );
   await expect(page.getByText(/recently found community packages/i)).toHaveCount(0);
   expect(errors).toEqual([]);
+});
+
+test('homepage publishes canonical social metadata and complete product schema', async ({
+  page,
+}) => {
+  const response = await page.goto('./');
+  expect(response?.status()).toBe(200);
+  await expect(page).toHaveTitle('Universal Agent Plugins - Install Plugins Across AI Agents');
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    'href',
+    'https://777genius.github.io/universal-agent-plugins/',
+  );
+  await expect(page.locator('link[rel="alternate"][hreflang]')).toHaveCount(0);
+  await expect(page.locator('meta[property="og:image"]')).toHaveAttribute(
+    'content',
+    'https://777genius.github.io/universal-agent-plugins/og-image.png',
+  );
+  await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute(
+    'content',
+    'summary_large_image',
+  );
+
+  const graph = await parseJsonLd(page);
+  expect(graph.map((item) => item['@type'])).toEqual(
+    expect.arrayContaining([
+      'WebPage',
+      'WebSite',
+      'Organization',
+      'SoftwareApplication',
+      'FAQPage',
+    ]),
+  );
+  const software = graph.find((item) => item['@type'] === 'SoftwareApplication');
+  expect(software?.offers).toEqual({ '@type': 'Offer', price: '0', priceCurrency: 'USD' });
+  const faq = graph.find((item) => item['@type'] === 'FAQPage') as
+    { mainEntity?: unknown[] } | undefined;
+  expect(faq?.mainEntity).toHaveLength(5);
+
+  const html = await response!.text();
+  expect(html).toContain('rel="canonical"');
+  expect(html).toContain('application/ld+json');
 });
 
 test.describe('mobile navigation and catalog', () => {
@@ -113,6 +162,94 @@ test('directory filters and reviewed detail keep automatic detection as the defa
   await expect(page.getByRole('link', { name: 'Native Go CLI · no Node.js' })).toBeVisible();
   await expect(page.locator('.command-snippet').first()).toContainText('agentplugins add');
   await expect(page.locator('.command-snippet').first()).not.toContainText('--target');
+});
+
+test('directory and reviewed plugin pages expose unique crawlable entities', async ({ page }) => {
+  await page.goto('./plugins');
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    'href',
+    'https://777genius.github.io/universal-agent-plugins/plugins/',
+  );
+  let graph = await parseJsonLd(page);
+  const itemList = graph.find((item) => item['@type'] === 'ItemList') as
+    { numberOfItems?: number; itemListElement?: unknown[] } | undefined;
+  expect(itemList?.numberOfItems).toBeGreaterThanOrEqual(20);
+  expect(itemList?.itemListElement).toHaveLength(itemList?.numberOfItems ?? 0);
+
+  await page.goto('./plugins/gitlab');
+  await expect(page).toHaveTitle('GitLab Agent Plugin | Universal Agent Plugins');
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    'href',
+    'https://777genius.github.io/universal-agent-plugins/plugins/gitlab/',
+  );
+  await expect(page.getByRole('navigation', { name: 'Breadcrumb' })).toContainText(
+    'Plugins/GitLab',
+  );
+  const description = await page.locator('meta[name="description"]').getAttribute('content');
+  expect(description).toContain('Install the GitLab Agent Plugin');
+  expect(description?.length).toBeLessThanOrEqual(160);
+  graph = await parseJsonLd(page);
+  expect(graph.map((item) => item['@type'])).toEqual(
+    expect.arrayContaining(['WebPage', 'SoftwareSourceCode', 'BreadcrumbList']),
+  );
+});
+
+test('sitemap lists only live canonical pages and unstable routes stay out of the index', async ({
+  page,
+  request,
+  baseURL,
+}) => {
+  const sitemapResponse = await request.get(new URL('sitemap.xml', baseURL).href);
+  expect(sitemapResponse.status()).toBe(200);
+  const sitemap = await sitemapResponse.text();
+  const locations = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map((match) => match[1]!);
+  expect(locations.length).toBeGreaterThanOrEqual(20);
+  expect(locations.every((location) => location.endsWith('/'))).toBe(true);
+  expect(locations.some((location) => /\/(ru|es|fr|zh)(?:\/|$)/.test(location))).toBe(false);
+  expect(sitemap).not.toContain('<lastmod>');
+  expect(sitemap).not.toContain('/plugins/community/');
+  expect(sitemap).not.toContain('/create-plugin/');
+
+  const prefix = '/universal-agent-plugins/';
+  const statuses = await Promise.all(
+    locations.map((location) => {
+      const pathname = new URL(location).pathname;
+      const relative = pathname.startsWith(prefix) ? pathname.slice(prefix.length) : pathname;
+      return request.get(new URL(relative, baseURL).href).then((response) => response.status());
+    }),
+  );
+  expect(new Set(statuses)).toEqual(new Set([200]));
+
+  const robotsResponse = await request.get(new URL('robots.txt', baseURL).href);
+  expect(robotsResponse.status()).toBe(200);
+  const robots = await robotsResponse.text();
+  expect(robots).toContain(
+    'Sitemap: https://777genius.github.io/universal-agent-plugins/sitemap.xml',
+  );
+  expect(robots).toContain(
+    'Sitemap: https://777genius.github.io/universal-agent-plugins/docs/sitemap.xml',
+  );
+
+  await page.goto('./plugins/community?source=discovery%3Aexample');
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute('content', 'noindex, follow');
+  await expect(page.locator('link[rel="canonical"]')).toHaveCount(0);
+  await expect(page.locator('script[type="application/ld+json"]')).toHaveCount(0);
+
+  await page.goto('./create-plugin');
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute('content', 'noindex, follow');
+});
+
+test('an unsupported localized route is never selected for browser-language visitors', async ({
+  browser,
+  baseURL,
+}) => {
+  const context = await browser.newContext({ locale: 'ru-RU' });
+  const page = await context.newPage();
+  const response = await page.goto(baseURL!);
+  expect(response?.status()).toBe(200);
+  expect(new URL(page.url()).pathname).toBe(new URL(baseURL!).pathname);
+  await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+  await context.close();
 });
 
 test('download page recommends the detected OS path and preserves the npx alternative', async ({

--- a/landing/tests/seo.test.ts
+++ b/landing/tests/seo.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  canonicalPath,
+  productSoftwareSchema,
+  seoDescription,
+  spdxLicenseUrl,
+} from '../utils/seo.ts';
+
+describe('SEO foundations', () => {
+  it('normalizes every indexable page to its GitHub Pages directory URL', () => {
+    assert.equal(canonicalPath('/'), '/');
+    assert.equal(canonicalPath('/plugins'), '/plugins/');
+    assert.equal(canonicalPath('plugins/gitlab/'), '/plugins/gitlab/');
+    assert.equal(canonicalPath('//plugins//gitlab//'), '/plugins/gitlab/');
+  });
+
+  it('keeps generated plugin descriptions complete and within snippet guidance', () => {
+    const description = seoDescription([
+      'Install the Example Agent Plugin for Codex, Claude Code, and Cursor.',
+      'A deliberately long explanation '.repeat(8),
+    ]);
+    assert.ok(description.length <= 160);
+    assert.ok(description.endsWith('…'));
+    assert.equal(description.includes('  '), false);
+  });
+
+  it('publishes complete free software application data', () => {
+    const schema = productSoftwareSchema({
+      siteUrl: 'https://example.com/product/',
+      githubUrl: 'https://github.com/example/product',
+      releasesUrl: 'https://github.com/example/product/releases',
+      docsUrl: 'https://example.com/product/docs/',
+      description: 'One CLI for Agent Plugins 1.0.',
+    });
+    assert.equal(schema.url, 'https://example.com/product/');
+    assert.deepEqual(schema.offers, {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+    });
+    assert.equal(schema.isAccessibleForFree, true);
+    assert.equal(spdxLicenseUrl('Apache-2.0'), 'https://spdx.org/licenses/Apache-2.0.html');
+    assert.equal(spdxLicenseUrl('invalid license'), undefined);
+  });
+});

--- a/landing/utils/seo.ts
+++ b/landing/utils/seo.ts
@@ -1,0 +1,63 @@
+const DEFAULT_DESCRIPTION_LIMIT = 160;
+
+export function canonicalPath(path: string): string {
+  const normalized = `/${path}`.replace(/\/{2,}/g, '/').replace(/\/+$/, '');
+  return normalized === '' ? '/' : `${normalized}/`;
+}
+
+export function seoDescription(
+  parts: Array<string | undefined>,
+  limit = DEFAULT_DESCRIPTION_LIMIT,
+) {
+  const value = parts
+    .filter((part): part is string => Boolean(part))
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (value.length <= limit) return value;
+
+  const candidate = value
+    .slice(0, limit - 1)
+    .replace(/\s+\S*$/, '')
+    .replace(/[,:;.!?]+$/, '');
+  return `${candidate || value.slice(0, limit - 1)}…`;
+}
+
+export function spdxLicenseUrl(license: string): string | undefined {
+  if (!/^[A-Za-z0-9.+-]+$/.test(license)) return undefined;
+  return `https://spdx.org/licenses/${license}.html`;
+}
+
+type ProductSoftwareSchemaOptions = {
+  siteUrl: string;
+  githubUrl: string;
+  releasesUrl: string;
+  docsUrl: string;
+  description: string;
+};
+
+export function productSoftwareSchema(options: ProductSoftwareSchemaOptions) {
+  const siteUrl = options.siteUrl.replace(/\/+$/, '');
+  return {
+    '@type': 'SoftwareApplication',
+    '@id': `${siteUrl}/#software`,
+    name: 'Universal Agent Plugins',
+    alternateName: 'UAP',
+    url: `${siteUrl}/`,
+    description: options.description,
+    applicationCategory: 'DeveloperApplication',
+    applicationSubCategory: 'Agent plugin manager',
+    operatingSystem: 'macOS, Linux, Windows',
+    isAccessibleForFree: true,
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+    },
+    downloadUrl: options.releasesUrl,
+    softwareHelp: options.docsUrl,
+    codeRepository: options.githubUrl,
+    license: 'https://www.apache.org/licenses/LICENSE-2.0',
+    featureList: 'Install, inspect, update, repair, switch source, and remove Agent Plugins 1.0',
+  };
+}

--- a/repotests/landing_contract_integration_test.go
+++ b/repotests/landing_contract_integration_test.go
@@ -76,8 +76,18 @@ func TestLandingSurface_LocalesLinksAndBrandingStayAligned(t *testing.T) {
 	seo := string(seoBody)
 	mustContain(t, seo, `https://777genius.github.io/universal-agent-plugins`)
 	mustNotContain(t, seo, `hookplex.dev`)
-	mustNotContain(t, seo, `priceCurrency`)
-	mustNotContain(t, seo, `offers:`)
+
+	seoUtilsBody, err := os.ReadFile(filepath.Join(landingRoot, "utils", "seo.ts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	seoUtils := string(seoUtilsBody)
+	mustContain(t, seoUtils, `'@type': 'SoftwareApplication'`)
+	mustContain(t, seoUtils, `isAccessibleForFree: true`)
+	mustContain(t, seoUtils, `offers:`)
+	mustContain(t, seoUtils, `price: '0'`)
+	mustContain(t, seoUtils, `priceCurrency: 'USD'`)
+	mustNotContain(t, seoUtils, `hookplex.dev`)
 
 	nuxtConfigBody, err := os.ReadFile(filepath.Join(landingRoot, "nuxt.config.ts"))
 	if err != nil {
@@ -240,7 +250,8 @@ func TestLandingSurface_LocalesLinksAndBrandingStayAligned(t *testing.T) {
 	}
 	pluginsPage := string(pluginsPageBody)
 	mustContain(t, pluginsPage, `const registry = useRegistry()`)
-	mustContain(t, pluginsPage, `useSeoMeta({`)
+	mustContain(t, pluginsPage, `usePageSeo('Agent Plugins Directory | Universal Agent Plugins'`)
+	mustContain(t, pluginsPage, `'@type': 'ItemList'`)
 	mustContain(t, pluginsPage, `<PluginCatalog`)
 	mustContain(t, pluginsPage, `:plugins="registry.plugins"`)
 
@@ -250,7 +261,9 @@ func TestLandingSurface_LocalesLinksAndBrandingStayAligned(t *testing.T) {
 	}
 	pluginDetailPage := string(pluginDetailPageBody)
 	mustContain(t, pluginDetailPage, `registry.plugins.find`)
-	mustContain(t, pluginDetailPage, `useSeoMeta({`)
+	mustContain(t, pluginDetailPage, `usePageSeo(`)
+	mustContain(t, pluginDetailPage, `'@type': 'SoftwareSourceCode'`)
+	mustContain(t, pluginDetailPage, `'@type': 'BreadcrumbList'`)
 	mustContain(t, pluginDetailPage, `<InstallPanel`)
 	mustContain(t, pluginDetailPage, `sourceUrl(plugin)`)
 

--- a/repotests/pages_contract_integration_test.go
+++ b/repotests/pages_contract_integration_test.go
@@ -66,14 +66,14 @@ func TestPagesSite_CombinesLandingRootAndDocsSubpath(t *testing.T) {
 	site := string(siteBody)
 	mustContain(t, site, `export const docsBasePath = process.env.DOCS_BASE_PATH || "/plugin-kit-ai/docs/";`)
 
-	i18nBody, err := os.ReadFile(filepath.Join(root, "landing", "data", "i18n.ts"))
+	nuxtConfigBody, err := os.ReadFile(filepath.Join(root, "landing", "nuxt.config.ts"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	i18n := string(i18nBody)
-	mustContain(t, i18n, `'/plugins'`)
-	mustContain(t, i18n, `const pluginDetailPages =`)
-	mustContain(t, i18n, "`/plugins/${plugin.slug ?? plugin.id}`")
+	nuxtConfig := string(nuxtConfigBody)
+	mustContain(t, nuxtConfig, `'/plugins'`)
+	mustContain(t, nuxtConfig, "`/plugins/${plugin.name}`")
+	mustContain(t, nuxtConfig, `const sitemapRoutes =`)
 
 	pluginDetailPageBody, err := os.ReadFile(filepath.Join(root, "landing", "pages", "plugins", "[slug].vue"))
 	if err != nil {


### PR DESCRIPTION
## What changed

- add canonical URLs, Open Graph and Twitter cards across public pages
- add WebSite, Organization, SoftwareApplication, FAQ, ItemList, plugin, and breadcrumb structured data
- publish a canonical sitemap containing only live reviewed pages
- keep dynamic community pages and the legacy authoring page out of search until they have stable crawlable content
- prevent browser-language redirects to unpublished localized routes
- give each reviewed plugin a unique search title, description, canonical URL, and breadcrumb
- normalize sitemap and robots URLs even when the configured site URL has a trailing slash

## Verification

- `pnpm run lint`
- `pnpm run test:registry` - 10 passed
- focused repository landing contract - passed
- production `nuxt generate`
- Playwright browser E2E - 12 passed
- generated HTML audit across all 29 sitemap URLs and 26 reviewed plugin pages
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a registry FAQ covering plugin installation, trust labels, authentication, and undo functionality.
  - Added breadcrumbs to plugin detail pages.
  - Improved structured data for the homepage, plugin directory, and plugin details.

- **SEO**
  - Added canonical URLs, improved metadata, sitemap configuration, and product/plugin schemas.
  - Error and creation pages now use appropriate indexing controls.
  - Updated documentation links to the current plugin directory.

- **Updates**
  - Locale handling now follows the selected route locale instead of browser-language detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->