### PR TITLE
feat(landing): explain automated plugin checks

### DIFF
--- a/landing/assets/styles/registry.scss
+++ b/landing/assets/styles/registry.scss
@@ -1747,6 +1747,19 @@ img {
   color: var(--cyan);
   font-size: 0.62rem;
   font-weight: 750;
+  text-decoration: none;
+  transition:
+    color 0.16s ease,
+    opacity 0.16s ease;
+}
+.plugin-card__security:hover,
+.plugin-card__security:focus-visible {
+  color: var(--primary-bright);
+}
+.plugin-card__security:focus-visible {
+  outline: 2px solid currentcolor;
+  outline-offset: 3px;
+  border-radius: 5px;
 }
 .plugin-card__security span {
   width: 16px;
@@ -2129,6 +2142,139 @@ img {
   font-size: 0.75rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
+}
+.security-review {
+  margin-top: 32px;
+  padding: 22px;
+  scroll-margin-top: 110px;
+  border: 1px solid var(--line-strong);
+  border-radius: 16px;
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--cyan) 6%, transparent), transparent 48%),
+    var(--surface);
+}
+.security-review--warnings {
+  background: linear-gradient(135deg, rgba(245, 196, 81, 0.07), transparent 48%), var(--surface);
+}
+.security-review--blocking_findings {
+  border-color: color-mix(in srgb, var(--coral) 45%, var(--line));
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--coral) 10%, transparent), transparent 48%),
+    var(--surface);
+}
+.security-review__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+}
+.security-review__eyebrow {
+  margin: 0 0 8px;
+  color: var(--primary-bright);
+  font:
+    750 0.62rem SFMono-Regular,
+    monospace;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.security-review h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+.security-review__status {
+  max-width: 230px;
+  padding: 6px 9px;
+  flex: 0 0 auto;
+  border: 1px solid currentcolor;
+  border-radius: 999px;
+  color: var(--cyan);
+  font-size: 0.6rem;
+  font-weight: 750;
+  text-align: center;
+}
+.security-review--warnings .security-review__status {
+  color: #f5c451;
+}
+.security-review--blocking_findings .security-review__status {
+  color: var(--coral);
+}
+.security-review__scope,
+.security-review__freshness,
+.security-review__disclaimer,
+.security-review__truncated,
+.security-review__empty,
+.security-review__maintainer > p {
+  color: var(--muted);
+  font-size: 0.76rem;
+  line-height: 1.55;
+}
+.security-review__scope {
+  margin: 18px 0 0;
+}
+.security-review__scope code {
+  color: var(--cyan);
+  font-size: 0.7rem;
+}
+.security-review__freshness {
+  margin: 8px 0 0;
+}
+.security-review__group,
+.security-review__maintainer {
+  margin-top: 22px;
+}
+.security-review__group h3,
+.security-review__maintainer summary {
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 750;
+}
+.security-review__maintainer summary {
+  cursor: pointer;
+}
+.security-review__maintainer > p {
+  margin: 10px 0 0;
+}
+.security-review__findings {
+  margin: 12px 0 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+  list-style: none;
+}
+.security-review__findings li {
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--surface-solid) 74%, transparent);
+}
+.security-review__finding-heading {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  color: var(--subtle);
+  font-size: 0.64rem;
+  overflow-wrap: anywhere;
+}
+.security-review__finding-heading code {
+  color: var(--primary-bright);
+  font-size: inherit;
+  font-weight: 750;
+}
+.security-review__findings p {
+  margin: 7px 0 0;
+  color: var(--muted);
+  font-size: 0.74rem;
+  line-height: 1.5;
+}
+.security-review__truncated,
+.security-review__empty {
+  margin: 18px 0 0;
+}
+.security-review__disclaimer {
+  margin: 20px 0 0;
+  padding-top: 16px;
+  border-top: 1px solid var(--line);
+  font-size: 0.7rem;
 }
 .status-card {
   margin-top: 36px;
@@ -2688,6 +2834,15 @@ img {
   .plugin-facts > div {
     grid-template-columns: 1fr;
     gap: 5px;
+  }
+  .security-review {
+    padding: 18px 15px;
+  }
+  .security-review__header {
+    flex-direction: column;
+  }
+  .security-review__status {
+    max-width: none;
   }
   .install-panel {
     padding: 18px 14px;

--- a/landing/components/registry/RegistryPluginCard.vue
+++ b/landing/components/registry/RegistryPluginCard.vue
@@ -83,21 +83,6 @@ const repositoryStars = computed(() =>
     maximumFractionDigits: 1,
   }).format(props.plugin.discovery?.stars ?? 0),
 );
-const securityLabel = computed(() => {
-  if (!props.plugin.security) return '';
-  if (props.plugin.security.outcome === 'blocking_findings') {
-    return 'Automated checks: blocking findings';
-  }
-  if (props.plugin.security.outcome === 'warnings') {
-    return 'Automated checks: warnings found';
-  }
-  return 'Automated checks: no blocking findings';
-});
-const securityTitle = computed(() =>
-  props.plugin.security
-    ? `LintAI ${props.plugin.security.scanner.version} checked this exact package revision for known patterns. This is not a guarantee of safety.`
-    : '',
-);
 const provenanceURL = computed(() => {
   const source = selectedDistribution.value?.source ?? props.plugin.source;
   if (!source?.revision) return '';
@@ -108,6 +93,15 @@ const detailURL = computed(() =>
   isDiscovered.value
     ? { path: '/plugins/community', query: { source: props.plugin.install_source } }
     : `/plugins/${props.plugin.name}`,
+);
+const securityDetailURL = computed(() =>
+  isDiscovered.value
+    ? {
+        path: '/plugins/community',
+        query: { source: props.plugin.install_source },
+        hash: '#security-review',
+      }
+    : `/plugins/${props.plugin.name}#security-review`,
 );
 
 function updateTargets(values: string[]) {
@@ -180,21 +174,11 @@ function updateAutoDetect(value: boolean) {
     >
       <span aria-hidden="true">★</span> {{ repositoryStars }} stars on repo · Agent Plugins 1.0
     </p>
-    <p
+    <SecurityAssessmentBadge
       v-if="plugin.security"
-      class="plugin-card__security"
-      :class="`plugin-card__security--${plugin.security.outcome}`"
-      :title="securityTitle"
-    >
-      <span aria-hidden="true">{{
-        plugin.security.outcome === 'blocking_findings'
-          ? '!'
-          : plugin.security.outcome === 'warnings'
-            ? '△'
-            : '✓'
-      }}</span>
-      {{ securityLabel }}
-    </p>
+      :plugin="plugin"
+      :details-to="securityDetailURL"
+    />
     <p class="plugin-card__description">{{ plugin.description }}</p>
     <div class="plugin-card__bottom">
       <button

--- a/landing/components/registry/SecurityAssessmentBadge.vue
+++ b/landing/components/registry/SecurityAssessmentBadge.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import type { RegistryPlugin } from '~/types/registry';
+import { securityAssessmentLabel, securityAssessmentTooltip } from '~/utils/securityPresentation';
+
+const props = defineProps<{
+  plugin: RegistryPlugin;
+  detailsTo: string | { path: string; query?: Record<string, string>; hash?: string };
+}>();
+const assessment = computed(() => props.plugin.security!);
+const label = computed(() => securityAssessmentLabel(assessment.value));
+const tooltip = computed(() => securityAssessmentTooltip(props.plugin));
+</script>
+
+<template>
+  <NuxtLink
+    class="plugin-card__security"
+    :class="`plugin-card__security--${assessment.outcome}`"
+    :to="detailsTo"
+    :title="tooltip"
+    :aria-label="`${label}. Open the full review for ${plugin.display_name}`"
+  >
+    <span aria-hidden="true">{{
+      assessment.outcome === 'blocking_findings'
+        ? '!'
+        : assessment.outcome === 'warnings'
+          ? 'i'
+          : '✓'
+    }}</span>
+    {{ label }}
+  </NuxtLink>
+</template>

--- a/landing/components/registry/SecurityAssessmentPanel.vue
+++ b/landing/components/registry/SecurityAssessmentPanel.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import type { RegistryPlugin } from '~/types/registry';
+import type { SecurityFinding } from '~/types/security';
+import {
+  formatSecurityDate,
+  groupSecurityFindings,
+  securityAssessmentHeading,
+  securityAssessmentLabel,
+  securityFindingLocation,
+  shortRevision,
+} from '~/utils/securityPresentation';
+
+const props = defineProps<{ plugin: RegistryPlugin }>();
+const assessment = computed(() => props.plugin.security!);
+const groups = computed(() => groupSecurityFindings(assessment.value));
+const heading = computed(() => securityAssessmentHeading(assessment.value));
+const label = computed(() => securityAssessmentLabel(assessment.value));
+const revision = computed(() => shortRevision(props.plugin.source.revision));
+
+function findingLocation(finding: SecurityFinding) {
+  return securityFindingLocation(finding);
+}
+</script>
+
+<template>
+  <section
+    id="security-review"
+    class="security-review"
+    :class="`security-review--${assessment.outcome}`"
+    aria-labelledby="security-review-title"
+  >
+    <div class="security-review__header">
+      <div>
+        <p class="security-review__eyebrow">Automated security review</p>
+        <h2 id="security-review-title">{{ heading }}</h2>
+      </div>
+      <span class="security-review__status">{{ label }}</span>
+    </div>
+
+    <p class="security-review__scope">
+      LintAI {{ assessment.scanner.version }} checked the exact indexed revision
+      <code>{{ revision }}</code> on {{ formatSecurityDate(assessment.generated_at) }}. This result
+      applies only to those package files.
+    </p>
+    <p class="security-review__freshness">
+      A newer upstream revision is different code. It must be indexed and checked again; the CLI
+      will not reuse this result for changed files.
+    </p>
+
+    <div v-if="groups.installer.length" class="security-review__group">
+      <h3>Things to review before installing</h3>
+      <ul class="security-review__findings">
+        <li
+          v-for="(finding, index) in groups.installer"
+          :key="`${finding.code}:${finding.path}:${finding.line}:${index}`"
+        >
+          <div class="security-review__finding-heading">
+            <code>{{ finding.code }}</code>
+            <span v-if="findingLocation(finding)">{{ findingLocation(finding) }}</span>
+          </div>
+          <p>{{ finding.message }}</p>
+        </li>
+      </ul>
+    </div>
+
+    <details v-if="groups.maintainer.length" class="security-review__maintainer">
+      <summary>Repository maintenance notes ({{ groups.maintainer.length }})</summary>
+      <p>
+        These findings concern the author's repository automation. They are useful hardening advice,
+        but those workflows are not run by the installer.
+      </p>
+      <ul class="security-review__findings">
+        <li
+          v-for="(finding, index) in groups.maintainer"
+          :key="`${finding.code}:${finding.path}:${finding.line}:${index}`"
+        >
+          <div class="security-review__finding-heading">
+            <code>{{ finding.code }}</code>
+            <span v-if="findingLocation(finding)">{{ findingLocation(finding) }}</span>
+          </div>
+          <p>{{ finding.message }}</p>
+        </li>
+      </ul>
+    </details>
+
+    <p v-if="groups.hidden" class="security-review__truncated">
+      Showing {{ assessment.findings.length }} of {{ assessment.counts.total }} findings. The signed
+      public summary is size-limited; the totals include every finding from the scan.
+    </p>
+    <p v-if="assessment.counts.total === 0" class="security-review__empty">
+      The automated rules did not detect a blocking pattern in the checked files.
+    </p>
+    <p class="security-review__disclaimer">
+      Automated checks reduce risk; they do not prove that a plugin is safe. Review the source and
+      permissions before installing software you do not trust.
+    </p>
+  </section>
+</template>

--- a/landing/pages/plugins/community.vue
+++ b/landing/pages/plugins/community.vue
@@ -101,6 +101,8 @@ usePageSeo(
               </dd>
             </div>
           </dl>
+
+          <SecurityAssessmentPanel v-if="plugin.security" :plugin="plugin" />
         </article>
 
         <InstallPanel v-model:targets="targets" v-model:auto-detect="autoDetect" :plugin="plugin" />

--- a/landing/tests/browser/landing.spec.ts
+++ b/landing/tests/browser/landing.spec.ts
@@ -53,8 +53,9 @@ test('homepage installs with auto-detection and exposes the full directory', asy
   const securityBadge = page.locator('.plugin-card__security').first();
   await expect(securityBadge).toBeVisible({ timeout: 15_000 });
   await expect(securityBadge).toContainText(
-    /Automated checks: (?:no blocking findings|warnings found|blocking findings)/,
+    /Automated review: (?:no blocking findings|\d+ notes?|\d+ blocking findings?)/,
   );
+  await expect(securityBadge).toHaveAttribute('title', /Checked indexed revision [0-9a-f]{12}/);
   await expect(page.getByText(/guarantee of safety/i)).toHaveCount(0);
   await expect(page.locator('.catalog-count')).toContainText(/[2-9]\d{3} plugins/, {
     timeout: 15_000,
@@ -277,6 +278,25 @@ test('community plugin titles open an installable plugin page instead of GitHub'
     timeout: 15_000,
   });
   await expect(page.locator('.install-panel')).toBeVisible();
+});
+
+test('security badges explain the exact checked revision and open full findings', async ({
+  page,
+}) => {
+  await page.goto('./');
+  const badge = page.locator('.plugin-card__security--warnings').first();
+  await expect(badge).toBeVisible({ timeout: 15_000 });
+  await expect(badge).toHaveAttribute('title', /SEC\d+:/);
+  await expect(badge).toHaveAttribute('href', /plugins\/community.*#security-review/);
+
+  await badge.click();
+  await expect(page).toHaveURL(/plugins\/community.*#security-review/);
+  const review = page.locator('#security-review');
+  await expect(review).toBeVisible({ timeout: 15_000 });
+  await expect(review).toContainText(/checked the exact indexed revision/i);
+  await expect(review).toContainText('A newer upstream revision is different code');
+  await expect(review).toContainText(/SEC\d+/);
+  await expect(review).toContainText('do not prove that a plugin is safe');
 });
 
 test('metadata-only community records stay out of the install catalog', async ({ page }) => {

--- a/landing/tests/securityPresentation.test.ts
+++ b/landing/tests/securityPresentation.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { RegistryPlugin } from '../types/registry.ts';
+import type { SecurityFinding } from '../types/security.ts';
+import {
+  groupSecurityFindings,
+  securityAssessmentHeading,
+  securityAssessmentLabel,
+  securityAssessmentTooltip,
+  securityFindingAudience,
+} from '../utils/securityPresentation.ts';
+
+const finding = (code: string, message = 'Review this pattern'): SecurityFinding => ({
+  code,
+  disposition: 'warning',
+  severity: 'warn',
+  confidence: 'high',
+  category: 'security',
+  path: '.github/workflows/test.yml',
+  line: 12,
+  message,
+});
+
+const plugin = (findings: SecurityFinding[], total = findings.length): RegistryPlugin =>
+  ({
+    display_name: 'Example',
+    source: { revision: 'abcdef1234567890abcdef1234567890abcdef12' },
+    security: {
+      generated_at: '2026-09-05T00:00:00Z',
+      scanner: { id: 'lintai', version: '0.1.2' },
+      policy: { id: 'agent-plugin-install', version: 1, digest: `sha256:${'1'.repeat(64)}` },
+      outcome: total ? 'warnings' : 'no_blocking_findings',
+      counts: { blocking: 0, warnings: total, total },
+      scanned_files: 4,
+      findings,
+    },
+  }) as RegistryPlugin;
+
+describe('security assessment presentation', () => {
+  it('separates repository automation notes from install-relevant findings', () => {
+    for (const code of ['SEC324', 'SEC325', 'SEC326', 'SEC327', 'SEC328']) {
+      assert.equal(securityFindingAudience(finding(code)), 'maintainer');
+    }
+    assert.equal(securityFindingAudience(finding('SEC329')), 'installer');
+    assert.equal(securityFindingAudience(finding('SEC999')), 'installer');
+
+    const assessment = plugin([finding('SEC324'), finding('SEC329')]).security!;
+    const groups = groupSecurityFindings(assessment);
+    assert.deepEqual(
+      groups.maintainer.map(({ code }) => code),
+      ['SEC324'],
+    );
+    assert.deepEqual(
+      groups.installer.map(({ code }) => code),
+      ['SEC329'],
+    );
+  });
+
+  it('uses calm note language without weakening signed blocking outcomes', () => {
+    const warning = plugin([finding('SEC324')]).security!;
+    assert.equal(securityAssessmentLabel(warning), 'Automated review: 1 note');
+    assert.equal(securityAssessmentHeading(warning), 'Repository maintenance notes');
+
+    const blocked = plugin([finding('SEC102')]);
+    blocked.security!.outcome = 'blocking_findings';
+    blocked.security!.counts = { blocking: 1, warnings: 0, total: 1 };
+    assert.equal(
+      securityAssessmentLabel(blocked.security!),
+      'Automated review: 1 blocking finding',
+    );
+    assert.equal(securityAssessmentHeading(blocked.security!), 'Review before installing');
+  });
+
+  it('binds the tooltip to the exact revision and previews real findings', () => {
+    const subject = plugin(
+      [finding('SEC329', 'MCP config launches a mutable package at runtime')],
+      3,
+    );
+    const tooltip = securityAssessmentTooltip(subject);
+    assert.match(tooltip, /indexed revision abcdef123456/);
+    assert.match(tooltip, /SEC329: MCP config launches a mutable package/);
+    assert.match(tooltip, /\+2 more/);
+    assert.match(tooltip, /not a guarantee of safety/);
+    assert.equal(groupSecurityFindings(subject.security!).hidden, 2);
+  });
+});

--- a/landing/utils/securityPresentation.ts
+++ b/landing/utils/securityPresentation.ts
@@ -1,0 +1,90 @@
+import type { RegistryPlugin } from '../types/registry';
+import type { SecurityFinding } from '../types/security';
+
+export type SecurityFindingAudience = 'installer' | 'maintainer';
+
+export interface SecurityFindingGroups {
+  installer: SecurityFinding[];
+  maintainer: SecurityFinding[];
+  hidden: number;
+}
+
+type SecurityAssessment = NonNullable<RegistryPlugin['security']>;
+
+// These findings describe repository automation. The workflows are not copied
+// to an agent or executed during installation, so present them as maintainer
+// hardening notes without hiding them from the public report.
+const maintainerFindingCodes = new Set(['SEC324', 'SEC325', 'SEC326', 'SEC327', 'SEC328']);
+
+export function securityFindingAudience(finding: SecurityFinding): SecurityFindingAudience {
+  return maintainerFindingCodes.has(finding.code) ? 'maintainer' : 'installer';
+}
+
+export function groupSecurityFindings(assessment: SecurityAssessment): SecurityFindingGroups {
+  const groups: SecurityFindingGroups = { installer: [], maintainer: [], hidden: 0 };
+  for (const finding of assessment.findings) {
+    groups[securityFindingAudience(finding)].push(finding);
+  }
+  groups.hidden = Math.max(0, assessment.counts.total - assessment.findings.length);
+  return groups;
+}
+
+export function securityAssessmentLabel(assessment: SecurityAssessment): string {
+  if (assessment.counts.blocking > 0) {
+    return `Automated review: ${formatCount(assessment.counts.blocking, 'blocking finding')}`;
+  }
+  if (assessment.counts.warnings > 0) {
+    return `Automated review: ${formatCount(assessment.counts.warnings, 'note')}`;
+  }
+  return 'Automated review: no blocking findings';
+}
+
+export function securityAssessmentHeading(assessment: SecurityAssessment): string {
+  const groups = groupSecurityFindings(assessment);
+  if (assessment.counts.blocking > 0) return 'Review before installing';
+  if (assessment.counts.warnings === 0) return 'No blocking findings detected';
+  if (groups.installer.length === 0 && groups.hidden === 0) return 'Repository maintenance notes';
+  return 'Automated review notes';
+}
+
+export function securityAssessmentTooltip(plugin: RegistryPlugin): string {
+  const assessment = plugin.security;
+  if (!assessment) return '';
+  const groups = groupSecurityFindings(assessment);
+  const revision = shortRevision(plugin.source.revision);
+  const lines = [
+    securityAssessmentLabel(assessment),
+    `Checked indexed revision ${revision} with LintAI ${assessment.scanner.version}.`,
+  ];
+  const preview = [...groups.installer, ...groups.maintainer].slice(0, 2);
+  lines.push(...preview.map((finding) => `${finding.code}: ${finding.message}`));
+  const remaining = assessment.counts.total - preview.length;
+  if (remaining > 0) lines.push(`+${remaining} more in the full review.`);
+  lines.push('This result applies only to the checked files and is not a guarantee of safety.');
+  return lines.join('\n');
+}
+
+export function shortRevision(revision: string | null): string {
+  return revision?.slice(0, 12) || 'unknown';
+}
+
+export function formatSecurityDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat('en', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(date);
+}
+
+export function securityFindingLocation(finding: SecurityFinding): string {
+  const path = finding.path.trim();
+  if (!path) return '';
+  return finding.line ? `${path}:${finding.line}` : path;
+}
+
+function formatCount(count: number, singular: string): string {
+  return `${count} ${singular}${count === 1 ? '' : 's'}`;
+}


### PR DESCRIPTION
## What changed

- replace the generic warning badge with a calmer automated review summary
- bind the badge and tooltip to the exact indexed revision and preview real findings
- add a detailed security review section to community plugin pages
- separate install-relevant concerns from GitHub Actions maintenance notes without changing signed outcomes
- explain how newer upstream revisions are re-indexed and rechecked

## Verification

- `pnpm run test:registry` - 21 passed
- `pnpm run lint` - passed
- `pnpm run generate` - passed against Directory 33, Discovery 38, Security 3
- Playwright `landing.spec.ts` - 23 passed using local Chrome


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added security assessment badges to plugin listings, including scan status, revision details, tooltips, and links to full reviews.
  - Added a security review section to community plugin pages with scan outcomes, findings, dates, locations, and installation guidance.
  - Added responsive layouts and status-specific styling for security review information.
- **Bug Fixes**
  - Improved security messaging by distinguishing notes from blocking findings and clarifying that reviews do not guarantee plugin safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->