### PR TITLE
fix(agentplugins): skip targets that fail activation preflight

### DIFF
--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -935,6 +935,36 @@ func TestInteractiveAddSkipsDetectedClientThatPackageCannotServe(t *testing.T) {
 	}
 }
 
+func TestInteractiveAddSkipsDetectedClientThatCannotPassActivationPreflight(t *testing.T) {
+	t.Parallel()
+	kiro := fixtureClient(t, domain.ClientKiro)
+	kiro.ExecutablePath = "/test/bin/kiro-cli"
+	fixture := newCLIFixture(t, []domain.DetectedClient{
+		fixtureClient(t, domain.ClientCursor), kiro,
+	})
+	fixture.app.Lifecycle.Activator = providers.Activator{Runner: &cliRunOnlyRunner{}}
+	plugin := writeCLIPlugin(t)
+	writeCLIMCP(t, plugin)
+
+	stdout, _, err := fixture.executeInput(true, "\n", "add", plugin, "--dry-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "Skipped installed clients that this package cannot install together: kiro") {
+		t.Fatalf("activation-aware interactive output = %q", stdout)
+	}
+	if strings.Contains(stdout, "Detected supported clients (all selected by default)") {
+		t.Fatalf("single preflight-capable target unexpectedly prompted for multiple clients: %q", stdout)
+	}
+	state, loadErr := fixture.store.Load()
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if len(state.Installations) != 0 {
+		t.Fatalf("interactive dry-run mutated state: %+v", state)
+	}
+}
+
 func TestInteractiveAddProbesOnlyTargetsSelectedAfterReadOnlyDetection(t *testing.T) {
 	clientCodex := fixtureClient(t, domain.ClientCodex)
 	clientCursor := fixtureClient(t, domain.ClientCursor)

--- a/cli/plugin-kit-ai/internal/agentpluginscli/directory_rollout_semantics_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/directory_rollout_semantics_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/directoryv1"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers"
 )
 
 type rolloutDirectoryFixture struct {
@@ -355,6 +356,58 @@ func TestInteractiveDirectoryAddOffersOnlyOneCompleteSignedTargetSet(t *testing.
 	}
 	if rollout.acquirer.verifiedCalls != 1 {
 		t.Fatalf("Directory package acquired %d times, want exactly once after target selection", rollout.acquirer.verifiedCalls)
+	}
+}
+
+func TestInteractiveDirectoryAddSkipsTargetThatCannotPassActivationPreflight(t *testing.T) {
+	rollout := newRolloutDirectoryFixture(t,
+		[]domain.ClientID{domain.ClientCursor, domain.ClientKiro},
+		[]domain.ClientID{domain.ClientCursor, domain.ClientKiro})
+	writeCLIMCP(t, rollout.v1.root)
+	loaded, err := rollout.cli.app.acquireLocal(context.Background(), rollout.v1.root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rollout.v1.tree = loaded.envelope.TreeDigest
+	rollout.v1.manifest = loaded.envelope.ManifestDigest
+	if err := loaded.cleanup(); err != nil {
+		t.Fatal(err)
+	}
+	release := &rollout.directory.bundle.Snapshot.Distributions[0].Releases[0]
+	release.TreeDigest = rollout.v1.tree
+	release.ManifestDigest = rollout.v1.manifest
+	for index := range rollout.directory.bundle.Snapshot.Evidence {
+		evidence := &rollout.directory.bundle.Snapshot.Evidence[index]
+		if evidence.DistributionID == "owner/rollout" && evidence.ReleaseSequence == 1 {
+			evidence.PackageTreeDigest = rollout.v1.tree
+		}
+	}
+	kiro := fixtureClient(t, domain.ClientKiro)
+	kiro.ExecutablePath = "/test/bin/kiro-cli"
+	rollout.cli.app.Detector = staticDetector{clients: []domain.DetectedClient{
+		fixtureClient(t, domain.ClientCursor), kiro,
+	}}
+	rollout.cli.app.Lifecycle.Activator = providers.Activator{Runner: &cliRunOnlyRunner{}}
+
+	stdout, _, err := rollout.cli.executeInput(true, "\n", "add", "rollout-demo", "--dry-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "Skipped installed clients that this package cannot install together: kiro") {
+		t.Fatalf("activation-aware Directory output = %q", stdout)
+	}
+	if strings.Contains(stdout, "Detected supported clients (all selected by default)") {
+		t.Fatalf("single preflight-capable Directory target unexpectedly prompted: %q", stdout)
+	}
+	if rollout.acquirer.verifiedCalls != 1 {
+		t.Fatalf("Directory package acquired %d times, want exactly once", rollout.acquirer.verifiedCalls)
+	}
+	state, loadErr := rollout.cli.store.Load()
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if len(state.Installations) != 0 {
+		t.Fatalf("interactive Directory dry-run mutated state: %+v", state)
 	}
 }
 

--- a/cli/plugin-kit-ai/internal/agentpluginscli/interactive_targets.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/interactive_targets.go
@@ -75,7 +75,25 @@ func (app App) compatibleDetectedTargets(ctx context.Context, source string, det
 		return compatible, nil, err
 	case isDirectorySelector(source):
 		compatible, err := app.compatibleDirectoryTargets(ctx, source, detected)
-		return compatible, nil, err
+		if err != nil {
+			return nil, nil, err
+		}
+		loaded, err := app.loadPackageFor(
+			ctx,
+			source,
+			withDetectedClients(app.addResolutionRequest(source, detectedClientIDs(compatible)), detectedClientMap(detected)),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		compatible = app.compatibleLoadedTargets(ctx, loaded, compatible)
+		if len(compatible) == 0 {
+			if loaded.cleanup != nil {
+				_ = loaded.cleanup()
+			}
+			return nil, nil, fmt.Errorf("the package cannot be installed automatically in any detected supported client; use --target to inspect a specific client")
+		}
+		return compatible, &loaded, nil
 	default:
 		loaded, err := app.loadPackageFor(ctx, source, app.addResolutionRequest(source, nil))
 		if err != nil {
@@ -220,11 +238,30 @@ func (app App) compatibleLoadedTargets(ctx context.Context, loaded loadedPackage
 			continue
 		}
 		plan, err := planner.Plan(ctx, candidate.envelope, client, domain.ScopeUser, physicalID)
-		if err == nil && plan.Status != domain.PlanUnsupported {
-			compatible = append(compatible, client)
+		if err != nil || plan.Status == domain.PlanUnsupported {
+			continue
 		}
+		if preflighter, ok := app.Lifecycle.Activator.(interface {
+			PreflightActivation(domain.ActivationRequest) error
+		}); ok {
+			err = preflighter.PreflightActivation(domain.ActivationRequest{
+				Client: client, Plan: plan, BackendExecutable: backendExecutable(client, clientMap), VerifyOnly: true,
+			})
+			if err != nil {
+				continue
+			}
+		}
+		compatible = append(compatible, client)
 	}
 	return compatible
+}
+
+func detectedClientIDs(clients []domain.DetectedClient) []domain.ClientID {
+	result := make([]domain.ClientID, len(clients))
+	for index, client := range clients {
+		result[index] = client.ClientID
+	}
+	return result
 }
 
 func detectedClientMap(clients []domain.DetectedClient) map[domain.ClientID]domain.DetectedClient {


### PR DESCRIPTION
## What

- filters interactive default targets through the same activation preflight used by the lifecycle
- acquires a signed Directory package once before prompting and reuses the verified package
- keeps explicit --target behavior unchanged and fail-closed

## Why

The short interactive command selected every detected client even when one client could not satisfy the platform activation capability. On macOS, a detected Kiro CLI then blocked the whole atomic group after the user accepted the default selection.

## Verification

- focused interactive local and signed Directory regressions pass
- full agentplugins CLI package passes
- all cli/plugin-kit-ai packages pass
- dry-run remains mutation-free

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Interactive `add` flows now skip detected clients that cannot complete activation preflight.
  - Skip messages identify excluded clients and the reason they were not selected.
  - When only one compatible target remains, the flow avoids unnecessary multi-client prompts.
  - Directory-based additions now correctly continue with compatible targets and report an error when none remain.
  - Dry-run operations continue to leave installation state unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->