### PR TITLE
fix(landing): hide non-installable discovery listings

### DIFF
--- a/landing/assets/styles/registry.scss
+++ b/landing/assets/styles/registry.scss
@@ -2142,6 +2142,7 @@ img {
 }
 .install-panel__heading {
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   gap: 15px;
   align-items: flex-start;
@@ -2166,9 +2167,8 @@ img {
 }
 .install-command-row {
   display: grid;
-  grid-template-columns: minmax(130px, 0.4fr) minmax(0, 1fr);
-  gap: 8px;
-  align-items: end;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 10px;
 }
 .install-command-row .target-select {
   margin: 0;
@@ -2223,6 +2223,43 @@ img {
 .command-stack {
   display: grid;
   gap: 10px;
+}
+.install-panel__empty {
+  margin-top: 22px;
+  padding: 18px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 13px;
+  border: 1px solid var(--line);
+  border-radius: 13px;
+  background: color-mix(in srgb, var(--surface-solid) 68%, transparent);
+}
+.install-panel__empty-icon {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--primary) 48%, var(--line));
+  border-radius: 50%;
+  color: var(--primary-bright);
+  font-weight: 800;
+}
+.install-panel__empty h3 {
+  margin: 1px 0 7px;
+  font-size: 0.92rem;
+}
+.install-panel__empty p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.76rem;
+  line-height: 1.6;
+}
+.install-panel__empty a {
+  display: inline-block;
+  margin-top: 12px;
+  color: var(--primary-bright);
+  font-size: 0.72rem;
+  font-weight: 750;
 }
 .install-panel__notice {
   margin: 17px 0 0;
@@ -2403,7 +2440,7 @@ img {
   }
   .install-panel {
     position: static;
-    max-width: 680px;
+    width: 100%;
   }
 }
 

--- a/landing/components/registry/InstallPanel.vue
+++ b/landing/components/registry/InstallPanel.vue
@@ -6,7 +6,7 @@ import { deliveryLabel, expectedDistribution, resolveDistribution } from '~/util
 const props = defineProps<{ plugin: RegistryPlugin }>();
 const targets = defineModel<ClientID[]>('targets', { required: true });
 const autoDetect = defineModel<boolean>('autoDetect', { required: true });
