### PR TITLE
fix(landing): handle unavailable discovery sources

### DIFF
--- a/landing/components/registry/InstallPanel.vue
+++ b/landing/components/registry/InstallPanel.vue
@@ -37,7 +37,10 @@ const targetOptions = computed(() =>
   })),
 );
 const commands = computed(() =>
-  current.value && targets.value.length && (autoDetect.value || hasCompleteSource.value)
+  props.plugin.installable &&
+  current.value &&
+  targets.value.length &&
+  (autoDetect.value || hasCompleteSource.value)
     ? pluginCommands(props.plugin, autoDetect.value ? undefined : targets.value)
     : undefined,
 );

--- a/landing/pages/plugins/community.vue
+++ b/landing/pages/plugins/community.vue
@@ -20,6 +20,9 @@ const availableClients = computed(() =>
     ? clients.filter((client) => plugin.value!.client_support.clients.includes(client.id))
     : [],
 );
+const sourceUnavailable = computed(
+  () => plugin.value?.discovery?.availability === 'unavailable',
+);
 const targets = ref<ClientID[]>([]);
 const autoDetect = ref(true);
 
@@ -76,7 +79,7 @@ usePageSeo(
               <dd>{{ plugin.author.name }}</dd>
             </div>
             <div>
-              <dt>Works with</dt>
+              <dt>{{ sourceUnavailable ? 'Last known agents' : 'Works with' }}</dt>
               <dd>
                 {{
                   availableClients.length
@@ -86,7 +89,7 @@ usePageSeo(
               </dd>
             </div>
             <div>
-              <dt>Components</dt>
+              <dt>{{ sourceUnavailable ? 'Last known components' : 'Components' }}</dt>
               <dd>
                 {{ plugin.components.length ? plugin.components.join(', ') : 'No installable tools' }}
               </dd>

--- a/landing/tests/browser/landing.spec.ts
+++ b/landing/tests/browser/landing.spec.ts
@@ -295,6 +295,22 @@ test('metadata-only community direct links explain why installation is unavailab
   await expect(page.locator('.command-snippet')).toHaveCount(0);
 });
 
+test('unavailable community sources never expose stale install guidance', async ({ page }) => {
+  await page.goto(
+    './plugins/community?source=discovery%3A777genius%2Funiversal-agent-plugins%2F%2Fbridges%2Fchrome-devtools%2Foverlay',
+  );
+  await expect(page.getByRole('heading', { name: 'Not ready to install' })).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByRole('status')).toContainText(
+    'This package is no longer available from its source.',
+  );
+  await expect(page.getByText('Last known agents')).toBeVisible();
+  await expect(page.getByText('Last known components')).toBeVisible();
+  await expect(page.locator('.command-snippet')).toHaveCount(0);
+  await expect(page.getByText('Automatic detection.')).toHaveCount(0);
+});
+
 test('community install controls use the full panel width for long sources', async ({ page }) => {
   await page.goto(
     './plugins/community?source=discovery%3Avectorize-io%2Fhindsight%2F%2Fhindsight-integrations%2Fagent-plugin',

--- a/landing/tests/registry.test.ts
+++ b/landing/tests/registry.test.ts
@@ -113,4 +113,39 @@ describe('unified registry landing', () => {
     assert.equal(portable.installable, true);
     assert.deepEqual(catalogVisiblePlugins([metadataOnly, portable]), [portable]);
   });
+
+  it('keeps every non-installable Discovery state out of the install catalog', () => {
+    const unavailable = discoveryPlugin(
+      {
+        ...discoveryRecord,
+        components: { extensions: 0, mcp: 1, skills: 0 },
+        compatible_clients: ['codex'],
+        availability: 'unavailable',
+      },
+      discoverySnapshot,
+    );
+    const unsupported = discoveryPlugin(
+      {
+        ...discoveryRecord,
+        slug: 'discovery:example/unsupported',
+        components: { extensions: 1, mcp: 0, skills: 0 },
+      },
+      discoverySnapshot,
+    );
+    const skillOnly = discoveryPlugin(
+      {
+        ...discoveryRecord,
+        slug: 'discovery:example/skill-only',
+        name: 'skill-only',
+        components: { extensions: 0, mcp: 0, skills: 1 },
+        compatible_clients: ['codex'],
+      },
+      discoverySnapshot,
+    );
+
+    assert.equal(unavailable.installable, false);
+    assert.equal(unsupported.installable, false);
+    assert.equal(skillOnly.installable, true);
+    assert.deepEqual(catalogVisiblePlugins([unavailable, unsupported, skillOnly]), [skillOnly]);
+  });
 });


### PR DESCRIPTION
## What changed
- suppress all install guidance when a Discovery source is not installable
- label retained compatibility and components as last-known data when the source is unavailable
- cover unavailable, unsupported, metadata-only, and skill-only records

## Verification
- current signed sequence 35 audited: 2,992 unique records, 2,549 visible, 443 hidden, 0 inconsistent states
- focused registry tests pass
- browser regression covers unavailable-source detail pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Installation commands are no longer shown for plugins that cannot be installed.
  - Unavailable community plugin pages now clearly indicate that installation is not ready.
  - Historical agent and component information is labeled as such when the source package is unavailable.
  - Unavailable or unsupported plugins no longer appear in the install catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->