### PR TITLE
fix(landing): move hero orbit right and animate clockwise logo travel

### DIFF
--- a/landing/assets/styles/hero-agent-field.scss
+++ b/landing/assets/styles/hero-agent-field.scss
@@ -8,7 +8,7 @@
 .hero-agent-field__plane {
   position: absolute;
   top: 50%;
-  left: 62%;
+  left: calc(62% + 100px);
   width: min(720px, 150%);
   aspect-ratio: 1;
   translate: -50% -50%;

--- a/landing/assets/styles/hero-agent-field.scss
+++ b/landing/assets/styles/hero-agent-field.scss
@@ -1,4 +1,5 @@
 .hero-agent-field {
+  --orbit-duration: 36s;
   position: absolute;
   inset: 0;
   perspective: 1125px;
@@ -27,7 +28,12 @@
   box-shadow:
     0 0 28px color-mix(in srgb, var(--cyan) 7%, transparent),
     inset 0 0 38px color-mix(in srgb, var(--primary) 6%, transparent);
-  animation: agent-orbit-spin 72s linear infinite;
+}
+.hero-agent-field__orbit {
+  position: absolute;
+  inset: 0;
+  transform-style: preserve-3d;
+  animation: agent-orbit-spin var(--orbit-duration) linear infinite;
 }
 .hero-agent-field__spoke {
   position: absolute;
@@ -48,7 +54,7 @@
   position: absolute;
   inset: 0;
   transform-style: preserve-3d;
-  animation: agent-orbit-spin 72s linear infinite reverse;
+  animation: agent-orbit-spin var(--orbit-duration) linear infinite reverse;
 }
 .hero-agent-field__rim {
   position: absolute;
@@ -100,7 +106,7 @@
 }
 .hero-agent-field:not(.hero-agent-field--active) {
   .hero-agent-field__plane,
-  .hero-agent-field__track,
+  .hero-agent-field__orbit,
   .hero-agent-field__rotor { animation-play-state: paused; }
 }
 @media (max-width: 720px) {
@@ -112,6 +118,6 @@
 }
 @media (prefers-reduced-motion: reduce) {
   .hero-agent-field__plane,
-  .hero-agent-field__track,
+  .hero-agent-field__orbit,
   .hero-agent-field__rotor { animation: none; }
 }

--- a/landing/components/registry/HeroAgentField.vue
+++ b/landing/components/registry/HeroAgentField.vue
@@ -42,27 +42,29 @@ onBeforeUnmount(() => {
   >
     <div class="hero-agent-field__plane">
       <div class="hero-agent-field__track">
-        <span
-          v-for="(client, index) in orbitClients"
-          :key="client.id"
-          class="hero-agent-field__spoke"
-          :data-client-id="client.id"
-          :style="{ '--angle': `${(index * 360) / orbitClients.length}deg` }"
-        >
-          <span class="hero-agent-field__node">
-            <span class="hero-agent-field__rotor">
-              <span
-                v-for="depth in 4"
-                :key="depth"
-                class="hero-agent-field__rim"
-                :style="{ '--rim-depth': `${-depth * 1.5}px` }"
-              />
-              <span class="hero-agent-field__face">
-                <img :src="asset(`client-icons/${client.icon}`)" alt="" width="26" height="26" >
+        <div class="hero-agent-field__orbit">
+          <span
+            v-for="(client, index) in orbitClients"
+            :key="client.id"
+            class="hero-agent-field__spoke"
+            :data-client-id="client.id"
+            :style="{ '--angle': `${(index * 360) / orbitClients.length}deg` }"
+          >
+            <span class="hero-agent-field__node">
+              <span class="hero-agent-field__rotor">
+                <span
+                  v-for="depth in 4"
+                  :key="depth"
+                  class="hero-agent-field__rim"
+                  :style="{ '--rim-depth': `${-depth * 1.5}px` }"
+                />
+                <span class="hero-agent-field__face">
+                  <img :src="asset(`client-icons/${client.icon}`)" alt="" width="26" height="26" >
+                </span>
               </span>
             </span>
           </span>
-        </span>
+        </div>
       </div>
       <span class="hero-agent-field__hub">
         <img :src="asset('icon.svg')" alt="" width="38" height="38" >

--- a/landing/tests/browser/hero-orbit.spec.ts
+++ b/landing/tests/browser/hero-orbit.spec.ts
@@ -42,10 +42,10 @@ test('CSS background depth animates on the right and pauses offscreen or hidden'
   await page.setViewportSize({ width: 1440, height: 1000 });
   await page.goto('./');
   const field = page.locator('.hero__demo .hero-agent-field');
-  const track = field.locator('.hero-agent-field__track');
+  const orbit = field.locator('.hero-agent-field__orbit');
   await expect(field).toHaveClass(/hero-agent-field--active/);
-  const first = await track.evaluate((node) => getComputedStyle(node).transform);
-  await expect.poll(() => track.evaluate((node) => getComputedStyle(node).transform)).not.toBe(first);
+  const first = await orbit.evaluate((node) => getComputedStyle(node).transform);
+  await expect.poll(() => orbit.evaluate((node) => getComputedStyle(node).transform)).not.toBe(first);
   expect(await field.locator('.hero-agent-field__plane').evaluate((node) => getComputedStyle(node).transform)).toMatch(/^matrix3d\(/);
   expect(await field.evaluate((node) => getComputedStyle(node).pointerEvents)).toBe('none');
   const copy = (await page.locator('.hero__copy').boundingBox())!;
@@ -75,7 +75,7 @@ test('CSS background depth animates on the right and pauses offscreen or hidden'
   expect(Math.abs(tiltMatrices[0]![1]! - tiltMatrices[1]![1]!)).toBeGreaterThan(0.5);
   await page.getByRole('contentinfo').scrollIntoViewIfNeeded();
   await expect(field).not.toHaveClass(/hero-agent-field--active/);
-  expect(await track.evaluate((node) => getComputedStyle(node).animationPlayState)).toBe('paused');
+  expect(await orbit.evaluate((node) => getComputedStyle(node).animationPlayState)).toBe('paused');
   await field.scrollIntoViewIfNeeded();
   await expect(field).toHaveClass(/hero-agent-field--active/);
   await page.evaluate(() => {
@@ -90,6 +90,51 @@ test('CSS background depth animates on the right and pauses offscreen or hidden'
   await expect(field).toHaveClass(/hero-agent-field--active/);
   await page.emulateMedia({ reducedMotion: 'reduce' });
   expect(await field.evaluate((node) => node.getAnimations({ subtree: true }).length)).toBe(0);
+});
+
+test('logos travel clockwise along a stationary ring and stay upright', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  await page.goto('./');
+  const field = page.locator('.hero-agent-field');
+  await expect(field).toHaveClass(/hero-agent-field--active/);
+  await expect(field.locator('.hero-agent-field__orbit')).toHaveCSS('animation-duration', '36s');
+  await expect(field.locator('.hero-agent-field__rotor').first()).toHaveCSS('animation-duration', '36s');
+  expect(await field.locator('.hero-agent-field__track').evaluate((node) => node.getAnimations().length)).toBe(0);
+  // Isolate travel from the camera tilt: a fixed ring alone cannot make this pass.
+  await field.locator('.hero-agent-field__plane').evaluate((node: HTMLElement) => {
+    node.style.animation = 'none';
+    node.style.transform = 'none';
+  });
+  const positions: { x: number; y: number; logoWidth: number; logoHeight: number }[][] = [];
+  for (const fraction of [0, 0.125]) {
+    await field.evaluate((node, progress) => {
+      for (const animation of node.getAnimations({ subtree: true })) {
+        animation.pause();
+        animation.currentTime = Number(animation.effect!.getTiming().duration) * progress;
+      }
+    }, fraction);
+    await page.evaluate(() => new Promise(requestAnimationFrame));
+    positions.push(await field.evaluate((node) => {
+      const ring = node.querySelector('.hero-agent-field__track')!.getBoundingClientRect();
+      return [...node.querySelectorAll('.hero-agent-field__node')].map((badge) => {
+        const rect = badge.getBoundingClientRect();
+        const logo = badge.querySelector('img')!.getBoundingClientRect();
+        return { x: rect.x + rect.width / 2 - ring.x - ring.width / 2,
+          y: rect.y + rect.height / 2 - ring.y - ring.height / 2,
+          logoWidth: logo.width, logoHeight: logo.height };
+      });
+    }));
+  }
+  for (const [index, start] of positions[0]!.entries()) {
+    const moved = positions[1]![index]!;
+    // +45 degrees is clockwise in screen coordinates (positive y points down).
+    expect(moved.x).toBeCloseTo((start.x - start.y) / Math.SQRT2, 0);
+    expect(moved.y).toBeCloseTo((start.x + start.y) / Math.SQRT2, 0);
+    expect(Math.hypot(moved.x, moved.y)).toBeCloseTo(Math.hypot(start.x, start.y), 0);
+    // At 45 degrees a missing counter-rotation enlarges the image bounding box.
+    expect(moved.logoWidth).toBeCloseTo(start.logoWidth, 1);
+    expect(moved.logoHeight).toBeCloseTo(start.logoHeight, 1);
+  }
 });
 
 test('larger breathing background never changes layout or blocks the foreground', async ({ page }) => {
@@ -155,7 +200,7 @@ test('logo thickness follows the viewing angle without extra animation loops', a
   expect(await field.locator('.hero-agent-field__rotor').first().locator('.hero-agent-field__rim')
     .evaluateAll((rims) => rims.map((rim) => new DOMMatrix(getComputedStyle(rim).transform).m43)))
     .toEqual([-1.5, -3, -4.5, -6]);
-  // Only the existing plane, track and counter-rotations animate, never individual slices.
+  // Only the plane, icon orbit and counter-rotations animate, never individual slices.
   expect(await field.evaluate((node) => node.getAnimations({ subtree: true }).length)).toBe(uniqueLogos.length + 3);
   const offsets: { x: number; y: number }[][] = [];
   for (const fraction of [0, 1]) {

--- a/landing/tests/browser/hero-orbit.spec.ts
+++ b/landing/tests/browser/hero-orbit.spec.ts
@@ -105,6 +105,8 @@ test('larger breathing background never changes layout or blocks the foreground'
     const planeWidth = await field.locator('.hero-agent-field__plane')
       .evaluate((node) => Number.parseFloat(getComputedStyle(node).width));
     const fieldWidth = (await field.boundingBox())!.width;
+    expect(await field.locator('.hero-agent-field__plane')
+      .evaluate((node) => Number.parseFloat(getComputedStyle(node).left))).toBeCloseTo(fieldWidth * 0.62 + 100, 1);
     expect(planeWidth).toBeCloseTo(Math.min(width <= 720 ? 492 : 720, fieldWidth * 1.5), 1);
     expect(await field.locator('.hero-agent-field__node').first()
       .evaluate((node) => Number.parseFloat(getComputedStyle(node).width))).toBe(width <= 720 ? 30 : 38);


### PR DESCRIPTION
## Summary
- Shift the decorative hero circle 100px to the right without moving the installation panel.
- Move all ten unique agent logos clockwise around the ring every 36 seconds, independently of the plane tilt; counter-rotate the faces to keep them upright.
- Preserve the existing circle size, breathing motion, 6px logo thickness, reduced-motion behavior and offscreen pause.

## Verification
- Headless Chromium preview passed: clockwise 45-degree travel for every logo, stable logo orientation, both themes, mobile widths, foreground controls, angle-dependent depth and no WebGL or page errors.
- Browser regressions cover the new motion and the 100px offset across six viewport widths.
- Exact-head Landing CI validates the generated site before merge.