### PR TITLE
fix(landing): make logo depth follow the orbit viewing angle

### DIFF
--- a/landing/assets/styles/hero-agent-field.scss
+++ b/landing/assets/styles/hero-agent-field.scss
@@ -33,6 +33,7 @@
   position: absolute;
   inset: 0;
   transform: rotate(var(--angle));
+  transform-style: preserve-3d;
 }
 .hero-agent-field__node {
   position: absolute;
@@ -41,8 +42,24 @@
   width: 38px;
   height: 38px;
   transform: translate(-50%, -50%) rotate(calc(-1 * var(--angle)));
+  transform-style: preserve-3d;
+}
+.hero-agent-field__rotor {
+  position: absolute;
+  inset: 0;
+  transform-style: preserve-3d;
+  animation: agent-orbit-spin 72s linear infinite reverse;
+}
+.hero-agent-field__rim {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: #a4b6d5;
+  transform: translateZ(var(--rim-depth));
 }
 .hero-agent-field__face {
+  position: absolute;
+  inset: 0;
   display: grid;
   place-items: center;
   width: 100%;
@@ -50,8 +67,8 @@
   border: 1px solid rgba(255, 255, 255, 0.95);
   border-radius: 50%;
   background: linear-gradient(145deg, #fff, #e1e8f8);
-  box-shadow: 0 3px 0 #a4b6d5, 0 6px 14px rgba(11, 24, 58, 0.2);
-  animation: agent-orbit-spin 72s linear infinite reverse;
+  box-shadow: 0 0 12px rgba(11, 24, 58, 0.16);
+  transform: translateZ(0);
 }
 .hero-agent-field__node img {
   width: 26px;
@@ -84,7 +101,7 @@
 .hero-agent-field:not(.hero-agent-field--active) {
   .hero-agent-field__plane,
   .hero-agent-field__track,
-  .hero-agent-field__face { animation-play-state: paused; }
+  .hero-agent-field__rotor { animation-play-state: paused; }
 }
 @media (max-width: 720px) {
   .hero-agent-field__plane { width: min(328px, 100%); }
@@ -96,5 +113,5 @@
 @media (prefers-reduced-motion: reduce) {
   .hero-agent-field__plane,
   .hero-agent-field__track,
-  .hero-agent-field__face { animation: none; }
+  .hero-agent-field__rotor { animation: none; }
 }

--- a/landing/components/registry/HeroAgentField.vue
+++ b/landing/components/registry/HeroAgentField.vue
@@ -50,8 +50,16 @@ onBeforeUnmount(() => {
           :style="{ '--angle': `${(index * 360) / orbitClients.length}deg` }"
         >
           <span class="hero-agent-field__node">
-            <span class="hero-agent-field__face">
-              <img :src="asset(`client-icons/${client.icon}`)" alt="" width="26" height="26" >
+            <span class="hero-agent-field__rotor">
+              <span
+                v-for="depth in 4"
+                :key="depth"
+                class="hero-agent-field__rim"
+                :style="{ '--rim-depth': `${-depth}px` }"
+              />
+              <span class="hero-agent-field__face">
+                <img :src="asset(`client-icons/${client.icon}`)" alt="" width="26" height="26" >
+              </span>
             </span>
           </span>
         </span>

--- a/landing/tests/browser/hero-orbit.spec.ts
+++ b/landing/tests/browser/hero-orbit.spec.ts
@@ -141,6 +141,43 @@ test('twice-sized breathing background never changes layout or blocks the foregr
   expect(sizes[2]!).toBeCloseTo(sizes[0]!, 1);
 });
 
+test('logo thickness follows the viewing angle without extra animation loops', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  await page.goto('./');
+  const field = page.locator('.hero-agent-field');
+  await expect(field).toHaveClass(/hero-agent-field--active/);
+  await expect(field.locator('.hero-agent-field__rim')).toHaveCount(uniqueLogos.length * 4);
+  // Only the existing plane, track and counter-rotations animate, never individual slices.
+  expect(await field.evaluate((node) => node.getAnimations({ subtree: true }).length)).toBe(uniqueLogos.length + 3);
+  const offsets: { x: number; y: number }[][] = [];
+  for (const fraction of [0, 1]) {
+    await field.evaluate((node, progress) => {
+      for (const animation of node.getAnimations({ subtree: true })) {
+        animation.pause();
+        animation.currentTime = (animation as CSSAnimation).animationName === 'agent-plane-tilt'
+          ? Number(animation.effect!.getTiming().duration) * progress : 0;
+      }
+    }, fraction);
+    await page.evaluate(() => new Promise(requestAnimationFrame));
+    offsets.push(await field.locator('.hero-agent-field__rotor').evaluateAll((rotors) => rotors.map((rotor) => {
+      const front = rotor.querySelector('.hero-agent-field__face')!.getBoundingClientRect();
+      const back = rotor.querySelector('.hero-agent-field__rim:nth-child(4)')!.getBoundingClientRect();
+      return { x: back.x + back.width / 2 - front.x - front.width / 2,
+        y: back.y + back.height / 2 - front.y - front.height / 2 };
+    })));
+  }
+  for (const [index, first] of offsets[0]!.entries()) {
+    const opposite = offsets[1]![index]!;
+    // Projected rear/front displacement, not just CSS strings: a flattened stack fails here.
+    expect(Math.hypot(first.x, first.y)).toBeGreaterThan(1);
+    expect(Math.hypot(opposite.x, opposite.y)).toBeGreaterThan(1);
+    expect(first.x * opposite.x + first.y * opposite.y).toBeLessThan(-1);
+  }
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  expect(await field.evaluate((node) => node.getAnimations({ subtree: true }).length)).toBe(0);
+  await expect(field.locator('.hero-agent-field__face')).toHaveCount(uniqueLogos.length);
+});
+
 test('installation works with WebGL forbidden and the orbit has no canvas or optional renderer', async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 1000 });
   await page.addInitScript(() => {


### PR DESCRIPTION
## Summary
- Replace fixed-offset badge thickness with four static CSS 3D rim layers behind each logo.
- Preserve the existing rotation, tilt, breathing, visibility pause and reduced-motion behavior with no new animation loops or dependencies.
- Add browser regression coverage that measures rear/front projection and its reversal at opposite tilt endpoints for all ten logos.

## Validation
- Independent scoped review: no material findings.
- Browser preview: projected depth reverses for all ten logos, both themes, 390px and 280px layouts, target selection and reset, reduced motion, offscreen pause, no page errors.
- Full generated-site browser suite runs in Landing CI; public Pages verification follows deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the hero agent field with layered, dimensional orbital ring visuals around client logos.
  * Improved the appearance of logo rings as they rotate through different viewing angles.

* **Bug Fixes**
  * Reduced-motion settings now reliably disable orbital animations while preserving logo visibility.

* **Tests**
  * Added browser coverage for ring depth, animation behavior, and reduced-motion rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->