### PR TITLE
fix(landing): enlarge hero orbit by fifty percent

### DIFF
--- a/landing/assets/styles/hero-agent-field.scss
+++ b/landing/assets/styles/hero-agent-field.scss
@@ -1,7 +1,7 @@
 .hero-agent-field {
   position: absolute;
   inset: 0;
-  perspective: 750px;
+  perspective: 1125px;
   pointer-events: none;
   opacity: 0.55;
 }

--- a/landing/assets/styles/hero-agent-field.scss
+++ b/landing/assets/styles/hero-agent-field.scss
@@ -9,7 +9,7 @@
   position: absolute;
   top: 50%;
   left: 62%;
-  width: min(480px, 100%);
+  width: min(720px, 150%);
   aspect-ratio: 1;
   translate: -50% -50%;
   transform-style: preserve-3d;
@@ -104,7 +104,7 @@
   .hero-agent-field__rotor { animation-play-state: paused; }
 }
 @media (max-width: 720px) {
-  .hero-agent-field__plane { width: min(328px, 100%); }
+  .hero-agent-field__plane { width: min(492px, 150%); }
   .hero-agent-field__node { width: 30px; height: 30px; }
   .hero-agent-field__node img { width: 22px; height: 22px; }
   .hero-agent-field__hub { width: 48px; height: 48px; border-radius: 14px; }

--- a/landing/tests/browser/hero-orbit.spec.ts
+++ b/landing/tests/browser/hero-orbit.spec.ts
@@ -92,7 +92,7 @@ test('CSS background depth animates on the right and pauses offscreen or hidden'
   expect(await field.evaluate((node) => node.getAnimations({ subtree: true }).length)).toBe(0);
 });
 
-test('twice-sized breathing background never changes layout or blocks the foreground', async ({ page }) => {
+test('larger breathing background never changes layout or blocks the foreground', async ({ page }) => {
   await page.goto('./');
   const field = page.locator('.hero-agent-field');
   await expect(field).toHaveClass(/hero-agent-field--active/);
@@ -103,8 +103,10 @@ test('twice-sized breathing background never changes layout or blocks the foregr
     const heroBefore = (await page.locator('.hero').boundingBox())!;
     const planeWidth = await field.locator('.hero-agent-field__plane')
       .evaluate((node) => Number.parseFloat(getComputedStyle(node).width));
-    expect(planeWidth).toBeLessThanOrEqual(width <= 720 ? 328 : 480);
-    if (width >= 390) expect(planeWidth).toBe(width <= 720 ? 328 : 480);
+    const fieldWidth = (await field.boundingBox())!.width;
+    expect(planeWidth).toBeCloseTo(Math.min(width <= 720 ? 492 : 720, fieldWidth * 1.5), 1);
+    expect(await field.locator('.hero-agent-field__node').first()
+      .evaluate((node) => Number.parseFloat(getComputedStyle(node).width))).toBe(width <= 720 ? 30 : 38);
     await field.evaluate((node: HTMLElement) => { node.style.display = 'none'; });
     expect(await page.locator('.hero__window').boundingBox()).toEqual(windowBefore);
     expect(await page.locator('.hero').boundingBox()).toEqual(heroBefore);

--- a/landing/tests/browser/hero-orbit.spec.ts
+++ b/landing/tests/browser/hero-orbit.spec.ts
@@ -96,6 +96,7 @@ test('larger breathing background never changes layout or blocks the foreground'
   await page.goto('./');
   const field = page.locator('.hero-agent-field');
   await expect(field).toHaveClass(/hero-agent-field--active/);
+  await expect(field).toHaveCSS('perspective', '1125px');
   for (const width of [1440, 1280, 1024, 800, 390, 280]) {
     await page.setViewportSize({ width, height: 1000 });
     await field.scrollIntoViewIfNeeded();


### PR DESCRIPTION
## Summary
- Increase the decorative orbit diameter by 1.5x: 480px to 720px on desktop and 328px to 492px on mobile.
- Scale the responsive width cap to 150% so narrow screens receive the same proportional increase.
- Preserve logo dimensions, 6px depth, tilt, breathing and zero layout contribution.
- Update responsive browser assertions for the larger diameter and unchanged badge size.

## Validation
- Browser preview passed opposite tilt endpoints, both themes, mobile widths, no horizontal overflow, unchanged installer bounds and target selection.
- git diff --check passes.
- Generated-site browser coverage runs in Landing CI; public proof follows deployment.