### PR TITLE
fix(ci): bound conformance npm bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Build pinned conformance corpus
         working-directory: .ci/agent-plugins-conformance-kit
         run: |
-          npm ci --ignore-scripts
+          npm ci --ignore-scripts --no-audit --no-fund
           npm run build
 
       - name: Run Agent Plugins loader conformance

--- a/repotests/release_surface_integration_test.go
+++ b/repotests/release_surface_integration_test.go
@@ -134,6 +134,7 @@ func TestReleaseSurface_MakefileDocsAndWorkflowsStayAligned(t *testing.T) {
 	mustContain(t, ciWorkflow, "name: Required")
 	mustContain(t, ciWorkflow, "- name: Run required lane")
 	mustContain(t, ciWorkflow, "- name: Check generated artifacts")
+	mustContain(t, ciWorkflow, "npm ci --ignore-scripts --no-audit --no-fund")
 	mustContain(t, polyglotWorkflow, "name: Polyglot Smoke")
 	mustContain(t, polyglotWorkflow, "push:")
 	mustContain(t, polyglotWorkflow, "name: polyglot-smoke (${{ matrix.os }})")


### PR DESCRIPTION
The pinned Agent Plugins conformance kit already uses an exact revision and lockfile, but `npm ci` still performs optional audit and funding network work. That can stall the Required lane after all repository tests have passed.

This keeps the locked install and disables only those optional requests. A repository contract prevents the flags from regressing.

Verification:
- exact pinned conformance revision installs and builds successfully
- focused release-surface contract passes
- workflow YAML parses successfully