### PR TITLE
fix(landing): clarify npx install path and plugin identity

### DIFF
--- a/landing/components/registry/CommandSnippet.vue
+++ b/landing/components/registry/CommandSnippet.vue
@@ -25,7 +25,7 @@ const visibleCommand = computed(() => {
   if (!props.compact) return props.command;
   if (props.command.includes(' --target '))
     return props.command.replace(' --target ', '\n--target ');
-  return props.command.replace(/^(agentplugins\s+\S+)\s+/, '$1\n');
+  return props.command.replace(/^(npx universal-agent-plugins\s+\S+)\s+/, '$1\n');
 });
 let timer: ReturnType<typeof setTimeout> | undefined;
 

--- a/landing/components/registry/InstallPanel.vue
+++ b/landing/components/registry/InstallPanel.vue
@@ -99,7 +99,7 @@ watch(availableClients, (next) => {
         href="https://github.com/777genius/universal-agent-plugins#quick-start"
         target="_blank"
         rel="noreferrer"
-        >Native Go CLI · no Node.js</a
+        >Run with npx</a
       >
     </div>
     <div v-if="unavailableDiscoveryReason" class="install-panel__empty" role="status">

--- a/landing/components/registry/PluginCatalog.vue
+++ b/landing/components/registry/PluginCatalog.vue
@@ -131,7 +131,11 @@ watch([query, category, component, source, trust, client, authentication, owner]
 </script>
 
 <template>
-  <section class="catalog" aria-labelledby="catalog-title">
+  <section
+    class="catalog"
+    aria-labelledby="catalog-title"
+    :data-discovery-state="discovery.state"
+  >
     <div class="section-heading">
       <p class="eyebrow">Plugin directory</p>
       <div class="catalog-heading-row">

--- a/landing/components/registry/RegistryPluginCard.vue
+++ b/landing/components/registry/RegistryPluginCard.vue
@@ -113,6 +113,7 @@ function updateAutoDetect(value: boolean) {
     class="plugin-card"
     :class="{ 'plugin-card--expanded': installExpanded }"
     :data-trust="isDiscovered ? 'community' : 'reviewed'"
+    :data-install-source="plugin.install_source"
   >
     <span
       v-if="!isDiscovered"

--- a/landing/tests/browser/landing.spec.ts
+++ b/landing/tests/browser/landing.spec.ts
@@ -274,13 +274,15 @@ test('community plugin titles open an installable plugin page instead of GitHub'
 
 test('metadata-only community records stay out of the install catalog', async ({ page }) => {
   await page.goto('./plugins');
+  await expect(page.locator('.catalog')).toHaveAttribute('data-discovery-state', /current|cached/, {
+    timeout: 15_000,
+  });
   await page.getByRole('searchbox', { name: 'Search plugins' }).fill('remotion');
   await expect(
     page.locator(
       '.plugin-card[data-install-source="discovery:remotion-dev/remotion//packages/agent-plugin"]',
     ),
-  ).toHaveCount(0, { timeout: 15_000 });
-  await expect(page.locator('.plugin-card[data-trust="community"]').first()).toBeVisible();
+  ).toHaveCount(0);
 });
 
 test('metadata-only community direct links explain why installation is unavailable', async ({

--- a/landing/tests/browser/landing.spec.ts
+++ b/landing/tests/browser/landing.spec.ts
@@ -41,7 +41,9 @@ test('homepage installs with auto-detection and exposes the full directory', asy
   await expect(page.locator('.hero-agent-field__hub img')).toHaveAttribute('src', /icon\.svg$/);
   await expect(page.getByRole('heading', { name: /One plugin/ })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'One plugin All your agents' })).toBeVisible();
-  await expect(page.locator('.command-snippet').first()).toContainText('agentplugins add');
+  await expect(page.locator('.command-snippet').first()).toContainText(
+    'npx universal-agent-plugins add',
+  );
   await expect(page.locator('.command-snippet').first()).not.toContainText('--target');
   await expect(page.getByText('Supported clients')).toBeVisible();
   await expect(page.locator('.client-strip li')).toHaveCount(11);
@@ -273,9 +275,12 @@ test('community plugin titles open an installable plugin page instead of GitHub'
 test('metadata-only community records stay out of the install catalog', async ({ page }) => {
   await page.goto('./plugins');
   await page.getByRole('searchbox', { name: 'Search plugins' }).fill('remotion');
-  await expect(page.locator('.plugin-card[data-trust="community"]')).toHaveCount(0, {
-    timeout: 15_000,
-  });
+  await expect(
+    page.locator(
+      '.plugin-card[data-install-source="discovery:remotion-dev/remotion//packages/agent-plugin"]',
+    ),
+  ).toHaveCount(0, { timeout: 15_000 });
+  await expect(page.locator('.plugin-card[data-trust="community"]').first()).toBeVisible();
 });
 
 test('metadata-only community direct links explain why installation is unavailable', async ({
@@ -359,8 +364,10 @@ test('directory filters and reviewed detail keep automatic detection as the defa
   await expect(page).toHaveURL(/\/plugins\/gitlab\/?$/, { timeout: 15_000 });
   await expect(page.getByRole('heading', { name: 'GitLab', exact: true })).toBeVisible();
   await expect(page.getByText('All installed agents')).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Native Go CLI · no Node.js' })).toBeVisible();
-  await expect(page.locator('.command-snippet').first()).toContainText('agentplugins add');
+  await expect(page.getByRole('link', { name: 'Run with npx' })).toBeVisible();
+  await expect(page.locator('.command-snippet').first()).toContainText(
+    'npx universal-agent-plugins add',
+  );
   await expect(page.locator('.command-snippet').first()).not.toContainText('--target');
 });
 

--- a/landing/tests/registry.test.ts
+++ b/landing/tests/registry.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { pluginCommands } from '../utils/commands.ts';
 import { discoveryPlugin } from '../utils/discovery.ts';
 import { catalogVisiblePlugins, filterPlugins } from '../utils/filter.ts';
-import { parseDirectoryData } from '../utils/registry.ts';
+import { mirroredIconPath, parseDirectoryData } from '../utils/registry.ts';
 import type { DiscoveryRecord, DiscoverySnapshot } from '../types/discovery.ts';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -56,8 +56,11 @@ describe('unified registry landing', () => {
   it('omits --target for installed-agent detection', () => {
     const plugin = registry.plugins.find((item) => item.installable);
     assert.ok(plugin);
-    assert.equal(pluginCommands(plugin).add.includes('--target'), false);
-    assert.match(pluginCommands(plugin).add, /^agentplugins add /);
+    const commands = pluginCommands(plugin);
+    assert.equal(commands.add.includes('--target'), false);
+    assert.match(commands.add, /^npx universal-agent-plugins add /);
+    for (const command of Object.values(commands))
+      assert.match(command, /^npx universal-agent-plugins /);
   });
 
   it('uses one comma-separated target flag for explicit multi-agent installation', () => {
@@ -68,6 +71,17 @@ describe('unified registry landing', () => {
     );
     assert.ok(plugin);
     assert.match(pluginCommands(plugin, ['codex', 'cursor']).add, / --target codex,cursor$/);
+  });
+
+  it('gives every reviewed plugin a local logo', () => {
+    for (const plugin of registry.plugins) {
+      const iconPath = mirroredIconPath(plugin);
+      assert.ok(iconPath, `${plugin.name} must have a local logo`);
+      assert.doesNotThrow(
+        () => readFileSync(resolve(root, 'public', iconPath)),
+        `${plugin.name} logo must exist`,
+      );
+    }
   });
 
   it('keeps reviewed results ahead of automatic discovery', () => {

--- a/landing/utils/commands.ts
+++ b/landing/utils/commands.ts
@@ -1,5 +1,7 @@
 import type { RegistryPlugin } from '../types/registry';
 
+const CLI_INVOCATION = 'npx universal-agent-plugins';
+
 export function pluginCommands(plugin: RegistryPlugin, targets?: string | readonly string[]) {
   const values = (targets === undefined ? [] : Array.isArray(targets) ? targets : [targets])
     .map((target) => target.trim())
@@ -7,10 +9,10 @@ export function pluginCommands(plugin: RegistryPlugin, targets?: string | readon
   if (targets !== undefined && !values.length) throw new Error('At least one target is required');
   const targetFlag = values.length ? ` --target ${values.join(',')}` : '';
   return {
-    add: `agentplugins add ${plugin.install_source}${targetFlag}`,
-    update: `agentplugins update ${plugin.name}${targetFlag}`,
-    repair: `agentplugins repair ${plugin.name}${targetFlag}`,
-    switch: `agentplugins switch ${plugin.name} --to <distribution-id>`,
-    remove: `agentplugins remove ${plugin.name}${targetFlag}`,
+    add: `${CLI_INVOCATION} add ${plugin.install_source}${targetFlag}`,
+    update: `${CLI_INVOCATION} update ${plugin.name}${targetFlag}`,
+    repair: `${CLI_INVOCATION} repair ${plugin.name}${targetFlag}`,
+    switch: `${CLI_INVOCATION} switch ${plugin.name} --to <distribution-id>`,
+    remove: `${CLI_INVOCATION} remove ${plugin.name}${targetFlag}`,
   };
 }

--- a/landing/utils/registry.ts
+++ b/landing/utils/registry.ts
@@ -1112,12 +1112,19 @@ export function githubSourceUrl(
 }
 
 export function mirroredIconPath(plugin: RegistryPlugin): string | undefined {
-  if (!plugin.built_in || !plugin.icon || !plugin.icon.path.startsWith('assets/plugin-icons/'))
-    return undefined;
-  const filename = plugin.icon.path.split('/').at(-1);
-  if (!filename) return undefined;
+  if (!plugin.built_in) return undefined;
+
+  const filename = plugin.icon?.path.startsWith('assets/plugin-icons/')
+    ? plugin.icon.path.split('/').at(-1)
+    : undefined;
   if (filename === 'context7.png') return 'plugin-icons/context7.svg';
   if (filename === 'greptile.png') return 'plugin-icons/greptile.svg';
-  if (filename.endsWith('.png')) return undefined;
-  return `plugin-icons/${filename}`;
+  if (filename === 'heroku.png') return 'plugin-icons/heroku.svg';
+  if (filename?.endsWith('.svg')) return `plugin-icons/${filename}`;
+
+  // Reviewed packages always receive a local, controlled identity. Reuse the
+  // publisher mark for Cloudflare's product family and the UAP mark as the
+  // honest fallback until a package-specific asset is added to the Directory.
+  if (plugin.name.startsWith('cloudflare-')) return 'plugin-icons/cloudflare.svg';
+  return 'icon.svg';
 }


### PR DESCRIPTION
## Summary

- show the zero-install `npx universal-agent-plugins` invocation throughout the catalog
- guarantee a local logo for every reviewed plugin, with publisher and UAP fallbacks
- keep evolving Discovery E2E scoped to the exact non-installable record

## Verification

- `pnpm run test:registry` - 15 passed
- `pnpm run lint` - passed
- production static generation - passed
- Playwright - 30 passed
- reviewed logo audit - 26/26 local assets present
