### PR TITLE
fix(landing): feature Context7 without placeholder logos

### DIFF
--- a/landing/components/registry/RegistryHero.vue
+++ b/landing/components/registry/RegistryHero.vue
@@ -11,7 +11,7 @@ const { current, expired, published } = useDirectoryStatus();
 const discovery = useDiscoveryStatus();
 const { asset } = useSite();
 const cliRepositoryUrl = computed(() => `https://github.com/${config.public.githubRepo}`);
-const preferredDemoNames = ['chrome-devtools', 'context7', 'cloudflare-docs'];
+const preferredDemoNames = ['context7', 'chrome-devtools', 'cloudflare-docs'];
 const displayedPluginCount = ref<number | null>(null);
 const pluginCount = computed(() =>
   displayedPluginCount.value === null

--- a/landing/tests/browser/landing.spec.ts
+++ b/landing/tests/browser/landing.spec.ts
@@ -41,8 +41,9 @@ test('homepage installs with auto-detection and exposes the full directory', asy
   await expect(page.locator('.hero-agent-field__hub img')).toHaveAttribute('src', /icon\.svg$/);
   await expect(page.getByRole('heading', { name: /One plugin/ })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'One plugin All your agents' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Install Context7' })).toBeVisible();
   await expect(page.locator('.command-snippet').first()).toContainText(
-    'npx universal-agent-plugins add',
+    'npx universal-agent-plugins add context7',
   );
   await expect(page.locator('.command-snippet').first()).not.toContainText('--target');
   await expect(page.getByText('Supported clients')).toBeVisible();

--- a/landing/tests/registry.test.ts
+++ b/landing/tests/registry.test.ts
@@ -73,15 +73,32 @@ describe('unified registry landing', () => {
     assert.match(pluginCommands(plugin, ['codex', 'cursor']).add, / --target codex,cursor$/);
   });
 
-  it('gives every reviewed plugin a local logo', () => {
+  it('uses only real local plugin or publisher logos without a generic fallback', () => {
     for (const plugin of registry.plugins) {
       const iconPath = mirroredIconPath(plugin);
-      assert.ok(iconPath, `${plugin.name} must have a local logo`);
+      if (!iconPath) continue;
       assert.doesNotThrow(
         () => readFileSync(resolve(root, 'public', iconPath)),
         `${plugin.name} logo must exist`,
       );
     }
+
+    assert.equal(
+      mirroredIconPath(registry.plugins.find((plugin) => plugin.name === 'agent-code-navigator')!),
+      undefined,
+    );
+    assert.equal(
+      mirroredIconPath(registry.plugins.find((plugin) => plugin.name === 'statsig')!),
+      undefined,
+    );
+    assert.equal(
+      mirroredIconPath(registry.plugins.find((plugin) => plugin.name === 'cloudflare-docs')!),
+      'plugin-icons/cloudflare.svg',
+    );
+    assert.equal(
+      mirroredIconPath(registry.plugins.find((plugin) => plugin.name === 'heroku')!),
+      'plugin-icons/heroku.svg',
+    );
   });
 
   it('keeps reviewed results ahead of automatic discovery', () => {

--- a/landing/utils/registry.ts
+++ b/landing/utils/registry.ts
@@ -1122,9 +1122,8 @@ export function mirroredIconPath(plugin: RegistryPlugin): string | undefined {
   if (filename === 'heroku.png') return 'plugin-icons/heroku.svg';
   if (filename?.endsWith('.svg')) return `plugin-icons/${filename}`;
 
-  // Reviewed packages always receive a local, controlled identity. Reuse the
-  // publisher mark for Cloudflare's product family and the UAP mark as the
-  // honest fallback until a package-specific asset is added to the Directory.
+  // Reuse Cloudflare's publisher mark for its product family. Other packages
+  // stay iconless unless the Directory owns a real package or publisher logo.
   if (plugin.name.startsWith('cloudflare-')) return 'plugin-icons/cloudflare.svg';
-  return 'icon.svg';
+  return undefined;
 }


### PR DESCRIPTION
## Summary

- use Context7 for the homepage install example
- keep reviewed plugins iconless when no real local brand asset exists
- retain real package and publisher-family logos only

## Verification

- node --experimental-strip-types --test landing/tests/registry.test.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The landing page now prioritizes the Context7 demo plugin, followed by Chrome DevTools and Cloudflare Docs.
  - Homepage visitors see updated installation guidance featuring the Context7 command explicitly.

- **Bug Fixes**
  - Plugin listings no longer display a generic logo when a specific local icon is unavailable.
  - Cloudflare plugins continue using the Cloudflare icon, while supported plugins display their corresponding local logos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->