### PR TITLE
feat(agentplugins): consume signed security assessments

### DIFF
--- a/cli/plugin-kit-ai/cmd/agentplugins/directory_configuration_test.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins/directory_configuration_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/777genius/plugin-kit-ai/cli/cmd/agentplugins/internal/bootstrapio"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/directoryv1"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/securityv1"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 )
 
@@ -54,9 +55,31 @@ func TestProductionDirectoryIgnoresCallerSuppliedConformanceData(t *testing.T) {
 }
 
 func TestProductionDefaultsUseTheStandaloneRegistry(t *testing.T) {
-	if want := "https://777genius.github.io/universal-agent-plugins-registry/"; !strings.HasPrefix(defaultDirectoryOrigin, want) || !strings.HasPrefix(defaultDiscoveryOrigin, want) {
-		t.Fatalf("production feed defaults must use the standalone registry: directory=%q discovery=%q", defaultDirectoryOrigin, defaultDiscoveryOrigin)
+	if want := "https://777genius.github.io/universal-agent-plugins-registry/"; !strings.HasPrefix(defaultDirectoryOrigin, want) || !strings.HasPrefix(defaultDiscoveryOrigin, want) || !strings.HasPrefix(defaultSecurityOrigin, want) {
+		t.Fatalf("production feed defaults must use the standalone registry: directory=%q discovery=%q security=%q", defaultDirectoryOrigin, defaultDiscoveryOrigin, defaultSecurityOrigin)
 	}
+}
+
+func TestProductionSecurityIndexUsesIndependentOriginAndPinnedTrust(t *testing.T) {
+	clearDirectoryEnvironment(t)
+	client, err := newSecurityClient(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.Origin != defaultSecurityOrigin || client.Trust.KeyID != defaultSecurityKeyID || len(client.Trust.PublicKey) != ed25519.PublicKeySize {
+		t.Fatalf("production Security Index configuration = %+v", client)
+	}
+	t.Setenv("AGENTPLUGINS_SECURITY_ORIGIN", "https://mirror.example/security/")
+	client, err = newSecurityClient(t.TempDir())
+	if err != nil || client.Origin != "https://mirror.example/security/" {
+		t.Fatalf("custom Security Index origin = %q err=%v", client.Origin, err)
+	}
+	for _, value := range []string{"http://mirror.example/security/", "https://mirror.example/security", "https://mirror.example/security/../trust/"} {
+		if _, err := productionFeedOrigin(value, defaultSecurityOrigin, "AGENTPLUGINS_SECURITY_ORIGIN"); err == nil {
+			t.Fatalf("unsafe Security Index origin accepted: %q", value)
+		}
+	}
+	_ = securityv1.SchemaVersion
 }
 
 func TestTestOnlyDependencyInjectionPreservesExactLaunchConformance(t *testing.T) {
@@ -165,7 +188,7 @@ func TestProductionDirectoryOriginValidation(t *testing.T) {
 
 func clearDirectoryEnvironment(t *testing.T) {
 	t.Helper()
-	for _, name := range append(append([]string{}, forbiddenProductionDirectoryVariables...), "AGENTPLUGINS_DIRECTORY_ORIGIN", "AGENTPLUGINS_DISCOVERY_ORIGIN") {
+	for _, name := range append(append([]string{}, forbiddenProductionDirectoryVariables...), "AGENTPLUGINS_DIRECTORY_ORIGIN", "AGENTPLUGINS_DISCOVERY_ORIGIN", "AGENTPLUGINS_SECURITY_ORIGIN") {
 		value, existed := os.LookupEnv(name)
 		if err := os.Unsetenv(name); err != nil {
 			t.Fatal(err)

--- a/cli/plugin-kit-ai/cmd/agentplugins/main.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/loader"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/processlock"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/securityscan"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/securityv1"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/sourceacquisition"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/specregistry"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/statemigration"
@@ -45,8 +46,12 @@ var (
 	defaultDiscoveryOrigin    = "https://777genius.github.io/universal-agent-plugins-registry/discovery/"
 	defaultDiscoveryKeyID     = "uap-discovery-2026-01"
 	defaultDiscoveryPublicKey = "IxWvGuscXR9crlCrGyBQZNqroYNVPbBA1B3pnjSffhc="
+	defaultSecurityOrigin     = "https://777genius.github.io/universal-agent-plugins-registry/security/"
+	defaultSecurityKeyID      = "uap-discovery-2026-01"
+	defaultSecurityPublicKey  = "IxWvGuscXR9crlCrGyBQZNqroYNVPbBA1B3pnjSffhc="
 	directoryClientFactory    = newDirectoryClient
 	discoveryClientFactory    = newDiscoveryClient
+	securityClientFactory     = newSecurityClient
 )
 
 func main() {
@@ -70,6 +75,10 @@ func run() error {
 		return err
 	}
 	discoveryClient, err := discoveryClientFactory(dataRoot)
+	if err != nil {
+		return err
+	}
+	securityClient, err := securityClientFactory(dataRoot)
 	if err != nil {
 		return err
 	}
@@ -111,6 +120,7 @@ func run() error {
 		SourceAcquirer:      lazySourceAcquirer{dataRoot: dataRoot, acquirer: sourceacquisition.Acquirer{TempRoot: dataRoot}},
 		PackageLoader:       packageLoader,
 		NativePackageLoader: loader.OpenAILoader{Loader: packageLoader},
+		SecurityIndex:       securityClient,
 		SecurityEvaluator: securityscan.Evaluator{
 			Scanner: securityscan.ReleaseScanner{Root: filepath.Join(dataRoot, "security", "lintai"), HTTPClient: lintaiReleaseHTTPClient()},
 			Cache:   securityscan.FileCache{Root: filepath.Join(dataRoot, "security", "assessments")}, Requirement: securityscan.DefaultRequirement(),
@@ -124,6 +134,21 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	return agentpluginscli.NewRoot(app).ExecuteContext(ctx)
+}
+
+func newSecurityClient(_ string) (*securityv1.Client, error) {
+	publicKey, err := base64.StdEncoding.Strict().DecodeString(defaultSecurityPublicKey)
+	if err != nil || len(publicKey) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("decode Security Index public key")
+	}
+	origin, err := productionFeedOrigin(os.Getenv("AGENTPLUGINS_SECURITY_ORIGIN"), defaultSecurityOrigin, "AGENTPLUGINS_SECURITY_ORIGIN")
+	if err != nil {
+		return nil, err
+	}
+	return &securityv1.Client{
+		Origin: origin, HTTPClient: hardenedHTTPClient("Security Index"),
+		Trust: securityv1.TrustStore{KeyID: defaultSecurityKeyID, PublicKey: ed25519.PublicKey(publicKey)},
+	}, nil
 }
 
 func newDiscoveryClient(dataRoot string) (*discoveryv1.Client, error) {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/app.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/app.go
@@ -23,6 +23,10 @@ type DiscoveryClient interface {
 	Load(context.Context, uint64) (discoveryv1.VerifiedBundle, error)
 }
 
+type SecurityIndex interface {
+	Lookup(context.Context, domain.SecuritySubject) (*domain.SecurityAssessment, error)
+}
+
 type SourceAcquirer interface {
 	AcquireLocal(context.Context, string) (domain.PackageSnapshot, error)
 	DiscoverGitHubPackages(context.Context, string, string) ([]string, error)
@@ -41,6 +45,7 @@ type App struct {
 	SourceAcquirer      SourceAcquirer
 	PackageLoader       ports.PackageLoader
 	NativePackageLoader ports.PackageLoader
+	SecurityIndex       SecurityIndex
 	SecurityEvaluator   ports.PackageSecurityEvaluator
 	Lifecycle           usecase.Service
 	StateMigrator       *statemigration.Migrator

--- a/cli/plugin-kit-ai/internal/agentpluginscli/source.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/source.go
@@ -565,8 +565,17 @@ func (app App) loadSnapshot(ctx context.Context, snapshot domain.PackageSnapshot
 	}
 	var assessment *domain.SecurityAssessment
 	if app.SecurityEvaluator != nil && envelope.FormatID == domain.FormatIDAgentPluginsV1 {
+		var trusted *domain.SecurityAssessment
+		if app.SecurityIndex != nil {
+			// The signed index is an optimization, not an availability dependency.
+			// Any fetch, signature, expiry, version, or subject mismatch falls back
+			// to the pinned local scanner before mutation.
+			trusted, _ = app.SecurityIndex.Lookup(ctx, domain.SecuritySubject{
+				TreeDigest: envelope.TreeDigest, ManifestDigest: envelope.ManifestDigest,
+			})
+		}
 		result, securityErr := app.SecurityEvaluator.Evaluate(ctx, domain.SecurityEvaluationInput{
-			SnapshotRoot: snapshot.Root, TreeDigest: envelope.TreeDigest, ManifestDigest: envelope.ManifestDigest,
+			SnapshotRoot: snapshot.Root, TreeDigest: envelope.TreeDigest, ManifestDigest: envelope.ManifestDigest, Trusted: trusted,
 		})
 		if securityErr != nil {
 			return fail(fmt.Errorf("security assessment failed before installation: %w", securityErr))

--- a/install/integrationctl/agentplugins/adapters/securityscan/evaluator_test.go
+++ b/install/integrationctl/agentplugins/adapters/securityscan/evaluator_test.go
@@ -160,6 +160,34 @@ func TestEvaluatorRejectsStaleTrustedEvidenceAndRescans(t *testing.T) {
 	}
 }
 
+func TestEvaluatorAcceptsOnlyExactTrustedEvidenceWithoutScanning(t *testing.T) {
+	requirement := DefaultRequirement()
+	trusted := domain.SecurityAssessment{
+		SchemaVersion: domain.SecurityReportSchemaVersion,
+		Subject:       domain.SecuritySubject{TreeDigest: testTreeDigest, ManifestDigest: testManifestDigest},
+		Scanner:       requirement.Scanner,
+		Policy:        requirement.Policy,
+		Outcome:       domain.SecurityWarnings,
+		Counts:        domain.SecurityCounts{Warnings: 1, Total: 1},
+		ScannedFiles:  2,
+		ReportDigest:  testTreeDigest,
+		Findings: []domain.SecurityFinding{{
+			Code: "SEC301", Disposition: "warning", Severity: "warn", Confidence: "high",
+			Category: "security", Path: "mcp.json", Message: "review endpoint",
+		}},
+	}
+	scanner := &scannerStub{body: reportJSON(t, nil)}
+	result, err := (Evaluator{Scanner: scanner, Requirement: requirement}).Evaluate(context.Background(), domain.SecurityEvaluationInput{
+		SnapshotRoot: t.TempDir(), TreeDigest: testTreeDigest, ManifestDigest: testManifestDigest, Trusted: &trusted,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scanner.calls != 0 || result.Evidence != domain.SecurityEvidenceSignedIndex || result.ReportDigest != trusted.ReportDigest {
+		t.Fatalf("exact trusted evidence was not reused: calls=%d result=%+v", scanner.calls, result)
+	}
+}
+
 func reportJSON(t *testing.T, findings []map[string]any) []byte {
 	t.Helper()
 	if findings == nil {

--- a/install/integrationctl/agentplugins/adapters/securityv1/client.go
+++ b/install/integrationctl/agentplugins/adapters/securityv1/client.go
@@ -1,0 +1,186 @@
+package securityv1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	pathpkg "path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+type Client struct {
+	Origin     string
+	HTTPClient *http.Client
+	Trust      TrustStore
+	Now        func() time.Time
+	// AllowHTTPForTests is never populated by production wiring.
+	AllowHTTPForTests bool
+
+	mu        sync.Mutex
+	attempted bool
+	snapshot  Snapshot
+	loadErr   error
+}
+
+// Lookup returns an authenticated assessment only for the exact package
+// subject. A missing, stale, or unavailable assessment is not an install
+// failure: the caller must run its pinned local scanner instead.
+func (client *Client) Lookup(ctx context.Context, subject domain.SecuritySubject) (*domain.SecurityAssessment, error) {
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if !client.attempted {
+		client.attempted = true
+		client.snapshot, client.loadErr = client.fetch(ctx)
+	}
+	if client.loadErr != nil {
+		return nil, client.loadErr
+	}
+	return Lookup(client.snapshot, subject), nil
+}
+
+func (client *Client) fetch(ctx context.Context) (Snapshot, error) {
+	if len(client.Trust.PublicKey) == 0 {
+		return Snapshot{}, ErrUnknownKey
+	}
+	origin, err := client.originURL()
+	if err != nil {
+		return Snapshot{}, err
+	}
+	httpClient := client.safeHTTPClient(origin, 0)
+	pointerBytes, err := fetchBounded(ctx, httpClient, origin.ResolveReference(&url.URL{Path: "latest.json"}).String(), MaxLatestBytes, 3)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	pointer, err := ParsePointer(pointerBytes)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	httpClient = client.safeHTTPClient(origin, pointer.FetchContract.MaxRedirects)
+	snapshotBytes, err := fetchBounded(ctx, httpClient, origin.ResolveReference(&url.URL{Path: pointer.SnapshotPath}).String(), pointer.FetchContract.SnapshotMaxBytes, pointer.FetchContract.RetryAttempts)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	envelopeBytes, err := fetchBounded(ctx, httpClient, origin.ResolveReference(&url.URL{Path: pointer.EnvelopePath}).String(), pointer.FetchContract.EnvelopeMaxBytes, pointer.FetchContract.RetryAttempts)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	snapshot, err := Verify(pointerBytes, snapshotBytes, envelopeBytes, client.Trust)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	now := time.Now().UTC()
+	if client.Now != nil {
+		now = client.Now().UTC()
+	}
+	if err := ValidityError(snapshot, now); err != nil {
+		return Snapshot{}, err
+	}
+	return snapshot, nil
+}
+
+var (
+	ErrUnsafeOrigin     = errors.New("unsafe Security Index origin")
+	ErrUnsafeRedirect   = errors.New("unsafe Security Index redirect")
+	ErrResponseTooLarge = errors.New("Security Index response exceeds declared limit")
+)
+
+func (client *Client) originURL() (*url.URL, error) {
+	parsed, err := url.Parse(client.Origin)
+	if err != nil || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, ErrUnsafeOrigin
+	}
+	if parsed.Scheme != "https" && (!client.AllowHTTPForTests || parsed.Scheme != "http") {
+		return nil, ErrUnsafeOrigin
+	}
+	if !strings.HasSuffix(parsed.Path, "/") {
+		parsed.Path += "/"
+	}
+	escaped := strings.ToLower(parsed.EscapedPath())
+	clean := strings.TrimSuffix(parsed.Path, "/")
+	if clean == "" {
+		clean = "/"
+	}
+	if strings.Contains(escaped, "%2f") || strings.Contains(escaped, "%5c") || strings.Contains(escaped, "%2e") || pathpkg.Clean(parsed.Path) != clean {
+		return nil, ErrUnsafeOrigin
+	}
+	return parsed, nil
+}
+
+func (client *Client) safeHTTPClient(origin *url.URL, maxRedirects int) *http.Client {
+	result := http.Client{Timeout: 20 * time.Second}
+	if client.HTTPClient != nil {
+		result = *client.HTTPClient
+		if result.Timeout == 0 {
+			result.Timeout = 20 * time.Second
+		}
+	}
+	result.Jar = nil
+	prior := result.CheckRedirect
+	result.CheckRedirect = func(request *http.Request, via []*http.Request) error {
+		if len(via) > maxRedirects {
+			return ErrUnsafeRedirect
+		}
+		escaped := strings.ToLower(request.URL.EscapedPath())
+		unsafePath := strings.Contains(escaped, "%2f") || strings.Contains(escaped, "%5c") || strings.Contains(escaped, "%2e") || pathpkg.Clean(request.URL.Path) != request.URL.Path
+		if request.URL.User != nil || request.URL.Scheme != origin.Scheme || !strings.EqualFold(request.URL.Host, origin.Host) || !strings.HasPrefix(request.URL.Path, origin.Path) || unsafePath {
+			return ErrUnsafeRedirect
+		}
+		if prior != nil {
+			if err := prior(request, via); err != nil {
+				return err
+			}
+		}
+		request.Header.Del("Authorization")
+		request.Header.Del("Proxy-Authorization")
+		request.Header.Del("Cookie")
+		return nil
+	}
+	return &result
+}
+
+func fetchBounded(ctx context.Context, client *http.Client, target string, maximum, attempts int) ([]byte, error) {
+	var last error
+	for attempt := 0; attempt < attempts; attempt++ {
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+		if err != nil {
+			return nil, err
+		}
+		request.Header.Set("Accept", "application/json")
+		request.Header.Set("User-Agent", "agentplugins-security-index/1")
+		response, err := client.Do(request)
+		if err == nil {
+			body, readErr := io.ReadAll(io.LimitReader(response.Body, int64(maximum)+1))
+			closeErr := response.Body.Close()
+			if readErr == nil && closeErr == nil && response.StatusCode == http.StatusOK && len(body) <= maximum {
+				return body, nil
+			}
+			if len(body) > maximum {
+				return nil, ErrResponseTooLarge
+			}
+			if readErr != nil {
+				last = readErr
+			} else if closeErr != nil {
+				last = closeErr
+			} else {
+				last = fmt.Errorf("Security Index origin returned HTTP %d", response.StatusCode)
+			}
+		} else {
+			last = err
+		}
+		if attempt+1 < attempts {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(time.Duration(attempt+1) * 100 * time.Millisecond):
+			}
+		}
+	}
+	return nil, last
+}

--- a/install/integrationctl/agentplugins/adapters/securityv1/models.go
+++ b/install/integrationctl/agentplugins/adapters/securityv1/models.go
@@ -1,0 +1,487 @@
+// Package securityv1 verifies automated LintAI assessments for exact Agent
+// Plugins package bytes. A successful check is evidence, not a safety claim.
+package securityv1
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+const (
+	SchemaVersion    = 1
+	SignatureDomain  = "UAP-SECURITY-INDEX-ED25519-V1"
+	MaxLatestBytes   = 16 << 10
+	MaxEnvelopeBytes = 16 << 10
+	MaxSnapshotBytes = 8 << 20
+	maxRecords       = 10_000
+	maxFindings      = 32
+)
+
+type Pointer struct {
+	PointerSchemaVersion  int           `json:"pointer_schema_version"`
+	SnapshotSchemaVersion int           `json:"snapshot_schema_version"`
+	Sequence              uint64        `json:"sequence"`
+	SnapshotPath          string        `json:"snapshot_path"`
+	EnvelopePath          string        `json:"envelope_path"`
+	FetchContract         FetchContract `json:"fetch_contract"`
+}
+
+type FetchContract struct {
+	MaxRedirects     int `json:"max_redirects"`
+	LatestMaxBytes   int `json:"latest_max_bytes"`
+	SnapshotMaxBytes int `json:"snapshot_max_bytes"`
+	EnvelopeMaxBytes int `json:"envelope_max_bytes"`
+	RetryAttempts    int `json:"retry_attempts"`
+}
+
+type Envelope struct {
+	EnvelopeSchemaVersion int    `json:"envelope_schema_version"`
+	SnapshotSchemaVersion int    `json:"snapshot_schema_version"`
+	Sequence              uint64 `json:"sequence"`
+	KeyID                 string `json:"key_id"`
+	Algorithm             string `json:"algorithm"`
+	SignatureDomain       string `json:"signature_domain"`
+	SnapshotDigest        string `json:"snapshot_digest"`
+	Signature             string `json:"signature"`
+}
+
+type DiscoveryIdentity struct {
+	Sequence       uint64 `json:"sequence"`
+	SnapshotDigest string `json:"snapshot_digest"`
+}
+
+type Coverage struct {
+	Subjects    int `json:"subjects"`
+	Checked     int `json:"checked"`
+	Unavailable int `json:"unavailable"`
+}
+
+type Record struct {
+	Subject      domain.SecuritySubject   `json:"subject"`
+	Outcome      string                   `json:"outcome"`
+	Counts       domain.SecurityCounts    `json:"counts"`
+	ScannedFiles int                      `json:"scanned_files"`
+	ReportDigest string                   `json:"report_digest,omitempty"`
+	ErrorCode    string                   `json:"error_code,omitempty"`
+	Findings     []domain.SecurityFinding `json:"findings"`
+}
+
+type Snapshot struct {
+	SecuritySchemaVersion int                    `json:"security_schema_version"`
+	Sequence              uint64                 `json:"sequence"`
+	PublicationID         string                 `json:"publication_id"`
+	SourceCommit          string                 `json:"source_commit"`
+	GeneratedAt           string                 `json:"generated_at"`
+	ExpiresAt             string                 `json:"expires_at"`
+	Complete              bool                   `json:"complete"`
+	Discovery             DiscoveryIdentity      `json:"discovery"`
+	Scanner               domain.SecurityScanner `json:"scanner"`
+	Policy                domain.SecurityPolicy  `json:"policy"`
+	Coverage              Coverage               `json:"coverage"`
+	Records               []Record               `json:"records"`
+}
+
+type TrustStore struct {
+	KeyID     string
+	PublicKey ed25519.PublicKey
+}
+
+var (
+	ErrStrictJSON       = errors.New("Security Index JSON is not strict schema 1")
+	ErrUnknownKey       = errors.New("unknown Security Index signing key")
+	ErrDigestMismatch   = errors.New("Security Index digest mismatch")
+	ErrInvalidSignature = errors.New("invalid Security Index signature")
+	ErrSequenceMismatch = errors.New("Security Index sequence mismatch")
+	ErrExpired          = errors.New("Security Index is expired")
+	ErrClockSkew        = errors.New("local clock is before Security Index generation time")
+)
+
+var (
+	keyIDPattern       = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$`)
+	publicationPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$`)
+	identifierPattern  = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
+	versionPattern     = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$`)
+	rulePattern        = regexp.MustCompile(`^[A-Z]+[0-9]+$`)
+	shaPattern         = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	digestPattern      = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	timestampPattern   = regexp.MustCompile(`^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$`)
+)
+
+var signaturePrefix = []byte(SignatureDomain + "\x00")
+
+func ParsePointer(body []byte) (Pointer, error) {
+	var value Pointer
+	if err := strictDecode(body, &value, MaxLatestBytes); err != nil {
+		return value, strictError("pointer: %v", err)
+	}
+	if err := exactObject(body, []string{"pointer_schema_version", "snapshot_schema_version", "sequence", "snapshot_path", "envelope_path", "fetch_contract"}); err != nil {
+		return value, strictError("pointer: %v", err)
+	}
+	var root map[string]json.RawMessage
+	_ = json.Unmarshal(body, &root)
+	if err := exactObject(root["fetch_contract"], []string{"max_redirects", "latest_max_bytes", "snapshot_max_bytes", "envelope_max_bytes", "retry_attempts"}); err != nil {
+		return value, strictError("fetch contract: %v", err)
+	}
+	stem := fmt.Sprintf("%020d", value.Sequence)
+	c := value.FetchContract
+	if value.PointerSchemaVersion != 1 || value.SnapshotSchemaVersion != 1 || value.Sequence < 1 ||
+		exactPath(value.SnapshotPath, "snapshots/"+stem+".json") != nil || exactPath(value.EnvelopePath, "snapshots/"+stem+".envelope.json") != nil ||
+		c.MaxRedirects != 0 || c.RetryAttempts < 1 || c.RetryAttempts > 3 || c.LatestMaxBytes < 1 || c.LatestMaxBytes > MaxLatestBytes ||
+		c.SnapshotMaxBytes < 1 || c.SnapshotMaxBytes > MaxSnapshotBytes || c.EnvelopeMaxBytes < 1 || c.EnvelopeMaxBytes > MaxEnvelopeBytes {
+		return value, strictError("invalid pointer identity or fetch contract")
+	}
+	return value, nil
+}
+
+func Verify(pointerBytes, snapshotBytes, envelopeBytes []byte, trust TrustStore) (Snapshot, error) {
+	pointer, err := ParsePointer(pointerBytes)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	var envelope Envelope
+	if err := strictDecode(envelopeBytes, &envelope, MaxEnvelopeBytes); err != nil {
+		return Snapshot{}, strictError("envelope: %v", err)
+	}
+	if err := exactObject(envelopeBytes, []string{"envelope_schema_version", "snapshot_schema_version", "sequence", "key_id", "algorithm", "signature_domain", "snapshot_digest", "signature"}); err != nil {
+		return Snapshot{}, strictError("envelope: %v", err)
+	}
+	if envelope.EnvelopeSchemaVersion != 1 || envelope.SnapshotSchemaVersion != 1 || envelope.Sequence < 1 || !keyIDPattern.MatchString(envelope.KeyID) ||
+		envelope.Algorithm != "Ed25519" || envelope.SignatureDomain != SignatureDomain || !digestPattern.MatchString(envelope.SnapshotDigest) {
+		return Snapshot{}, strictError("invalid envelope")
+	}
+	if trust.KeyID != envelope.KeyID || !keyIDPattern.MatchString(trust.KeyID) || len(trust.PublicKey) != ed25519.PublicKeySize {
+		return Snapshot{}, ErrUnknownKey
+	}
+	digest := sha256.Sum256(snapshotBytes)
+	if "sha256:"+hex.EncodeToString(digest[:]) != envelope.SnapshotDigest {
+		return Snapshot{}, ErrDigestMismatch
+	}
+	signature, err := base64.StdEncoding.Strict().DecodeString(envelope.Signature)
+	if err != nil || len(signature) != ed25519.SignatureSize || !ed25519.Verify(trust.PublicKey, SignatureMessage(snapshotBytes), signature) {
+		return Snapshot{}, ErrInvalidSignature
+	}
+	snapshot, err := parseSnapshot(snapshotBytes)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	if pointer.Sequence != snapshot.Sequence || envelope.Sequence != snapshot.Sequence || pointer.SnapshotSchemaVersion != snapshot.SecuritySchemaVersion {
+		return Snapshot{}, ErrSequenceMismatch
+	}
+	return snapshot, nil
+}
+
+func SignatureMessage(snapshot []byte) []byte {
+	message := make([]byte, 0, len(signaturePrefix)+8+len(snapshot))
+	message = append(message, signaturePrefix...)
+	message = binary.BigEndian.AppendUint64(message, uint64(len(snapshot)))
+	return append(message, snapshot...)
+}
+
+func Lookup(snapshot Snapshot, subject domain.SecuritySubject) *domain.SecurityAssessment {
+	index := sort.Search(len(snapshot.Records), func(index int) bool {
+		return compareSubject(snapshot.Records[index].Subject, subject) >= 0
+	})
+	if index >= len(snapshot.Records) || snapshot.Records[index].Subject != subject || snapshot.Records[index].Outcome == "check_unavailable" {
+		return nil
+	}
+	record := snapshot.Records[index]
+	assessment := domain.SecurityAssessment{
+		SchemaVersion: SchemaVersion, Subject: record.Subject, Scanner: snapshot.Scanner, Policy: snapshot.Policy,
+		Outcome: domain.SecurityOutcome(record.Outcome), Counts: record.Counts, ScannedFiles: record.ScannedFiles,
+		ReportDigest: record.ReportDigest, Findings: append([]domain.SecurityFinding(nil), record.Findings...),
+	}
+	return &assessment
+}
+
+func ValidityError(snapshot Snapshot, now time.Time) error {
+	generated, err := parseTimestamp(snapshot.GeneratedAt)
+	if err != nil {
+		return err
+	}
+	expires, err := parseTimestamp(snapshot.ExpiresAt)
+	if err != nil {
+		return err
+	}
+	if now.UTC().Before(generated) {
+		return ErrClockSkew
+	}
+	if !now.UTC().Before(expires) {
+		return ErrExpired
+	}
+	return nil
+}
+
+func parseSnapshot(body []byte) (Snapshot, error) {
+	var value Snapshot
+	if err := strictDecode(body, &value, MaxSnapshotBytes); err != nil {
+		return value, strictError("snapshot: %v", err)
+	}
+	rootFields := []string{"security_schema_version", "sequence", "publication_id", "source_commit", "generated_at", "expires_at", "complete", "discovery", "scanner", "policy", "coverage", "records"}
+	if err := exactObject(body, rootFields); err != nil {
+		return value, strictError("snapshot: %v", err)
+	}
+	var root map[string]json.RawMessage
+	_ = json.Unmarshal(body, &root)
+	for name, fields := range map[string][]string{
+		"discovery": {"sequence", "snapshot_digest"}, "scanner": {"id", "version"},
+		"policy": {"id", "version", "digest"}, "coverage": {"subjects", "checked", "unavailable"},
+	} {
+		if err := exactObject(root[name], fields); err != nil {
+			return value, strictError("%s: %v", name, err)
+		}
+	}
+	var records []json.RawMessage
+	_ = json.Unmarshal(root["records"], &records)
+	if len(records) != len(value.Records) {
+		return value, strictError("records are invalid")
+	}
+	for index, raw := range records {
+		if err := validateRecordShape(raw, value.Records[index]); err != nil {
+			return value, strictError("record %d: %v", index, err)
+		}
+	}
+	if value.SecuritySchemaVersion != 1 || value.Sequence < 1 || !publicationPattern.MatchString(value.PublicationID) || !shaPattern.MatchString(value.SourceCommit) || !value.Complete ||
+		value.Discovery.Sequence < 1 || !digestPattern.MatchString(value.Discovery.SnapshotDigest) || !identifierPattern.MatchString(value.Scanner.ID) || !versionPattern.MatchString(value.Scanner.Version) ||
+		!identifierPattern.MatchString(value.Policy.ID) || value.Policy.Version < 1 || !digestPattern.MatchString(value.Policy.Digest) || value.Records == nil || len(value.Records) > maxRecords {
+		return value, strictError("invalid snapshot identity")
+	}
+	generated, err := parseTimestamp(value.GeneratedAt)
+	if err != nil {
+		return value, strictError("generated_at: %v", err)
+	}
+	expires, err := parseTimestamp(value.ExpiresAt)
+	if err != nil || !expires.After(generated) || expires.Sub(generated) > 31*24*time.Hour {
+		return value, strictError("invalid snapshot lifetime")
+	}
+	checked := 0
+	for index, record := range value.Records {
+		if err := validateRecord(record); err != nil {
+			return value, strictError("record %d: %v", index, err)
+		}
+		if record.Outcome != "check_unavailable" {
+			checked++
+		}
+		if index > 0 && compareSubject(value.Records[index-1].Subject, record.Subject) >= 0 {
+			return value, strictError("records are duplicated or not ordered")
+		}
+	}
+	if value.Coverage.Subjects != len(value.Records) || value.Coverage.Checked != checked || value.Coverage.Unavailable != len(value.Records)-checked {
+		return value, strictError("coverage is inconsistent")
+	}
+	return value, nil
+}
+
+func validateRecordShape(body []byte, record Record) error {
+	fields := []string{"subject", "outcome", "counts", "scanned_files", "findings"}
+	if record.Outcome == "check_unavailable" {
+		fields = append(fields, "error_code")
+	} else {
+		fields = append(fields, "report_digest")
+	}
+	if err := exactObject(body, fields); err != nil {
+		return err
+	}
+	var raw map[string]json.RawMessage
+	_ = json.Unmarshal(body, &raw)
+	if err := exactObject(raw["subject"], []string{"tree_digest", "manifest_digest"}); err != nil {
+		return err
+	}
+	if err := exactObject(raw["counts"], []string{"blocking", "warnings", "total"}); err != nil {
+		return err
+	}
+	var findings []json.RawMessage
+	_ = json.Unmarshal(raw["findings"], &findings)
+	if len(findings) != len(record.Findings) {
+		return errors.New("findings are invalid")
+	}
+	for index, finding := range findings {
+		fields := []string{"code", "disposition", "severity", "confidence", "category", "path", "message"}
+		if record.Findings[index].Line > 0 {
+			fields = append(fields, "line")
+		}
+		if err := exactObject(finding, fields); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRecord(record Record) error {
+	if !digestPattern.MatchString(record.Subject.TreeDigest) || !digestPattern.MatchString(record.Subject.ManifestDigest) || record.Counts.Blocking < 0 || record.Counts.Warnings < 0 ||
+		record.Counts.Total != record.Counts.Blocking+record.Counts.Warnings || record.ScannedFiles < 0 || record.Findings == nil || len(record.Findings) > maxFindings {
+		return errors.New("invalid subject, counts, or finding projection")
+	}
+	if record.Outcome == "check_unavailable" {
+		if record.Counts.Total != 0 || record.ScannedFiles != 0 || record.ReportDigest != "" || len(record.Findings) != 0 || (record.ErrorCode != "acquisition_failed" && record.ErrorCode != "scan_failed") {
+			return errors.New("invalid unavailable result")
+		}
+		return nil
+	}
+	if record.ErrorCode != "" || !digestPattern.MatchString(record.ReportDigest) {
+		return errors.New("invalid checked result")
+	}
+	expected := "no_blocking_findings"
+	if record.Counts.Blocking > 0 {
+		expected = "blocking_findings"
+	} else if record.Counts.Warnings > 0 {
+		expected = "warnings"
+	}
+	if record.Outcome != expected {
+		return errors.New("outcome does not match counts")
+	}
+	projectedBlocking, projectedWarnings := 0, 0
+	for index, finding := range record.Findings {
+		if !rulePattern.MatchString(finding.Code) || utf8.RuneCountInString(finding.Message) < 1 || len(finding.Message) > 2000 || len(finding.Path) > 1024 || finding.Line < 0 ||
+			(finding.Disposition != "blocking" && finding.Disposition != "warning") || (finding.Severity != "allow" && finding.Severity != "warn" && finding.Severity != "deny") ||
+			(finding.Confidence != "low" && finding.Confidence != "medium" && finding.Confidence != "high") || strings.TrimSpace(finding.Category) == "" || len(finding.Category) > 64 {
+			return fmt.Errorf("invalid finding %d", index)
+		}
+		if finding.Disposition == "blocking" {
+			projectedBlocking++
+		} else {
+			projectedWarnings++
+		}
+		if index > 0 && compareFinding(record.Findings[index-1], finding) > 0 {
+			return errors.New("findings are not ordered")
+		}
+	}
+	if projectedBlocking > record.Counts.Blocking || projectedWarnings > record.Counts.Warnings {
+		return errors.New("finding projection exceeds counts")
+	}
+	return nil
+}
+
+func compareSubject(left, right domain.SecuritySubject) int {
+	if value := strings.Compare(left.TreeDigest, right.TreeDigest); value != 0 {
+		return value
+	}
+	return strings.Compare(left.ManifestDigest, right.ManifestDigest)
+}
+
+func compareFinding(left, right domain.SecurityFinding) int {
+	leftKey := fmt.Sprintf("%s\x00%s\x00%s\x00%010d\x00%s", left.Disposition, left.Code, left.Path, left.Line, left.Message)
+	rightKey := fmt.Sprintf("%s\x00%s\x00%s\x00%010d\x00%s", right.Disposition, right.Code, right.Path, right.Line, right.Message)
+	return strings.Compare(leftKey, rightKey)
+}
+
+func strictDecode(body []byte, destination any, limit int) error {
+	if len(body) == 0 || len(body) > limit || !json.Valid(body) {
+		return errors.New("empty, oversized, or invalid JSON")
+	}
+	if err := rejectDuplicateKeys(body); err != nil {
+		return err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(destination); err != nil {
+		return err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return errors.New("trailing JSON value")
+	}
+	return nil
+}
+
+func rejectDuplicateKeys(body []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	if err := scanJSONValue(decoder); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		return errors.New("trailing JSON")
+	}
+	return nil
+}
+
+func scanJSONValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delimiter, compound := token.(json.Delim)
+	if !compound {
+		return nil
+	}
+	switch delimiter {
+	case '{':
+		keys := map[string]bool{}
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := keyToken.(string)
+			if !ok || keys[key] {
+				return fmt.Errorf("duplicate or invalid JSON key %q", key)
+			}
+			keys[key] = true
+			if err := scanJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		_, err = decoder.Token()
+		return err
+	case '[':
+		for decoder.More() {
+			if err := scanJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		_, err = decoder.Token()
+		return err
+	default:
+		return errors.New("unexpected JSON delimiter")
+	}
+}
+
+func exactObject(body []byte, fields []string) error {
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(body, &object); err != nil {
+		return err
+	}
+	if len(object) != len(fields) {
+		return errors.New("object fields do not match schema")
+	}
+	for _, field := range fields {
+		if _, ok := object[field]; !ok {
+			return fmt.Errorf("missing field %q", field)
+		}
+	}
+	return nil
+}
+
+func exactPath(actual, expected string) error {
+	if actual != expected || strings.ContainsAny(actual, `\:`) || strings.HasPrefix(actual, "/") || path.Clean(actual) != actual {
+		return errors.New("unsafe artifact path")
+	}
+	return nil
+}
+
+func parseTimestamp(value string) (time.Time, error) {
+	if !timestampPattern.MatchString(value) {
+		return time.Time{}, errors.New("timestamp must use second-precision UTC")
+	}
+	return time.Parse(time.RFC3339, value)
+}
+
+func strictError(format string, arguments ...any) error {
+	return fmt.Errorf("%w: %s", ErrStrictJSON, fmt.Sprintf(format, arguments...))
+}

--- a/install/integrationctl/agentplugins/adapters/securityv1/securityv1_test.go
+++ b/install/integrationctl/agentplugins/adapters/securityv1/securityv1_test.go
@@ -1,0 +1,156 @@
+package securityv1
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/securityscan"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+const (
+	treeDigest     = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	manifestDigest = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+type fixture struct {
+	pointer, snapshot, envelope []byte
+	trust                       TrustStore
+}
+
+func makeFixture(t *testing.T) fixture {
+	t.Helper()
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requirement := securityscan.DefaultRequirement()
+	snapshot := Snapshot{
+		SecuritySchemaVersion: 1,
+		Sequence:              7,
+		PublicationID:         "security-test-7",
+		SourceCommit:          strings.Repeat("c", 40),
+		GeneratedAt:           "2026-09-05T00:00:00Z",
+		ExpiresAt:             "2026-10-05T00:00:00Z",
+		Complete:              true,
+		Discovery:             DiscoveryIdentity{Sequence: 20, SnapshotDigest: "sha256:" + strings.Repeat("d", 64)},
+		Scanner:               requirement.Scanner,
+		Policy:                requirement.Policy,
+		Coverage:              Coverage{Subjects: 1, Checked: 1},
+		Records: []Record{{
+			Subject: domain.SecuritySubject{TreeDigest: treeDigest, ManifestDigest: manifestDigest},
+			Outcome: "warnings", Counts: domain.SecurityCounts{Warnings: 1, Total: 1}, ScannedFiles: 2,
+			ReportDigest: "sha256:" + strings.Repeat("e", 64),
+			Findings: []domain.SecurityFinding{{
+				Code: "SEC301", Disposition: "warning", Severity: "warn", Confidence: "high",
+				Category: "security", Path: "mcp.json", Line: 2, Message: "review this endpoint",
+			}},
+		}},
+	}
+	snapshotBody, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshotBody = append(snapshotBody, '\n')
+	digest := sha256.Sum256(snapshotBody)
+	envelopeBody, err := json.Marshal(Envelope{
+		EnvelopeSchemaVersion: 1, SnapshotSchemaVersion: 1, Sequence: 7,
+		KeyID: "security-test", Algorithm: "Ed25519", SignatureDomain: SignatureDomain,
+		SnapshotDigest: "sha256:" + hex.EncodeToString(digest[:]),
+		Signature:      base64.StdEncoding.EncodeToString(ed25519.Sign(private, SignatureMessage(snapshotBody))),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	envelopeBody = append(envelopeBody, '\n')
+	pointerBody, err := json.Marshal(Pointer{
+		PointerSchemaVersion: 1, SnapshotSchemaVersion: 1, Sequence: 7,
+		SnapshotPath: "snapshots/00000000000000000007.json",
+		EnvelopePath: "snapshots/00000000000000000007.envelope.json",
+		FetchContract: FetchContract{MaxRedirects: 0, LatestMaxBytes: MaxLatestBytes,
+			SnapshotMaxBytes: MaxSnapshotBytes, EnvelopeMaxBytes: MaxEnvelopeBytes, RetryAttempts: 3},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fixture{pointer: append(pointerBody, '\n'), snapshot: snapshotBody, envelope: envelopeBody,
+		trust: TrustStore{KeyID: "security-test", PublicKey: public}}
+}
+
+func TestVerifyAndLookupExactSubject(t *testing.T) {
+	value := makeFixture(t)
+	snapshot, err := Verify(value.pointer, value.snapshot, value.envelope, value.trust)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assessment := Lookup(snapshot, domain.SecuritySubject{TreeDigest: treeDigest, ManifestDigest: manifestDigest})
+	if assessment == nil || assessment.Outcome != domain.SecurityWarnings || assessment.Counts.Warnings != 1 {
+		t.Fatalf("exact assessment = %+v", assessment)
+	}
+	if Lookup(snapshot, domain.SecuritySubject{TreeDigest: "sha256:" + strings.Repeat("f", 64), ManifestDigest: manifestDigest}) != nil {
+		t.Fatal("a changed tree digest reused an assessment")
+	}
+	if err := assessment.Validate(securityscan.DefaultRequirement(), assessment.Subject); err != nil {
+		t.Fatalf("signed assessment does not satisfy the local contract: %v", err)
+	}
+}
+
+func TestVerifyRejectsTamperingDuplicateKeysAndWrongDomain(t *testing.T) {
+	value := makeFixture(t)
+	tampered := append([]byte(nil), value.snapshot...)
+	tampered[len(tampered)-2] ^= 1
+	if _, err := Verify(value.pointer, tampered, value.envelope, value.trust); err != ErrDigestMismatch {
+		t.Fatalf("tamper error = %v", err)
+	}
+	duplicate := []byte(strings.Replace(string(value.pointer), `"sequence":7`, `"sequence":7,"sequence":7`, 1))
+	if _, err := ParsePointer(duplicate); err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("duplicate key error = %v", err)
+	}
+	wrongDomain := append([]byte(nil), value.envelope...)
+	wrongDomain = []byte(strings.Replace(string(wrongDomain), SignatureDomain, "UAP-DISCOVERY-INDEX-ED25519-V1", 1))
+	if _, err := Verify(value.pointer, value.snapshot, wrongDomain, value.trust); err == nil {
+		t.Fatal("wrong signature domain was accepted")
+	}
+}
+
+func TestClientFetchesOnceAndFallsBackForUnknownSubject(t *testing.T) {
+	value := makeFixture(t)
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		calls++
+		var body []byte
+		switch request.URL.Path {
+		case "/security/latest.json":
+			body = value.pointer
+		case "/security/snapshots/00000000000000000007.json":
+			body = value.snapshot
+		case "/security/snapshots/00000000000000000007.envelope.json":
+			body = value.envelope
+		default:
+			http.NotFound(writer, request)
+			return
+		}
+		_, _ = writer.Write(body)
+	}))
+	defer server.Close()
+	client := &Client{Origin: server.URL + "/security/", HTTPClient: server.Client(), Trust: value.trust,
+		AllowHTTPForTests: true, Now: func() time.Time { return time.Date(2026, 9, 6, 0, 0, 0, 0, time.UTC) }}
+	assessment, err := client.Lookup(context.Background(), domain.SecuritySubject{TreeDigest: treeDigest, ManifestDigest: manifestDigest})
+	if err != nil || assessment == nil {
+		t.Fatalf("first lookup = %+v, %v", assessment, err)
+	}
+	missing, err := client.Lookup(context.Background(), domain.SecuritySubject{TreeDigest: treeDigest, ManifestDigest: "sha256:" + strings.Repeat("f", 64)})
+	if err != nil || missing != nil || calls != 3 {
+		t.Fatalf("memoized lookup = %+v, %v calls=%d", missing, err, calls)
+	}
+}

--- a/install/integrationctl/agentplugins/domain/security.go
+++ b/install/integrationctl/agentplugins/domain/security.go
@@ -105,7 +105,7 @@ func (assessment SecurityAssessment) Validate(requirement SecurityRequirement, s
 	if !securityDigestPattern.MatchString(assessment.Subject.TreeDigest) || !securityDigestPattern.MatchString(assessment.Subject.ManifestDigest) || !securityDigestPattern.MatchString(assessment.Policy.Digest) || !securityDigestPattern.MatchString(assessment.ReportDigest) {
 		return errors.New("security assessment contains an invalid digest")
 	}
-	if assessment.Counts.Blocking < 0 || assessment.Counts.Warnings < 0 || assessment.Counts.Total < 0 || assessment.Counts.Total < assessment.Counts.Blocking+assessment.Counts.Warnings || assessment.ScannedFiles < 0 {
+	if assessment.Counts.Blocking < 0 || assessment.Counts.Warnings < 0 || assessment.Counts.Total < 0 || assessment.Counts.Total != assessment.Counts.Blocking+assessment.Counts.Warnings || assessment.ScannedFiles < 0 {
 		return errors.New("security assessment contains invalid counts")
 	}
 	expected := SecurityNoBlockingFindings
@@ -117,10 +117,19 @@ func (assessment SecurityAssessment) Validate(requirement SecurityRequirement, s
 	if assessment.Outcome != expected {
 		return errors.New("security assessment outcome does not match its counts")
 	}
+	projectedBlocking, projectedWarnings := 0, 0
 	for _, finding := range assessment.Findings {
 		if strings.TrimSpace(finding.Code) == "" || strings.TrimSpace(finding.Message) == "" || (finding.Disposition != "blocking" && finding.Disposition != "warning") {
 			return errors.New("security assessment contains an invalid finding")
 		}
+		if finding.Disposition == "blocking" {
+			projectedBlocking++
+		} else {
+			projectedWarnings++
+		}
+	}
+	if projectedBlocking > assessment.Counts.Blocking || projectedWarnings > assessment.Counts.Warnings {
+		return errors.New("security assessment finding projection exceeds its counts")
 	}
 	return nil
 }

--- a/install/integrationctl/agentplugins/domain/security_test.go
+++ b/install/integrationctl/agentplugins/domain/security_test.go
@@ -1,0 +1,37 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSecurityAssessmentRequiresExactCountsAndBoundedFindingProjection(t *testing.T) {
+	subject := SecuritySubject{
+		TreeDigest:     "sha256:" + strings.Repeat("a", 64),
+		ManifestDigest: "sha256:" + strings.Repeat("b", 64),
+	}
+	requirement := SecurityRequirement{
+		Scanner: SecurityScanner{ID: SecurityScannerID, Version: SecurityScannerVersion},
+		Policy:  SecurityPolicy{ID: SecurityPolicyID, Version: SecurityPolicyVersion, Digest: "sha256:" + strings.Repeat("c", 64)},
+	}
+	valid := SecurityAssessment{
+		SchemaVersion: SecurityReportSchemaVersion, Subject: subject, Scanner: requirement.Scanner, Policy: requirement.Policy,
+		Outcome: SecurityWarnings, Counts: SecurityCounts{Warnings: 2, Total: 2}, ScannedFiles: 3,
+		ReportDigest: "sha256:" + strings.Repeat("d", 64),
+		Findings:     []SecurityFinding{{Code: "SEC301", Disposition: "warning", Message: "review endpoint"}},
+	}
+	if err := valid.Validate(requirement, subject); err != nil {
+		t.Fatalf("valid projected assessment: %v", err)
+	}
+	invalidTotal := valid
+	invalidTotal.Counts.Total = 3
+	if err := invalidTotal.Validate(requirement, subject); err == nil {
+		t.Fatal("accepted a count total that did not equal blocking plus warnings")
+	}
+	invalidProjection := valid
+	invalidProjection.Counts = SecurityCounts{Warnings: 0, Total: 0}
+	invalidProjection.Outcome = SecurityNoBlockingFindings
+	if err := invalidProjection.Validate(requirement, subject); err == nil {
+		t.Fatal("accepted a finding projection larger than the signed counts")
+	}
+}


### PR DESCRIPTION
## Summary
- verify the separately signed Security Index with strict bounded parsing and domain-separated Ed25519 signatures
- reuse assessments only for the exact package tree, manifest, scanner, and policy identity
- fall back to the pinned local LintAI scan on absence, expiry, tampering, or any feed error

## Verification
- focused security index, evaluator, domain, CLI, and production wiring tests
- exact digest mismatch, tamper, duplicate-key, signature-domain, expiry, and fetch-once regressions
- `git diff --check`

No package code is executed while reading the index. Signed results are evidence of automated checks, not a guarantee of safety.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving trusted security assessments from a signed Security Index.
  - Security Index data is verified for authenticity, validity, and integrity before use.
  - Added safe configuration for the Security Index origin, including secure redirect and response handling.

- **Bug Fixes**
  - Improved security assessment validation by enforcing exact finding counts and validating finding details.
  - Falls back to local scanning when trusted index data is unavailable or cannot be verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->