### PR TITLE
fix(agentplugins): align signed security policy digest

### DIFF
--- a/install/integrationctl/agentplugins/adapters/securityscan/policy.go
+++ b/install/integrationctl/agentplugins/adapters/securityscan/policy.go
@@ -44,6 +44,9 @@ func policyDigest() string {
 	if err != nil {
 		panic(err)
 	}
+	// The signed Security Index uses the registry's canonical JSON profile,
+	// where a trailing LF is part of the bytes covered by every digest.
+	body = append(body, '\n')
 	digest := sha256.Sum256(body)
 	return "sha256:" + hex.EncodeToString(digest[:])
 }

--- a/install/integrationctl/agentplugins/adapters/securityscan/policy_test.go
+++ b/install/integrationctl/agentplugins/adapters/securityscan/policy_test.go
@@ -1,0 +1,10 @@
+package securityscan
+
+import "testing"
+
+func TestDefaultPolicyDigestMatchesSignedSecurityIndexContract(t *testing.T) {
+	const expected = "sha256:41d3640d31eac89e7b30777bbbe937b307908e4a8d7c29a3a0edca49cfe1d755"
+	if actual := DefaultRequirement().Policy.Digest; actual != expected {
+		t.Fatalf("policy digest = %q, want %q", actual, expected)
+	}
+}


### PR DESCRIPTION
## Summary

- hash the install security policy with the registry canonical JSON trailing LF
- pin the exact cross-language digest in a regression test
- allow exact signed Security Index assessments to bypass redundant local scans

## Evidence

- `go test ./...`
- `go test ./...` in `cli/plugin-kit-ai`
- focused securityscan and securityv1 tests
- isolated public Upstash Context7 dry-run returned `Evidence: signed index` and did not download LintAI

The unrelated full integrationctl macOS case-collision fixture remains platform-specific; GitHub Linux CI is the authoritative gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected security policy digest calculation to match the signed security index contract.
  - Ensured the default policy digest remains consistent with the expected SHA-256 value.

- **Tests**
  - Added validation for the default policy digest against the signed security index contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->