### PR TITLE
feat(landing): refine hero motion and reveal sections on scroll

### DIFF
--- a/landing/assets/styles/hero-agent-field.scss
+++ b/landing/assets/styles/hero-agent-field.scss
@@ -9,7 +9,7 @@
 .hero-agent-field__plane {
   position: absolute;
   top: 50%;
-  left: calc(62% + 100px);
+  left: calc(62% - 100px);
   width: min(720px, 150%);
   aspect-ratio: 1;
   translate: -50% -50%;
@@ -87,12 +87,16 @@
   left: 50%;
   display: grid;
   place-items: center;
-  width: 58px;
-  height: 58px;
+  width: 116px;
+  height: 116px;
   border: 1px solid var(--line-strong);
-  border-radius: 18px;
+  border-radius: 36px;
   background: var(--surface-solid);
   transform: translate(-50%, -50%) translateZ(12px);
+}
+.hero-agent-field__hub img {
+  width: 76px;
+  height: 76px;
 }
 @keyframes agent-orbit-spin {
   to { transform: rotate(360deg); }
@@ -113,8 +117,8 @@
   .hero-agent-field__plane { width: min(492px, 150%); }
   .hero-agent-field__node { width: 30px; height: 30px; }
   .hero-agent-field__node img { width: 22px; height: 22px; }
-  .hero-agent-field__hub { width: 48px; height: 48px; border-radius: 14px; }
-  .hero-agent-field__hub img { width: 32px; height: 32px; }
+  .hero-agent-field__hub { width: 96px; height: 96px; border-radius: 28px; }
+  .hero-agent-field__hub img { width: 64px; height: 64px; }
 }
 @media (prefers-reduced-motion: reduce) {
   .hero-agent-field__plane,

--- a/landing/assets/styles/main.scss
+++ b/landing/assets/styles/main.scss
@@ -74,3 +74,32 @@ body {
 .app-header {
   backdrop-filter: blur(10px);
 }
+
+/* Progressive enhancement: sections remain visible until the client observer is ready. */
+.scroll-reveal-ready .scroll-reveal {
+  opacity: 0;
+  transform: translate3d(0, 18px, 0);
+  transition:
+    opacity 320ms ease-out,
+    transform 420ms cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: opacity, transform;
+}
+
+/* Establish the hidden state without playing the transition backwards on hydration. */
+.scroll-reveal-ready:not(.scroll-reveal-active) .scroll-reveal {
+  transition: none;
+}
+
+.scroll-reveal-ready .scroll-reveal.scroll-reveal--visible {
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+  will-change: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scroll-reveal-ready .scroll-reveal {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}

--- a/landing/components/registry/RegistryDirectory.vue
+++ b/landing/components/registry/RegistryDirectory.vue
@@ -16,7 +16,7 @@ const intro = computed(() => {
 </script>
 
 <template>
-  <div id="plugins" class="container catalog-wrap">
+  <div id="plugins" class="container catalog-wrap" data-scroll-reveal>
     <PluginCatalog :plugins="registry.plugins" heading="Find your plugin" :intro="intro" />
   </div>
 </template>

--- a/landing/components/registry/RegistryFaq.vue
+++ b/landing/components/registry/RegistryFaq.vue
@@ -3,7 +3,12 @@ import { registryFaqItems } from '~/data/registryFaq';
 </script>
 
 <template>
-  <section id="faq" class="registry-faq container" aria-labelledby="faq-title">
+  <section
+    id="faq"
+    class="registry-faq container"
+    aria-labelledby="faq-title"
+    data-scroll-reveal
+  >
     <div class="section-heading section-heading--center">
       <p class="eyebrow">FAQ</p>
       <h2 id="faq-title">Common questions</h2>

--- a/landing/components/registry/RegistryWhy.vue
+++ b/landing/components/registry/RegistryWhy.vue
@@ -1,5 +1,10 @@
 <template>
-  <section id="why" class="registry-benefits container" aria-labelledby="why-title">
+  <section
+    id="why"
+    class="registry-benefits container"
+    aria-labelledby="why-title"
+    data-scroll-reveal
+  >
     <div class="section-heading section-heading--center">
       <p class="eyebrow">Why it works</p>
       <h2 id="why-title">One standard. Native delivery.</h2>

--- a/landing/plugins/scroll-reveal.client.ts
+++ b/landing/plugins/scroll-reveal.client.ts
@@ -1,0 +1,44 @@
+const REVEAL_SELECTOR = '[data-scroll-reveal]';
+
+export default defineNuxtPlugin((nuxtApp) => {
+  let observer: IntersectionObserver | undefined;
+  let activationFrame: number | undefined;
+
+  const revealSections = () => {
+    observer?.disconnect();
+    if (activationFrame !== undefined) cancelAnimationFrame(activationFrame);
+    document.documentElement.classList.remove('scroll-reveal-active');
+
+    const revealable = [...document.querySelectorAll<HTMLElement>(REVEAL_SELECTOR)];
+
+    for (const section of revealable) section.classList.add('scroll-reveal');
+
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (reduceMotion || !('IntersectionObserver' in window)) {
+      for (const section of revealable) section.classList.add('scroll-reveal--visible');
+      document.documentElement.classList.add('scroll-reveal-ready');
+      return;
+    }
+
+    document.documentElement.classList.add('scroll-reveal-ready');
+    activationFrame = requestAnimationFrame(() => {
+      document.documentElement.classList.add('scroll-reveal-active');
+      observer = new IntersectionObserver(
+        (entries) => {
+          for (const entry of entries) {
+            if (!entry.isIntersecting) continue;
+            const section = entry.target as HTMLElement;
+            section.classList.add('scroll-reveal--visible');
+            observer?.unobserve(section);
+          }
+        },
+        { rootMargin: '0px 0px -8% 0px', threshold: 0.06 },
+      );
+      for (const section of revealable) {
+        if (section.isConnected) observer.observe(section);
+      }
+    });
+  };
+
+  nuxtApp.hook('page:finish', () => requestAnimationFrame(revealSections));
+});

--- a/landing/tests/browser/hero-orbit.spec.ts
+++ b/landing/tests/browser/hero-orbit.spec.ts
@@ -151,10 +151,14 @@ test('larger breathing background never changes layout or blocks the foreground'
       .evaluate((node) => Number.parseFloat(getComputedStyle(node).width));
     const fieldWidth = (await field.boundingBox())!.width;
     expect(await field.locator('.hero-agent-field__plane')
-      .evaluate((node) => Number.parseFloat(getComputedStyle(node).left))).toBeCloseTo(fieldWidth * 0.62 + 100, 1);
+      .evaluate((node) => Number.parseFloat(getComputedStyle(node).left))).toBeCloseTo(fieldWidth * 0.62 - 100, 1);
     expect(planeWidth).toBeCloseTo(Math.min(width <= 720 ? 492 : 720, fieldWidth * 1.5), 1);
     expect(await field.locator('.hero-agent-field__node').first()
       .evaluate((node) => Number.parseFloat(getComputedStyle(node).width))).toBe(width <= 720 ? 30 : 38);
+    expect(await field.locator('.hero-agent-field__hub')
+      .evaluate((node) => Number.parseFloat(getComputedStyle(node).width))).toBe(width <= 720 ? 96 : 116);
+    expect(await field.locator('.hero-agent-field__hub img')
+      .evaluate((node) => Number.parseFloat(getComputedStyle(node).width))).toBe(width <= 720 ? 64 : 76);
     await field.evaluate((node: HTMLElement) => { node.style.display = 'none'; });
     expect(await page.locator('.hero__window').boundingBox()).toEqual(windowBefore);
     expect(await page.locator('.hero').boundingBox()).toEqual(heroBefore);

--- a/landing/tests/browser/landing.spec.ts
+++ b/landing/tests/browser/landing.spec.ts
@@ -74,6 +74,54 @@ test('homepage omits the counter when discovery cannot load', async ({ page }) =
   await expect(page.locator('.hero__plugin-count')).toHaveCount(0);
 });
 
+test('below-fold sections reveal quickly on scroll without animating the hero', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 480 });
+  await page.goto('./');
+
+  await expect(page.locator('.hero-shell')).not.toHaveClass(/scroll-reveal/);
+  await expect(page.locator('#plugins')).toHaveClass(/scroll-reveal/);
+  const section = page.locator('#why');
+  await expect(section).toHaveClass(/scroll-reveal/);
+  await expect(page.locator('html')).toHaveClass(/scroll-reveal-active/);
+  await expect(section).not.toHaveClass(/scroll-reveal--visible/);
+  await expect(section).toHaveCSS('opacity', '0');
+
+  await section.scrollIntoViewIfNeeded();
+  await expect(section).toHaveClass(/scroll-reveal--visible/);
+  await expect(section).toHaveCSS('opacity', '1', { timeout: 1_000 });
+});
+
+test('scroll reveals respect reduced motion', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await page.goto('./');
+
+  const section = page.locator('#why');
+  await expect(section).toHaveClass(/scroll-reveal--visible/);
+  await expect(section).toHaveCSS('opacity', '1');
+  expect(
+    await section.evaluate((node) => Number.parseFloat(getComputedStyle(node).transitionDuration)),
+  ).toBeLessThanOrEqual(0.00001);
+});
+
+test(
+  'below-fold content stays visible when JavaScript is disabled',
+  async ({ browser, baseURL }) => {
+    const context = await browser.newContext({ javaScriptEnabled: false });
+    try {
+      const page = await context.newPage();
+      await page.goto(baseURL!);
+      const section = page.locator('#why');
+      await expect(section).toBeVisible();
+      await expect(section).not.toHaveClass(/scroll-reveal/);
+      await expect(section).toHaveCSS('opacity', '1');
+    } finally {
+      await context.close();
+    }
+  },
+);
+
 test('plugin counter stays inside the hero on a narrow screen', async ({ page }) => {
   await page.setViewportSize({ width: 280, height: 844 });
   await page.emulateMedia({ reducedMotion: 'reduce' });


### PR DESCRIPTION
## Summary
- Move the decorative hero orbit 200px left from its previous position and double the central mark on desktop and mobile.
- Reveal the directory, benefits, and FAQ as they enter the viewport with a fast CSS transition.
- Keep the hero static at load, content visible without JavaScript, and motion disabled for reduced-motion users.

## Verification
- Headless Chromium visual QA passed for the adjusted desktop/mobile orbit, 3D depth, clockwise travel, target selection, both themes, and no WebGL or page errors.
- Scroll-reveal QA passed for the 18px/420ms transition, unchanged layout dimensions, and reduced-motion fallback.
- Browser regression coverage checks six orbit viewports, doubled hub dimensions, reveal-on-scroll, reduced motion, and no-JavaScript visibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scroll-triggered reveal animations for landing page sections.
  * Added support for reduced-motion preferences and graceful display when JavaScript or browser observation features are unavailable.
  * Enlarged and repositioned the hero animation hub across desktop and mobile layouts.

* **Bug Fixes**
  * Prevented reveal animations from affecting the initial page layout or hero experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->