### PR TITLE
fix(landing): place breathing agent orbit behind installer

### DIFF
--- a/landing/assets/styles/hero-agent-field.scss
+++ b/landing/assets/styles/hero-agent-field.scss
@@ -1,20 +1,22 @@
 .hero-agent-field {
-  position: relative;
-  width: 100%;
-  height: 290px;
+  position: absolute;
+  inset: 0;
   perspective: 900px;
   pointer-events: none;
+  opacity: 0.55;
 }
 .hero-agent-field__plane {
   position: absolute;
   top: 50%;
-  left: 50%;
-  width: min(240px, calc(100% - 56px));
+  left: 62%;
+  width: min(480px, 100%);
   aspect-ratio: 1;
   translate: -50% -50%;
   transform-style: preserve-3d;
   transform: rotateX(18deg) rotateY(-12deg) rotateZ(-8deg);
-  animation: agent-plane-tilt 18s ease-in-out infinite alternate;
+  animation:
+    agent-plane-tilt 18s ease-in-out infinite alternate,
+    agent-orbit-breathe 12s ease-in-out infinite;
 }
 .hero-agent-field__track {
   position: absolute;
@@ -75,14 +77,17 @@
 @keyframes agent-plane-tilt {
   to { transform: rotateX(-12deg) rotateY(16deg) rotateZ(8deg); }
 }
+@keyframes agent-orbit-breathe {
+  0%, 100% { scale: 0.96; }
+  50% { scale: 1.04; }
+}
 .hero-agent-field:not(.hero-agent-field--active) {
   .hero-agent-field__plane,
   .hero-agent-field__track,
   .hero-agent-field__face { animation-play-state: paused; }
 }
 @media (max-width: 720px) {
-  .hero-agent-field { height: 200px; }
-  .hero-agent-field__plane { width: min(164px, calc(100% - 48px)); }
+  .hero-agent-field__plane { width: min(328px, 100%); }
   .hero-agent-field__node { width: 30px; height: 30px; }
   .hero-agent-field__node img { width: 22px; height: 22px; }
   .hero-agent-field__hub { width: 48px; height: 48px; border-radius: 14px; }

--- a/landing/assets/styles/registry.scss
+++ b/landing/assets/styles/registry.scss
@@ -326,11 +326,12 @@ img {
 }
 .hero__demo {
   position: relative;
-  display: grid;
-  gap: 12px;
+  isolation: isolate;
 }
 
 .hero__window {
+  position: relative;
+  z-index: 1;
   overflow: hidden;
   border: 1px solid var(--line-strong);
   border-radius: 20px;

--- a/landing/components/registry/HeroAgentField.vue
+++ b/landing/components/registry/HeroAgentField.vue
@@ -2,6 +2,10 @@
 import { clients } from '~/data/clients';
 
 const { asset } = useSite();
+// Shared branding appears once here; actual client support and selection stay unchanged.
+const orbitClients = clients.filter(
+  (client, index) => clients.findIndex((candidate) => candidate.icon === client.icon) === index,
+);
 const field = ref<HTMLElement>();
 const inView = ref(false);
 const pageVisible = ref(true);
@@ -39,11 +43,11 @@ onBeforeUnmount(() => {
     <div class="hero-agent-field__plane">
       <div class="hero-agent-field__track">
         <span
-          v-for="(client, index) in clients"
+          v-for="(client, index) in orbitClients"
           :key="client.id"
           class="hero-agent-field__spoke"
           :data-client-id="client.id"
-          :style="{ '--angle': `${(index * 360) / clients.length}deg` }"
+          :style="{ '--angle': `${(index * 360) / orbitClients.length}deg` }"
         >
           <span class="hero-agent-field__node">
             <span class="hero-agent-field__face">

--- a/landing/tests/browser/hero-orbit.spec.ts
+++ b/landing/tests/browser/hero-orbit.spec.ts
@@ -1,15 +1,18 @@
 import { expect, test } from '@playwright/test';
 import { clients } from '../../data/clients';
 
-test('CSS orbit is visible without JavaScript and keeps every logo on the circle', async ({ browser, baseURL }) => {
+const uniqueLogos = clients.filter((client, index) => clients.findIndex((item) => item.icon === client.icon) === index);
+
+test('CSS background works without JavaScript and keeps unique logos on the circle', async ({ browser, baseURL }) => {
   const context = await browser.newContext({ baseURL, javaScriptEnabled: false, reducedMotion: 'reduce' });
   const page = await context.newPage();
   try {
     await page.goto('./');
     const field = page.locator('.hero__demo .hero-agent-field');
     await expect(field).toHaveAttribute('aria-hidden', 'true');
-    await expect(field.locator('[data-client-id]')).toHaveCount(clients.length);
-    for (const client of clients) {
+    await expect(field.locator('[data-client-id]')).toHaveCount(uniqueLogos.length);
+    await expect(field.locator('img[src$="/openai.svg"]')).toHaveCount(1);
+    for (const client of uniqueLogos) {
       const logo = field.locator(`[data-client-id="${client.id}"] img`);
       await expect(logo).toHaveAttribute('src', new RegExp(`/client-icons/${client.icon}$`));
       await expect.poll(() => logo.evaluate((image: HTMLImageElement) => image.complete && image.naturalWidth > 0)).toBe(true);
@@ -35,7 +38,7 @@ test('CSS orbit is visible without JavaScript and keeps every logo on the circle
   }
 });
 
-test('historical CSS depth animates on the right and pauses offscreen or hidden', async ({ page }) => {
+test('CSS background depth animates on the right and pauses offscreen or hidden', async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 1000 });
   await page.goto('./');
   const field = page.locator('.hero__demo .hero-agent-field');
@@ -49,7 +52,12 @@ test('historical CSS depth animates on the right and pauses offscreen or hidden'
   const bounds = (await field.boundingBox())!;
   const installation = (await page.locator('.hero__window').boundingBox())!;
   expect(bounds.x).toBeGreaterThan(copy.x + copy.width);
-  expect(bounds.y + bounds.height).toBeLessThanOrEqual(installation.y);
+  expect(bounds.y).toBeCloseTo(installation.y, 1);
+  expect(bounds.height).toBeCloseTo(installation.height, 1);
+  expect(await field.evaluate((node) => getComputedStyle(node).position)).toBe('absolute');
+  const sceneAnimations = await field.evaluate((node) => node.getAnimations({ subtree: true })
+    .map((animation) => (animation as CSSAnimation).animationName));
+  expect(sceneAnimations).toContain('agent-orbit-breathe');
   await page.getByRole('contentinfo').scrollIntoViewIfNeeded();
   await expect(field).not.toHaveClass(/hero-agent-field--active/);
   expect(await track.evaluate((node) => getComputedStyle(node).animationPlayState)).toBe('paused');
@@ -69,14 +77,24 @@ test('historical CSS depth animates on the right and pauses offscreen or hidden'
   expect(await field.evaluate((node) => node.getAnimations({ subtree: true }).length)).toBe(0);
 });
 
-test('all logos stay within the scene and clear the command throughout responsive rotation', async ({ page }) => {
+test('twice-sized breathing background never changes layout or blocks the foreground', async ({ page }) => {
   await page.goto('./');
   const field = page.locator('.hero-agent-field');
   await expect(field).toHaveClass(/hero-agent-field--active/);
   for (const width of [1440, 1280, 1024, 800, 390, 280]) {
     await page.setViewportSize({ width, height: 1000 });
     await field.scrollIntoViewIfNeeded();
-    for (const time of [0, 9000, 18000, 36000, 54000]) {
+    const windowBefore = (await page.locator('.hero__window').boundingBox())!;
+    const heroBefore = (await page.locator('.hero').boundingBox())!;
+    const planeWidth = await field.locator('.hero-agent-field__plane')
+      .evaluate((node) => Number.parseFloat(getComputedStyle(node).width));
+    expect(planeWidth).toBeLessThanOrEqual(width <= 720 ? 328 : 480);
+    if (width >= 390) expect(planeWidth).toBe(width <= 720 ? 328 : 480);
+    await field.evaluate((node: HTMLElement) => { node.style.display = 'none'; });
+    expect(await page.locator('.hero__window').boundingBox()).toEqual(windowBefore);
+    expect(await page.locator('.hero').boundingBox()).toEqual(heroBefore);
+    await field.evaluate((node: HTMLElement) => { node.style.removeProperty('display'); });
+    for (const time of [0, 5000, 10000, 36000, 54000]) {
       await field.evaluate((node, elapsed) => {
         for (const animation of node.getAnimations({ subtree: true })) {
           animation.pause();
@@ -84,20 +102,28 @@ test('all logos stay within the scene and clear the command throughout responsiv
         }
       }, time);
       await page.evaluate(() => new Promise(requestAnimationFrame));
-      const scene = (await field.boundingBox())!;
       const installation = (await page.locator('.hero__window').boundingBox())!;
-      for (const node of await field.locator('.hero-agent-field__node').all()) {
-        const rect = (await node.boundingBox())!;
-        const label = `${width}px, ${time}ms`;
-        expect(rect.x, label).toBeGreaterThanOrEqual(Math.max(0, scene.x));
-        expect(rect.x + rect.width, label).toBeLessThanOrEqual(Math.min(width, scene.x + scene.width));
-        expect(rect.y, label).toBeGreaterThanOrEqual(scene.y);
-        expect(rect.y + rect.height, label).toBeLessThanOrEqual(scene.y + scene.height);
-        expect(rect.y + rect.height, label).toBeLessThan(installation.y);
-      }
+      expect(installation).toEqual(windowBefore);
       expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
     }
   }
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  await field.scrollIntoViewIfNeeded();
+  const sizes: number[] = [];
+  for (const progress of [0, 0.5, 1]) {
+    await field.evaluate((node, fraction) => {
+      for (const animation of node.getAnimations({ subtree: true })) {
+        animation.pause();
+        animation.currentTime = (animation as CSSAnimation).animationName === 'agent-orbit-breathe'
+          ? Number(animation.effect!.getTiming().duration) * fraction : 0;
+      }
+    }, progress);
+    await page.evaluate(() => new Promise(requestAnimationFrame));
+    sizes.push((await field.locator('.hero-agent-field__track').boundingBox())!.width);
+  }
+  expect(sizes[1]!).toBeGreaterThan(sizes[0]! * 1.05);
+  expect(sizes[1]!).toBeLessThan(sizes[0]! * 1.25);
+  expect(sizes[2]!).toBeCloseTo(sizes[0]!, 1);
 });
 
 test('installation works with WebGL forbidden and the orbit has no canvas or optional renderer', async ({ page }) => {
@@ -120,6 +146,11 @@ test('installation works with WebGL forbidden and the orbit has no canvas or opt
   await page.keyboard.press('Escape');
   await expect(page.locator('.hero__demo .command-snippet')).toContainText('--target cursor');
   await page.getByRole('button', { name: 'Toggle theme', exact: true }).click();
-  await expect(field.locator('[data-client-id]')).toHaveCount(clients.length);
+  await expect(field.locator('[data-client-id]')).toHaveCount(uniqueLogos.length);
+  // Only decorative logos are deduplicated, never the actual install targets.
+  await page.getByRole('button', { name: /Choose target agents:/ }).click();
+  await expect(page.getByRole('checkbox', { name: /^Codex / })).toBeVisible();
+  await expect(page.getByRole('checkbox', { name: /^ChatGPT / })).toBeVisible();
+  await page.keyboard.press('Escape');
   expect(errors).toEqual([]);
 });


### PR DESCRIPTION
## Change
Make the CSS orbit a decorative background in the right hero column, without reserving space or moving the installation card.

- Double the nominal circle size to 480px desktop and 328px mobile, with narrow-screen clamping.
- Show one shared OpenAI logo for Codex and ChatGPT in the decoration only.
- Add a gentle 12-second expand/contract cycle, independent of tilt and rotation.
- Preserve reduced-motion and offscreen/hidden pause; no new dependencies or WebGL.

## Verification
Independent scoped review: no material findings. Browser regressions cover geometry, zero layout contribution, responsive bounds, breathing endpoints, and usable foreground controls. Actual Codex and ChatGPT installation choices remain separate.

Production build and browser tests run in Landing CI.