### PR TITLE
feat(agentplugins): scan packages before installation

### DIFF
--- a/cli/plugin-kit-ai/cmd/agentplugins/main.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/discoveryv1"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/loader"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/processlock"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/securityscan"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/sourceacquisition"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/specregistry"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/statemigration"
@@ -110,11 +111,15 @@ func run() error {
 		SourceAcquirer:      lazySourceAcquirer{dataRoot: dataRoot, acquirer: sourceacquisition.Acquirer{TempRoot: dataRoot}},
 		PackageLoader:       packageLoader,
 		NativePackageLoader: loader.OpenAILoader{Loader: packageLoader},
-		Lifecycle:           lifecycle,
-		Input:               os.Stdin,
-		Output:              os.Stdout,
-		ErrorOutput:         os.Stderr,
-		Terminal:            term.IsTerminal(int(os.Stdin.Fd())),
+		SecurityEvaluator: securityscan.Evaluator{
+			Scanner: securityscan.ReleaseScanner{Root: filepath.Join(dataRoot, "security", "lintai"), HTTPClient: lintaiReleaseHTTPClient()},
+			Cache:   securityscan.FileCache{Root: filepath.Join(dataRoot, "security", "assessments")}, Requirement: securityscan.DefaultRequirement(),
+		},
+		Lifecycle:   lifecycle,
+		Input:       os.Stdin,
+		Output:      os.Stdout,
+		ErrorOutput: os.Stderr,
+		Terminal:    term.IsTerminal(int(os.Stdin.Fd())),
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -250,6 +255,24 @@ func hardenedHTTPClient(feed string) *http.Client {
 				!strings.EqualFold(request.URL.Scheme, via[0].URL.Scheme) ||
 				!strings.EqualFold(request.URL.Host, via[0].URL.Host) {
 				return fmt.Errorf("%s redirect must remain on the original HTTPS origin", feed)
+			}
+			request.Header.Del("Authorization")
+			request.Header.Del("Cookie")
+			request.Header.Del("Proxy-Authorization")
+			return nil
+		},
+	}
+}
+
+func lintaiReleaseHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: 30 * time.Second,
+		CheckRedirect: func(request *http.Request, via []*http.Request) error {
+			if len(via) == 0 || len(via) > 2 || request.URL.Scheme != "https" {
+				return fmt.Errorf("invalid LintAI release redirect")
+			}
+			if request.URL.Hostname() != "github.com" && request.URL.Hostname() != "release-assets.githubusercontent.com" {
+				return fmt.Errorf("LintAI release redirect uses an untrusted host")
 			}
 			request.Header.Del("Authorization")
 			request.Header.Del("Cookie")

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -104,6 +104,9 @@ func runAddWithClients(ctx context.Context, cmd *cobra.Command, app App, opts *o
 }
 
 func runAddLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *options, loaded loadedPackage, activationComplete, authComplete bool, clients []domain.DetectedClient) error {
+	if err := authorizeSecurityAssessment(cmd, app, opts, &loaded); err != nil {
+		return err
+	}
 	if automatedMutation(app, opts) && strings.TrimSpace(opts.target) == "" {
 		return fmt.Errorf("automated installation requires --target")
 	}
@@ -127,14 +130,14 @@ func runAddLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *option
 	planned, err := service.Add(ctx, input)
 	if err != nil {
 		if planned.Plan.Status == domain.PlanUnsupported {
-			if renderErr := renderAddResultError(cmd.OutOrStdout(), opts.format, loaded.envelope, planned, opts.dryRun, err); renderErr != nil {
+			if renderErr := renderAddResultErrorWithSecurity(cmd.OutOrStdout(), opts.format, loaded.envelope, loaded.security, planned, opts.dryRun, err); renderErr != nil {
 				return renderErr
 			}
 		}
 		return err
 	}
 	if opts.dryRun || planned.NoChange {
-		return renderAddResult(cmd.OutOrStdout(), opts.format, loaded.envelope, planned, opts.dryRun)
+		return renderAddResultWithSecurity(cmd.OutOrStdout(), opts.format, loaded.envelope, loaded.security, planned, opts.dryRun)
 	}
 	if opts.format == "human" {
 		if err := renderHumanPlan(cmd.OutOrStdout(), loaded.envelope, planned); err != nil {
@@ -143,7 +146,7 @@ func runAddLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *option
 	}
 	freshInstall := planned.Activation.Activation == ""
 	if !freshInstall && opts.format == "human" && app.Terminal && !activationComplete && !authComplete {
-		if err := renderAddResult(cmd.OutOrStdout(), opts.format, loaded.envelope, planned, false); err != nil {
+		if err := renderAddResultWithSecurity(cmd.OutOrStdout(), opts.format, loaded.envelope, loaded.security, planned, false); err != nil {
 			return err
 		}
 		return resumeInteractiveLifecycle(ctx, cmd, service, input, loaded.envelope, planned)
@@ -161,7 +164,7 @@ func runAddLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *option
 	}
 	if !confirmed {
 		if opts.format == "json" {
-			return renderAddResult(cmd.OutOrStdout(), opts.format, loaded.envelope, planned, false)
+			return renderAddResultWithSecurity(cmd.OutOrStdout(), opts.format, loaded.envelope, loaded.security, planned, false)
 		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No changes made.")
 		return nil
@@ -170,7 +173,7 @@ func runAddLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *option
 	input.Confirmed = true
 	input.InstallationID = planned.InstallationID
 	result, err := service.Add(ctx, input)
-	if renderErr := renderAddResultError(cmd.OutOrStdout(), opts.format, loaded.envelope, result, false, err); renderErr != nil && err == nil {
+	if renderErr := renderAddResultErrorWithSecurity(cmd.OutOrStdout(), opts.format, loaded.envelope, loaded.security, result, false, err); renderErr != nil && err == nil {
 		err = renderErr
 	}
 	if err == nil && freshInstall && opts.format == "human" && app.Terminal {
@@ -478,8 +481,17 @@ func renderAddResult(writer io.Writer, format string, envelope domain.PackageEnv
 	return renderAddResultError(writer, format, envelope, result, dryRun, nil)
 }
 
+func renderAddResultWithSecurity(writer io.Writer, format string, envelope domain.PackageEnvelope, security *domain.SecurityAssessment, result usecase.AddResult, dryRun bool) error {
+	return renderAddResultErrorWithSecurity(writer, format, envelope, security, result, dryRun, nil)
+}
+
 func renderAddResultError(writer io.Writer, format string, envelope domain.PackageEnvelope, result usecase.AddResult, dryRun bool, commandErr error) error {
+	return renderAddResultErrorWithSecurity(writer, format, envelope, nil, result, dryRun, commandErr)
+}
+
+func renderAddResultErrorWithSecurity(writer io.Writer, format string, envelope domain.PackageEnvelope, security *domain.SecurityAssessment, result usecase.AddResult, dryRun bool, commandErr error) error {
 	data := newAddResultData(envelope, result, dryRun)
+	data.Security = security
 	data.envelopeResult = addEnvelopeResult(result, commandErr)
 	if format == "json" {
 		return writeJSONOutput(writer, "add", data)
@@ -529,16 +541,17 @@ func renderAddResultError(writer io.Writer, format string, envelope domain.Packa
 }
 
 type addResultData struct {
-	OperationID    string            `json:"operation_id,omitempty"`
-	Plugin         string            `json:"plugin"`
-	Version        string            `json:"version,omitempty"`
-	Source         string            `json:"source"`
-	Revision       string            `json:"revision,omitempty"`
-	TreeDigest     string            `json:"tree_digest"`
-	ManifestDigest string            `json:"manifest_digest"`
-	NextAction     string            `json:"next_action,omitempty"`
-	DryRun         bool              `json:"dry_run"`
-	Result         usecase.AddResult `json:"result"`
+	OperationID    string                     `json:"operation_id,omitempty"`
+	Plugin         string                     `json:"plugin"`
+	Version        string                     `json:"version,omitempty"`
+	Source         string                     `json:"source"`
+	Revision       string                     `json:"revision,omitempty"`
+	TreeDigest     string                     `json:"tree_digest"`
+	ManifestDigest string                     `json:"manifest_digest"`
+	Security       *domain.SecurityAssessment `json:"security,omitempty"`
+	NextAction     string                     `json:"next_action,omitempty"`
+	DryRun         bool                       `json:"dry_run"`
+	Result         usecase.AddResult          `json:"result"`
 	envelopeResult string
 }
 

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
@@ -22,22 +22,23 @@ type addTargetResult struct {
 }
 
 type addMultiResult struct {
-	OperationID    string                    `json:"operation_id,omitempty"`
-	Batch          bool                      `json:"batch"`
-	Status         string                    `json:"status"`
-	Succeeded      int                       `json:"succeeded"`
-	Failed         int                       `json:"failed"`
-	Plugin         string                    `json:"plugin"`
-	Version        string                    `json:"version,omitempty"`
-	Source         string                    `json:"source"`
-	Revision       string                    `json:"revision,omitempty"`
-	TreeDigest     string                    `json:"tree_digest,omitempty"`
-	ManifestDigest string                    `json:"manifest_digest,omitempty"`
-	Directory      *domain.DirectoryOrigin   `json:"directory,omitempty"`
-	DryRun         bool                      `json:"dry_run"`
-	Targets        []addTargetResult         `json:"targets"`
-	Acquisition    *addAcquisitionProof      `json:"acquisition,omitempty"`
-	TargetOutcomes map[string]addTargetProof `json:"target_outcomes,omitempty"`
+	OperationID    string                     `json:"operation_id,omitempty"`
+	Batch          bool                       `json:"batch"`
+	Status         string                     `json:"status"`
+	Succeeded      int                        `json:"succeeded"`
+	Failed         int                        `json:"failed"`
+	Plugin         string                     `json:"plugin"`
+	Version        string                     `json:"version,omitempty"`
+	Source         string                     `json:"source"`
+	Revision       string                     `json:"revision,omitempty"`
+	TreeDigest     string                     `json:"tree_digest,omitempty"`
+	ManifestDigest string                     `json:"manifest_digest,omitempty"`
+	Security       *domain.SecurityAssessment `json:"security,omitempty"`
+	Directory      *domain.DirectoryOrigin    `json:"directory,omitempty"`
+	DryRun         bool                       `json:"dry_run"`
+	Targets        []addTargetResult          `json:"targets"`
+	Acquisition    *addAcquisitionProof       `json:"acquisition,omitempty"`
+	TargetOutcomes map[string]addTargetProof  `json:"target_outcomes,omitempty"`
 }
 
 type addAcquisitionProof struct {
@@ -83,6 +84,9 @@ func runAddManyWithClients(ctx context.Context, cmd *cobra.Command, app App, opt
 }
 
 func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *options, loaded loadedPackage, targets []domain.ClientID, activationComplete, authComplete bool, clients []domain.DetectedClient) error {
+	if err := authorizeSecurityAssessment(cmd, app, opts, &loaded); err != nil {
+		return err
+	}
 	if len(targets) == 1 {
 		if activationComplete || authComplete {
 			return runAddLoaded(ctx, cmd, app, opts, loaded, activationComplete, authComplete, clients)
@@ -97,6 +101,7 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 		Batch: true, Status: "planned", Plugin: loaded.envelope.Manifest.Name,
 		Version: loaded.envelope.Manifest.Version, Source: publicPackageSource(loaded.envelope.Source),
 		Revision: loaded.envelope.Source.ResolvedRevision, TreeDigest: loaded.envelope.TreeDigest, ManifestDigest: loaded.envelope.ManifestDigest,
+		Security:  loaded.security,
 		Directory: cloneDirectoryOrigin(loaded.directory),
 		DryRun:    opts.dryRun, Targets: make([]addTargetResult, 0, len(targets)),
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/app.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/app.go
@@ -41,6 +41,7 @@ type App struct {
 	SourceAcquirer      SourceAcquirer
 	PackageLoader       ports.PackageLoader
 	NativePackageLoader ports.PackageLoader
+	SecurityEvaluator   ports.PackageSecurityEvaluator
 	Lifecycle           usecase.Service
 	StateMigrator       *statemigration.Migrator
 	LegacyLifecycle     ports.LegacyLifecycle
@@ -59,6 +60,7 @@ type options struct {
 	noColor             bool
 	externalUninstalled bool
 	purgeData           bool
+	acceptSecurityRisk  bool
 }
 
 func (app App) input() io.Reader {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/engine_boundary.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/engine_boundary.go
@@ -86,6 +86,9 @@ func runSwitch(ctx context.Context, cmd *cobra.Command, app App, opts *options, 
 	if loaded.envelope.Manifest.Name != installation.DeclaredName {
 		return fmt.Errorf("switch source manifest name %q does not match installed product %q", loaded.envelope.Manifest.Name, installation.DeclaredName)
 	}
+	if err := authorizeSecurityAssessment(cmd, app, opts, &loaded); err != nil {
+		return err
+	}
 	output := switchOutput{DryRun: true, Status: "planned", Source: publicPackageSource(loaded.envelope.Source), Revision: loaded.envelope.Source.ResolvedRevision,
 		TreeDigest: loaded.envelope.TreeDigest, ManifestDigest: loaded.envelope.ManifestDigest, Directory: cloneDirectoryOrigin(loaded.directory),
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
@@ -121,6 +121,9 @@ func runRepair(ctx context.Context, cmd *cobra.Command, app App, opts *options, 
 		defer loaded.cleanup()
 	}
 	restoreCatalogEvidence(&loaded, binding)
+	if err := authorizeSecurityAssessment(cmd, app, opts, &loaded); err != nil {
+		return err
+	}
 	if err := prepareLoadedPackageForClient(&loaded, selected.ClientID); err != nil {
 		return err
 	}
@@ -240,6 +243,9 @@ func runUpdate(ctx context.Context, cmd *cobra.Command, app App, opts *options, 
 	}
 	if domain.ComputeSourceBindingID(loaded.envelope.Source) != installation.Source.SourceBindingID {
 		return fmt.Errorf("resolved source identity changed; use agentplugins rebind after reviewing provenance")
+	}
+	if err := authorizeSecurityAssessment(cmd, app, opts, &loaded); err != nil {
+		return err
 	}
 	clients, err := app.Detector.Detect(ctx)
 	if err != nil {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/repair_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/repair_multi.go
@@ -116,6 +116,13 @@ func runRepairMany(ctx context.Context, cmd *cobra.Command, app App, opts *optio
 			defer loaded.cleanup()
 		}
 	}
+	for _, key := range keys {
+		loaded := loadedByRevision[key]
+		if err := authorizeSecurityAssessment(cmd, app, opts, &loaded); err != nil {
+			return err
+		}
+		loadedByRevision[key] = loaded
+	}
 	service := lifecycleService(app, detected)
 	inputs := make([]usecase.AddInput, 0, len(targets))
 	result := repairMultiResult{Batch: true, Status: "planned", Plugin: installation.DeclaredName, DryRun: opts.dryRun, Targets: make([]repairTargetResult, 0, len(targets))}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/root.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/root.go
@@ -23,6 +23,7 @@ func NewRoot(app App) *cobra.Command {
 	flags.BoolVar(&opts.dryRun, "dry-run", false, "show the exact plan without changes")
 	flags.StringVar(&opts.format, "format", "human", "output format: human or json")
 	flags.BoolVar(&opts.noColor, "no-color", false, "disable color output")
+	flags.BoolVar(&opts.acceptSecurityRisk, "accept-security-risk", false, "continue despite blocking automated security findings")
 
 	root.AddCommand(newAddCommand(app, opts))
 	root.AddCommand(newUpdateCommand(app, opts))

--- a/cli/plugin-kit-ai/internal/agentpluginscli/security.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/security.go
@@ -1,0 +1,82 @@
+package agentpluginscli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/spf13/cobra"
+)
+
+func authorizeSecurityAssessment(cmd *cobra.Command, app App, opts *options, loaded *loadedPackage) error {
+	if loaded.security == nil || loaded.securityAuthorized {
+		return nil
+	}
+	assessment := *loaded.security
+	if opts.format == "human" {
+		renderSecurityAssessment(cmd, assessment)
+	}
+	if assessment.Counts.Blocking == 0 || opts.dryRun {
+		loaded.securityAuthorized = true
+		return nil
+	}
+	if opts.acceptSecurityRisk {
+		if opts.format == "human" {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Continuing because --accept-security-risk was explicitly provided.")
+		}
+		loaded.securityAuthorized = true
+		return nil
+	}
+	if opts.format != "human" || !app.Terminal {
+		if opts.format == "json" {
+			if err := writeJSONResult(cmd.OutOrStdout(), cmd.Name(), outputResultFailure, map[string]any{
+				"status": "blocked_by_security_review", "security": assessment,
+				"next_action": "Review the findings and rerun with --accept-security-risk only if you accept the risk.",
+			}); err != nil {
+				return err
+			}
+		}
+		return fmt.Errorf("installation stopped: automated security checks found %d blocking finding(s); review them and rerun with --accept-security-risk to continue", assessment.Counts.Blocking)
+	}
+	confirmed, err := promptYesNo(cmd.InOrStdin(), cmd.OutOrStdout(), "Blocking security findings were detected. Continue anyway? [y/N]")
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		return fmt.Errorf("installation cancelled after automated security review; no files were changed")
+	}
+	loaded.securityAuthorized = true
+	return nil
+}
+
+func renderSecurityAssessment(cmd *cobra.Command, assessment domain.SecurityAssessment) {
+	source := "local scan"
+	switch assessment.Evidence {
+	case domain.SecurityEvidenceSignedIndex:
+		source = "signed index"
+	case domain.SecurityEvidenceCache:
+		source = "verified cache"
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Automated security checks: %s (%s %s, exact package revision)\n", securityOutcomeLabel(assessment), assessment.Scanner.ID, assessment.Scanner.Version)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Evidence: %s. Automated checks are not a guarantee of safety.\n", source)
+	for _, finding := range assessment.Findings {
+		location := strings.TrimSpace(finding.Path)
+		if finding.Line > 0 {
+			location = fmt.Sprintf("%s:%d", location, finding.Line)
+		}
+		if location != "" {
+			location += " - "
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  [%s] %s %s%s\n", strings.ToUpper(finding.Disposition), finding.Code, location, finding.Message)
+	}
+}
+
+func securityOutcomeLabel(assessment domain.SecurityAssessment) string {
+	if assessment.Counts.Blocking > 0 {
+		return fmt.Sprintf("%d blocking, %d warning", assessment.Counts.Blocking, assessment.Counts.Warnings)
+	}
+	if assessment.Counts.Warnings > 0 {
+		return fmt.Sprintf("%d warning(s), no blocking findings", assessment.Counts.Warnings)
+	}
+	return "no blocking findings"
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/security_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/security_test.go
@@ -1,0 +1,67 @@
+package agentpluginscli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/spf13/cobra"
+)
+
+func TestBlockingSecurityAssessmentRequiresExplicitNonInteractiveOverride(t *testing.T) {
+	loaded := loadedPackage{security: testSecurityAssessment(1, 2)}
+	command := securityTestCommand(&bytes.Buffer{}, strings.NewReader(""))
+	err := authorizeSecurityAssessment(command, App{Terminal: false}, &options{format: "human"}, &loaded)
+	if err == nil || !strings.Contains(err.Error(), "--accept-security-risk") || loaded.securityAuthorized {
+		t.Fatalf("blocking assessment error=%v authorized=%t", err, loaded.securityAuthorized)
+	}
+	if err := authorizeSecurityAssessment(command, App{Terminal: false}, &options{format: "human", acceptSecurityRisk: true}, &loaded); err != nil || !loaded.securityAuthorized {
+		t.Fatalf("explicit override error=%v authorized=%t", err, loaded.securityAuthorized)
+	}
+}
+
+func TestBlockingSecurityAssessmentPromptsInteractiveUser(t *testing.T) {
+	output := &bytes.Buffer{}
+	loaded := loadedPackage{security: testSecurityAssessment(1, 0)}
+	command := securityTestCommand(output, strings.NewReader("yes\n"))
+	if err := authorizeSecurityAssessment(command, App{Terminal: true}, &options{format: "human"}, &loaded); err != nil {
+		t.Fatal(err)
+	}
+	if !loaded.securityAuthorized || !strings.Contains(output.String(), "not a guarantee of safety") || !strings.Contains(output.String(), "Continue anyway") {
+		t.Fatalf("unexpected security prompt output: %s", output.String())
+	}
+}
+
+func TestWarningSecurityAssessmentDoesNotPrompt(t *testing.T) {
+	output := &bytes.Buffer{}
+	loaded := loadedPackage{security: testSecurityAssessment(0, 3)}
+	command := securityTestCommand(output, strings.NewReader(""))
+	if err := authorizeSecurityAssessment(command, App{Terminal: true}, &options{format: "human"}, &loaded); err != nil {
+		t.Fatal(err)
+	}
+	if !loaded.securityAuthorized || strings.Contains(output.String(), "Continue anyway") {
+		t.Fatalf("warning assessment prompted unexpectedly: %s", output.String())
+	}
+}
+
+func securityTestCommand(output *bytes.Buffer, input *strings.Reader) *cobra.Command {
+	command := &cobra.Command{}
+	command.SetOut(output)
+	command.SetIn(input)
+	return command
+}
+
+func testSecurityAssessment(blocking, warnings int) *domain.SecurityAssessment {
+	outcome := domain.SecurityNoBlockingFindings
+	if blocking > 0 {
+		outcome = domain.SecurityBlockingFindings
+	} else if warnings > 0 {
+		outcome = domain.SecurityWarnings
+	}
+	return &domain.SecurityAssessment{
+		Scanner: domain.SecurityScanner{ID: domain.SecurityScannerID, Version: domain.SecurityScannerVersion},
+		Outcome: outcome, Counts: domain.SecurityCounts{Blocking: blocking, Warnings: warnings, Total: blocking + warnings},
+		Findings: []domain.SecurityFinding{{Code: "SEC330", Disposition: "blocking", Path: "mcp.json", Message: "test finding"}},
+	}
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/source.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/source.go
@@ -27,6 +27,8 @@ const maxAutodiscoveryPackageCandidates = 16
 
 type loadedPackage struct {
 	envelope              domain.PackageEnvelope
+	security              *domain.SecurityAssessment
+	securityAuthorized    bool
 	hints                 domain.CompatibilityHints
 	origin                domain.OriginMode
 	directory             *domain.DirectoryOrigin
@@ -561,7 +563,17 @@ func (app App) loadSnapshot(ctx context.Context, snapshot domain.PackageSnapshot
 	if envelope.TreeDigest != snapshot.TreeDigest {
 		return fail(fmt.Errorf("loader changed the acquired immutable package digest"))
 	}
-	return loadedPackage{envelope: envelope, origin: origin, directory: cloneDirectoryOrigin(directory), directorySelection: cloneDirectorySelection(selection), cleanup: func() error { return packagedigest.Remove(snapshot) }}, nil
+	var assessment *domain.SecurityAssessment
+	if app.SecurityEvaluator != nil && envelope.FormatID == domain.FormatIDAgentPluginsV1 {
+		result, securityErr := app.SecurityEvaluator.Evaluate(ctx, domain.SecurityEvaluationInput{
+			SnapshotRoot: snapshot.Root, TreeDigest: envelope.TreeDigest, ManifestDigest: envelope.ManifestDigest,
+		})
+		if securityErr != nil {
+			return fail(fmt.Errorf("security assessment failed before installation: %w", securityErr))
+		}
+		assessment = &result
+	}
+	return loadedPackage{envelope: envelope, security: assessment, origin: origin, directory: cloneDirectoryOrigin(directory), directorySelection: cloneDirectorySelection(selection), cleanup: func() error { return packagedigest.Remove(snapshot) }}, nil
 }
 
 // loadAcquiredSnapshot selects a manifest format from the immutable snapshot.

--- a/cli/plugin-kit-ai/internal/agentpluginscli/update_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/update_multi.go
@@ -64,6 +64,9 @@ func runUpdateMany(ctx context.Context, cmd *cobra.Command, app App, opts *optio
 		}
 		return err
 	}
+	if err := authorizeSecurityAssessment(cmd, app, opts, &prepared.loaded); err != nil {
+		return err
+	}
 	if opts.dryRun {
 		return renderUpdateMultiResult(cmd, opts, prepared.result)
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/validate.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/validate.go
@@ -24,17 +24,18 @@ type validationSource struct {
 }
 
 type validationResult struct {
-	Conformant     bool                 `json:"conformant"`
-	Name           string               `json:"name"`
-	Version        string               `json:"version,omitempty"`
-	FormatID       string               `json:"format_id"`
-	SchemaURI      string               `json:"schema_uri"`
-	SchemaVersion  string               `json:"schema_version"`
-	Source         validationSource     `json:"source"`
-	TreeDigest     string               `json:"tree_digest"`
-	ManifestDigest string               `json:"manifest_digest"`
-	Components     validationComponents `json:"components"`
-	Diagnostics    []domain.Diagnostic  `json:"diagnostics,omitempty"`
+	Conformant     bool                       `json:"conformant"`
+	Name           string                     `json:"name"`
+	Version        string                     `json:"version,omitempty"`
+	FormatID       string                     `json:"format_id"`
+	SchemaURI      string                     `json:"schema_uri"`
+	SchemaVersion  string                     `json:"schema_version"`
+	Source         validationSource           `json:"source"`
+	TreeDigest     string                     `json:"tree_digest"`
+	ManifestDigest string                     `json:"manifest_digest"`
+	Components     validationComponents       `json:"components"`
+	Diagnostics    []domain.Diagnostic        `json:"diagnostics,omitempty"`
+	Security       *domain.SecurityAssessment `json:"security,omitempty"`
 }
 
 func newValidateCommand(app App, opts *options) *cobra.Command {
@@ -58,8 +59,12 @@ func newValidateCommand(app App, opts *options) *cobra.Command {
 				defer loaded.cleanup()
 			}
 			result := newValidationResult(loaded.envelope)
+			result.Security = loaded.security
 			if opts.format == "json" {
 				return writeJSONOutput(cmd.OutOrStdout(), "validate", result)
+			}
+			if loaded.security != nil {
+				renderSecurityAssessment(cmd, *loaded.security)
 			}
 			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Valid Agent Plugin: %s %s\nSchema: %s\nSource: %s\nComponents: %d skills, %d MCP servers, %d app bindings\n",
 				result.Name, result.Version, result.SchemaURI, publicPackageSource(loaded.envelope.Source),

--- a/install/integrationctl/agentplugins/adapters/securityscan/cache.go
+++ b/install/integrationctl/agentplugins/adapters/securityscan/cache.go
@@ -1,0 +1,91 @@
+package securityscan
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+type Cache interface {
+	Load(string) (domain.SecurityAssessment, bool)
+	Store(string, domain.SecurityAssessment) error
+}
+
+type FileCache struct {
+	Root string
+}
+
+func CacheKey(subject domain.SecuritySubject, requirement domain.SecurityRequirement) string {
+	value := strings.Join([]string{subject.TreeDigest, subject.ManifestDigest, requirement.Scanner.ID, requirement.Scanner.Version, requirement.Policy.ID, fmt.Sprint(requirement.Policy.Version), requirement.Policy.Digest}, "\x00")
+	digest := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(digest[:])
+}
+
+func (cache FileCache) Load(key string) (domain.SecurityAssessment, bool) {
+	body, err := os.ReadFile(filepath.Join(cache.Root, key+".json"))
+	if err != nil || len(body) > 1<<20 {
+		return domain.SecurityAssessment{}, false
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(body)))
+	decoder.DisallowUnknownFields()
+	var assessment domain.SecurityAssessment
+	if decoder.Decode(&assessment) != nil {
+		return domain.SecurityAssessment{}, false
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return domain.SecurityAssessment{}, false
+	}
+	return assessment, true
+}
+
+func (cache FileCache) Store(key string, assessment domain.SecurityAssessment) error {
+	if len(key) != 64 || cache.Root == "" {
+		return errors.New("invalid security cache target")
+	}
+	if err := os.MkdirAll(cache.Root, 0o700); err != nil {
+		return fmt.Errorf("create security cache: %w", err)
+	}
+	body, err := json.Marshal(assessment)
+	if err != nil {
+		return fmt.Errorf("encode security cache: %w", err)
+	}
+	temporary, err := os.CreateTemp(cache.Root, ".assessment-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create security cache entry: %w", err)
+	}
+	temporaryName := temporary.Name()
+	defer os.Remove(temporaryName)
+	if err := temporary.Chmod(0o600); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if _, err := temporary.Write(body); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	target := filepath.Join(cache.Root, key+".json")
+	if runtime.GOOS == "windows" {
+		_ = os.Remove(target)
+	}
+	if err := os.Rename(temporaryName, target); err != nil {
+		return fmt.Errorf("commit security cache entry: %w", err)
+	}
+	return nil
+}

--- a/install/integrationctl/agentplugins/adapters/securityscan/evaluator.go
+++ b/install/integrationctl/agentplugins/adapters/securityscan/evaluator.go
@@ -1,0 +1,119 @@
+package securityscan
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+const maxPublishedFindings = 32
+
+type Evaluator struct {
+	Scanner     Scanner
+	Cache       Cache
+	Requirement domain.SecurityRequirement
+}
+
+func (evaluator Evaluator) Evaluate(ctx context.Context, input domain.SecurityEvaluationInput) (domain.SecurityAssessment, error) {
+	requirement := evaluator.Requirement
+	if requirement.Scanner.ID == "" {
+		requirement = DefaultRequirement()
+	}
+	subject := domain.SecuritySubject{TreeDigest: input.TreeDigest, ManifestDigest: input.ManifestDigest}
+	if input.Trusted != nil {
+		trusted := *input.Trusted
+		if err := trusted.Validate(requirement, subject); err == nil {
+			trusted.Evidence = domain.SecurityEvidenceSignedIndex
+			return trusted, nil
+		}
+	}
+	key := CacheKey(subject, requirement)
+	if evaluator.Cache != nil {
+		if cached, ok := evaluator.Cache.Load(key); ok && cached.Validate(requirement, subject) == nil {
+			cached.Evidence = domain.SecurityEvidenceCache
+			return cached, nil
+		}
+	}
+	if evaluator.Scanner == nil {
+		return domain.SecurityAssessment{}, errors.New("security scanner is unavailable")
+	}
+	body, err := evaluator.Scanner.Scan(ctx, input.SnapshotRoot)
+	if err != nil {
+		return domain.SecurityAssessment{}, err
+	}
+	report, err := decodeReport(body)
+	if err != nil {
+		return domain.SecurityAssessment{}, err
+	}
+	assessment, err := assessmentFromReport(subject, requirement, report, body)
+	if err != nil {
+		return domain.SecurityAssessment{}, err
+	}
+	assessment.Evidence = domain.SecurityEvidenceLocalScan
+	if evaluator.Cache != nil {
+		cached := assessment
+		cached.Evidence = ""
+		if err := evaluator.Cache.Store(key, cached); err != nil {
+			return domain.SecurityAssessment{}, fmt.Errorf("store security assessment: %w", err)
+		}
+	}
+	return assessment, nil
+}
+
+func assessmentFromReport(subject domain.SecuritySubject, requirement domain.SecurityRequirement, report rawReport, rawReportBody []byte) (domain.SecurityAssessment, error) {
+	digest := sha256.Sum256(rawReportBody)
+	assessment := domain.SecurityAssessment{
+		SchemaVersion: domain.SecurityReportSchemaVersion,
+		Subject:       subject,
+		Scanner:       requirement.Scanner,
+		Policy:        requirement.Policy,
+		ScannedFiles:  report.Stats.ScannedFiles,
+		ReportDigest:  "sha256:" + hex.EncodeToString(digest[:]),
+		Findings:      make([]domain.SecurityFinding, 0, min(len(report.Findings), maxPublishedFindings)),
+	}
+	for _, finding := range report.Findings {
+		code := strings.TrimSpace(finding.RuleCode)
+		message := strings.TrimSpace(finding.Message)
+		if code == "" || message == "" {
+			return domain.SecurityAssessment{}, errors.New("lintai report contains an incomplete finding")
+		}
+		disposition := disposition(code, strings.ToLower(finding.Severity), strings.ToLower(finding.Confidence))
+		assessment.Counts.Total++
+		if disposition == "blocking" {
+			assessment.Counts.Blocking++
+		} else {
+			assessment.Counts.Warnings++
+		}
+		line := 0
+		if finding.Location.Start != nil {
+			line = finding.Location.Start.Line
+		}
+		assessment.Findings = append(assessment.Findings, domain.SecurityFinding{
+			Code: code, Disposition: disposition, Severity: strings.ToLower(finding.Severity), Confidence: strings.ToLower(finding.Confidence),
+			Category: strings.ToLower(finding.Category), Path: filepathSlash(strings.TrimSpace(finding.Location.NormalizedPath)), Line: line, Message: message,
+		})
+	}
+	domain.SortSecurityFindings(assessment.Findings)
+	if len(assessment.Findings) > maxPublishedFindings {
+		assessment.Findings = assessment.Findings[:maxPublishedFindings]
+	}
+	assessment.Outcome = domain.SecurityNoBlockingFindings
+	if assessment.Counts.Blocking > 0 {
+		assessment.Outcome = domain.SecurityBlockingFindings
+	} else if assessment.Counts.Warnings > 0 {
+		assessment.Outcome = domain.SecurityWarnings
+	}
+	if err := assessment.Validate(requirement, subject); err != nil {
+		return domain.SecurityAssessment{}, err
+	}
+	return assessment, nil
+}
+
+func filepathSlash(path string) string {
+	return strings.ReplaceAll(path, "\\", "/")
+}

--- a/install/integrationctl/agentplugins/adapters/securityscan/evaluator_test.go
+++ b/install/integrationctl/agentplugins/adapters/securityscan/evaluator_test.go
@@ -1,0 +1,188 @@
+package securityscan
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+const (
+	testTreeDigest     = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	testManifestDigest = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+type scannerStub struct {
+	body  []byte
+	calls int
+}
+
+func TestReleaseScannerVerifiesArchiveBeforeInstallingBinary(t *testing.T) {
+	archive := tarArchive(t, "release/lintai", []byte("scanner"))
+	digest := sha256.Sum256(archive)
+	original := releaseAssets["test/test"]
+	releaseAssets["test/test"] = releaseAsset{Name: "lintai.tar.gz", Digest: hex.EncodeToString(digest[:])}
+	t.Cleanup(func() {
+		if original.Name == "" {
+			delete(releaseAssets, "test/test")
+		} else {
+			releaseAssets["test/test"] = original
+		}
+	})
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		_, _ = writer.Write(archive)
+	}))
+	defer server.Close()
+	root := t.TempDir()
+	resolved, err := (ReleaseScanner{Root: root, HTTPClient: server.Client(), Origin: server.URL + "/", GOOS: "test", GOARCH: "test"}).resolve(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(resolved)
+	if err != nil || string(body) != "scanner" || filepath.Base(resolved) != "lintai" {
+		t.Fatalf("unexpected installed scanner: path=%s body=%q err=%v", resolved, body, err)
+	}
+}
+
+func TestReleaseScannerRejectsChecksumMismatch(t *testing.T) {
+	original := releaseAssets["test/test"]
+	releaseAssets["test/test"] = releaseAsset{Name: "lintai.tar.gz", Digest: strings.Repeat("0", 64)}
+	t.Cleanup(func() {
+		if original.Name == "" {
+			delete(releaseAssets, "test/test")
+		} else {
+			releaseAssets["test/test"] = original
+		}
+	})
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		_, _ = writer.Write(tarArchive(t, "lintai", []byte("scanner")))
+	}))
+	defer server.Close()
+	_, err := (ReleaseScanner{Root: t.TempDir(), HTTPClient: server.Client(), Origin: server.URL + "/", GOOS: "test", GOARCH: "test"}).resolve(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "checksum") {
+		t.Fatalf("checksum mismatch error = %v", err)
+	}
+}
+
+func tarArchive(t *testing.T, name string, body []byte) []byte {
+	t.Helper()
+	var output bytes.Buffer
+	gz := gzip.NewWriter(&output)
+	writer := tar.NewWriter(gz)
+	if err := writer.WriteHeader(&tar.Header{Name: name, Typeflag: tar.TypeReg, Mode: 0o755, Size: int64(len(body))}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(writer, bytes.NewReader(body)); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return output.Bytes()
+}
+
+func (scanner *scannerStub) Scan(context.Context, string) ([]byte, error) {
+	scanner.calls++
+	return scanner.body, nil
+}
+
+type memoryCache map[string]domain.SecurityAssessment
+
+func (cache memoryCache) Load(key string) (domain.SecurityAssessment, bool) {
+	value, ok := cache[key]
+	return value, ok
+}
+
+func (cache memoryCache) Store(key string, value domain.SecurityAssessment) error {
+	cache[key] = value
+	return nil
+}
+
+func TestEvaluatorClassifiesHighConfidenceInstallRiskAndCachesExactTuple(t *testing.T) {
+	scanner := &scannerStub{body: reportJSON(t, []map[string]any{
+		finding("SEC330", "warn", "high", "mcp.json", "remote content is piped to a shell"),
+		finding("SEC302", "warn", "high", "mcp.json", "plain HTTP endpoint"),
+	})}
+	cache := memoryCache{}
+	evaluator := Evaluator{Scanner: scanner, Cache: cache, Requirement: DefaultRequirement()}
+	input := domain.SecurityEvaluationInput{SnapshotRoot: t.TempDir(), TreeDigest: testTreeDigest, ManifestDigest: testManifestDigest}
+
+	first, err := evaluator.Evaluate(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Outcome != domain.SecurityBlockingFindings || first.Counts.Blocking != 1 || first.Counts.Warnings != 1 || first.Evidence != domain.SecurityEvidenceLocalScan {
+		t.Fatalf("unexpected first assessment: %+v", first)
+	}
+	second, err := evaluator.Evaluate(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scanner.calls != 1 || second.Evidence != domain.SecurityEvidenceCache {
+		t.Fatalf("exact cache tuple was not reused: calls=%d assessment=%+v", scanner.calls, second)
+	}
+}
+
+func TestEvaluatorRejectsStaleTrustedEvidenceAndRescans(t *testing.T) {
+	scanner := &scannerStub{body: reportJSON(t, nil)}
+	requirement := DefaultRequirement()
+	trusted := domain.SecurityAssessment{
+		SchemaVersion: domain.SecurityReportSchemaVersion,
+		Subject:       domain.SecuritySubject{TreeDigest: testTreeDigest, ManifestDigest: testManifestDigest},
+		Scanner:       domain.SecurityScanner{ID: domain.SecurityScannerID, Version: "0.1.1"},
+		Policy:        requirement.Policy,
+		Outcome:       domain.SecurityNoBlockingFindings,
+		ReportDigest:  testTreeDigest,
+	}
+	result, err := (Evaluator{Scanner: scanner, Requirement: requirement}).Evaluate(context.Background(), domain.SecurityEvaluationInput{
+		SnapshotRoot: t.TempDir(), TreeDigest: testTreeDigest, ManifestDigest: testManifestDigest, Trusted: &trusted,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scanner.calls != 1 || result.Evidence != domain.SecurityEvidenceLocalScan {
+		t.Fatalf("stale evidence bypassed local scan: calls=%d result=%+v", scanner.calls, result)
+	}
+}
+
+func reportJSON(t *testing.T, findings []map[string]any) []byte {
+	t.Helper()
+	if findings == nil {
+		findings = []map[string]any{}
+	}
+	body, err := json.Marshal(map[string]any{
+		"schema_version": 1,
+		"tool":           map[string]any{"name": "lintai", "version": domain.SecurityScannerVersion},
+		"policy":         map[string]any{"id": domain.SecurityPolicyID, "version": domain.SecurityPolicyVersion, "presets": []string{"recommended", "preview", "threat-review", "supply-chain", "advisory"}},
+		"stats":          map[string]any{"scanned_files": 3, "skipped_files": 0},
+		"findings":       findings,
+		"diagnostics":    []any{},
+		"runtime_errors": []any{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func finding(code, severity, confidence, path, message string) map[string]any {
+	return map[string]any{
+		"rule_code": code, "category": "security", "severity": severity, "confidence": confidence, "message": message,
+		"location": map[string]any{"normalized_path": path, "span": map[string]any{"start_byte": 0, "end_byte": 1}, "start": map[string]any{"line": 1, "column": 1}, "end": nil},
+	}
+}

--- a/install/integrationctl/agentplugins/adapters/securityscan/policy.go
+++ b/install/integrationctl/agentplugins/adapters/securityscan/policy.go
@@ -1,0 +1,61 @@
+package securityscan
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+// blockingRuleCodes is intentionally narrow and versioned. It contains
+// high-confidence behavior that can persist, execute remote content, damage the
+// host, or exfiltrate sensitive data. Other findings remain visible warnings.
+var blockingRuleCodes = map[string]struct{}{
+	"SEC102": {}, "SEC103": {}, "SEC330": {}, "SEC344": {},
+	"SEC637": {}, "SEC640": {}, "SEC645": {}, "SEC648": {},
+	"SEC652": {}, "SEC653": {}, "SEC654": {}, "SEC658": {}, "SEC659": {}, "SEC660": {},
+	"SEC665": {}, "SEC666": {}, "SEC671": {}, "SEC672": {},
+	"SEC674": {}, "SEC675": {}, "SEC676": {}, "SEC680": {}, "SEC681": {}, "SEC682": {},
+	"SEC684": {}, "SEC686": {}, "SEC697": {}, "SEC698": {}, "SEC701": {}, "SEC702": {},
+	"SEC706": {}, "SEC710": {}, "SEC717": {}, "SEC718": {}, "SEC725": {}, "SEC726": {},
+	"SEC729": {}, "SEC730": {}, "SEC733": {}, "SEC734": {}, "SEC738": {}, "SEC742": {},
+}
+
+func DefaultRequirement() domain.SecurityRequirement {
+	return domain.SecurityRequirement{
+		Scanner: domain.SecurityScanner{ID: domain.SecurityScannerID, Version: domain.SecurityScannerVersion},
+		Policy:  domain.SecurityPolicy{ID: domain.SecurityPolicyID, Version: domain.SecurityPolicyVersion, Digest: policyDigest()},
+	}
+}
+
+func policyDigest() string {
+	codes := make([]string, 0, len(blockingRuleCodes))
+	for code := range blockingRuleCodes {
+		codes = append(codes, code)
+	}
+	sort.Strings(codes)
+	document := map[string]any{
+		"id": domain.SecurityPolicyID, "version": domain.SecurityPolicyVersion,
+		"blocking_confidence": "high", "blocking_rule_codes": codes, "deny_is_blocking": true,
+	}
+	body, err := json.Marshal(document)
+	if err != nil {
+		panic(err)
+	}
+	digest := sha256.Sum256(body)
+	return "sha256:" + hex.EncodeToString(digest[:])
+}
+
+func disposition(code, severity, confidence string) string {
+	if severity == "deny" {
+		return "blocking"
+	}
+	if confidence == "high" {
+		if _, ok := blockingRuleCodes[code]; ok {
+			return "blocking"
+		}
+	}
+	return "warning"
+}

--- a/install/integrationctl/agentplugins/adapters/securityscan/release.go
+++ b/install/integrationctl/agentplugins/adapters/securityscan/release.go
@@ -1,0 +1,212 @@
+package securityscan
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+const (
+	defaultReleaseOrigin = "https://github.com/777genius/lintai/releases/download/v0.1.2/"
+	maxReleaseAsset      = 32 << 20
+)
+
+type releaseAsset struct {
+	Name   string
+	Digest string
+	Zip    bool
+}
+
+var releaseAssets = map[string]releaseAsset{
+	"darwin/arm64":     {"lintai-v0.1.2-aarch64-apple-darwin.tar.gz", "b02b40ad25ae6a2c9358400b1560ec4c358a82ff9f3d2ad6daf0bcbf0a426277", false},
+	"darwin/amd64":     {"lintai-v0.1.2-x86_64-apple-darwin.tar.gz", "dbc74549d6f4da4e4460d4a671f8da7933298d9a82831b058f37a210e7291eb9", false},
+	"linux/arm64":      {"lintai-v0.1.2-aarch64-unknown-linux-gnu.tar.gz", "31df7193cfe8298bec99af9b843f38379e93ab82fee6dd577debdc55a5c1e051", false},
+	"linux/amd64":      {"lintai-v0.1.2-x86_64-unknown-linux-gnu.tar.gz", "c06fcb33a13f1483f20f4cb30d2c701cd01c6b8ba43e3b7322ebab3c1ae11e72", false},
+	"linux/amd64-musl": {"lintai-v0.1.2-x86_64-unknown-linux-musl.tar.gz", "c4f6b45cb959855107d9b1425eed1e4409c5c7d9f3e15c1784f7e2c2569c9792", false},
+	"windows/amd64":    {"lintai-v0.1.2-x86_64-pc-windows-msvc.zip", "4cc96dfbefb0a213767ed591bd6f78ab83fd06e9b40af1fad4590e53457c96c4", true},
+	"windows/arm64":    {"lintai-v0.1.2-aarch64-pc-windows-msvc.zip", "ff85139ee2968a829daf0e4f8d701c7dbe3ec1078ca8bb81029057be75b86629", true},
+}
+
+type ReleaseScanner struct {
+	Root       string
+	HTTPClient *http.Client
+	Origin     string
+	GOOS       string
+	GOARCH     string
+}
+
+func (scanner ReleaseScanner) Scan(ctx context.Context, packageRoot string) ([]byte, error) {
+	executable, err := scanner.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return (CommandScanner{Executable: executable}).Scan(ctx, packageRoot)
+}
+
+func (scanner ReleaseScanner) resolve(ctx context.Context) (string, error) {
+	goos, goarch := scanner.GOOS, scanner.GOARCH
+	if goos == "" {
+		goos = runtime.GOOS
+	}
+	if goarch == "" {
+		goarch = runtime.GOARCH
+	}
+	key := goos + "/" + goarch
+	if goos == "linux" && goarch == "amd64" && usesMusl() {
+		key += "-musl"
+	}
+	asset, ok := releaseAssets[key]
+	if !ok {
+		return "", fmt.Errorf("lintai security scanner is not released for %s", key)
+	}
+	if scanner.Root == "" {
+		return "", errors.New("lintai security scanner cache root is unavailable")
+	}
+	binaryName := "lintai"
+	if goos == "windows" {
+		binaryName += ".exe"
+	}
+	directory := filepath.Join(scanner.Root, domain.SecurityScannerVersion, strings.ReplaceAll(key, "/", "-"))
+	executable := filepath.Join(directory, binaryName)
+	if info, err := os.Lstat(executable); err == nil && info.Mode().IsRegular() {
+		return executable, nil
+	}
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return "", fmt.Errorf("create lintai cache: %w", err)
+	}
+	origin := scanner.Origin
+	if origin == "" {
+		origin = defaultReleaseOrigin
+	}
+	client := scanner.HTTPClient
+	if client == nil {
+		client = &http.Client{}
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, origin+asset.Name, nil)
+	if err != nil {
+		return "", err
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return "", fmt.Errorf("download lintai security scanner: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download lintai security scanner: HTTP %d", response.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxReleaseAsset+1))
+	if err != nil || len(body) > maxReleaseAsset {
+		return "", errors.New("downloaded lintai release asset is unreadable or oversized")
+	}
+	digest := sha256.Sum256(body)
+	if hex.EncodeToString(digest[:]) != asset.Digest {
+		return "", errors.New("downloaded lintai release asset failed checksum verification")
+	}
+	binary, err := extractReleaseBinary(body, asset.Zip, binaryName)
+	if err != nil {
+		return "", err
+	}
+	temporary, err := os.CreateTemp(directory, ".lintai-*.tmp")
+	if err != nil {
+		return "", err
+	}
+	temporaryName := temporary.Name()
+	defer os.Remove(temporaryName)
+	if err := temporary.Chmod(0o700); err != nil {
+		_ = temporary.Close()
+		return "", err
+	}
+	if _, err := temporary.Write(binary); err != nil {
+		_ = temporary.Close()
+		return "", err
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return "", err
+	}
+	if err := temporary.Close(); err != nil {
+		return "", err
+	}
+	if err := os.Rename(temporaryName, executable); err != nil {
+		if info, statErr := os.Lstat(executable); statErr == nil && info.Mode().IsRegular() {
+			return executable, nil
+		}
+		return "", fmt.Errorf("commit lintai security scanner: %w", err)
+	}
+	return executable, nil
+}
+
+func extractReleaseBinary(body []byte, zipAsset bool, binaryName string) ([]byte, error) {
+	if zipAsset {
+		archive, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
+		if err != nil {
+			return nil, fmt.Errorf("open lintai release archive: %w", err)
+		}
+		for _, entry := range archive.File {
+			if filepath.Base(filepath.ToSlash(entry.Name)) != binaryName || !entry.Mode().IsRegular() || entry.UncompressedSize64 > maxReleaseAsset {
+				continue
+			}
+			reader, err := entry.Open()
+			if err != nil {
+				return nil, err
+			}
+			value, readErr := io.ReadAll(io.LimitReader(reader, maxReleaseAsset+1))
+			closeErr := reader.Close()
+			if readErr != nil || closeErr != nil || len(value) > maxReleaseAsset {
+				return nil, errors.New("read lintai binary from release archive")
+			}
+			return value, nil
+		}
+		return nil, errors.New("lintai release archive does not contain the expected binary")
+	}
+	gzipReader, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("open lintai release archive: %w", err)
+	}
+	defer gzipReader.Close()
+	tarReader := tar.NewReader(gzipReader)
+	for {
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read lintai release archive: %w", err)
+		}
+		if filepath.Base(filepath.ToSlash(header.Name)) != binaryName || header.Typeflag != tar.TypeReg || header.Size < 0 || header.Size > maxReleaseAsset {
+			continue
+		}
+		value, err := io.ReadAll(io.LimitReader(tarReader, maxReleaseAsset+1))
+		if err != nil || len(value) > maxReleaseAsset {
+			return nil, errors.New("read lintai binary from release archive")
+		}
+		return value, nil
+	}
+	return nil, errors.New("lintai release archive does not contain the expected binary")
+}
+
+func usesMusl() bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	for _, candidate := range []string{"/lib/ld-musl-x86_64.so.1", "/lib64/ld-musl-x86_64.so.1"} {
+		if _, err := os.Stat(candidate); err == nil {
+			return true
+		}
+	}
+	return false
+}

--- a/install/integrationctl/agentplugins/adapters/securityscan/scanner.go
+++ b/install/integrationctl/agentplugins/adapters/securityscan/scanner.go
@@ -1,0 +1,155 @@
+package securityscan
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+const (
+	maxScannerOutput = 8 << 20
+	maxScannerError  = 64 << 10
+)
+
+type Scanner interface {
+	Scan(context.Context, string) ([]byte, error)
+}
+
+type CommandScanner struct {
+	Executable string
+	Timeout    time.Duration
+}
+
+func (scanner CommandScanner) Scan(ctx context.Context, packageRoot string) ([]byte, error) {
+	if strings.TrimSpace(scanner.Executable) == "" {
+		return nil, errors.New("lintai executable is unavailable")
+	}
+	executable, err := filepath.Abs(scanner.Executable)
+	if err != nil || !filepath.IsAbs(executable) {
+		return nil, fmt.Errorf("resolve lintai executable: %w", err)
+	}
+	deadline := scanner.Timeout
+	if deadline <= 0 {
+		deadline = 30 * time.Second
+	}
+	scanCtx, cancel := context.WithTimeout(ctx, deadline)
+	defer cancel()
+	command := exec.CommandContext(scanCtx, executable, "scan-agent-plugin", packageRoot)
+	command.Dir = packageRoot
+	command.Env = scannerEnvironment()
+	stdout := &limitedBuffer{limit: maxScannerOutput}
+	stderr := &limitedBuffer{limit: maxScannerError}
+	command.Stdout = stdout
+	command.Stderr = stderr
+	err = command.Run()
+	if errors.Is(scanCtx.Err(), context.DeadlineExceeded) {
+		return nil, fmt.Errorf("lintai security scan timed out")
+	}
+	if stdout.overflow || stderr.overflow {
+		return nil, fmt.Errorf("lintai security scan exceeded its output limit")
+	}
+	if err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+			return nil, fmt.Errorf("lintai security scan failed: %s", strings.TrimSpace(stderr.String()))
+		}
+	}
+	return append([]byte(nil), stdout.Bytes()...), nil
+}
+
+func scannerEnvironment() []string {
+	allowed := []string{"SystemRoot", "WINDIR", "TEMP", "TMP", "TMPDIR"}
+	environment := make([]string, 0, len(allowed)+1)
+	for _, key := range allowed {
+		if value, ok := os.LookupEnv(key); ok {
+			environment = append(environment, key+"="+value)
+		}
+	}
+	if runtime.GOOS != "windows" {
+		environment = append(environment, "PATH=/usr/bin:/bin")
+	}
+	return environment
+}
+
+type limitedBuffer struct {
+	bytes.Buffer
+	limit    int
+	overflow bool
+}
+
+func (buffer *limitedBuffer) Write(value []byte) (int, error) {
+	if buffer.Buffer.Len()+len(value) > buffer.limit {
+		remaining := buffer.limit - buffer.Buffer.Len()
+		if remaining > 0 {
+			_, _ = buffer.Buffer.Write(value[:remaining])
+		}
+		buffer.overflow = true
+		return len(value), nil
+	}
+	return buffer.Buffer.Write(value)
+}
+
+type rawReport struct {
+	SchemaVersion int `json:"schema_version"`
+	Tool          struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	} `json:"tool"`
+	Policy struct {
+		ID      string   `json:"id"`
+		Version int      `json:"version"`
+		Presets []string `json:"presets"`
+	} `json:"policy"`
+	Stats struct {
+		ScannedFiles int `json:"scanned_files"`
+		SkippedFiles int `json:"skipped_files"`
+	} `json:"stats"`
+	Findings      []rawFinding      `json:"findings"`
+	Diagnostics   []json.RawMessage `json:"diagnostics"`
+	RuntimeErrors []json.RawMessage `json:"runtime_errors"`
+}
+
+type rawFinding struct {
+	RuleCode   string `json:"rule_code"`
+	Category   string `json:"category"`
+	Severity   string `json:"severity"`
+	Confidence string `json:"confidence"`
+	Message    string `json:"message"`
+	Location   struct {
+		NormalizedPath string `json:"normalized_path"`
+		Start          *struct {
+			Line int `json:"line"`
+		} `json:"start"`
+	} `json:"location"`
+}
+
+func decodeReport(body []byte) (rawReport, error) {
+	if len(body) == 0 || len(body) > maxScannerOutput || !json.Valid(body) {
+		return rawReport{}, errors.New("lintai returned invalid JSON")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	var report rawReport
+	if err := decoder.Decode(&report); err != nil {
+		return rawReport{}, fmt.Errorf("decode lintai report: %w", err)
+	}
+	if report.SchemaVersion != 1 || report.Tool.Name != "lintai" || report.Tool.Version != domain.SecurityScannerVersion || report.Policy.ID != domain.SecurityPolicyID || report.Policy.Version != domain.SecurityPolicyVersion {
+		return rawReport{}, errors.New("lintai report has an unsupported scanner or policy identity")
+	}
+	if len(report.RuntimeErrors) != 0 {
+		return rawReport{}, errors.New("lintai could not scan every selected package surface")
+	}
+	if report.Stats.ScannedFiles < 0 || report.Stats.SkippedFiles < 0 {
+		return rawReport{}, errors.New("lintai report contains invalid scan counts")
+	}
+	return report, nil
+}

--- a/install/integrationctl/agentplugins/domain/security.go
+++ b/install/integrationctl/agentplugins/domain/security.go
@@ -1,0 +1,145 @@
+package domain
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const (
+	SecurityReportSchemaVersion = 1
+	SecurityScannerID           = "lintai"
+	SecurityScannerVersion      = "0.1.2"
+	SecurityPolicyID            = "agent-plugin-install"
+	SecurityPolicyVersion       = 1
+)
+
+var securityDigestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+type SecurityOutcome string
+
+const (
+	SecurityNoBlockingFindings SecurityOutcome = "no_blocking_findings"
+	SecurityWarnings           SecurityOutcome = "warnings"
+	SecurityBlockingFindings   SecurityOutcome = "blocking_findings"
+)
+
+type SecurityEvidenceSource string
+
+const (
+	SecurityEvidenceSignedIndex SecurityEvidenceSource = "signed_index"
+	SecurityEvidenceCache       SecurityEvidenceSource = "cache"
+	SecurityEvidenceLocalScan   SecurityEvidenceSource = "local_scan"
+)
+
+type SecuritySubject struct {
+	TreeDigest     string `json:"tree_digest"`
+	ManifestDigest string `json:"manifest_digest"`
+}
+
+type SecurityScanner struct {
+	ID      string `json:"id"`
+	Version string `json:"version"`
+}
+
+type SecurityPolicy struct {
+	ID      string `json:"id"`
+	Version int    `json:"version"`
+	Digest  string `json:"digest"`
+}
+
+type SecurityCounts struct {
+	Blocking int `json:"blocking"`
+	Warnings int `json:"warnings"`
+	Total    int `json:"total"`
+}
+
+type SecurityFinding struct {
+	Code        string `json:"code"`
+	Disposition string `json:"disposition"`
+	Severity    string `json:"severity"`
+	Confidence  string `json:"confidence"`
+	Category    string `json:"category"`
+	Path        string `json:"path"`
+	Line        int    `json:"line,omitempty"`
+	Message     string `json:"message"`
+}
+
+type SecurityAssessment struct {
+	SchemaVersion int                    `json:"schema_version"`
+	Subject       SecuritySubject        `json:"subject"`
+	Scanner       SecurityScanner        `json:"scanner"`
+	Policy        SecurityPolicy         `json:"policy"`
+	Outcome       SecurityOutcome        `json:"outcome"`
+	Counts        SecurityCounts         `json:"counts"`
+	ScannedFiles  int                    `json:"scanned_files"`
+	ReportDigest  string                 `json:"report_digest"`
+	Findings      []SecurityFinding      `json:"findings,omitempty"`
+	Evidence      SecurityEvidenceSource `json:"evidence_source,omitempty"`
+}
+
+type SecurityRequirement struct {
+	Scanner SecurityScanner
+	Policy  SecurityPolicy
+}
+
+type SecurityEvaluationInput struct {
+	SnapshotRoot   string
+	TreeDigest     string
+	ManifestDigest string
+	Trusted        *SecurityAssessment
+}
+
+func (assessment SecurityAssessment) Validate(requirement SecurityRequirement, subject SecuritySubject) error {
+	if assessment.SchemaVersion != SecurityReportSchemaVersion {
+		return fmt.Errorf("unsupported security report schema %d", assessment.SchemaVersion)
+	}
+	if assessment.Subject != subject {
+		return errors.New("security assessment does not describe the acquired package")
+	}
+	if assessment.Scanner != requirement.Scanner || assessment.Policy != requirement.Policy {
+		return errors.New("security assessment scanner or policy is stale")
+	}
+	if !securityDigestPattern.MatchString(assessment.Subject.TreeDigest) || !securityDigestPattern.MatchString(assessment.Subject.ManifestDigest) || !securityDigestPattern.MatchString(assessment.Policy.Digest) || !securityDigestPattern.MatchString(assessment.ReportDigest) {
+		return errors.New("security assessment contains an invalid digest")
+	}
+	if assessment.Counts.Blocking < 0 || assessment.Counts.Warnings < 0 || assessment.Counts.Total < 0 || assessment.Counts.Total < assessment.Counts.Blocking+assessment.Counts.Warnings || assessment.ScannedFiles < 0 {
+		return errors.New("security assessment contains invalid counts")
+	}
+	expected := SecurityNoBlockingFindings
+	if assessment.Counts.Blocking > 0 {
+		expected = SecurityBlockingFindings
+	} else if assessment.Counts.Warnings > 0 {
+		expected = SecurityWarnings
+	}
+	if assessment.Outcome != expected {
+		return errors.New("security assessment outcome does not match its counts")
+	}
+	for _, finding := range assessment.Findings {
+		if strings.TrimSpace(finding.Code) == "" || strings.TrimSpace(finding.Message) == "" || (finding.Disposition != "blocking" && finding.Disposition != "warning") {
+			return errors.New("security assessment contains an invalid finding")
+		}
+	}
+	return nil
+}
+
+func SortSecurityFindings(findings []SecurityFinding) {
+	sort.Slice(findings, func(i, j int) bool {
+		left, right := findings[i], findings[j]
+		if left.Disposition != right.Disposition {
+			return left.Disposition < right.Disposition
+		}
+		if left.Code != right.Code {
+			return left.Code < right.Code
+		}
+		if left.Path != right.Path {
+			return left.Path < right.Path
+		}
+		if left.Line != right.Line {
+			return left.Line < right.Line
+		}
+		return left.Message < right.Message
+	})
+}

--- a/install/integrationctl/agentplugins/ports/interfaces.go
+++ b/install/integrationctl/agentplugins/ports/interfaces.go
@@ -43,6 +43,12 @@ type PackageLoader interface {
 	Load(context.Context, domain.LoadInput) (domain.PackageEnvelope, error)
 }
 
+// PackageSecurityEvaluator inspects the already acquired immutable snapshot.
+// It must complete before any client or managed package file is changed.
+type PackageSecurityEvaluator interface {
+	Evaluate(context.Context, domain.SecurityEvaluationInput) (domain.SecurityAssessment, error)
+}
+
 type ClientDetector interface {
 	Detect(context.Context) ([]domain.DetectedClient, error)
 }


### PR DESCRIPTION
## Summary

- run LintAI's fixed Agent Plugins 1.0 scan against the immutable staged package before client planning or mutation
- verify and lazily install the exact v0.1.2 scanner release by pinned archive checksum across supported platforms
- cache only the exact tree, manifest, scanner, and policy tuple
- show warnings without prompting and require explicit confirmation or `--accept-security-risk` for blocking findings
- expose neutral automated-check evidence without claiming that a package is safe

## Verification

- `go test ./cli/plugin-kit-ai/internal/agentpluginscli ./cli/plugin-kit-ai/cmd/agentplugins ./install/integrationctl/agentplugins/adapters/securityscan ./install/integrationctl/agentplugins/domain`
- real disposable-package checks for clean, warning, blocking, and cache-hit outcomes
- noninteractive blocking add stopped before any client or managed-package files were written

`go test ./...` reached the repository's existing 10-minute `repotests` timeout in the Gemini generated-config canary; all packages changed by this PR passed independently.
