### PR TITLE
feat(landing): refine orbit depth filters and feature cards

### DIFF
--- a/landing/assets/styles/hero-agent-field.scss
+++ b/landing/assets/styles/hero-agent-field.scss
@@ -1,7 +1,7 @@
 .hero-agent-field {
   position: absolute;
   inset: 0;
-  perspective: 900px;
+  perspective: 750px;
   pointer-events: none;
   opacity: 0.55;
 }
@@ -13,7 +13,7 @@
   aspect-ratio: 1;
   translate: -50% -50%;
   transform-style: preserve-3d;
-  transform: rotateX(18deg) rotateY(-12deg) rotateZ(-8deg);
+  transform: rotateX(36deg) rotateY(-28deg) rotateZ(-12deg);
   animation:
     agent-plane-tilt 18s ease-in-out infinite alternate,
     agent-orbit-breathe 12s ease-in-out infinite;
@@ -75,7 +75,7 @@
   to { transform: rotate(360deg); }
 }
 @keyframes agent-plane-tilt {
-  to { transform: rotateX(-12deg) rotateY(16deg) rotateZ(8deg); }
+  to { transform: rotateX(-32deg) rotateY(30deg) rotateZ(12deg); }
 }
 @keyframes agent-orbit-breathe {
   0%, 100% { scale: 0.96; }

--- a/landing/assets/styles/registry-benefits.scss
+++ b/landing/assets/styles/registry-benefits.scss
@@ -1,0 +1,84 @@
+.registry-benefits {
+  padding-block: 76px;
+}
+.registry-benefits__grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+.registry-benefits__card {
+  --benefit-accent: var(--cyan);
+  position: relative;
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--surface);
+  overflow: hidden;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 22px;
+    width: 44px;
+    height: 2px;
+    background: var(--benefit-accent);
+    opacity: 0.75;
+  }
+  &:nth-child(2),
+  &:nth-child(4) {
+    --benefit-accent: var(--primary-bright);
+  }
+  h3 {
+    margin: 19px 0 9px;
+    color: var(--text);
+    font-size: 1rem;
+    letter-spacing: -0.025em;
+  }
+  p {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.86rem;
+    line-height: 1.65;
+  }
+  code {
+    color: var(--text);
+    font-size: 0.9em;
+  }
+}
+.registry-benefits__signature {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--line);
+
+  svg {
+    width: 30px;
+    height: 30px;
+    flex-shrink: 0;
+    color: var(--benefit-accent);
+  }
+}
+.registry-benefits__number {
+  color: color-mix(in srgb, var(--text) 40%, var(--surface-solid));
+  font-size: 2.6rem;
+  font-weight: 450;
+  line-height: 1;
+  letter-spacing: -0.075em;
+  font-variant-numeric: tabular-nums;
+}
+@media (max-width: 980px) {
+  .registry-benefits__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+@media (max-width: 720px) {
+  .registry-benefits {
+    padding-block: 56px;
+  }
+  .registry-benefits__grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/landing/assets/styles/registry.scss
+++ b/landing/assets/styles/registry.scss
@@ -893,13 +893,9 @@ img {
   padding-block: 90px;
 }
 .catalog-controls {
-  padding: 12px;
   display: grid;
   grid-template-columns: minmax(260px, 1.7fr) repeat(3, minmax(140px, 0.7fr));
-  gap: 9px;
-  border: 1px solid var(--line);
-  border-radius: 15px;
-  background: var(--surface);
+  gap: 12px 20px;
 }
 .catalog-controls input {
   width: 100%;
@@ -953,6 +949,32 @@ img {
 }
 .catalog-advanced-filters {
   display: contents;
+}
+/* Flat toolbar only; dropdown panels and installation controls keep their surfaces. */
+.catalog-controls .search-field input,
+.catalog-controls .app-select__trigger,
+.catalog-controls .app-combobox__anchor,
+.catalog-controls .catalog-filter-toggle {
+  border: 0;
+  border-bottom: 1px solid var(--line-strong);
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+.catalog-controls .search-field input:hover,
+.catalog-controls .app-select__trigger:hover,
+.catalog-controls .app-combobox__anchor:hover {
+  border-bottom-color: var(--primary-bright);
+  background: transparent;
+}
+.catalog-controls .app-select__trigger[data-state='open'],
+.catalog-controls .app-combobox__anchor:focus-within {
+  border-bottom-color: var(--primary-bright);
+  box-shadow: inset 0 -1px var(--primary-bright);
+}
+.catalog-controls .app-combobox__input {
+  border: 0;
+  background: transparent;
 }
 .catalog-filter-toggle {
   display: none;
@@ -2219,46 +2241,6 @@ img {
   font-size: 0.68rem;
 }
 
-.registry-benefits {
-  padding-block: 90px;
-}
-.registry-benefits__grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 16px;
-}
-.registry-benefits__grid article {
-  min-height: 230px;
-  padding: 24px;
-  border: 1px solid var(--line);
-  border-radius: 20px;
-  background:
-    radial-gradient(
-      circle at top right,
-      color-mix(in srgb, var(--cyan) 10%, transparent),
-      transparent 44%
-    ),
-    var(--surface);
-}
-.registry-benefits__grid article > span {
-  color: var(--cyan);
-  font:
-    750 0.7rem 'JetBrains Mono',
-    monospace;
-  letter-spacing: 0.1em;
-}
-.registry-benefits__grid h3 {
-  margin: 42px 0 12px;
-}
-.registry-benefits__grid p {
-  margin: 0;
-  color: var(--muted);
-  font-size: 0.86rem;
-}
-.registry-benefits__grid code {
-  color: var(--cyan);
-}
-
 .community-plugin-state {
   min-height: 55vh;
   padding-block: 100px;
@@ -2273,8 +2255,7 @@ img {
 
 @supports (animation-timeline: view()) {
   .catalog > .section-heading,
-  .catalog-controls,
-  .registry-benefits__grid article {
+  .catalog-controls {
     animation: section-rise linear both;
     animation-timeline: view();
     animation-range: entry 0 entry 34%;
@@ -2417,9 +2398,6 @@ img {
     grid-template-columns: 1fr;
     gap: 35px;
   }
-  .registry-benefits__grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
   .plugin-page__grid {
     grid-template-columns: 1fr;
   }
@@ -2525,7 +2503,6 @@ img {
   .how,
   .catalog-wrap,
   .validation-section,
-  .registry-benefits,
   .registry-faq {
     padding-block: 65px;
   }
@@ -2556,15 +2533,6 @@ img {
   .workflow-step:nth-child(2),
   .workflow-step:nth-child(3) {
     translate: none;
-  }
-  .registry-benefits__grid {
-    grid-template-columns: 1fr;
-  }
-  .registry-benefits__grid article {
-    min-height: auto;
-  }
-  .registry-benefits__grid h3 {
-    margin-top: 24px;
   }
   .plugin-grid {
     grid-template-columns: 1fr;

--- a/landing/components/registry/RegistryHero.vue
+++ b/landing/components/registry/RegistryHero.vue
@@ -182,7 +182,7 @@ function updateTargets(values: string[]) {
                 <span class="hero-quick-start__number hero-quick-start__number--run">2</span>
                 <span class="hero-quick-start__label"
                   ><strong>Copy and run</strong
-                  ><small>No target flag means auto-detect</small></span
+                  ><small>In your terminal</small></span
                 >
                 <CommandSnippet v-if="command" :command="command" kind="add" inline />
                 <p v-else class="install-panel__notice" role="status">

--- a/landing/components/registry/RegistryWhy.vue
+++ b/landing/components/registry/RegistryWhy.vue
@@ -6,29 +6,54 @@
       <p>The package stays portable; the installer handles each client's format and lifecycle.</p>
     </div>
     <div class="registry-benefits__grid">
-      <article>
-        <span>01</span>
+      <article class="registry-benefits__card">
+        <div class="registry-benefits__signature" aria-hidden="true">
+          <span class="registry-benefits__number">01</span>
+          <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m16 3 11 6v14l-11 6-11-6V9Z M5 9l11 6 11-6 M16 15v14 M10.5 6l11 6v6" />
+          </svg>
+        </div>
         <h3>Standard first</h3>
         <p>
           Packages are read from Agent Plugins 1.0 <code>plugin.json</code>, without a second
           install manifest.
         </p>
       </article>
-      <article>
-        <span>02</span>
+      <article class="registry-benefits__card">
+        <div class="registry-benefits__signature" aria-hidden="true">
+          <span class="registry-benefits__number">02</span>
+          <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="12" width="8" height="8" rx="2" />
+            <rect x="22" y="3" width="7" height="7" rx="2" />
+            <rect x="22" y="22" width="7" height="7" rx="2" />
+            <path d="M11 16h5V6.5h6 M16 16v9.5h6 M16 16h12" />
+          </svg>
+        </div>
         <h3>Client-aware</h3>
         <p>
           Codex, Cursor, Claude Code, Gemini CLI, OpenCode, and other clients receive the format
           they support.
         </p>
       </article>
-      <article>
-        <span>03</span>
+      <article class="registry-benefits__card">
+        <div class="registry-benefits__signature" aria-hidden="true">
+          <span class="registry-benefits__number">03</span>
+          <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M26 12a11 11 0 0 0-19-4L4 11 M4 5v6h6 M6 20a11 11 0 0 0 19 4l3-3 M28 27v-6h-6 M11 16l3 3 7-7" />
+          </svg>
+        </div>
         <h3>Full lifecycle</h3>
         <p>Add, inspect, update, repair, switch source, or remove a plugin through the same CLI.</p>
       </article>
-      <article>
-        <span>04</span>
+      <article class="registry-benefits__card">
+        <div class="registry-benefits__signature" aria-hidden="true">
+          <span class="registry-benefits__number">04</span>
+          <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M2 16s5-9 14-9 14 9 14 9-5 9-14 9S2 16 2 16Z" />
+            <circle cx="16" cy="16" r="4" />
+            <path d="M16 2v2 M16 28v2" />
+          </svg>
+        </div>
         <h3>Source visible</h3>
         <p>
           Reviewed packages and community discovery remain clearly labeled, with their source
@@ -38,3 +63,5 @@
     </div>
   </section>
 </template>
+
+<style src="~/assets/styles/registry-benefits.scss" lang="scss" />

--- a/landing/tests/browser/hero-orbit.spec.ts
+++ b/landing/tests/browser/hero-orbit.spec.ts
@@ -58,6 +58,21 @@ test('CSS background depth animates on the right and pauses offscreen or hidden'
   const sceneAnimations = await field.evaluate((node) => node.getAnimations({ subtree: true })
     .map((animation) => (animation as CSSAnimation).animationName));
   expect(sceneAnimations).toContain('agent-orbit-breathe');
+  const tiltMatrices: number[][] = [];
+  for (const progress of [0, 1]) {
+    tiltMatrices.push(await field.evaluate((node, fraction) => {
+      const plane = node.querySelector('.hero-agent-field__plane')!;
+      const tilt = plane.getAnimations().find((animation) =>
+        (animation as CSSAnimation).animationName === 'agent-plane-tilt')!;
+      tilt.pause();
+      tilt.currentTime = Number(tilt.effect!.getTiming().duration) * fraction;
+      const matrix = new DOMMatrix(getComputedStyle(plane).transform);
+      return [matrix.m13, matrix.m23];
+    }, progress));
+  }
+  // Real out-of-plane rotation changes depth on both axes, not just a flat spin.
+  expect(Math.abs(tiltMatrices[0]![0]! - tiltMatrices[1]![0]!)).toBeGreaterThan(0.5);
+  expect(Math.abs(tiltMatrices[0]![1]! - tiltMatrices[1]![1]!)).toBeGreaterThan(0.5);
   await page.getByRole('contentinfo').scrollIntoViewIfNeeded();
   await expect(field).not.toHaveClass(/hero-agent-field--active/);
   expect(await track.evaluate((node) => getComputedStyle(node).animationPlayState)).toBe('paused');

--- a/landing/tests/browser/visual-controls.spec.ts
+++ b/landing/tests/browser/visual-controls.spec.ts
@@ -62,6 +62,8 @@ test('numbered benefits remain readable in both themes and responsive layouts', 
       }
       expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
     }
+    // The desktop theme control is intentionally absent from the compact mobile header.
+    await page.setViewportSize({ width: 1440, height: 1000 });
     await page.getByRole('button', { name: 'Toggle theme', exact: true }).click();
   }
 });

--- a/landing/tests/browser/visual-controls.spec.ts
+++ b/landing/tests/browser/visual-controls.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test';
+
+test('flat filters retain keyboard selection, category search, and reset', async ({ page }) => {
+  await page.goto('./');
+  await expect(page.getByText('In your terminal', { exact: true })).toBeVisible();
+  await expect(page.getByText('No target flag means auto-detect')).toHaveCount(0);
+  const controls = page.getByRole('search', { name: 'Filter plugins' });
+  await controls.scrollIntoViewIfNeeded();
+  await expect(controls).toHaveCSS('border-top-width', '0px');
+  await expect(controls).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+  for (const field of await controls.locator('.search-field input, .app-select__trigger, .app-combobox__anchor').all()) {
+    await expect(field).toHaveCSS('border-radius', '0px');
+    await expect(field).toHaveCSS('border-top-width', '0px');
+    await expect(field).toHaveCSS('background-image', 'none');
+    await expect(field).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+    expect((await field.boundingBox())!.height).toBeGreaterThanOrEqual(44);
+    await field.hover();
+    await expect(field).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+  }
+  const trust = page.getByRole('combobox', { name: 'Filter by trust level', exact: true });
+  await trust.focus();
+  await page.keyboard.press('Enter');
+  await page.getByRole('option', { name: 'Reviewed plugins', exact: true }).click();
+  await expect(trust).toBeFocused();
+  await expect(page.locator('.plugin-card[data-trust="community"]')).toHaveCount(0);
+  await expect(page.locator('.plugin-card').first()).toBeVisible();
+  await trust.click();
+  await page.getByRole('option', { name: 'All trust levels', exact: true }).click();
+  const category = page.getByRole('combobox', { name: 'Filter by category', exact: true });
+  await category.fill('impossible-category-qa');
+  await expect(page.locator('.app-combobox__empty')).toBeVisible();
+  await category.fill('All categories');
+  await page.getByRole('option', { name: 'All categories', exact: true }).click();
+  await page.keyboard.press('Escape');
+  await page.getByRole('searchbox', { name: 'Search plugins' }).fill('gitlab');
+  await expect(page.locator('.plugin-card').first()).toBeVisible();
+  await page.getByRole('button', { name: 'Clear plugin search' }).click();
+  await expect(page.getByRole('searchbox', { name: 'Search plugins' })).toHaveValue('');
+});
+
+test('numbered benefits remain readable in both themes and responsive layouts', async ({ page }) => {
+  await page.goto('./');
+  const cards = page.locator('.registry-benefits__card');
+  await expect(cards).toHaveCount(4);
+  await expect(page.locator('.registry-benefits__signature svg')).toHaveCount(4);
+  await expect(page.locator('.registry-benefits__number')).toHaveText(['01', '02', '03', '04']);
+  const headings = ['Standard first', 'Client-aware', 'Full lifecycle', 'Source visible'];
+  for (const reducedMotion of ['no-preference', 'reduce'] as const) {
+    await page.emulateMedia({ reducedMotion });
+    for (const width of [1440, 800, 390, 280]) {
+      await page.setViewportSize({ width, height: 1000 });
+      await cards.first().scrollIntoViewIfNeeded();
+      const columns = await page.locator('.registry-benefits__grid').evaluate((node) =>
+        getComputedStyle(node).gridTemplateColumns.split(' ').length);
+      expect(columns).toBe(width > 980 ? 4 : width > 720 ? 2 : 1);
+      for (const [index, card] of (await cards.all()).entries()) {
+        await expect(card.getByRole('heading', { name: headings[index], exact: true })).toBeVisible();
+        const box = (await card.boundingBox())!;
+        expect(box.x).toBeGreaterThanOrEqual(0);
+        expect(box.x + box.width).toBeLessThanOrEqual(width);
+        expect(await card.evaluate((node) => node.scrollWidth <= node.clientWidth)).toBe(true);
+      }
+      expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+    }
+    await page.getByRole('button', { name: 'Toggle theme', exact: true }).click();
+  }
+});


### PR DESCRIPTION
## Change
- Make the existing background orbit tilt more clearly in 3D using CSS only; retain breathing, visibility pause and reduced motion.
- Flatten catalog filters and search into an unboxed toolbar, including hover and focus states. Dropdown panels remain readable.
- Replace the hero hint with In your terminal.
- Refresh benefit cards with larger numbers, distinct inline icons and compact spacing; move their styles into a dedicated file.

## Verification
Independent review caught one hover cascade conflict, now fixed with regression coverage. Browser checks cover real depth changes, zero layout movement, keyboard filtering, category search/reset, responsive cards and both themes. No new dependencies or installer behavior changes.