### PR TITLE
fix(landing): increase orbit logo thickness by half

### DIFF
--- a/landing/components/registry/HeroAgentField.vue
+++ b/landing/components/registry/HeroAgentField.vue
@@ -55,7 +55,7 @@ onBeforeUnmount(() => {
                 v-for="depth in 4"
                 :key="depth"
                 class="hero-agent-field__rim"
-                :style="{ '--rim-depth': `${-depth}px` }"
+                :style="{ '--rim-depth': `${-depth * 1.5}px` }"
               />
               <span class="hero-agent-field__face">
                 <img :src="asset(`client-icons/${client.icon}`)" alt="" width="26" height="26" >

--- a/landing/tests/browser/hero-orbit.spec.ts
+++ b/landing/tests/browser/hero-orbit.spec.ts
@@ -147,6 +147,9 @@ test('logo thickness follows the viewing angle without extra animation loops', a
   const field = page.locator('.hero-agent-field');
   await expect(field).toHaveClass(/hero-agent-field--active/);
   await expect(field.locator('.hero-agent-field__rim')).toHaveCount(uniqueLogos.length * 4);
+  expect(await field.locator('.hero-agent-field__rotor').first().locator('.hero-agent-field__rim')
+    .evaluateAll((rims) => rims.map((rim) => new DOMMatrix(getComputedStyle(rim).transform).m43)))
+    .toEqual([-1.5, -3, -4.5, -6]);
   // Only the existing plane, track and counter-rotations animate, never individual slices.
   expect(await field.evaluate((node) => node.getAnimations({ subtree: true }).length)).toBe(uniqueLogos.length + 3);
   const offsets: { x: number; y: number }[][] = [];


### PR DESCRIPTION
## Summary
- Increase logo rim depth from 4px to 6px as requested.
- Keep four static slices, the front face size, animation count and viewing-angle behavior unchanged.
- Assert exact slice depths in the existing browser regression test.

## Validation
- git diff --check passes.
- Landing CI covers generated-site behavior and the existing 22 browser tests.
- Public visual and projection checks follow deployment.