### PR TITLE
test(readme): align native CLI wording

### DIFF
--- a/npm/agentplugins/test/documentation-contract.test.js
+++ b/npm/agentplugins/test/documentation-contract.test.js
@@ -116,7 +116,7 @@ test("root documentation recommends the native Go installer without hiding npm",
     return;
   }
   const markdown = fs.readFileSync(documents[0][1], "utf8");
-  assert.match(markdown, /native Go CLI does not require Node\.js/i);
+  assert.match(markdown, /Node\.js is not a requirement of the native CLI/i);
   assert.match(markdown, /brew install 777genius\/agentplugins\/agentplugins/);
   assert.match(
     markdown,


### PR DESCRIPTION
The native install README was updated to clearer wording, but the npm documentation contract still matched the old sentence.

This updates the assertion to the current equivalent statement without weakening the Node.js-free native CLI requirement.

Verification:
- `node --test npm/agentplugins/test/documentation-contract.test.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation contract to reflect the current wording about Node.js requirements for the native CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->