### PR TITLE
fix(landing): animate plugin count after discovery

### DIFF
--- a/landing/assets/styles/registry.scss
+++ b/landing/assets/styles/registry.scss
@@ -309,11 +309,15 @@ img {
   gap: 12px;
 }
 .hero__actions .button--primary {
+  min-width: 225px;
   border: 0;
   background: linear-gradient(120deg, var(--cyan), #7c6cff 54%, var(--primary));
   box-shadow:
     0 14px 34px color-mix(in srgb, var(--primary) 20%, transparent),
     inset 0 1px 0 rgba(255, 255, 255, 0.35);
+}
+.hero__plugin-count {
+  font-variant-numeric: tabular-nums;
 }
 .hero__demo {
   position: relative;

--- a/landing/components/registry/RegistryHero.vue
+++ b/landing/components/registry/RegistryHero.vue
@@ -1,17 +1,60 @@
 <script setup lang="ts">
 import type { ClientID, RegistryIndex } from '~/types/registry';
 import { pluginCommands } from '~/utils/commands';
+import { countAtElapsed, PLUGIN_COUNT_ANIMATION_MS } from '~/utils/countAnimation';
 import { deliveryLabel, expectedDistribution, resolveDistribution } from '~/utils/registry';
 
 const props = defineProps<{ registry: RegistryIndex }>();
 const config = useRuntimeConfig();
 const { current, expired, published } = useDirectoryStatus();
+const discovery = useDiscoveryStatus();
 const { asset } = useSite();
 const cliRepositoryUrl = computed(() => `https://github.com/${config.public.githubRepo}`);
 const preferredDemoNames = ['chrome-devtools', 'context7', 'cloudflare-docs'];
+const displayedPluginCount = ref<number | null>(null);
 const pluginCount = computed(() =>
-  new Intl.NumberFormat('en').format(props.registry.plugins.length),
+  displayedPluginCount.value === null
+    ? null
+    : new Intl.NumberFormat('en').format(displayedPluginCount.value),
 );
+const countAnimationCompleted = useState('hero-plugin-count-animated', () => false);
+let countAnimationFrame: number | undefined;
+
+if (import.meta.client) {
+  watch(
+    () => discovery.value.state,
+    (state) => {
+      if (state !== 'current' && state !== 'cached') return;
+
+      const target = props.registry.plugins.length;
+      if (
+        countAnimationCompleted.value ||
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      ) {
+        displayedPluginCount.value = target;
+        countAnimationCompleted.value = true;
+        return;
+      }
+
+      countAnimationCompleted.value = true;
+      displayedPluginCount.value = 0;
+      const startedAt = performance.now();
+      const updateCount = (now: number) => {
+        const elapsed = now - startedAt;
+        displayedPluginCount.value = countAtElapsed(target, elapsed);
+        if (elapsed < PLUGIN_COUNT_ANIMATION_MS) {
+          countAnimationFrame = requestAnimationFrame(updateCount);
+        }
+      };
+      countAnimationFrame = requestAnimationFrame(updateCount);
+    },
+    { immediate: true },
+  );
+
+  onBeforeUnmount(() => {
+    if (countAnimationFrame !== undefined) cancelAnimationFrame(countAnimationFrame);
+  });
+}
 
 const demoPlugin = computed(() => {
   const ranked = [
@@ -95,9 +138,11 @@ function updateTargets(values: string[]) {
           command. Let the CLI detect installed agents, or choose exactly where the plugin goes.
         </p>
         <div class="hero__actions">
-          <a class="button button--primary" href="#plugins"
-            >Explore {{ pluginCount }} plugins <span aria-hidden="true">→</span></a
-          >
+          <a class="button button--primary" href="#plugins">
+            Explore
+            <span v-if="pluginCount !== null" class="hero__plugin-count">{{ pluginCount }}</span>
+            plugins <span aria-hidden="true">→</span>
+          </a>
           <a
             class="button button--secondary"
             :href="cliRepositoryUrl"

--- a/landing/tests/browser/landing.spec.ts
+++ b/landing/tests/browser/landing.spec.ts
@@ -10,6 +10,14 @@ const parseJsonLd = async (page: import('@playwright/test').Page) => {
 
 test('homepage installs with auto-detection and exposes the full directory', async ({ page }) => {
   const errors: string[] = [];
+  let releaseDiscovery!: () => void;
+  const discoveryGate = new Promise<void>((resolve) => {
+    releaseDiscovery = resolve;
+  });
+  await page.route('**/discovery/**', async (route) => {
+    await discoveryGate;
+    await route.continue();
+  });
   page.on('console', (message) => {
     if (message.type() === 'error') errors.push(message.text());
   });
@@ -18,6 +26,10 @@ test('homepage installs with auto-detection and exposes the full directory', asy
   });
 
   await page.goto('./');
+  const explorePlugins = page.getByRole('link', { name: 'Explore plugins' });
+  await expect(explorePlugins).toBeVisible();
+  await expect(explorePlugins.locator('.hero__plugin-count')).toHaveCount(0);
+  releaseDiscovery();
   await expect(page.locator('link[rel="icon"][type="image/svg+xml"]')).toHaveAttribute(
     'href',
     /icon\.svg$/,
@@ -35,7 +47,9 @@ test('homepage installs with auto-detection and exposes the full directory', asy
   await expect(page.locator('.catalog-count')).toContainText(/[2-9]\d{3} plugins/, {
     timeout: 15_000,
   });
-  await expect(page.getByRole('link', { name: /Explore [\d,]+ plugins/ })).toBeVisible();
+  await expect(page.getByRole('link', { name: /Explore [\d,]+ plugins/ })).toBeVisible({
+    timeout: 5_000,
+  });
   await expect(page.getByRole('link', { name: 'Add a plugin', exact: true })).toContainText(
     'Add plugin',
   );

--- a/landing/tests/countAnimation.test.ts
+++ b/landing/tests/countAnimation.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { countAtElapsed, PLUGIN_COUNT_ANIMATION_MS } from '../utils/countAnimation.ts';
+
+describe('plugin count animation', () => {
+  it('counts linearly from zero to the exact total in two seconds', () => {
+    assert.equal(PLUGIN_COUNT_ANIMATION_MS, 2_000);
+    assert.equal(countAtElapsed(2_875, 0), 0);
+    assert.equal(countAtElapsed(2_875, 1_000), 1_437);
+    assert.equal(countAtElapsed(2_875, 2_000), 2_875);
+    assert.equal(countAtElapsed(2_875, 3_000), 2_875);
+  });
+
+  it('stays monotonic and handles invalid totals safely', () => {
+    const values = Array.from({ length: 121 }, (_, index) =>
+      countAtElapsed(2_875, (PLUGIN_COUNT_ANIMATION_MS * index) / 120),
+    );
+    assert.ok(values.every((value, index) => index === 0 || value >= values[index - 1]!));
+    assert.equal(countAtElapsed(-10, 1_000), 0);
+  });
+});

--- a/landing/utils/countAnimation.ts
+++ b/landing/utils/countAnimation.ts
@@ -1,0 +1,14 @@
+export const PLUGIN_COUNT_ANIMATION_MS = 2_000;
+
+export function countAtElapsed(
+  target: number,
+  elapsedMs: number,
+  durationMs = PLUGIN_COUNT_ANIMATION_MS,
+): number {
+  const safeTarget = Math.max(0, Math.floor(target));
+  if (safeTarget === 0) return 0;
+  if (durationMs <= 0 || elapsedMs >= durationMs) return safeTarget;
+  if (elapsedMs <= 0) return 0;
+
+  return Math.floor(safeTarget * (elapsedMs / durationMs));
+}


### PR DESCRIPTION
## What changed
- keep the Explore plugins CTA count-free until signed Discovery finishes loading
- animate from 0 to the complete catalog total over exactly two seconds
- show the final value immediately for reduced-motion users and on repeat navigation
- reserve button width to avoid layout shift

## Verification
- 12/12 landing unit and contract tests
- lint
- production Nuxt generate
- 13/13 Playwright browser E2E, including a delayed Discovery assertion
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The plugin count in the “Explore plugins” action now animates from zero to the current total.
  - The animation respects reduced-motion preferences and displays the count only when available.
- **Style**
  - The hero action button now maintains a minimum width for a more consistent layout.
  - Plugin-count digits use uniform spacing to prevent visual shifting as the number changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->