-const { asset } = useSite();
+const { asset, sourceUrl } = useSite();
 const { current, expired, published } = useDirectoryStatus();
 const autoOption = {
   label: 'All installed agents (recommended)',
@@ -53,6 +53,14 @@ const chatgptSelected = computed(
     !autoDetect.value &&
     selectedTargets.value.some((target) => target.client === 'chatgpt' && target.app_binding),
 );
+const unavailableDiscoveryReason = computed(() => {
+  if (props.plugin.trust_state !== 'conformant_unreviewed' || props.plugin.installable) return '';
+  if (props.plugin.discovery?.availability === 'unavailable')
+    return 'This package is no longer available from its source.';
+  if (!props.plugin.components.length)
+    return "We found this project, but it doesn't include any tools the installer can add yet.";
+  return 'This package does not support any of the agents available in the installer yet.';
+});
 
 function updateTargets(values: string[]) {
   const allowed = new Set(availableClients.value.map((client) => client.id));
@@ -78,9 +86,12 @@ watch(availableClients, (next) => {
     <div class="install-panel__heading">
       <div>
         <p class="eyebrow">Installer</p>
-        <h2 id="install-title">Use with your agent</h2>
+        <h2 id="install-title">
+          {{ unavailableDiscoveryReason ? 'Not ready to install' : 'Use with your agent' }}
+        </h2>
       </div>
       <a
+        v-if="!unavailableDiscoveryReason"
         class="install-panel__cli-link"
         href="https://github.com/777genius/universal-agent-plugins#quick-start"
         target="_blank"
@@ -88,7 +99,15 @@ watch(availableClients, (next) => {
         >Native Go CLI · no Node.js</a
       >
     </div>
-    <div v-if="commands" class="command-stack">
+    <div v-if="unavailableDiscoveryReason" class="install-panel__empty" role="status">
+      <span class="install-panel__empty-icon" aria-hidden="true">i</span>
+      <div>
+        <h3>This plugin is not installable yet</h3>
+        <p>{{ unavailableDiscoveryReason }}</p>
+        <a :href="sourceUrl(plugin)" target="_blank" rel="noreferrer">View package source</a>
+      </div>
+    </div>
+    <div v-else-if="commands" class="command-stack">
       <div class="install-command-row">
         <div class="target-select">
           <span>Agents</span
@@ -108,15 +127,22 @@ watch(availableClients, (next) => {
       <CommandSnippet label="Repair" kind="repair" :command="commands.repair" />
       <CommandSnippet label="Remove" kind="remove" :command="commands.remove" />
     </div>
-    <p v-if="expired" class="install-panel__notice" role="status">
+    <p v-if="!unavailableDiscoveryReason && expired" class="install-panel__notice" role="status">
       <strong>Commands unavailable: stale Directory.</strong> This signed snapshot has expired.
       Browse its history, then return after a fresh snapshot is published.
     </p>
-    <p v-else-if="!published" class="install-panel__notice" role="status">
+    <p
+      v-else-if="!unavailableDiscoveryReason && !published"
+      class="install-panel__notice"
+      role="status"
+    >
       <strong>Commands unavailable in review preview.</strong> Unresolved data is for review only;
       production commands require a published signed Directory snapshot.
     </p>
-    <p v-else-if="!autoDetect && !hasCompleteSource" class="install-panel__notice">
+    <p
+      v-else-if="!unavailableDiscoveryReason && !autoDetect && !hasCompleteSource"
+      class="install-panel__notice"
+    >
       <strong>Commands unavailable.</strong> {{ resolution.unavailable_reason }}
     </p>
     <p v-if="autoDetect && commands" class="install-panel__notice">
@@ -129,10 +155,6 @@ watch(availableClients, (next) => {
       {{ plugin.display_name }} in Apps or Plugins, connect it, and start a new chat. Availability
       depends on your account and workspace.
     </p>
-    <p class="install-panel__notice">
-      <strong>Clear outcomes.</strong> If an agent needs activation or sign-in, the CLI shows the
-      exact next step. It never receives your OAuth credentials.
-    </p>
     <p v-if="!autoDetect && resolution.fallback_reason && current" class="install-panel__notice">
       <strong>Expected source fallback: {{ expectedSource?.label }}.</strong>
       {{ resolution.fallback_reason }}
@@ -142,17 +164,9 @@ watch(availableClients, (next) => {
       and suggest compatible target/source combinations; it never mixes distributions across
       clients.
     </p>
-    <p v-if="!plugin.built_in" class="install-panel__notice">
-      <strong>Pinned direct source.</strong> Add uses the full commit pin. Update and remove use the
-      installed manifest name.
-    </p>
-    <p v-if="plugin.client_support.resolution === 'install_time'" class="install-panel__notice">
-      <strong>Checked at install time.</strong> The CLI validates the package and selected target
-      before it changes managed files.
-    </p>
-    <p class="install-panel__footnote">
-      The CLI plans all selected targets before mutation. Use <code>switch</code> to change source;
-      update and repair stay on the recorded distribution.
+    <p v-if="commands" class="install-panel__footnote">
+      The CLI checks every selected agent before changing files and shows any sign-in or activation
+      step. OAuth credentials stay with the agent.
     </p>
   </aside>
 </template>

--- a/landing/components/registry/PluginCatalog.vue
+++ b/landing/components/registry/PluginCatalog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { availableFilters, filterPlugins } from '~/utils/filter';
+import { availableFilters, catalogVisiblePlugins, filterPlugins } from '~/utils/filter';
 import type { RegistryPlugin } from '~/types/registry';
 
 const props = withDefaults(
@@ -22,7 +22,8 @@ const mobileFiltersOpen = ref(false);
 const pageSize = 48;
 const displayLimit = ref(pageSize);
 const discovery = useDiscoveryStatus();
-const filters = computed(() => availableFilters(props.plugins));
+const catalogPlugins = computed(() => catalogVisiblePlugins(props.plugins));
+const filters = computed(() => availableFilters(catalogPlugins.value));
 type FilterOption = { value: string; label: string };
 let previousCategoryOptions: FilterOption[] = [];
 let previousComponentOptions: FilterOption[] = [];
@@ -81,7 +82,7 @@ const ownerOptions = computed(() => [
   ...filters.value.owners.map((item) => ({ value: item, label: item })),
 ]);
 const visible = computed(() =>
-  filterPlugins(props.plugins, {
+  filterPlugins(catalogPlugins.value, {
     query: query.value,
     category: category.value === 'all' ? '' : category.value,
     component:
@@ -104,7 +105,7 @@ const activeFilterCount = computed(
     ).length,
 );
 const catalogSummary = computed(() => {
-  const total = props.plugins.length;
+  const total = catalogPlugins.value.length;
   if (!visible.value.length) return `No matches · ${total} total`;
   if (visible.value.length === total) return `${displayed.value.length} shown · ${total} plugins`;
   if (displayed.value.length < visible.value.length)

--- a/landing/components/registry/RegistryDirectory.vue
+++ b/landing/components/registry/RegistryDirectory.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
 import type { RegistryIndex } from '~/types/registry';
+import { catalogVisiblePlugins } from '~/utils/filter';
 
 const props = defineProps<{ registry: RegistryIndex }>();
+const catalogPlugins = computed(() => catalogVisiblePlugins(props.registry.plugins));
 const reviewedCount = computed(
   () =>
-    props.registry.plugins.filter((plugin) => plugin.trust_state !== 'conformant_unreviewed')
+    catalogPlugins.value.filter((plugin) => plugin.trust_state !== 'conformant_unreviewed')
       .length,
 );
-const discoveryCount = computed(() => props.registry.plugins.length - reviewedCount.value);
+const discoveryCount = computed(() => catalogPlugins.value.length - reviewedCount.value);
 const intro = computed(() => {
   const reviewed = `${reviewedCount.value} reviewed plugins`;
   const discovered = discoveryCount.value ? ` plus ${discoveryCount.value} community packages` : '';

--- a/landing/components/registry/RegistryHero.vue
+++ b/landing/components/registry/RegistryHero.vue
@@ -2,6 +2,7 @@
 import type { ClientID, RegistryIndex } from '~/types/registry';
 import { pluginCommands } from '~/utils/commands';
 import { countAtElapsed, PLUGIN_COUNT_ANIMATION_MS } from '~/utils/countAnimation';
+import { catalogVisiblePlugins } from '~/utils/filter';
 import { deliveryLabel, expectedDistribution, resolveDistribution } from '~/utils/registry';
 
 const props = defineProps<{ registry: RegistryIndex }>();
@@ -26,7 +27,7 @@ if (import.meta.client) {
     (state) => {
       if (state !== 'current' && state !== 'cached') return;
 
-      const target = props.registry.plugins.length;
+      const target = catalogVisiblePlugins(props.registry.plugins).length;
       if (
         countAnimationCompleted.value ||
         window.matchMedia('(prefers-reduced-motion: reduce)').matches

--- a/landing/pages/plugins/community.vue
+++ b/landing/pages/plugins/community.vue
@@ -62,7 +62,9 @@ usePageSeo(
               <img :src="pluginIcon(plugin)" alt="" width="54" height="54" loading="eager" >
             </span>
             <div>
-              <div class="plugin-profile__meta">Community plugin</div>
+              <div class="plugin-profile__meta">
+                {{ plugin.installable ? 'Community plugin' : 'Community listing' }}
+              </div>
               <h1>{{ plugin.display_name }}</h1>
             </div>
           </div>
@@ -75,11 +77,19 @@ usePageSeo(
             </div>
             <div>
               <dt>Works with</dt>
-              <dd>{{ availableClients.map((client) => client.name).join(', ') }}</dd>
+              <dd>
+                {{
+                  availableClients.length
+                    ? availableClients.map((client) => client.name).join(', ')
+                    : 'No supported agents yet'
+                }}
+              </dd>
             </div>
             <div>
               <dt>Components</dt>
-              <dd>{{ plugin.components.join(', ') }}</dd>
+              <dd>
+                {{ plugin.components.length ? plugin.components.join(', ') : 'No installable tools' }}
+              </dd>
             </div>
             <div>
               <dt>Source</dt>

--- a/landing/tests/browser/landing.spec.ts
+++ b/landing/tests/browser/landing.spec.ts
@@ -270,6 +270,63 @@ test('community plugin titles open an installable plugin page instead of GitHub'
   await expect(page.locator('.install-panel')).toBeVisible();
 });
 
+test('metadata-only community records stay out of the install catalog', async ({ page }) => {
+  await page.goto('./plugins');
+  await page.getByRole('searchbox', { name: 'Search plugins' }).fill('remotion');
+  await expect(page.locator('.plugin-card[data-trust="community"]')).toHaveCount(0, {
+    timeout: 15_000,
+  });
+});
+
+test('metadata-only community direct links explain why installation is unavailable', async ({
+  page,
+}) => {
+  await page.goto(
+    './plugins/community?source=discovery%3Aremotion-dev%2Fremotion%2F%2Fpackages%2Fagent-plugin',
+  );
+  await expect(page.getByRole('heading', { name: 'remotion', exact: true })).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByRole('heading', { name: 'Not ready to install' })).toBeVisible();
+  await expect(page.getByRole('status')).toContainText('This plugin is not installable yet');
+  await expect(page.getByRole('status')).toContainText("doesn't include any tools");
+  await expect(page.getByText('No supported agents yet')).toBeVisible();
+  await expect(page.getByText('No installable tools')).toBeVisible();
+  await expect(page.locator('.command-snippet')).toHaveCount(0);
+});
+
+test('community install controls use the full panel width for long sources', async ({ page }) => {
+  await page.goto(
+    './plugins/community?source=discovery%3Avectorize-io%2Fhindsight%2F%2Fhindsight-integrations%2Fagent-plugin',
+  );
+
+  const selector = page.locator('.install-command-row .target-select');
+  const addCommand = page.locator('.install-command-row > .command-snippet');
+  await expect(selector).toBeVisible({ timeout: 15_000 });
+  await expect(addCommand).toBeVisible();
+
+  for (const width of [1280, 980, 390]) {
+    await page.setViewportSize({ width, height: 900 });
+    const selectorBox = (await selector.boundingBox())!;
+    const commandBox = (await addCommand.boundingBox())!;
+    expect(Math.abs(selectorBox.x - commandBox.x)).toBeLessThanOrEqual(1);
+    expect(Math.abs(selectorBox.width - commandBox.width)).toBeLessThanOrEqual(1);
+    expect(commandBox.y).toBeGreaterThan(selectorBox.y + selectorBox.height);
+    expect(
+      await page.evaluate(
+        () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+      ),
+    ).toBe(false);
+
+    if (width <= 980) {
+      const gridBox = (await page.locator('.plugin-page__grid').boundingBox())!;
+      const panelBox = (await page.locator('.install-panel').boundingBox())!;
+      expect(Math.abs(gridBox.x - panelBox.x)).toBeLessThanOrEqual(1);
+      expect(Math.abs(gridBox.width - panelBox.width)).toBeLessThanOrEqual(1);
+    }
+  }
+});
+
 test('directory filters and reviewed detail keep automatic detection as the default', async ({
   page,
 }) => {

--- a/landing/tests/registry.test.ts
+++ b/landing/tests/registry.test.ts
@@ -4,8 +4,10 @@ import { describe, it } from 'node:test';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { pluginCommands } from '../utils/commands.ts';
-import { filterPlugins } from '../utils/filter.ts';
+import { discoveryPlugin } from '../utils/discovery.ts';
+import { catalogVisiblePlugins, filterPlugins } from '../utils/filter.ts';
 import { parseDirectoryData } from '../utils/registry.ts';
+import type { DiscoveryRecord, DiscoverySnapshot } from '../types/discovery.ts';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const pointer = JSON.parse(
@@ -15,6 +17,35 @@ const snapshot = JSON.parse(
   readFileSync(resolve(root, 'public/registry/schemas/1', pointer.snapshot_path), 'utf8'),
 ) as unknown;
 const registry = parseDirectoryData(snapshot, 'published_snapshot');
+const discoverySnapshot = {
+  sequence: 1,
+  generated_at: '2026-01-01T00:00:00Z',
+  expires_at: '2027-01-01T00:00:00Z',
+} as DiscoverySnapshot;
+const discoveryRecord = {
+  slug: 'discovery:example/plugin',
+  name: 'example',
+  description: 'Example package',
+  owner: 'example',
+  repository: 'example/plugin',
+  package_path: '',
+  revision: '1'.repeat(40),
+  version: '1.0.0',
+  license: 'Apache-2.0',
+  schema_version: '1.0.0',
+  components: { extensions: 0, mcp: 0, skills: 0 },
+  mcp_transports: [],
+  compatible_clients: [],
+  authentication: 'not_required',
+  status: 'conformant_unreviewed',
+  runtime_reviewed: false,
+  tree_digest: `sha256:${'2'.repeat(64)}`,
+  manifest_digest: `sha256:${'3'.repeat(64)}`,
+  stars: 1,
+  repository_updated_at: '2026-01-01T00:00:00Z',
+  reviewed_distribution_id: null,
+  availability: 'available',
+} satisfies DiscoveryRecord;
 
 describe('unified registry landing', () => {
   it('loads the signed reviewed directory used by the site', () => {
@@ -61,5 +92,25 @@ describe('unified registry landing', () => {
       },
     };
     assert.equal(filterPlugins([discovered, reviewed], {})[0]?.name, reviewed.name);
+  });
+
+  it('keeps metadata-only discovery records out of the install catalog', () => {
+    const metadataOnly = discoveryPlugin(discoveryRecord, discoverySnapshot);
+    const portable = discoveryPlugin(
+      {
+        ...discoveryRecord,
+        slug: 'discovery:example/portable',
+        name: 'portable',
+        components: { extensions: 0, mcp: 0, skills: 1 },
+        compatible_clients: ['codex'],
+      },
+      discoverySnapshot,
+    );
+
+    assert.equal(metadataOnly.installable, false);
+    assert.equal(metadataOnly.distributions[0]?.selectable, false);
+    assert.equal(metadataOnly.distributions[0]?.releases[0]?.selectable, false);
+    assert.equal(portable.installable, true);
+    assert.deepEqual(catalogVisiblePlugins([metadataOnly, portable]), [portable]);
   });
 });

--- a/landing/utils/discovery.ts
+++ b/landing/utils/discovery.ts
@@ -252,6 +252,8 @@ export function discoveryPlugin(
     delivery: 'managed' as const,
     scopes: ['user'],
   }));
+  const installable =
+    record.availability === 'available' && components.length > 0 && targets.length > 0;
   const revision = record.revision;
   const source = {
     repository: record.repository,
@@ -269,7 +271,7 @@ export function discoveryPlugin(
     evidence: [],
     package_evidence: [],
     release_status: 'active' as const,
-    selectable: record.availability === 'available',
+    selectable: installable,
     blocking_clients: [],
     materialized_clients: [],
     meets_minimum_capabilities: true,
@@ -286,7 +288,7 @@ export function discoveryPlugin(
     source,
     install_source: record.slug,
     built_in: false,
-    installable: record.availability === 'available',
+    installable,
     components,
     default_distribution: record.slug,
     declared_default_distribution: record.slug,
@@ -304,7 +306,7 @@ export function discoveryPlugin(
         package_evidence: [],
         status: record.availability === 'available' ? 'active' : 'suspended',
         release_status: 'active',
-        selectable: record.availability === 'available',
+        selectable: installable,
         targets,
         components,
         releases: [release],

--- a/landing/utils/filter.ts
+++ b/landing/utils/filter.ts
@@ -11,6 +11,13 @@ export interface CatalogFilters {
   owner?: string;
 }
 
+/** Keep metadata-only Discovery records available by direct URL, not in the install catalog. */
+export function catalogVisiblePlugins(plugins: RegistryPlugin[]): RegistryPlugin[] {
+  return plugins.filter(
+    (plugin) => plugin.trust_state !== 'conformant_unreviewed' || plugin.installable,
+  );
+}
+
 function normalized(value: string): string {
   return value.trim().toLowerCase();
 }


### PR DESCRIPTION
## Summary

- distinguish source availability from an actually installable Agent Plugins package
- keep metadata-only Discovery records out of the public install catalog and its count
- show a clear direct-link state instead of blank facts and unrelated technical notices
- stack agent selection and long community commands at full width across responsive layouts

## Verification

- `node --test --experimental-strip-types landing/tests/registry.test.ts`
- exact Remotion metadata-only regression
- exact Hindsight responsive layout regression at 1280, 980, and 390 px
