### PR TITLE
feat(landing): show every agent on the left-hand 3D hero orbit

### DIFF
--- a/landing/assets/styles/registry.scss
+++ b/landing/assets/styles/registry.scss
@@ -285,8 +285,17 @@ img {
   gap: clamp(42px, 5vw, 70px);
 }
 .hero h1 {
+  font-size: clamp(2.7rem, 4.4vw, 4.1rem);
   max-width: 650px;
   margin-bottom: 22px;
+}
+.hero__copy {
+  position: relative;
+  isolation: isolate;
+}
+.hero__copy h1,
+.hero__lead {
+  text-shadow: 0 2px 18px var(--bg);
 }
 .hero h1 em {
   display: inline-block;
@@ -295,6 +304,7 @@ img {
   white-space: nowrap;
   background: linear-gradient(110deg, var(--primary-bright), var(--cyan) 80%);
   background-clip: text;
+  text-shadow: none;
   -webkit-background-clip: text;
 }
 .hero__lead {
@@ -325,129 +335,107 @@ img {
 
 .hero-agent-field {
   position: absolute;
-  z-index: 0;
+  z-index: -1;
   top: 50%;
-  right: clamp(-160px, 3vw, 55px);
-  width: min(48vw, 610px);
+  left: 48%;
+  width: calc(100% + clamp(48px, 100vw - 1180px, 200px));
   aspect-ratio: 1;
-  translate: 0 -50%;
-  opacity: 0.34;
+  translate: -50% -50%;
+  perspective: 900px;
+  opacity: 0.46;
   pointer-events: none;
 }
-.hero-agent-field__orbit,
-.hero-agent-field__hub,
-.hero-agent-field__node,
-.hero-agent-field__signal {
+.hero-agent-field__plane {
   position: absolute;
+  inset: 0;
+  transform-style: preserve-3d;
+  transform: rotateX(18deg) rotateY(-12deg) rotateZ(-8deg);
+  animation: agent-plane-tilt 18s ease-in-out infinite alternate;
+}
+.hero-agent-field__plane::before {
+  content: '';
+  position: absolute;
+  inset: 26%;
+  border: 1px dashed color-mix(in srgb, var(--primary) 45%, transparent);
   border-radius: 50%;
+  transform: translateZ(-16px);
 }
-.hero-agent-field__orbit {
-  inset: 12%;
-  border: 1px solid color-mix(in srgb, var(--cyan) 40%, transparent);
-  box-shadow: inset 0 0 80px color-mix(in srgb, var(--primary) 5%, transparent);
+.hero-agent-field__track {
+  position: absolute;
+  inset: 9%;
+  border: 1px solid color-mix(in srgb, var(--cyan) 65%, transparent);
+  border-radius: 50%;
+  transform-style: preserve-3d;
+  box-shadow:
+    0 0 28px color-mix(in srgb, var(--cyan) 9%, transparent),
+    inset 0 0 45px color-mix(in srgb, var(--primary) 8%, transparent);
+  animation: agent-orbit-spin 72s linear infinite;
 }
-.hero-agent-field__orbit--outer {
-  animation: agent-orbit-spin 34s linear infinite;
+.hero-agent-field__track::after {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border: 1px solid color-mix(in srgb, var(--primary) 25%, transparent);
+  border-radius: inherit;
+  transform: translateZ(-10px);
 }
-.hero-agent-field__orbit--inner {
-  inset: 30%;
-  border-style: dashed;
-  border-color: color-mix(in srgb, var(--primary) 48%, transparent);
-  animation: agent-orbit-spin 24s linear infinite reverse;
+.hero-agent-field__spoke {
+  position: absolute;
+  inset: 0;
+  transform: rotate(var(--angle));
 }
-.hero-agent-field__hub,
 .hero-agent-field__node {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 44px;
+  height: 44px;
+  transform: translate(-50%, -50%) rotate(calc(-1 * var(--angle)));
+}
+.hero-agent-field__face {
   display: grid;
   place-items: center;
-  border: 1px solid color-mix(in srgb, var(--cyan) 38%, var(--line));
-  background: rgba(255, 255, 255, 0.94);
-  box-shadow:
-    0 0 0 6px color-mix(in srgb, var(--surface-solid) 55%, transparent),
-    0 0 34px color-mix(in srgb, var(--cyan) 22%, transparent);
-}
-.hero-agent-field__hub {
-  top: 50%;
-  left: 50%;
-  width: 72px;
-  height: 72px;
-  translate: -50% -50%;
-}
-.hero-agent-field__node {
-  width: 46px;
-  height: 46px;
-  animation: agent-node-drift 6s ease-in-out infinite;
+  width: 100%;
+  height: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.95);
+  border-radius: 50%;
+  background: linear-gradient(145deg, #fff, #e1e8f8);
+  box-shadow: 0 4px 0 #a4b6d5, 0 8px 20px rgba(11, 24, 58, 0.3);
+  animation: agent-orbit-spin 72s linear infinite reverse;
 }
 .hero-agent-field__node img {
-  width: 24px;
-  height: 24px;
+  width: 26px;
+  height: 26px;
   object-fit: contain;
 }
-.hero-agent-field__node--1 {
-  top: 6%;
-  left: 47%;
-}
-.hero-agent-field__node--2 {
-  top: 25%;
-  right: 6%;
-  animation-delay: -1s;
-}
-.hero-agent-field__node--3 {
-  right: 14%;
-  bottom: 13%;
-  animation-delay: -2s;
-}
-.hero-agent-field__node--4 {
-  bottom: 4%;
-  left: 38%;
-  animation-delay: -3s;
-}
-.hero-agent-field__node--5 {
-  bottom: 23%;
-  left: 7%;
-  animation-delay: -4s;
-}
-.hero-agent-field__node--6 {
-  top: 19%;
-  left: 9%;
-  animation-delay: -5s;
-}
-.hero-agent-field__signal {
+.hero-agent-field__hub {
+  position: absolute;
   top: 50%;
   left: 50%;
-  width: 90px;
-  height: 90px;
-  border: 1px solid color-mix(in srgb, var(--primary) 55%, transparent);
-  translate: -50% -50%;
-  animation: agent-signal 4.8s ease-out infinite;
-}
-.hero-agent-field__signal--2 {
-  animation-delay: 1.6s;
-}
-.hero-agent-field__signal--3 {
-  animation-delay: 3.2s;
+  display: grid;
+  place-items: center;
+  width: 58px;
+  height: 58px;
+  border: 1px solid var(--line-strong);
+  border-radius: 18px;
+  background: var(--surface-solid);
+  transform: translate(-50%, -50%) translateZ(12px);
+  opacity: 0.45;
 }
 @keyframes agent-orbit-spin {
   to {
-    rotate: 360deg;
+    transform: rotate(360deg);
   }
 }
-@keyframes agent-node-drift {
-  50% {
-    transform: translateY(-7px) scale(1.04);
+@keyframes agent-plane-tilt {
+  to {
+    transform: rotateX(-12deg) rotateY(16deg) rotateZ(8deg);
   }
 }
-@keyframes agent-signal {
-  0% {
-    opacity: 0;
-    scale: 0.55;
-  }
-  18% {
-    opacity: 0.7;
-  }
-  100% {
-    opacity: 0;
-    scale: 4.4;
-  }
+.hero-agent-field:not(.hero-agent-field--active) .hero-agent-field__plane,
+.hero-agent-field:not(.hero-agent-field--active) .hero-agent-field__track,
+.hero-agent-field:not(.hero-agent-field--active) .hero-agent-field__face {
+  animation-play-state: paused;
 }
 .hero__window {
   overflow: hidden;
@@ -2520,10 +2508,9 @@ img {
     margin: 25px auto 0;
   }
   .hero-agent-field {
-    top: 24%;
-    right: -80px;
-    width: 570px;
-    opacity: 0.24;
+    left: 50%;
+    width: min(100%, 550px);
+    opacity: 0.34;
   }
   .client-strip {
     grid-template-columns: repeat(6, minmax(0, 1fr));
@@ -2644,10 +2631,17 @@ img {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
   .hero-agent-field {
-    top: 19%;
-    right: -180px;
-    width: 470px;
-    opacity: 0.2;
+    top: 25%;
+    width: min(100%, 320px);
+    opacity: 0.22;
+  }
+  .hero-agent-field__node {
+    width: 34px;
+    height: 34px;
+  }
+  .hero-agent-field__node img {
+    width: 22px;
+    height: 22px;
   }
   .client-strip li > a {
     min-height: 66px;
@@ -2819,9 +2813,9 @@ img {
   .workflow-path--animate::before {
     transform: none;
   }
-  .hero-agent-field__orbit,
-  .hero-agent-field__node,
-  .hero-agent-field__signal {
+  .hero-agent-field__plane,
+  .hero-agent-field__track,
+  .hero-agent-field__face {
     animation: none !important;
   }
 }

--- a/landing/assets/styles/registry.scss
+++ b/landing/assets/styles/registry.scss
@@ -336,9 +336,9 @@ img {
 .hero-agent-field {
   position: absolute;
   z-index: -1;
-  top: 50%;
-  left: 48%;
-  width: calc(100% + clamp(48px, 100vw - 1180px, 200px));
+  top: 54%;
+  left: 50%;
+  width: calc(100% + clamp(16px, 100vw - 1180px, 160px));
   aspect-ratio: 1;
   translate: -50% -50%;
   perspective: 900px;
@@ -2508,8 +2508,11 @@ img {
     margin: 25px auto 0;
   }
   .hero-agent-field {
+    top: 50%;
     left: 50%;
-    width: min(100%, 550px);
+    width: auto;
+    height: calc(100% + 40px);
+    max-width: 100%;
     opacity: 0.34;
   }
   .client-strip {
@@ -2631,8 +2634,9 @@ img {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
   .hero-agent-field {
-    top: 25%;
-    width: min(100%, 320px);
+    top: 27%;
+    width: min(100%, 300px);
+    height: auto;
     opacity: 0.22;
   }
   .hero-agent-field__node {

--- a/landing/components/registry/HeroAgentField.vue
+++ b/landing/components/registry/HeroAgentField.vue
@@ -1,26 +1,60 @@
 <script setup lang="ts">
+import { clients } from '~/data/clients';
+
 const { asset } = useSite();
-const featuredClientIDs = new Set(['codex', 'cursor', 'claude', 'gemini', 'opencode', 'windsurf']);
-const featuredClients = clients.filter((client) => featuredClientIDs.has(client.id));
+const field = ref<HTMLElement>();
+const inView = ref(false);
+const pageVisible = ref(true);
+let observer: IntersectionObserver | undefined;
+const updatePageVisibility = () => {
+  pageVisible.value = !document.hidden;
+};
+
+onMounted(() => {
+  updatePageVisibility();
+  document.addEventListener('visibilitychange', updatePageVisibility);
+  if (field.value && 'IntersectionObserver' in window) {
+    observer = new IntersectionObserver(([entry]) => {
+      inView.value = Boolean(entry?.isIntersecting);
+    });
+    observer.observe(field.value);
+  } else {
+    inView.value = true;
+  }
+});
+
+onBeforeUnmount(() => {
+  observer?.disconnect();
+  document.removeEventListener('visibilitychange', updatePageVisibility);
+});
 </script>
 
 <template>
-  <div class="hero-agent-field" aria-hidden="true">
-    <span class="hero-agent-field__orbit hero-agent-field__orbit--outer" />
-    <span class="hero-agent-field__orbit hero-agent-field__orbit--inner" />
-    <span class="hero-agent-field__hub">
-      <img :src="asset('icon.svg')" alt="" width="34" height="34" >
-    </span>
-    <span
-      v-for="(client, index) in featuredClients"
-      :key="client.id"
-      class="hero-agent-field__node"
-      :class="`hero-agent-field__node--${index + 1}`"
-    >
-      <img :src="asset(`client-icons/${client.icon}`)" alt="" width="22" height="22" >
-    </span>
-    <span class="hero-agent-field__signal hero-agent-field__signal--1" />
-    <span class="hero-agent-field__signal hero-agent-field__signal--2" />
-    <span class="hero-agent-field__signal hero-agent-field__signal--3" />
+  <div
+    ref="field"
+    class="hero-agent-field"
+    :class="{ 'hero-agent-field--active': inView && pageVisible }"
+    aria-hidden="true"
+  >
+    <div class="hero-agent-field__plane">
+      <div class="hero-agent-field__track">
+        <span
+          v-for="(client, index) in clients"
+          :key="client.id"
+          class="hero-agent-field__spoke"
+          :data-client-id="client.id"
+          :style="{ '--angle': `${(index * 360) / clients.length}deg` }"
+        >
+          <span class="hero-agent-field__node">
+            <span class="hero-agent-field__face">
+              <img :src="asset(`client-icons/${client.icon}`)" alt="" width="26" height="26" >
+            </span>
+          </span>
+        </span>
+      </div>
+      <span class="hero-agent-field__hub">
+        <img :src="asset('icon.svg')" alt="" width="34" height="34" >
+      </span>
+    </div>
   </div>
 </template>

--- a/landing/components/registry/RegistryHero.vue
+++ b/landing/components/registry/RegistryHero.vue
@@ -129,9 +129,9 @@ function updateTargets(values: string[]) {
 
 <template>
   <section class="hero-shell">
-    <HeroAgentField />
     <div class="hero container">
       <div class="hero__copy">
+        <HeroAgentField />
         <h1>One plugin<br ><em>All your agents</em></h1>
         <p class="hero__lead">
           Install, update, repair, and remove Agent Plugins 1.0 across supported AI agents with one

--- a/landing/tests/browser/hero-orbit.spec.ts
+++ b/landing/tests/browser/hero-orbit.spec.ts
@@ -97,3 +97,43 @@ test('mobile orbit keeps every logo visible and honors reduced motion', async ({
     true,
   );
 });
+
+test('orbit clears navigation and installation throughout responsive rotation', async ({
+  page,
+}) => {
+  await page.goto('./');
+  const field = page.locator('.hero-agent-field');
+  await expect(field).toHaveClass(/hero-agent-field--active/);
+  for (const width of [1440, 1280, 1024, 800, 390, 280]) {
+    await page.setViewportSize({ width, height: 1000 });
+    for (let time = 0; time < 72_000; time += 9_000) {
+      await field.evaluate((element, elapsed) => {
+        for (const animation of element.getAnimations({ subtree: true })) {
+          animation.pause();
+          animation.currentTime = elapsed;
+        }
+      }, time);
+      await page.evaluate(() => new Promise(requestAnimationFrame));
+      const bounds = await page.evaluate(() => {
+        const installation = document.querySelector('.hero__demo')!.getBoundingClientRect();
+        const header = document.querySelector('.app-header')!.getBoundingClientRect();
+        return {
+          installation: { x: installation.x, y: installation.y },
+          headerBottom: header.bottom,
+          nodes: [...document.querySelectorAll('.hero-agent-field__node')].map((element) => {
+            const rect = element.getBoundingClientRect();
+            return { x: rect.x, y: rect.y, right: rect.right, bottom: rect.bottom };
+          }),
+        };
+      });
+      for (const node of bounds.nodes) {
+        const context = `${width}px at ${time}ms`;
+        expect(node.x, context).toBeGreaterThanOrEqual(0);
+        expect(node.right, context).toBeLessThanOrEqual(width);
+        expect(node.y, context).toBeGreaterThanOrEqual(bounds.headerBottom);
+        if (width > 980) expect(node.right, context).toBeLessThan(bounds.installation.x);
+        else expect(node.bottom, context).toBeLessThan(bounds.installation.y);
+      }
+    }
+  }
+});

--- a/landing/tests/browser/hero-orbit.spec.ts
+++ b/landing/tests/browser/hero-orbit.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from '@playwright/test';
+import { clients } from '../../data/clients';
+
+test('hero orbit reuses every supported client and places logos on one circumference', async ({
+  page,
+}) => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await page.goto('./');
+  const field = page.locator('.hero__copy .hero-agent-field');
+  await expect(field).toHaveAttribute('aria-hidden', 'true');
+  await expect(field.locator('.hero-agent-field__node')).toHaveCount(clients.length);
+  expect(
+    await field
+      .locator('[data-client-id]')
+      .evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-client-id'))),
+  ).toEqual(clients.map((client) => client.id));
+  for (const client of clients) {
+    const logo = field.locator(`[data-client-id="${client.id}"] img`);
+    await expect(logo).toHaveAttribute('src', new RegExp(`/client-icons/${client.icon}$`));
+    expect(
+      await logo.evaluate((image: HTMLImageElement) => image.complete && image.naturalWidth > 0),
+    ).toBe(true);
+  }
+
+  // Flatten only the camera for this geometry check, not the radial placement.
+  await field.locator('.hero-agent-field__plane').evaluate((node: HTMLElement) => {
+    node.style.transform = 'none';
+  });
+  await expect
+    .poll(() =>
+      field
+        .locator('.hero-agent-field__plane')
+        .evaluate((node) => getComputedStyle(node).transform),
+    )
+    .toBe('none');
+  const radii = await field.evaluate((element) => {
+    const track = element.querySelector('.hero-agent-field__track')!.getBoundingClientRect();
+    const center = { x: track.x + track.width / 2, y: track.y + track.height / 2 };
+    return [...element.querySelectorAll('.hero-agent-field__node')].map((node) => {
+      const rect = node.getBoundingClientRect();
+      return Math.abs(
+        Math.hypot(rect.x + rect.width / 2 - center.x, rect.y + rect.height / 2 - center.y) -
+          track.width / 2,
+      );
+    });
+  });
+  expect(Math.max(...radii)).toBeLessThan(2);
+});
+
+test('hero orbit animates with depth, stays left of installation, and pauses offscreen', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  await page.goto('./');
+  const field = page.locator('.hero-agent-field');
+  await expect(field).toHaveClass(/hero-agent-field--active/);
+  const track = field.locator('.hero-agent-field__track');
+  const firstTransform = await track.evaluate((node) => getComputedStyle(node).transform);
+  await expect
+    .poll(() => track.evaluate((node) => getComputedStyle(node).transform))
+    .not.toBe(firstTransform);
+  expect(
+    await field
+      .locator('.hero-agent-field__plane')
+      .evaluate((node) => getComputedStyle(node).transform),
+  ).toMatch(/^matrix3d\(/);
+  expect(await field.evaluate((node) => getComputedStyle(node).pointerEvents)).toBe('none');
+
+  const installation = (await page.locator('.hero__demo').boundingBox())!;
+  for (const node of await field.locator('.hero-agent-field__node').all()) {
+    const rect = (await node.boundingBox())!;
+    expect(rect.x).toBeGreaterThanOrEqual(0);
+    expect(rect.x + rect.width).toBeLessThan(installation.x);
+  }
+  await page.getByRole('contentinfo').scrollIntoViewIfNeeded();
+  await expect(field).not.toHaveClass(/hero-agent-field--active/);
+  expect(await track.evaluate((node) => getComputedStyle(node).animationPlayState)).toBe('paused');
+  await page.getByRole('heading', { name: 'One plugin All your agents' }).scrollIntoViewIfNeeded();
+  await expect(field).toHaveClass(/hero-agent-field--active/);
+});
+
+test('mobile orbit keeps every logo visible and honors reduced motion', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await page.goto('./');
+  const field = page.locator('.hero-agent-field');
+  await expect(field.locator('.hero-agent-field__node')).toHaveCount(clients.length);
+  expect(await field.evaluate((node) => node.getAnimations({ subtree: true }).length)).toBe(0);
+  const installation = (await page.locator('.hero__demo').boundingBox())!;
+  for (const node of await field.locator('.hero-agent-field__node').all()) {
+    const rect = (await node.boundingBox())!;
+    expect(rect.x).toBeGreaterThanOrEqual(0);
+    expect(rect.x + rect.width).toBeLessThanOrEqual(390);
+    expect(rect.y + rect.height).toBeLessThan(installation.y);
+  }
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(
+    true,
+  );
+});


### PR DESCRIPTION
## Summary

- Move the decorative orbit behind the left-hand hero copy, clear of the installation panel.
- Reuse all 11 entries from the shared supported-client list and their existing official logos.
- Place badge centers evenly on a single circular track, with counter-rotation to keep logos readable.
- Add a subtle CSS-only 3D tilt, layered ring, and badge depth; no new dependency or continuous JavaScript loop.
- Pause outside the viewport or in hidden tabs, and honor reduced motion.
- Keep the headline within its column and adapt the orbit for tablet/mobile layouts.

## Verification

- 12 unit tests passed; lint and production generate passed.
- 19 Playwright browser tests passed.
- Geometric test verifies each badge center lies on the track circumference.
- Eight rotation phases at six viewport widths stay clear of navigation and installation.
- Visually inspected dark/light desktop and mobile states.

No installer, package, registry policy, or authentication changes.