### PR TITLE
feat(landing): show signed security assessments

### DIFF
--- a/cmd/agentplugins-registry-mirror/main.go
+++ b/cmd/agentplugins-registry-mirror/main.go
@@ -1,5 +1,6 @@
-// Command agentplugins-registry-mirror verifies the signed public Directory and
-// Discovery feeds, then copies their byte-exact artifacts into a staging tree.
+// Command agentplugins-registry-mirror verifies the signed public Directory,
+// Discovery, and Security feeds, then copies their byte-exact artifacts into a
+// staging tree.
 // It is intentionally a build-time tool: it never signs, executes, or mutates
 // an installed client configuration.
 package main
@@ -7,6 +8,7 @@ package main
 import (
 	"bytes"
 	"crypto/ed25519"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -24,6 +26,7 @@ import (
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/directoryv1"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/discoveryv1"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/securityv1"
 )
 
 const (
@@ -56,6 +59,9 @@ type mirrorMetadata struct {
 	DiscoverySequence  uint64 `json:"discovery_sequence"`
 	DiscoveryDigest    string `json:"discovery_digest"`
 	DiscoveryCommit    string `json:"discovery_source_commit"`
+	SecuritySequence   uint64 `json:"security_sequence"`
+	SecurityDigest     string `json:"security_digest"`
+	SecurityCommit     string `json:"security_source_commit"`
 	GeneratedFiles     int    `json:"generated_files"`
 }
 
@@ -96,6 +102,10 @@ func run(registry, origin, output, previous string) error {
 	if err != nil {
 		return fmt.Errorf("discovery: %w", err)
 	}
+	security, err := fetchSecurity(client, base, registry)
+	if err != nil {
+		return fmt.Errorf("security: %w", err)
+	}
 	metadata := mirrorMetadata{
 		SchemaVersion:      1,
 		RegistryRepository: registry,
@@ -105,6 +115,9 @@ func run(registry, origin, output, previous string) error {
 		DiscoverySequence:  discovery.bundle.Snapshot.Sequence,
 		DiscoveryDigest:    discovery.bundle.Digest,
 		DiscoveryCommit:    discovery.bundle.Snapshot.SourceCommit,
+		SecuritySequence:   security.snapshot.Sequence,
+		SecurityDigest:     security.digest,
+		SecurityCommit:     security.snapshot.SourceCommit,
 		GeneratedFiles:     0,
 	}
 	if previous != "" {
@@ -120,7 +133,7 @@ func run(registry, origin, output, previous string) error {
 	if err := os.MkdirAll(stage, 0o755); err != nil {
 		return fmt.Errorf("create staging directory: %w", err)
 	}
-	files := stagedFiles(directory, discovery)
+	files := stagedFiles(directory, discovery, security)
 	for _, file := range files {
 		if err := writeStaged(stage, file.rel, file.body); err != nil {
 			return err
@@ -143,7 +156,7 @@ func run(registry, origin, output, previous string) error {
 	if err := os.Rename(stage, output); err != nil {
 		return fmt.Errorf("publish staging tree: %w", err)
 	}
-	fmt.Printf("verified Directory seq %d and Discovery seq %d; mirrored %d files to %s\n", metadata.DirectorySequence, metadata.DiscoverySequence, metadata.GeneratedFiles, output)
+	fmt.Printf("verified Directory seq %d, Discovery seq %d, and Security seq %d; mirrored %d files to %s\n", metadata.DirectorySequence, metadata.DiscoverySequence, metadata.SecuritySequence, metadata.GeneratedFiles, output)
 	return nil
 }
 
@@ -152,7 +165,7 @@ type mirrorFile struct {
 	body []byte
 }
 
-func stagedFiles(directory directoryResult, discovery discoveryResult) []mirrorFile {
+func stagedFiles(directory directoryResult, discovery discoveryResult, security securityResult) []mirrorFile {
 	return []mirrorFile{
 		{rel: "registry/schemas/1/latest.json", body: directory.pointerBytes},
 		{rel: "registry/schemas/1/snapshots/" + directory.stem + ".json", body: directory.snapshotBytes},
@@ -163,6 +176,9 @@ func stagedFiles(directory directoryResult, discovery discoveryResult) []mirrorF
 		{rel: "discovery/snapshots/" + discovery.stem + ".envelope.json", body: discovery.envelopeBytes},
 		{rel: "discovery/search/" + discovery.stem + ".json", body: discovery.searchBytes},
 		{rel: "discovery/trusted-keys.json", body: discovery.trustBytes},
+		{rel: "security/latest.json", body: security.pointerBytes},
+		{rel: "security/snapshots/" + security.stem + ".json", body: security.snapshotBytes},
+		{rel: "security/snapshots/" + security.stem + ".envelope.json", body: security.envelopeBytes},
 	}
 }
 
@@ -268,6 +284,72 @@ func parseDiscoverySnapshot(body []byte) (discoveryv1.Snapshot, error) {
 	return snapshot, nil
 }
 
+type securityResult struct {
+	pointerBytes, snapshotBytes, envelopeBytes []byte
+	stem                                       string
+	digest                                     string
+	snapshot                                   securityv1.Snapshot
+}
+
+func fetchSecurity(client *http.Client, base *url.URL, registry string) (securityResult, error) {
+	pointerBytes, err := get(client, base.ResolveReference(&url.URL{Path: "security/latest.json"}).String(), securityv1.MaxLatestBytes)
+	if err != nil {
+		return securityResult{}, err
+	}
+	pointer, err := securityv1.ParsePointer(pointerBytes)
+	if err != nil {
+		return securityResult{}, err
+	}
+	getArtifact := func(relative string, limit int) ([]byte, error) {
+		return get(client, base.ResolveReference(&url.URL{Path: "security/" + relative}).String(), limit)
+	}
+	snapshotBytes, err := getArtifact(pointer.SnapshotPath, pointer.FetchContract.SnapshotMaxBytes)
+	if err != nil {
+		return securityResult{}, err
+	}
+	envelopeBytes, err := getArtifact(pointer.EnvelopePath, pointer.FetchContract.EnvelopeMaxBytes)
+	if err != nil {
+		return securityResult{}, err
+	}
+	snapshotIdentity, err := parseSecuritySnapshot(snapshotBytes)
+	if err != nil {
+		return securityResult{}, err
+	}
+	trust, err := fetchSecurityTrust(registry, snapshotIdentity.SourceCommit)
+	if err != nil {
+		return securityResult{}, err
+	}
+	snapshot, err := securityv1.Verify(pointerBytes, snapshotBytes, envelopeBytes, trust)
+	if err != nil {
+		return securityResult{}, err
+	}
+	if err := securityv1.ValidityError(snapshot, time.Now().UTC()); err != nil {
+		return securityResult{}, err
+	}
+	digest := sha256.Sum256(snapshotBytes)
+	return securityResult{
+		pointerBytes:  pointerBytes,
+		snapshotBytes: snapshotBytes,
+		envelopeBytes: envelopeBytes,
+		stem:          fmt.Sprintf("%020d", pointer.Sequence),
+		digest:        fmt.Sprintf("sha256:%x", digest[:]),
+		snapshot:      snapshot,
+	}, nil
+}
+
+func parseSecuritySnapshot(body []byte) (securityv1.Snapshot, error) {
+	// Verify performs the full strict schema check after the source commit has
+	// selected the immutable trust document.
+	var snapshot securityv1.Snapshot
+	if err := json.Unmarshal(body, &snapshot); err != nil {
+		return snapshot, err
+	}
+	if !shaPattern.MatchString(snapshot.SourceCommit) {
+		return snapshot, fmt.Errorf("malformed source_commit %q", snapshot.SourceCommit)
+	}
+	return snapshot, nil
+}
+
 func fetchTrustBytes(registry, revision, relative string) ([]byte, trustedKeysDocument, error) {
 	if !shaPattern.MatchString(revision) {
 		return nil, trustedKeysDocument{}, fmt.Errorf("invalid trust revision %q", revision)
@@ -351,6 +433,24 @@ func fetchDiscoveryTrust(registry, revision string) ([]byte, discoveryv1.TrustSt
 		return nil, discoveryv1.TrustStore{}, errors.New("Discovery trust document is not anchored to the release bootstrap key")
 	}
 	return body, discoveryv1.TrustStore{Keys: keys}, nil
+}
+
+func fetchSecurityTrust(registry, revision string) (securityv1.TrustStore, error) {
+	_, document, err := fetchTrustBytes(registry, revision, "registry/discovery/trusted-keys.json")
+	if err != nil {
+		return securityv1.TrustStore{}, err
+	}
+	for _, item := range document.Keys {
+		if item.ID != discoveryKeyID || item.PublicKey != discoveryPublicKey || (item.State != "" && item.State != "current") {
+			continue
+		}
+		raw, err := base64.StdEncoding.Strict().DecodeString(item.PublicKey)
+		if err != nil || len(raw) != ed25519.PublicKeySize {
+			return securityv1.TrustStore{}, fmt.Errorf("invalid public key for %q", item.ID)
+		}
+		return securityv1.TrustStore{KeyID: item.ID, PublicKey: ed25519.PublicKey(raw)}, nil
+	}
+	return securityv1.TrustStore{}, errors.New("Security trust document is not anchored to the current release bootstrap key")
 }
 
 func strictDecode(body []byte, destination any) error {
@@ -538,14 +638,17 @@ func enforceMonotonic(previousPath string, candidate mirrorMetadata) error {
 	if previous.RegistryRepository != "" && previous.RegistryRepository != candidate.RegistryRepository {
 		return fmt.Errorf("candidate registry %q differs from previous marker %q", candidate.RegistryRepository, previous.RegistryRepository)
 	}
-	if candidate.DirectorySequence < previous.DirectorySequence || candidate.DiscoverySequence < previous.DiscoverySequence {
-		return fmt.Errorf("candidate feed regresses previous marker (directory %d/%d, discovery %d/%d)", candidate.DirectorySequence, previous.DirectorySequence, candidate.DiscoverySequence, previous.DiscoverySequence)
+	if candidate.DirectorySequence < previous.DirectorySequence || candidate.DiscoverySequence < previous.DiscoverySequence || candidate.SecuritySequence < previous.SecuritySequence {
+		return fmt.Errorf("candidate feed regresses previous marker (directory %d/%d, discovery %d/%d, security %d/%d)", candidate.DirectorySequence, previous.DirectorySequence, candidate.DiscoverySequence, previous.DiscoverySequence, candidate.SecuritySequence, previous.SecuritySequence)
 	}
 	if candidate.DirectorySequence == previous.DirectorySequence && candidate.DirectoryDigest != previous.DirectoryDigest {
 		return errors.New("Directory sequence has conflicting authenticated bytes")
 	}
 	if candidate.DiscoverySequence == previous.DiscoverySequence && candidate.DiscoveryDigest != previous.DiscoveryDigest {
 		return errors.New("Discovery sequence has conflicting authenticated bytes")
+	}
+	if previous.SecuritySequence > 0 && candidate.SecuritySequence == previous.SecuritySequence && candidate.SecurityDigest != previous.SecurityDigest {
+		return errors.New("Security sequence has conflicting authenticated bytes")
 	}
 	return nil
 }

--- a/cmd/agentplugins-registry-mirror/main_test.go
+++ b/cmd/agentplugins-registry-mirror/main_test.go
@@ -83,6 +83,47 @@ func TestEnforceMonotonicRejectsSameSequenceConflict(t *testing.T) {
 	}
 }
 
+func TestEnforceMonotonicProtectsSecurityFeed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "MIRROR_METADATA.json")
+	if err := os.WriteFile(path, []byte(`{
+  "schema_version": 1,
+  "registry_repository": "777genius/universal-agent-plugins-registry",
+  "directory_sequence": 10,
+  "directory_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "directory_source_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "discovery_sequence": 8,
+  "discovery_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "discovery_source_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "security_sequence": 3,
+  "security_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "security_source_commit": "cccccccccccccccccccccccccccccccccccccccc",
+  "generated_files": 13
+}
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	base := mirrorMetadata{
+		SchemaVersion:      1,
+		RegistryRepository: defaultRegistry,
+		DirectorySequence:  10,
+		DirectoryDigest:    "sha256:" + strings.Repeat("a", 64),
+		DiscoverySequence:  8,
+		DiscoveryDigest:    "sha256:" + strings.Repeat("b", 64),
+		SecuritySequence:   3,
+		SecurityDigest:     "sha256:" + strings.Repeat("c", 64),
+	}
+	rollback := base
+	rollback.SecuritySequence = 2
+	if err := enforceMonotonic(path, rollback); err == nil || !strings.Contains(err.Error(), "regresses") {
+		t.Fatalf("Security rollback was not rejected: %v", err)
+	}
+	conflict := base
+	conflict.SecurityDigest = "sha256:" + strings.Repeat("d", 64)
+	if err := enforceMonotonic(path, conflict); err == nil || !strings.Contains(err.Error(), "Security sequence") {
+		t.Fatalf("Security same-sequence conflict was not rejected: %v", err)
+	}
+}
+
 func TestWriteStagedRejectsTraversal(t *testing.T) {
 	for _, relative := range []string{"../escape", "/absolute", "a\\b", "a/../../escape"} {
 		if err := writeStaged(t.TempDir(), relative, []byte("x")); err == nil {
@@ -93,7 +134,11 @@ func TestWriteStagedRejectsTraversal(t *testing.T) {
 
 func TestStagedFilesFollowSignedPointerPaths(t *testing.T) {
 	const stem = "00000000000000000027"
-	files := stagedFiles(directoryResult{stem: stem}, discoveryResult{stem: stem})
+	files := stagedFiles(
+		directoryResult{stem: stem},
+		discoveryResult{stem: stem},
+		securityResult{stem: stem},
+	)
 	paths := make(map[string]bool, len(files))
 	for _, file := range files {
 		paths[file.rel] = true
@@ -106,6 +151,9 @@ func TestStagedFilesFollowSignedPointerPaths(t *testing.T) {
 		"discovery/snapshots/" + stem + ".json",
 		"discovery/snapshots/" + stem + ".envelope.json",
 		"discovery/search/" + stem + ".json",
+		"security/latest.json",
+		"security/snapshots/" + stem + ".json",
+		"security/snapshots/" + stem + ".envelope.json",
 	} {
 		if !paths[expected] {
 			t.Fatalf("signed pointer artifact path is missing: %s", expected)
@@ -116,6 +164,8 @@ func TestStagedFilesFollowSignedPointerPaths(t *testing.T) {
 		"registry/schemas/1/" + stem + ".envelope.json",
 		"discovery/" + stem + ".json",
 		"discovery/" + stem + ".envelope.json",
+		"security/" + stem + ".json",
+		"security/" + stem + ".envelope.json",
 	} {
 		if paths[unexpected] {
 			t.Fatalf("legacy root artifact path must not be emitted: %s", unexpected)

--- a/landing/assets/styles/registry.scss
+++ b/landing/assets/styles/registry.scss
@@ -1738,6 +1738,31 @@ img {
   font-size: 0.66rem;
   font-weight: 700;
 }
+.plugin-card__security {
+  width: fit-content;
+  margin: 8px 0 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--cyan);
+  font-size: 0.62rem;
+  font-weight: 750;
+}
+.plugin-card__security span {
+  width: 16px;
+  height: 16px;
+  display: inline-grid;
+  place-items: center;
+  border: 1px solid currentcolor;
+  border-radius: 50%;
+  font-size: 0.55rem;
+}
+.plugin-card__security--warnings {
+  color: #f5c451;
+}
+.plugin-card__security--blocking_findings {
+  color: var(--coral);
+}
 .plugin-card__ribbon {
   position: absolute;
   top: 14px;

--- a/landing/components/registry/RegistryPluginCard.vue
+++ b/landing/components/registry/RegistryPluginCard.vue
@@ -83,6 +83,21 @@ const repositoryStars = computed(() =>
     maximumFractionDigits: 1,
   }).format(props.plugin.discovery?.stars ?? 0),
 );
+const securityLabel = computed(() => {
+  if (!props.plugin.security) return '';
+  if (props.plugin.security.outcome === 'blocking_findings') {
+    return 'Automated checks: blocking findings';
+  }
+  if (props.plugin.security.outcome === 'warnings') {
+    return 'Automated checks: warnings found';
+  }
+  return 'Automated checks: no blocking findings';
+});
+const securityTitle = computed(() =>
+  props.plugin.security
+    ? `LintAI ${props.plugin.security.scanner.version} checked this exact package revision for known patterns. This is not a guarantee of safety.`
+    : '',
+);
 const provenanceURL = computed(() => {
   const source = selectedDistribution.value?.source ?? props.plugin.source;
   if (!source?.revision) return '';
@@ -164,6 +179,21 @@ function updateAutoDetect(value: boolean) {
       title="Stars belong to the GitHub repository, not this individual package"
     >
       <span aria-hidden="true">★</span> {{ repositoryStars }} stars on repo · Agent Plugins 1.0
+    </p>
+    <p
+      v-if="plugin.security"
+      class="plugin-card__security"
+      :class="`plugin-card__security--${plugin.security.outcome}`"
+      :title="securityTitle"
+    >
+      <span aria-hidden="true">{{
+        plugin.security.outcome === 'blocking_findings'
+          ? '!'
+          : plugin.security.outcome === 'warnings'
+            ? '△'
+            : '✓'
+      }}</span>
+      {{ securityLabel }}
     </p>
     <p class="plugin-card__description">{{ plugin.description }}</p>
     <div class="plugin-card__bottom">

--- a/landing/composables/useRegistry.ts
+++ b/landing/composables/useRegistry.ts
@@ -1,5 +1,6 @@
 import type { RegistryIndex } from '~/types/registry';
 import { BrowserDiscoveryCache, discoveryPlugin, loadDiscovery } from '~/utils/discovery';
+import { applySecurityAssessment, loadSecurity } from '~/utils/security';
 
 export function useRegistry(): RegistryIndex {
   const config = useRuntimeConfig();
@@ -16,6 +17,13 @@ export function useRegistry(): RegistryIndex {
       status.value = { state: 'loading', count: 0 };
       const baseURL = String(config.public.baseURL).replace(/\/?$/, '/');
       const origin = new URL(`${baseURL}discovery/`, location.origin);
+      const security = loadSecurity({
+        origin: new URL(`${baseURL}security/`, location.origin),
+        trust: {
+          keyID: String(config.public.discoveryKeyID),
+          publicKeyBase64: String(config.public.discoveryPublicKey),
+        },
+      }).catch(() => undefined);
       try {
         const bundle = await loadDiscovery({
           origin,
@@ -39,6 +47,13 @@ export function useRegistry(): RegistryIndex {
           sequence: bundle.snapshot.sequence,
           generatedAt: bundle.snapshot.generated_at,
         };
+        const securityBundle = await security;
+        if (securityBundle) {
+          await waitForCatalogInteractionToFinish();
+          registry.value.plugins = registry.value.plugins.map((plugin) =>
+            applySecurityAssessment(plugin, securityBundle.snapshot),
+          );
+        }
       } catch (error) {
         registry.value.plugins = registry.value.plugins.filter(
           (plugin) => plugin.trust_state !== 'conformant_unreviewed',

--- a/landing/tests/browser/landing.spec.ts
+++ b/landing/tests/browser/landing.spec.ts
@@ -50,6 +50,12 @@ test('homepage installs with auto-detection and exposes the full directory', asy
   await expect(page.locator('.client-strip li')).toHaveCount(11);
   await expect(page.getByRole('contentinfo')).toHaveCount(1);
   await expect(page.locator('.plugin-card').first()).toBeVisible();
+  const securityBadge = page.locator('.plugin-card__security').first();
+  await expect(securityBadge).toBeVisible({ timeout: 15_000 });
+  await expect(securityBadge).toContainText(
+    /Automated checks: (?:no blocking findings|warnings found|blocking findings)/,
+  );
+  await expect(page.getByText(/guarantee of safety/i)).toHaveCount(0);
   await expect(page.locator('.catalog-count')).toContainText(/[2-9]\d{3} plugins/, {
     timeout: 15_000,
   });

--- a/landing/tests/security.test.ts
+++ b/landing/tests/security.test.ts
@@ -1,0 +1,194 @@
+import assert from 'node:assert/strict';
+import { createHash, generateKeyPairSync, sign } from 'node:crypto';
+import { describe, it } from 'node:test';
+import type { RegistryPlugin } from '../types/registry.ts';
+import {
+  applySecurityAssessment,
+  loadSecurity,
+  lookupSecurity,
+  verifySecurity,
+} from '../utils/security.ts';
+import { canonicalJSON, signedMessage } from '../utils/signedFeed.ts';
+
+const encoder = new TextEncoder();
+const now = new Date('2026-09-06T00:00:00Z');
+const tree = `sha256:${'1'.repeat(64)}`;
+const manifest = `sha256:${'2'.repeat(64)}`;
+
+function bytes(value: unknown) {
+  return encoder.encode(canonicalJSON(value, 'Security Index'));
+}
+
+function digest(value: Uint8Array) {
+  return `sha256:${createHash('sha256').update(value).digest('hex')}`;
+}
+
+function fixture(sequence = 7) {
+  const record = {
+    subject: { tree_digest: tree, manifest_digest: manifest },
+    outcome: 'warnings' as const,
+    counts: { blocking: 0, warnings: 1, total: 1 },
+    scanned_files: 2,
+    report_digest: `sha256:${'3'.repeat(64)}`,
+    findings: [
+      {
+        code: 'SEC301',
+        disposition: 'warning' as const,
+        severity: 'warn' as const,
+        confidence: 'high' as const,
+        category: 'security',
+        path: 'mcp.json',
+        line: 2,
+        message: 'Review this endpoint',
+      },
+    ],
+  };
+  const snapshot = {
+    security_schema_version: 1 as const,
+    sequence,
+    publication_id: `security-test-${sequence}`,
+    source_commit: 'a'.repeat(40),
+    generated_at: '2026-09-05T00:00:00Z',
+    expires_at: '2026-10-05T00:00:00Z',
+    complete: true as const,
+    discovery: { sequence: 20, snapshot_digest: `sha256:${'4'.repeat(64)}` },
+    scanner: { id: 'lintai', version: '0.1.2' },
+    policy: { id: 'agent-plugin-install', version: 1, digest: `sha256:${'5'.repeat(64)}` },
+    coverage: { subjects: 1, checked: 1, unavailable: 0 },
+    records: [record],
+  };
+  const snapshotBytes = bytes(snapshot);
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+  const rawPublicKey = publicKey
+    .export({ format: 'der', type: 'spki' })
+    .subarray(-32);
+  const envelope = {
+    envelope_schema_version: 1 as const,
+    snapshot_schema_version: 1 as const,
+    sequence,
+    key_id: 'security-test',
+    algorithm: 'Ed25519' as const,
+    signature_domain: 'UAP-SECURITY-INDEX-ED25519-V1' as const,
+    snapshot_digest: digest(snapshotBytes),
+    signature: sign(null, signedMessage('UAP-SECURITY-INDEX-ED25519-V1', snapshotBytes), privateKey).toString('base64'),
+  };
+  const stem = String(sequence).padStart(20, '0');
+  const pointer = {
+    pointer_schema_version: 1 as const,
+    snapshot_schema_version: 1 as const,
+    sequence,
+    snapshot_path: `snapshots/${stem}.json`,
+    envelope_path: `snapshots/${stem}.envelope.json`,
+    fetch_contract: {
+      max_redirects: 0,
+      latest_max_bytes: 16 << 10,
+      snapshot_max_bytes: 8 << 20,
+      envelope_max_bytes: 16 << 10,
+      retry_attempts: 3,
+    },
+  };
+  return {
+    payloads: {
+      pointer: bytes(pointer),
+      snapshot: snapshotBytes,
+      envelope: bytes(envelope),
+    },
+    trust: {
+      keyID: 'security-test',
+      publicKeyBase64: rawPublicKey.toString('base64'),
+    },
+    snapshot,
+  };
+}
+
+describe('signed public Security Index', () => {
+  it('verifies and decorates only the exact package revision', async () => {
+    const data = fixture();
+    const bundle = await verifySecurity(
+      data.payloads.pointer,
+      data.payloads.snapshot,
+      data.payloads.envelope,
+      data.trust,
+      now,
+    );
+    assert.equal(
+      lookupSecurity(bundle.snapshot.records, {
+        tree_digest: tree,
+        manifest_digest: manifest,
+      })?.outcome,
+      'warnings',
+    );
+    assert.equal(
+      lookupSecurity(bundle.snapshot.records, {
+        tree_digest: tree,
+        manifest_digest: `sha256:${'f'.repeat(64)}`,
+      }),
+      undefined,
+    );
+    const plugin = {
+      discovery: { tree_digest: tree, manifest_digest: manifest },
+    } as RegistryPlugin;
+    const decorated = applySecurityAssessment(plugin, bundle.snapshot);
+    assert.equal(decorated.security?.scanner.version, '0.1.2');
+    assert.equal(decorated.security?.counts.warnings, 1);
+  });
+
+  it('rejects tampering, stale feeds, and inconsistent counts', async () => {
+    const data = fixture();
+    const tampered = structuredClone(data.payloads);
+    tampered.snapshot[tampered.snapshot.length - 2] ^= 1;
+    await assert.rejects(
+      verifySecurity(
+        tampered.pointer,
+        tampered.snapshot,
+        tampered.envelope,
+        data.trust,
+        now,
+      ),
+      /canonical|digest|JSON/,
+    );
+    await assert.rejects(
+      verifySecurity(
+        data.payloads.pointer,
+        data.payloads.snapshot,
+        data.payloads.envelope,
+        data.trust,
+        new Date('2026-10-05T00:00:00Z'),
+      ),
+      /stale/,
+    );
+
+    const invalid = fixture();
+    const snapshot = JSON.parse(new TextDecoder().decode(invalid.payloads.snapshot));
+    snapshot.records[0].counts.total = 0;
+    await assert.rejects(
+      verifySecurity(
+        invalid.payloads.pointer,
+        bytes(snapshot),
+        invalid.payloads.envelope,
+        invalid.trust,
+        now,
+      ),
+      /record|counts|digest/,
+    );
+  });
+
+  it('loads the three bounded artifacts from one origin', async () => {
+    const data = fixture();
+    const origin = new URL('https://catalog.example/security/');
+    const stem = '00000000000000000007';
+    const values = new Map([
+      [new URL('latest.json', origin).href, data.payloads.pointer],
+      [new URL(`snapshots/${stem}.json`, origin).href, data.payloads.snapshot],
+      [new URL(`snapshots/${stem}.envelope.json`, origin).href, data.payloads.envelope],
+    ]);
+    const fetcher: typeof fetch = async (input) => {
+      const value = values.get(String(input));
+      return value
+        ? new Response(value, { status: 200 })
+        : new Response('', { status: 404 });
+    };
+    const bundle = await loadSecurity({ origin, trust: data.trust, fetcher, now });
+    assert.equal(bundle.snapshot.sequence, 7);
+  });
+});

--- a/landing/types/registry.ts
+++ b/landing/types/registry.ts
@@ -1,3 +1,5 @@
+import type { SecurityFinding } from './security';
+
 export interface PluginAuthor {
   name: string;
   email?: string;
@@ -170,6 +172,15 @@ export interface RegistryPlugin {
     mcp_transports: string[];
     availability: 'available' | 'unavailable';
     reviewed_distribution_id?: string;
+  };
+  security?: {
+    generated_at: string;
+    scanner: { id: string; version: string };
+    policy: { id: string; version: number; digest: string };
+    outcome: 'no_blocking_findings' | 'warnings' | 'blocking_findings';
+    counts: { blocking: number; warnings: number; total: number };
+    scanned_files: number;
+    findings: SecurityFinding[];
   };
 }
 

--- a/landing/types/security.ts
+++ b/landing/types/security.ts
@@ -1,0 +1,83 @@
+export type SecurityOutcome =
+  | 'no_blocking_findings'
+  | 'warnings'
+  | 'blocking_findings'
+  | 'check_unavailable';
+
+export interface SecuritySubject {
+  tree_digest: string;
+  manifest_digest: string;
+}
+
+export interface SecurityFinding {
+  code: string;
+  disposition: 'blocking' | 'warning';
+  severity: 'allow' | 'warn' | 'deny';
+  confidence: 'low' | 'medium' | 'high';
+  category: string;
+  path: string;
+  line?: number;
+  message: string;
+}
+
+export interface SecurityRecord {
+  subject: SecuritySubject;
+  outcome: SecurityOutcome;
+  counts: { blocking: number; warnings: number; total: number };
+  scanned_files: number;
+  report_digest?: string;
+  error_code?: 'acquisition_failed' | 'scan_failed';
+  findings: SecurityFinding[];
+}
+
+export interface SecurityPointer {
+  pointer_schema_version: 1;
+  snapshot_schema_version: 1;
+  sequence: number;
+  snapshot_path: string;
+  envelope_path: string;
+  fetch_contract: {
+    max_redirects: number;
+    latest_max_bytes: number;
+    snapshot_max_bytes: number;
+    envelope_max_bytes: number;
+    retry_attempts: number;
+  };
+}
+
+export interface SecurityEnvelope {
+  envelope_schema_version: 1;
+  snapshot_schema_version: 1;
+  sequence: number;
+  key_id: string;
+  algorithm: 'Ed25519';
+  signature_domain: 'UAP-SECURITY-INDEX-ED25519-V1';
+  snapshot_digest: string;
+  signature: string;
+}
+
+export interface SecuritySnapshot {
+  security_schema_version: 1;
+  sequence: number;
+  publication_id: string;
+  source_commit: string;
+  generated_at: string;
+  expires_at: string;
+  complete: true;
+  discovery: { sequence: number; snapshot_digest: string };
+  scanner: { id: string; version: string };
+  policy: { id: string; version: number; digest: string };
+  coverage: { subjects: number; checked: number; unavailable: number };
+  records: SecurityRecord[];
+}
+
+export interface SecurityBundle {
+  pointer: SecurityPointer;
+  envelope: SecurityEnvelope;
+  snapshot: SecuritySnapshot;
+}
+
+export interface SecurityTrust {
+  keyID: string;
+  publicKeyBase64: string;
+}

--- a/landing/utils/discovery.ts
+++ b/landing/utils/discovery.ts
@@ -7,19 +7,29 @@ import type {
   DiscoverySnapshot,
 } from '../types/discovery';
 import type { ClientID, ComponentID, RegistryPlugin } from '../types/registry';
+import {
+  assertExactKeys,
+  bytesEqual,
+  canonicalJSON,
+  decodeBase64,
+  encodeBase64,
+  fetchSignedArtifact,
+  parseCanonicalJSON,
+  parseUTCTimestamp,
+  sha256Digest,
+  signedMessage,
+  type ArtifactResponse,
+} from './signedFeed.ts';
 
-const signatureDomain = 'UAP-DISCOVERY-INDEX-ED25519-V1\0';
+const signatureDomain = 'UAP-DISCOVERY-INDEX-ED25519-V1';
 const digestPattern = /^sha256:[0-9a-f]{64}$/;
 const revisionPattern = /^[0-9a-f]{40}$/;
-const timestampPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
 const repositoryPattern = /^[a-z0-9][a-z0-9-]*\/[a-z0-9][a-z0-9._-]*$/;
 const packagePathPattern = /^(?:|[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)*)$/;
 // Unreviewed Discovery metadata cannot assert the registered app binding that
 // ChatGPT requires. Reviewed Directory products add ChatGPT independently.
 const clientOrder: ClientID[] = ['codex', 'cursor', 'copilot', 'vscode', 'kiro'];
 const transportOrder = ['sse', 'stdio', 'streamable-http'];
-const encoder = new TextEncoder();
-const decoder = new TextDecoder('utf-8', { fatal: true });
 
 type ArtifactName = keyof DiscoveryBundle['bytes'];
 
@@ -106,10 +116,11 @@ export async function loadDiscovery(options: DiscoveryLoadOptions): Promise<Disc
         () => undefined,
       )
     : undefined;
-  const pointerResponse = await fetchArtifact(
+  const pointerResponse = await fetchSignedArtifact(
     new URL('latest.json', options.origin),
     16 << 10,
     fetcher,
+    'Discovery',
     cachedRaw?.etags.pointer,
   ).catch((error: unknown) => ({ error }));
 
@@ -137,10 +148,11 @@ export async function loadDiscovery(options: DiscoveryLoadOptions): Promise<Disc
     ];
     const loaded = await Promise.all(
       artifactSpecs.map(async ([name, path, maximum]) => {
-        const response = await fetchArtifact(
+        const response = await fetchSignedArtifact(
           new URL(path, options.origin),
           maximum,
           fetcher,
+          'Discovery',
           undefined,
         );
         if (response.notModified) throw new Error(`Discovery ${name} returned an unexpected 304`);
@@ -180,9 +192,9 @@ export async function verifyDiscovery(
   now = new Date(),
 ): Promise<DiscoveryBundle> {
   const pointer = parsePointer(bytes.pointer);
-  const envelope = parseCanonical<DiscoveryEnvelope>(bytes.envelope, 'envelope');
-  const snapshot = parseCanonical<DiscoverySnapshot>(bytes.snapshot, 'snapshot');
-  const search = parseCanonical<DiscoverySearch>(bytes.search, 'search');
+  const envelope = parseCanonicalJSON<DiscoveryEnvelope>(bytes.envelope, 'Discovery', 'envelope');
+  const snapshot = parseCanonicalJSON<DiscoverySnapshot>(bytes.snapshot, 'Discovery', 'snapshot');
+  const search = parseCanonicalJSON<DiscoverySearch>(bytes.search, 'Discovery', 'search');
   assertEnvelope(envelope, trust);
   assertSnapshot(snapshot);
   assertSearch(search);
@@ -206,8 +218,8 @@ export async function verifyDiscovery(
     throw new Error('Discovery record count mismatch');
   }
   if (
-    (await sha256(bytes.snapshot)) !== envelope.snapshot_digest ||
-    (await sha256(bytes.search)) !== snapshot.search_projection.digest
+    (await sha256Digest(bytes.snapshot)) !== envelope.snapshot_digest ||
+    (await sha256Digest(bytes.search)) !== snapshot.search_projection.digest
   ) {
     throw new Error('Discovery digest mismatch');
   }
@@ -218,7 +230,7 @@ export async function verifyDiscovery(
   const key = await crypto.subtle.importKey('raw', publicKey, { name: 'Ed25519' }, false, [
     'verify',
   ]);
-  if (!(await crypto.subtle.verify('Ed25519', key, signature, signatureMessage(bytes.snapshot)))) {
+  if (!(await crypto.subtle.verify('Ed25519', key, signature, signedMessage(signatureDomain, bytes.snapshot)))) {
     throw new Error('Discovery signature is invalid');
   }
   for (let index = 0; index < snapshot.records.length; index += 1) {
@@ -228,11 +240,11 @@ export async function verifyDiscovery(
       last_seen: _lastSeen,
       ...compact
     } = snapshot.records[index]!;
-    if (canonicalValue(compact) !== canonicalValue(search.records[index]))
+    if (canonicalJSON(compact, 'Discovery') !== canonicalJSON(search.records[index], 'Discovery'))
       throw new Error('Discovery search record mismatch');
   }
-  const generated = parseTimestamp(snapshot.generated_at);
-  const expires = parseTimestamp(snapshot.expires_at);
+  const generated = parseUTCTimestamp(snapshot.generated_at, 'Discovery');
+  const expires = parseUTCTimestamp(snapshot.expires_at, 'Discovery');
   if (now.getTime() < generated.getTime())
     throw new Error('Discovery local clock is before generation time');
   if (now.getTime() >= expires.getTime()) throw new Error('Discovery snapshot is stale');
@@ -341,41 +353,9 @@ export function discoveryPlugin(
   };
 }
 
-interface ArtifactResponse {
-  bytes: Uint8Array;
-  etag?: string;
-  notModified: boolean;
-}
-
-async function fetchArtifact(
-  url: URL,
-  maximum: number,
-  fetcher: typeof fetch,
-  etag?: string,
-): Promise<ArtifactResponse> {
-  const headers = new Headers({ accept: 'application/json' });
-  if (etag) headers.set('if-none-match', etag);
-  const response = await fetcher(url, {
-    cache: 'no-cache',
-    credentials: 'omit',
-    headers,
-    redirect: 'error',
-  });
-  if (response.status === 304) return { bytes: new Uint8Array(), etag, notModified: true };
-  if (!response.ok || (response.url && new URL(response.url).origin !== url.origin))
-    throw new Error(`Discovery request failed with HTTP ${response.status}`);
-  const declared = Number(response.headers.get('content-length'));
-  if (Number.isFinite(declared) && declared > maximum)
-    throw new Error('Discovery response exceeds its size limit');
-  const bytes = new Uint8Array(await response.arrayBuffer());
-  if (!bytes.length || bytes.length > maximum)
-    throw new Error('Discovery response exceeds its size limit');
-  return { bytes, etag: response.headers.get('etag') ?? undefined, notModified: false };
-}
-
 function parsePointer(bytes: Uint8Array): DiscoveryPointer {
-  const value = parseCanonical<DiscoveryPointer>(bytes, 'pointer');
-  assertKeys(
+  const value = parseCanonicalJSON<DiscoveryPointer>(bytes, 'Discovery', 'pointer');
+  assertExactKeys(
     value,
     [
       'pointer_schema_version',
@@ -386,9 +366,10 @@ function parsePointer(bytes: Uint8Array): DiscoveryPointer {
       'search_path',
       'fetch_contract',
     ],
+    'Discovery',
     'pointer',
   );
-  assertKeys(
+  assertExactKeys(
     value.fetch_contract,
     [
       'max_redirects',
@@ -398,6 +379,7 @@ function parsePointer(bytes: Uint8Array): DiscoveryPointer {
       'search_max_bytes',
       'retry_attempts',
     ],
+    'Discovery',
     'fetch contract',
   );
   requirePublicSequence(value.sequence, 'pointer');
@@ -427,7 +409,7 @@ function parsePointer(bytes: Uint8Array): DiscoveryPointer {
 }
 
 function assertEnvelope(value: DiscoveryEnvelope, trust: DiscoveryTrust) {
-  assertKeys(
+  assertExactKeys(
     value,
     [
       'envelope_schema_version',
@@ -439,6 +421,7 @@ function assertEnvelope(value: DiscoveryEnvelope, trust: DiscoveryTrust) {
       'snapshot_digest',
       'signature',
     ],
+    'Discovery',
     'envelope',
   );
   requirePublicSequence(value.sequence, 'envelope');
@@ -456,7 +439,7 @@ function assertEnvelope(value: DiscoveryEnvelope, trust: DiscoveryTrust) {
 }
 
 function assertSnapshot(value: DiscoverySnapshot) {
-  assertKeys(
+  assertExactKeys(
     value,
     [
       'discovery_schema_version',
@@ -471,9 +454,15 @@ function assertSnapshot(value: DiscoverySnapshot) {
       'search_projection',
       'records',
     ],
+    'Discovery',
     'snapshot',
   );
-  assertKeys(value.search_projection, ['path', 'digest', 'record_count'], 'search projection');
+  assertExactKeys(
+    value.search_projection,
+    ['path', 'digest', 'record_count'],
+    'Discovery',
+    'search projection',
+  );
   requirePublicSequence(value.sequence, 'snapshot');
   if (
     value.discovery_schema_version !== 1 ||
@@ -487,12 +476,17 @@ function assertSnapshot(value: DiscoverySnapshot) {
     value.records.length > 10_000
   )
     throw new Error('Discovery snapshot is invalid');
-  const generated = parseTimestamp(value.generated_at);
-  const expires = parseTimestamp(value.expires_at);
+  const generated = parseUTCTimestamp(value.generated_at, 'Discovery');
+  const expires = parseUTCTimestamp(value.expires_at, 'Discovery');
   if (expires <= generated || expires.getTime() - generated.getTime() > 7 * 86_400_000)
     throw new Error('Discovery lifetime is invalid');
   value.partitions.forEach((partition) => {
-    assertKeys(partition, ['query', 'size_min', 'size_max', 'total_count'], 'partition');
+    assertExactKeys(
+      partition,
+      ['query', 'size_min', 'size_max', 'total_count'],
+      'Discovery',
+      'partition',
+    );
     if (
       !partition.query ||
       !integer(partition.size_min) ||
@@ -510,12 +504,17 @@ function assertSnapshot(value: DiscoverySnapshot) {
 }
 
 function assertSearch(value: DiscoverySearch) {
-  assertKeys(value, ['search_schema_version', 'sequence', 'generated_at', 'records'], 'search');
+  assertExactKeys(
+    value,
+    ['search_schema_version', 'sequence', 'generated_at', 'records'],
+    'Discovery',
+    'search',
+  );
   requirePublicSequence(value.sequence, 'search');
   if (value.search_schema_version !== 1 || value.records.length > 10_000) {
     throw new Error('Discovery search projection is invalid');
   }
-  assertRecords(value.records, false, parseTimestamp(value.generated_at));
+  assertRecords(value.records, false, parseUTCTimestamp(value.generated_at, 'Discovery'));
 }
 
 function assertRecords(records: DiscoveryRecord[], full: boolean, generated: Date) {
@@ -547,12 +546,18 @@ function assertRecords(records: DiscoveryRecord[], full: boolean, generated: Dat
       'reviewed_distribution_id',
       'availability',
     ];
-    assertKeys(
+    assertExactKeys(
       record,
       full ? [...commonFields, 'author', 'first_seen', 'last_seen'] : commonFields,
+      'Discovery',
       'record',
     );
-    assertKeys(record.components, ['extensions', 'mcp', 'skills'], 'components');
+    assertExactKeys(
+      record.components,
+      ['extensions', 'mcp', 'skills'],
+      'Discovery',
+      'components',
+    );
     if (full && record.author) {
       const authorKeys = Object.keys(record.author);
       if (
@@ -594,10 +599,10 @@ function assertRecords(records: DiscoveryRecord[], full: boolean, generated: Dat
       !['not_required', 'required', 'unknown'].includes(record.authentication)
     )
       throw new Error(`Discovery record ${record.slug} is invalid`);
-    parseTimestamp(record.repository_updated_at);
+    parseUTCTimestamp(record.repository_updated_at, 'Discovery');
     if (full) {
-      const first = parseTimestamp(record.first_seen ?? '');
-      const last = parseTimestamp(record.last_seen ?? '');
+      const first = parseUTCTimestamp(record.first_seen ?? '', 'Discovery');
+      const last = parseUTCTimestamp(record.last_seen ?? '', 'Discovery');
       if (first > last || last > generated || (record.author && !record.author.name.trim()))
         throw new Error('Discovery seen interval is invalid');
     } else if (
@@ -611,73 +616,6 @@ function assertRecords(records: DiscoveryRecord[], full: boolean, generated: Dat
     slugs.add(record.slug);
     prior = order;
   });
-}
-
-function parseCanonical<T>(bytes: Uint8Array, label: string): T {
-  const text = decoder.decode(bytes);
-  const value = JSON.parse(text) as T;
-  if (canonicalValue(value) !== text) throw new Error(`Discovery ${label} is not canonical JSON`);
-  return value;
-}
-
-function canonicalValue(value: unknown): string {
-  validateCanonical(value);
-  const sort = (item: unknown): unknown =>
-    Array.isArray(item)
-      ? item.map(sort)
-      : item && typeof item === 'object'
-        ? Object.fromEntries(
-            Object.entries(item)
-              .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
-              .map(([key, child]) => [key, sort(child)]),
-          )
-        : item;
-  return `${JSON.stringify(sort(value))}\n`;
-}
-
-function validateCanonical(value: unknown) {
-  if (value === null || typeof value === 'boolean') return;
-  if (typeof value === 'number') {
-    if (!Number.isSafeInteger(value))
-      throw new Error('Discovery JSON contains a non-integer number');
-    return;
-  }
-  if (typeof value === 'string') {
-    if (value !== value.normalize('NFC')) throw new Error('Discovery JSON contains non-NFC text');
-    return;
-  }
-  if (Array.isArray(value)) return value.forEach(validateCanonical);
-  if (!value || typeof value !== 'object')
-    throw new Error('Discovery JSON contains an unsupported value');
-  const folded = new Set<string>();
-  Object.entries(value).forEach(([key, child]) => {
-    if (key !== key.normalize('NFC') || folded.has(key.toLocaleLowerCase()))
-      throw new Error('Discovery JSON contains colliding keys');
-    folded.add(key.toLocaleLowerCase());
-    validateCanonical(child);
-  });
-}
-
-async function sha256(bytes: Uint8Array) {
-  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', Uint8Array.from(bytes)));
-  return `sha256:${[...digest].map((byte) => byte.toString(16).padStart(2, '0')).join('')}`;
-}
-
-function signatureMessage(snapshot: Uint8Array) {
-  const prefix = encoder.encode(signatureDomain);
-  const result = new Uint8Array(prefix.length + 8 + snapshot.length);
-  result.set(prefix);
-  new DataView(result.buffer).setBigUint64(prefix.length, BigInt(snapshot.length));
-  result.set(snapshot, prefix.length + 8);
-  return result;
-}
-
-function parseTimestamp(value: string) {
-  if (!timestampPattern.test(value))
-    throw new Error('Discovery timestamp must use second-precision UTC');
-  const parsed = new Date(value);
-  if (!Number.isFinite(parsed.getTime())) throw new Error('Discovery timestamp is invalid');
-  return parsed;
 }
 
 function orderedEnums(values: readonly string[], allowed: readonly string[]) {
@@ -698,29 +636,4 @@ function integer(value: number) {
 function requirePublicSequence(value: number, label: string) {
   if (!Number.isSafeInteger(value) || value < 1)
     throw new Error(`Discovery ${label} sequence is invalid`);
-}
-
-function assertKeys(value: object, expected: string[], label: string) {
-  const actual = Object.keys(value).sort();
-  const wanted = [...expected].sort();
-  if (actual.length !== wanted.length || actual.some((key, index) => key !== wanted[index])) {
-    throw new Error(`Discovery ${label} fields do not match schema 1`);
-  }
-}
-
-function bytesEqual(left: Uint8Array, right: Uint8Array) {
-  return left.length === right.length && left.every((byte, index) => byte === right[index]);
-}
-
-function encodeBase64(bytes: Uint8Array) {
-  let binary = '';
-  for (let offset = 0; offset < bytes.length; offset += 0x8000) {
-    binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000));
-  }
-  return btoa(binary);
-}
-
-function decodeBase64(value: string) {
-  const binary = atob(value);
-  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
 }

--- a/landing/utils/security.ts
+++ b/landing/utils/security.ts
@@ -1,0 +1,426 @@
+import type {
+  SecurityBundle,
+  SecurityEnvelope,
+  SecurityPointer,
+  SecurityRecord,
+  SecuritySnapshot,
+  SecuritySubject,
+  SecurityTrust,
+} from '../types/security';
+import type { RegistryPlugin } from '../types/registry';
+import {
+  assertExactKeys,
+  decodeBase64,
+  fetchSignedArtifact,
+  parseCanonicalJSON,
+  parseUTCTimestamp,
+  sha256Digest,
+  signedMessage,
+} from './signedFeed.ts';
+
+const namespace = 'Security Index';
+const signatureDomain = 'UAP-SECURITY-INDEX-ED25519-V1';
+const digestPattern = /^sha256:[0-9a-f]{64}$/;
+const revisionPattern = /^[0-9a-f]{40}$/;
+const identifierPattern = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+const publicationPattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$/;
+const versionPattern = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
+const findingPattern = /^[A-Z]+\d+$/;
+
+export interface SecurityLoadOptions {
+  origin: URL;
+  trust: SecurityTrust;
+  fetcher?: typeof fetch;
+  now?: Date;
+}
+
+export async function loadSecurity(options: SecurityLoadOptions): Promise<SecurityBundle> {
+  const fetcher = options.fetcher ?? fetch;
+  const pointerResponse = await fetchWithRetry(
+    new URL('latest.json', options.origin),
+    16 << 10,
+    fetcher,
+    3,
+  );
+  const pointer = parsePointer(pointerResponse.bytes);
+  const [snapshotResponse, envelopeResponse] = await Promise.all([
+    fetchWithRetry(
+      new URL(pointer.snapshot_path, options.origin),
+      pointer.fetch_contract.snapshot_max_bytes,
+      fetcher,
+      pointer.fetch_contract.retry_attempts,
+    ),
+    fetchWithRetry(
+      new URL(pointer.envelope_path, options.origin),
+      pointer.fetch_contract.envelope_max_bytes,
+      fetcher,
+      pointer.fetch_contract.retry_attempts,
+    ),
+  ]);
+  return verifySecurity(
+    pointerResponse.bytes,
+    snapshotResponse.bytes,
+    envelopeResponse.bytes,
+    options.trust,
+    options.now ?? new Date(),
+  );
+}
+
+export async function verifySecurity(
+  pointerBytes: Uint8Array,
+  snapshotBytes: Uint8Array,
+  envelopeBytes: Uint8Array,
+  trust: SecurityTrust,
+  now = new Date(),
+): Promise<SecurityBundle> {
+  const pointer = parsePointer(pointerBytes);
+  const envelope = parseCanonicalJSON<SecurityEnvelope>(envelopeBytes, namespace, 'envelope');
+  const snapshot = parseCanonicalJSON<SecuritySnapshot>(snapshotBytes, namespace, 'snapshot');
+  assertEnvelope(envelope, trust);
+  assertSnapshot(snapshot);
+  if (pointer.sequence !== snapshot.sequence || envelope.sequence !== snapshot.sequence) {
+    throw new Error(`${namespace} sequence mismatch`);
+  }
+  if ((await sha256Digest(snapshotBytes)) !== envelope.snapshot_digest) {
+    throw new Error(`${namespace} digest mismatch`);
+  }
+  const publicKey = decodeBase64(trust.publicKeyBase64);
+  const signature = decodeBase64(envelope.signature);
+  if (publicKey.length !== 32 || signature.length !== 64) {
+    throw new Error(`${namespace} key or signature has an invalid length`);
+  }
+  const key = await crypto.subtle.importKey('raw', publicKey, { name: 'Ed25519' }, false, [
+    'verify',
+  ]);
+  if (
+    !(await crypto.subtle.verify(
+      'Ed25519',
+      key,
+      signature,
+      signedMessage(signatureDomain, snapshotBytes),
+    ))
+  ) {
+    throw new Error(`${namespace} signature is invalid`);
+  }
+  const generated = parseUTCTimestamp(snapshot.generated_at, namespace);
+  const expires = parseUTCTimestamp(snapshot.expires_at, namespace);
+  if (now.getTime() < generated.getTime()) {
+    throw new Error(`${namespace} local clock is before generation time`);
+  }
+  if (now.getTime() >= expires.getTime()) throw new Error(`${namespace} is stale`);
+  return { pointer, envelope, snapshot };
+}
+
+export function applySecurityAssessment(
+  plugin: RegistryPlugin,
+  snapshot: SecuritySnapshot,
+): RegistryPlugin {
+  const subject = plugin.discovery && {
+    tree_digest: plugin.discovery.tree_digest,
+    manifest_digest: plugin.discovery.manifest_digest,
+  };
+  if (!subject) return plugin;
+  const record = lookupSecurity(snapshot.records, subject);
+  if (!record || record.outcome === 'check_unavailable') return plugin;
+  return {
+    ...plugin,
+    security: {
+      generated_at: snapshot.generated_at,
+      scanner: snapshot.scanner,
+      policy: snapshot.policy,
+      outcome: record.outcome,
+      counts: record.counts,
+      scanned_files: record.scanned_files,
+      findings: record.findings,
+    },
+  };
+}
+
+export function lookupSecurity(
+  records: SecurityRecord[],
+  subject: SecuritySubject,
+): SecurityRecord | undefined {
+  let low = 0;
+  let high = records.length;
+  const wanted = subjectKey(subject);
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    if (subjectKey(records[middle]!.subject) < wanted) low = middle + 1;
+    else high = middle;
+  }
+  return records[low]?.subject.tree_digest === subject.tree_digest &&
+    records[low]?.subject.manifest_digest === subject.manifest_digest
+    ? records[low]
+    : undefined;
+}
+
+function parsePointer(bytes: Uint8Array): SecurityPointer {
+  const value = parseCanonicalJSON<SecurityPointer>(bytes, namespace, 'pointer');
+  assertExactKeys(
+    value,
+    [
+      'pointer_schema_version',
+      'snapshot_schema_version',
+      'sequence',
+      'snapshot_path',
+      'envelope_path',
+      'fetch_contract',
+    ],
+    namespace,
+    'pointer',
+  );
+  assertExactKeys(
+    value.fetch_contract,
+    [
+      'max_redirects',
+      'latest_max_bytes',
+      'snapshot_max_bytes',
+      'envelope_max_bytes',
+      'retry_attempts',
+    ],
+    namespace,
+    'fetch contract',
+  );
+  const stem = String(value.sequence).padStart(20, '0');
+  const contract = value.fetch_contract;
+  if (
+    !publicSequence(value.sequence) ||
+    value.pointer_schema_version !== 1 ||
+    value.snapshot_schema_version !== 1 ||
+    value.snapshot_path !== `snapshots/${stem}.json` ||
+    value.envelope_path !== `snapshots/${stem}.envelope.json` ||
+    contract.max_redirects !== 0 ||
+    contract.retry_attempts < 1 ||
+    contract.retry_attempts > 3 ||
+    contract.latest_max_bytes !== 16 << 10 ||
+    contract.snapshot_max_bytes !== 8 << 20 ||
+    contract.envelope_max_bytes !== 16 << 10
+  ) {
+    throw new Error(`${namespace} pointer is invalid`);
+  }
+  return value;
+}
+
+function assertEnvelope(value: SecurityEnvelope, trust: SecurityTrust) {
+  assertExactKeys(
+    value,
+    [
+      'envelope_schema_version',
+      'snapshot_schema_version',
+      'sequence',
+      'key_id',
+      'algorithm',
+      'signature_domain',
+      'snapshot_digest',
+      'signature',
+    ],
+    namespace,
+    'envelope',
+  );
+  if (
+    value.envelope_schema_version !== 1 ||
+    value.snapshot_schema_version !== 1 ||
+    !publicSequence(value.sequence) ||
+    value.key_id !== trust.keyID ||
+    value.algorithm !== 'Ed25519' ||
+    value.signature_domain !== signatureDomain ||
+    !digestPattern.test(value.snapshot_digest) ||
+    !/^[A-Za-z0-9+/]{86}==$/.test(value.signature)
+  ) {
+    throw new Error(`${namespace} envelope is invalid`);
+  }
+}
+
+function assertSnapshot(value: SecuritySnapshot) {
+  assertExactKeys(
+    value,
+    [
+      'security_schema_version',
+      'sequence',
+      'publication_id',
+      'source_commit',
+      'generated_at',
+      'expires_at',
+      'complete',
+      'discovery',
+      'scanner',
+      'policy',
+      'coverage',
+      'records',
+    ],
+    namespace,
+    'snapshot',
+  );
+  assertExactKeys(value.discovery, ['sequence', 'snapshot_digest'], namespace, 'discovery identity');
+  assertExactKeys(value.scanner, ['id', 'version'], namespace, 'scanner');
+  assertExactKeys(value.policy, ['id', 'version', 'digest'], namespace, 'policy');
+  assertExactKeys(value.coverage, ['subjects', 'checked', 'unavailable'], namespace, 'coverage');
+  if (
+    value.security_schema_version !== 1 ||
+    !publicSequence(value.sequence) ||
+    !value.complete ||
+    !publicationPattern.test(value.publication_id) ||
+    !revisionPattern.test(value.source_commit) ||
+    !publicSequence(value.discovery.sequence) ||
+    !digestPattern.test(value.discovery.snapshot_digest) ||
+    !identifierPattern.test(value.scanner.id) ||
+    !versionPattern.test(value.scanner.version) ||
+    !identifierPattern.test(value.policy.id) ||
+    !publicSequence(value.policy.version) ||
+    !digestPattern.test(value.policy.digest) ||
+    !Array.isArray(value.records) ||
+    value.records.length > 10_000
+  ) {
+    throw new Error(`${namespace} snapshot identity is invalid`);
+  }
+  const generated = parseUTCTimestamp(value.generated_at, namespace);
+  const expires = parseUTCTimestamp(value.expires_at, namespace);
+  if (expires <= generated || expires.getTime() - generated.getTime() > 31 * 86_400_000) {
+    throw new Error(`${namespace} lifetime is invalid`);
+  }
+  let checked = 0;
+  let prior = '';
+  value.records.forEach((record, index) => {
+    assertRecord(record);
+    const key = subjectKey(record.subject);
+    if (index && key <= prior) {
+      throw new Error(`${namespace} records are duplicated or not ordered`);
+    }
+    prior = key;
+    if (record.outcome !== 'check_unavailable') checked += 1;
+  });
+  if (
+    !nonNegativeInteger(value.coverage.subjects) ||
+    !nonNegativeInteger(value.coverage.checked) ||
+    !nonNegativeInteger(value.coverage.unavailable) ||
+    value.coverage.subjects !== value.records.length ||
+    value.coverage.checked !== checked ||
+    value.coverage.unavailable !== value.records.length - checked
+  ) {
+    throw new Error(`${namespace} coverage is inconsistent`);
+  }
+}
+
+function assertRecord(record: SecurityRecord) {
+  const unavailable = record.outcome === 'check_unavailable';
+  assertExactKeys(
+    record,
+    unavailable
+      ? ['subject', 'outcome', 'counts', 'scanned_files', 'error_code', 'findings']
+      : ['subject', 'outcome', 'counts', 'scanned_files', 'report_digest', 'findings'],
+    namespace,
+    'record',
+  );
+  assertExactKeys(record.subject, ['tree_digest', 'manifest_digest'], namespace, 'subject');
+  assertExactKeys(record.counts, ['blocking', 'warnings', 'total'], namespace, 'counts');
+  if (
+    !digestPattern.test(record.subject.tree_digest) ||
+    !digestPattern.test(record.subject.manifest_digest) ||
+    !nonNegativeInteger(record.counts.blocking) ||
+    !nonNegativeInteger(record.counts.warnings) ||
+    !nonNegativeInteger(record.counts.total) ||
+    record.counts.total !== record.counts.blocking + record.counts.warnings ||
+    !nonNegativeInteger(record.scanned_files) ||
+    !Array.isArray(record.findings) ||
+    record.findings.length > 32
+  ) {
+    throw new Error(`${namespace} record is invalid`);
+  }
+  if (unavailable) {
+    if (
+      (record.error_code !== 'acquisition_failed' && record.error_code !== 'scan_failed') ||
+      record.counts.total ||
+      record.scanned_files ||
+      record.report_digest ||
+      record.findings.length
+    ) {
+      throw new Error(`${namespace} unavailable record is invalid`);
+    }
+    return;
+  }
+  if (
+    !['no_blocking_findings', 'warnings', 'blocking_findings'].includes(record.outcome) ||
+    !digestPattern.test(record.report_digest ?? '') ||
+    record.error_code
+  ) {
+    throw new Error(`${namespace} checked record is invalid`);
+  }
+  const expected = record.counts.blocking
+    ? 'blocking_findings'
+    : record.counts.warnings
+      ? 'warnings'
+      : 'no_blocking_findings';
+  if (record.outcome !== expected) throw new Error(`${namespace} outcome does not match counts`);
+  let projectedBlocking = 0;
+  let projectedWarnings = 0;
+  let prior = '';
+  record.findings.forEach((finding, index) => {
+    const fields = ['code', 'disposition', 'severity', 'confidence', 'category', 'path', 'message'];
+    if (finding.line !== undefined) fields.push('line');
+    assertExactKeys(finding, fields, namespace, 'finding');
+    if (
+      !findingPattern.test(finding.code) ||
+      !['blocking', 'warning'].includes(finding.disposition) ||
+      !['allow', 'warn', 'deny'].includes(finding.severity) ||
+      !['low', 'medium', 'high'].includes(finding.confidence) ||
+      !finding.category.trim() ||
+      [...finding.category].length > 64 ||
+      [...finding.path].length > 1024 ||
+      (finding.line !== undefined &&
+        (!Number.isSafeInteger(finding.line) || finding.line < 1)) ||
+      !finding.message.trim() ||
+      [...finding.message].length > 2000
+    ) {
+      throw new Error(`${namespace} finding is invalid`);
+    }
+    const key = findingKey(finding);
+    if (index && key < prior) throw new Error(`${namespace} findings are not ordered`);
+    prior = key;
+    if (finding.disposition === 'blocking') projectedBlocking += 1;
+    else projectedWarnings += 1;
+  });
+  if (
+    projectedBlocking > record.counts.blocking ||
+    projectedWarnings > record.counts.warnings
+  ) {
+    throw new Error(`${namespace} finding projection exceeds counts`);
+  }
+}
+
+async function fetchWithRetry(
+  url: URL,
+  maximum: number,
+  fetcher: typeof fetch,
+  attempts: number,
+) {
+  let last: unknown;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      return await fetchSignedArtifact(url, maximum, fetcher, namespace);
+    } catch (error) {
+      last = error;
+      if (attempt + 1 < attempts) {
+        await new Promise((resolve) => setTimeout(resolve, (attempt + 1) * 100));
+      }
+    }
+  }
+  throw last;
+}
+
+function publicSequence(value: number) {
+  return Number.isSafeInteger(value) && value >= 1;
+}
+
+function nonNegativeInteger(value: number) {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+function subjectKey(subject: SecuritySubject) {
+  return `${subject.tree_digest}\0${subject.manifest_digest}`;
+}
+
+function findingKey(finding: SecurityRecord['findings'][number]) {
+  return `${finding.disposition}\0${finding.code}\0${finding.path}\0${String(
+    finding.line ?? 0,
+  ).padStart(10, '0')}\0${finding.message}`;
+}

--- a/landing/utils/signedFeed.ts
+++ b/landing/utils/signedFeed.ts
@@ -1,0 +1,149 @@
+const encoder = new TextEncoder();
+const decoder = new TextDecoder('utf-8', { fatal: true });
+
+export interface ArtifactResponse {
+  bytes: Uint8Array;
+  etag?: string;
+  notModified: boolean;
+}
+
+export async function fetchSignedArtifact(
+  url: URL,
+  maximum: number,
+  fetcher: typeof fetch,
+  namespace: string,
+  etag?: string,
+): Promise<ArtifactResponse> {
+  const headers = new Headers({ accept: 'application/json' });
+  if (etag) headers.set('if-none-match', etag);
+  const response = await fetcher(url, {
+    cache: 'no-cache',
+    credentials: 'omit',
+    headers,
+    redirect: 'error',
+  });
+  if (response.status === 304) return { bytes: new Uint8Array(), etag, notModified: true };
+  if (!response.ok || (response.url && new URL(response.url).origin !== url.origin)) {
+    throw new Error(`${namespace} request failed with HTTP ${response.status}`);
+  }
+  const declared = Number(response.headers.get('content-length'));
+  if (Number.isFinite(declared) && declared > maximum) {
+    throw new Error(`${namespace} response exceeds its size limit`);
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (!bytes.length || bytes.length > maximum) {
+    throw new Error(`${namespace} response exceeds its size limit`);
+  }
+  return { bytes, etag: response.headers.get('etag') ?? undefined, notModified: false };
+}
+
+export function parseCanonicalJSON<T>(
+  bytes: Uint8Array,
+  namespace: string,
+  label: string,
+): T {
+  const text = decoder.decode(bytes);
+  const value = JSON.parse(text) as T;
+  if (canonicalJSON(value, namespace) !== text) {
+    throw new Error(`${namespace} ${label} is not canonical JSON`);
+  }
+  return value;
+}
+
+export function canonicalJSON(value: unknown, namespace = 'Signed feed'): string {
+  validateCanonical(value, namespace);
+  const sort = (item: unknown): unknown =>
+    Array.isArray(item)
+      ? item.map(sort)
+      : item && typeof item === 'object'
+        ? Object.fromEntries(
+            Object.entries(item)
+              .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+              .map(([key, child]) => [key, sort(child)]),
+          )
+        : item;
+  return `${JSON.stringify(sort(value))}\n`;
+}
+
+function validateCanonical(value: unknown, namespace: string) {
+  if (value === null || typeof value === 'boolean') return;
+  if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value)) {
+      throw new Error(`${namespace} JSON contains a non-integer number`);
+    }
+    return;
+  }
+  if (typeof value === 'string') {
+    if (value !== value.normalize('NFC')) {
+      throw new Error(`${namespace} JSON contains non-NFC text`);
+    }
+    return;
+  }
+  if (Array.isArray(value)) return value.forEach((child) => validateCanonical(child, namespace));
+  if (!value || typeof value !== 'object') {
+    throw new Error(`${namespace} JSON contains an unsupported value`);
+  }
+  const folded = new Set<string>();
+  Object.entries(value).forEach(([key, child]) => {
+    if (key !== key.normalize('NFC') || folded.has(key.toLocaleLowerCase())) {
+      throw new Error(`${namespace} JSON contains colliding keys`);
+    }
+    folded.add(key.toLocaleLowerCase());
+    validateCanonical(child, namespace);
+  });
+}
+
+export async function sha256Digest(bytes: Uint8Array) {
+  const digest = new Uint8Array(
+    await crypto.subtle.digest('SHA-256', Uint8Array.from(bytes)),
+  );
+  return `sha256:${[...digest].map((byte) => byte.toString(16).padStart(2, '0')).join('')}`;
+}
+
+export function signedMessage(domain: string, snapshot: Uint8Array) {
+  const prefix = encoder.encode(`${domain}\0`);
+  const result = new Uint8Array(prefix.length + 8 + snapshot.length);
+  result.set(prefix);
+  new DataView(result.buffer).setBigUint64(prefix.length, BigInt(snapshot.length));
+  result.set(snapshot, prefix.length + 8);
+  return result;
+}
+
+export function parseUTCTimestamp(value: string, namespace: string) {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(value)) {
+    throw new Error(`${namespace} timestamp must use second-precision UTC`);
+  }
+  const parsed = new Date(value);
+  if (!Number.isFinite(parsed.getTime())) throw new Error(`${namespace} timestamp is invalid`);
+  return parsed;
+}
+
+export function assertExactKeys(
+  value: object,
+  expected: string[],
+  namespace: string,
+  label: string,
+) {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (actual.length !== wanted.length || actual.some((key, index) => key !== wanted[index])) {
+    throw new Error(`${namespace} ${label} fields do not match schema 1`);
+  }
+}
+
+export function decodeBase64(value: string) {
+  const binary = atob(value);
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+export function encodeBase64(bytes: Uint8Array) {
+  let binary = '';
+  for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000));
+  }
+  return btoa(binary);
+}
+
+export function bytesEqual(left: Uint8Array, right: Uint8Array) {
+  return left.length === right.length && left.every((byte, index) => byte === right[index]);
+}

--- a/repotests/pages_contract_integration_test.go
+++ b/repotests/pages_contract_integration_test.go
@@ -21,6 +21,7 @@ func TestPagesSite_CombinesLandingRootAndDocsSubpath(t *testing.T) {
 	mustContain(t, workflow, "DOCS_BASE_PATH: /universal-agent-plugins/docs/")
 	mustContain(t, workflow, "go run ./cmd/agentplugins-registry-mirror")
 	mustContain(t, workflow, "MIRROR_METADATA.json")
+	mustContain(t, workflow, "uap-registry-mirror")
 	mustContain(t, workflow, "777genius/universal-agent-plugins-registry")
 	mustContain(t, workflow, "pnpm run build:pages")
 	mustContain(t, workflow, "path: .pages-dist")
@@ -74,6 +75,15 @@ func TestPagesSite_CombinesLandingRootAndDocsSubpath(t *testing.T) {
 	mustContain(t, nuxtConfig, `'/plugins'`)
 	mustContain(t, nuxtConfig, "`/plugins/${plugin.name}`")
 	mustContain(t, nuxtConfig, `const sitemapRoutes =`)
+
+	mirrorBody, err := os.ReadFile(filepath.Join(root, "cmd", "agentplugins-registry-mirror", "main.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mirror := string(mirrorBody)
+	mustContain(t, mirror, `"security/latest.json"`)
+	mustContain(t, mirror, `securityv1.Verify`)
+	mustContain(t, mirror, `Security sequence has conflicting authenticated bytes`)
 
 	pluginDetailPageBody, err := os.ReadFile(filepath.Join(root, "landing", "pages", "plugins", "[slug].vue"))
 	if err != nil {


### PR DESCRIPTION
## Summary

- mirror the signed Security Index beside Directory and Discovery during every Pages build
- verify Security signatures and exact package digests in the browser before showing an assessment
- label exact Discovery revisions with no-blocking, warning, or blocking results without claiming safety
- keep unavailable checks and revision mismatches unlabeled

## Verification

- `go test ./cmd/agentplugins-registry-mirror ./install/integrationctl/agentplugins/adapters/securityv1`
- `go test ./repotests -run TestPagesSite_CombinesLandingRootAndDocsSubpath -count=1`
- `node --test --experimental-strip-types landing/tests/security.test.ts`
- live signature verification of Security sequence 2 with 2,754 subjects
- full landing generation and browser E2E run in GitHub Actions