### PR TITLE
fix(ci): isolate public npm OpenCode repair fixture

### DIFF
--- a/.github/workflows/agentplugins-npm-publish.yml
+++ b/.github/workflows/agentplugins-npm-publish.yml
@@ -223,8 +223,9 @@ jobs:
           # registry. The CLI repo's own Codex example intentionally exercises
           # app metadata and is not a suitable repair fixture.
           repair_source="777genius/universal-agent-plugins-registry@1388c89521bca4b53454776b584ee0c4996b31c0//plugins/context7"
+          mkdir -p "${XDG_CONFIG_HOME}/opencode"
           run_agentplugins add "${repair_source}" --target opencode --format json | jq -e '.result == "success" and .data.succeeded == 1 and .data.failed == 0' >/dev/null
-          repair_file="$(jq -er '.installations[0].clients | to_entries[] | .value.native_objects[] | select(.kind == "opencode_global_mcp_server") | .path' "${AGENTPLUGINS_HOME}/state-v2.json")"
+          repair_file="$(jq -er '[.installations[] | select(.declared_name == "context7") | .clients[] | select(.client_id == "opencode") | .native_objects[] | select(.kind == "opencode_global_mcp_server") | .path] | if length == 1 and (.[0] | type == "string" and length > 0) then .[0] else error("expected exactly one Context7 OpenCode repair path") end' "${AGENTPLUGINS_HOME}/state-v2.json")"
           test -f "${repair_file}"
           jq -e '.mcp.context7' "${repair_file}" > /dev/null
           jq 'del(.mcp.context7)' "${repair_file}" > "${root}/repair-mutated.json"

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -279,6 +279,22 @@ func TestAgentpluginsReadmesUseUnversionedNpxExamples(t *testing.T) {
 	}
 }
 
+func TestAgentpluginsPublicNpmRepairFixtureIsIsolatedAndUnambiguous(t *testing.T) {
+	workflow := readRepoFile(t, RepoRoot(t), ".github", "workflows", "agentplugins-npm-publish.yml")
+	job := yamlJob(t, workflow, "verify-public")
+	const configHome = `XDG_CONFIG_HOME="${root}/config"`
+	const surface = `mkdir -p "${XDG_CONFIG_HOME}/opencode"`
+	const add = `run_agentplugins add "${repair_source}" --target opencode`
+	mustContain(t, job, configHome)
+	mustContain(t, job, surface)
+	mustContain(t, job, add)
+	mustAppearBefore(t, job, configHome, surface)
+	mustAppearBefore(t, job, surface, add)
+	mustContain(t, job, `[.installations[] | select(.declared_name == "context7") | .clients[] | select(.client_id == "opencode") | .native_objects[] | select(.kind == "opencode_global_mcp_server") | .path] | if length == 1 and (.[0] | type == "string" and length > 0) then .[0] else error("expected exactly one Context7 OpenCode repair path") end`)
+	mustNotContain(t, job, `.installations[0]`)
+	mustAppearBefore(t, job, add, `repair_file="$(jq -er`)
+}
+
 func TestAgentpluginsNativeInstallSurfaceIsChecksumAndVersionBound(t *testing.T) {
 	root := RepoRoot(t)
 	unixInstaller := readRepoFile(t, root, "install.sh")


### PR DESCRIPTION
## Summary

- Create the synthetic OpenCode profile under the already isolated XDG config root before the public npm repair check.
- Select exactly one Context7/OpenCode managed MCP path instead of relying on installation index 0. Retained data receipts and installation-ID ordering make that index unreliable.
- Add a focused regression contract for setup ordering and unambiguous selection.

No product runtime, detection, permission, publication, or provenance rule changes. The immutable 0.1.45 release and its tag are unchanged.

## Verification

- Focused release-contract tests passed with `GOMAXPROCS=2 go test -p=1 ./repotests -run 'TestAgentplugins(ReleaseContractsStayFailClosed|PublicNpmRepairFixtureIsIsolatedAndUnambiguous)$' -count=1`.
- [Release 0.1.45](https://github.com/777genius/universal-agent-plugins/releases/tag/agentplugins-v0.1.45) passed all six native platform proofs in [run 33871384058](https://github.com/777genius/universal-agent-plugins/actions/runs/33871384058).
- Public npm `universal-agent-plugins@0.1.45` independently passed an isolated macOS ARM64 add/info/re-add/repair/remove cycle for `github/github-mcp-server@9205304fedf10540c33ae41fcf6352fa97dcc9be`, without a package subpath, across codex,cursor,kiro. Canonical subpath was `agent-plugin`; digest was `sha256:277d1d6ac82febff8dcb43808f158308f04f57eb03f9621163bd0d1941d8e7a0`.
- Immutable full-SHA update correctly required explicit switch and did not mutate state. A separate local-package add/update/remove proof passed on all three targets.
- The same public npm release passed the Context7 OpenCode repair scenario with the correct isolated profile: add, delete only the managed MCP entry, repair, compare the restored entry, remove, verify no remaining installed-client bindings.
- Public npm provenance and synthetic three-client lifecycle already passed within [run 33871956413](https://github.com/777genius/universal-agent-plugins/actions/runs/33871956413), before the final missing-OpenCode-fixture failure. That historical run remains failed; this PR fixes future harness runs, not the release artifacts.

These are installer/configuration lifecycle checks in synthetic client profiles. No agent model, MCP tool, login, or OAuth behavior is claimed.
