### PR TITLE
fix(landing): keep animated plugin counter width stable

### DIFF
--- a/landing/assets/styles/registry.scss
+++ b/landing/assets/styles/registry.scss
@@ -309,7 +309,7 @@ img {
   gap: 12px;
 }
 .hero__actions .button--primary {
-  min-width: 16rem;
+  min-width: min(16rem, calc(100vw - 2rem));
   border: 0;
   background: linear-gradient(120deg, var(--cyan), #7c6cff 54%, var(--primary));
   box-shadow:

--- a/landing/assets/styles/registry.scss
+++ b/landing/assets/styles/registry.scss
@@ -309,7 +309,7 @@ img {
   gap: 12px;
 }
 .hero__actions .button--primary {
-  min-width: 225px;
+  min-width: 16rem;
   border: 0;
   background: linear-gradient(120deg, var(--cyan), #7c6cff 54%, var(--primary));
   box-shadow:

--- a/landing/tests/browser/landing.spec.ts
+++ b/landing/tests/browser/landing.spec.ts
@@ -74,6 +74,29 @@ test('homepage omits the counter when discovery cannot load', async ({ page }) =
   await expect(page.locator('.hero__plugin-count')).toHaveCount(0);
 });
 
+test('plugin counter stays inside the hero on a narrow screen', async ({ page }) => {
+  await page.setViewportSize({ width: 280, height: 844 });
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  let releaseDiscovery!: () => void;
+  const discoveryGate = new Promise<void>((resolve) => {
+    releaseDiscovery = resolve;
+  });
+  await page.route('**/discovery/**', async (route) => {
+    await discoveryGate;
+    await route.continue();
+  });
+  await page.goto('./');
+  await page.evaluate(() => document.fonts.ready);
+  const initialWidth = (await page.locator('.hero__actions .button--primary').boundingBox())!.width;
+  releaseDiscovery();
+  await expect(page.locator('.hero__plugin-count')).toContainText(/[\d,]+/);
+  const container = (await page.locator('.hero.container').boundingBox())!;
+  const button = (await page.locator('.hero__actions .button--primary').boundingBox())!;
+  expect(button.width).toBe(initialWidth);
+  expect(button.x).toBeGreaterThanOrEqual(container.x);
+  expect(button.x + button.width).toBeLessThanOrEqual(container.x + container.width);
+});
+
 test('homepage publishes canonical social metadata and complete product schema', async ({
   page,
 }) => {

--- a/landing/tests/browser/landing.spec.ts
+++ b/landing/tests/browser/landing.spec.ts
@@ -26,9 +26,12 @@ test('homepage installs with auto-detection and exposes the full directory', asy
   });
 
   await page.goto('./');
-  const explorePlugins = page.getByRole('link', { name: 'Explore plugins' });
+  const explorePlugins = page.locator('.hero__actions .button--primary');
   await expect(explorePlugins).toBeVisible();
+  await expect(explorePlugins).toHaveAccessibleName('Explore plugins');
   await expect(explorePlugins.locator('.hero__plugin-count')).toHaveCount(0);
+  await page.evaluate(() => document.fonts.ready);
+  const initialButtonWidth = (await explorePlugins.boundingBox())!.width;
   releaseDiscovery();
   await expect(page.locator('link[rel="icon"][type="image/svg+xml"]')).toHaveAttribute(
     'href',
@@ -47,14 +50,28 @@ test('homepage installs with auto-detection and exposes the full directory', asy
   await expect(page.locator('.catalog-count')).toContainText(/[2-9]\d{3} plugins/, {
     timeout: 15_000,
   });
-  await expect(page.getByRole('link', { name: /Explore [\d,]+ plugins/ })).toBeVisible({
-    timeout: 5_000,
-  });
+  const catalogSummary = await page.locator('.catalog-count').innerText();
+  const totalPlugins = Number(catalogSummary.match(/(\d+) plugins/)![1]);
+  await expect(explorePlugins).toHaveAccessibleName(
+    `Explore ${totalPlugins.toLocaleString('en')} plugins`,
+    { timeout: 5_000 },
+  );
+  expect((await explorePlugins.boundingBox())!.width).toBe(initialButtonWidth);
   await expect(page.getByRole('link', { name: 'Add a plugin', exact: true })).toContainText(
     'Add plugin',
   );
   await expect(page.getByText(/recently found community packages/i)).toHaveCount(0);
   expect(errors).toEqual([]);
+});
+
+test('homepage omits the counter when discovery cannot load', async ({ page }) => {
+  await page.route('**/discovery/**', (route) => route.abort());
+  await page.goto('./');
+  await expect(page.locator('.discovery-status--unavailable')).toBeVisible();
+  await expect(page.locator('.hero__actions .button--primary')).toHaveAccessibleName(
+    'Explore plugins',
+  );
+  await expect(page.locator('.hero__plugin-count')).toHaveCount(0);
 });
 
 test('homepage publishes canonical social metadata and complete product schema', async ({


### PR DESCRIPTION
## Summary

- Reserve enough button width for the loaded four-digit count, capped for narrow viewports.
- Assert the exact final total and unchanged button width in browser E2E.
- Verify that unavailable Discovery leaves the button without a misleading partial count.
- Cover a 280px viewport with reduced motion and unchanged width before/after loading.

## Verification

- Reproduced the desktop regression before the CSS fix: 225px to 231.46875px.
- Measured animation from 0 to 2,976 in 1.94 seconds, with 117 monotonic updates.
- Production Nuxt generate passed.
- All 15 Playwright browser tests passed after the final fix.
- Live normal and reduced-motion checks confirmed counter behavior.

Only button sizing and browser tests change. No installer or registry publication changes.