### PR TITLE
fix(agentplugins): simplify security review output

### DIFF
--- a/cli/plugin-kit-ai/internal/agentpluginscli/app.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/app.go
@@ -66,6 +66,7 @@ type options struct {
 	externalUninstalled bool
 	purgeData           bool
 	acceptSecurityRisk  bool
+	securityDetails     bool
 }
 
 func (app App) input() io.Reader {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/root.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/root.go
@@ -24,6 +24,7 @@ func NewRoot(app App) *cobra.Command {
 	flags.StringVar(&opts.format, "format", "human", "output format: human or json")
 	flags.BoolVar(&opts.noColor, "no-color", false, "disable color output")
 	flags.BoolVar(&opts.acceptSecurityRisk, "accept-security-risk", false, "continue despite blocking automated security findings")
+	flags.BoolVar(&opts.securityDetails, "security-details", false, "show every automated security finding in human output")
 
 	root.AddCommand(newAddCommand(app, opts))
 	root.AddCommand(newUpdateCommand(app, opts))

--- a/cli/plugin-kit-ai/internal/agentpluginscli/security.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/security.go
@@ -8,13 +8,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const securityFindingPreviewLimit = 3
+
+var repositoryMaintenanceSecurityCodes = map[string]struct{}{
+	"SEC324": {},
+	"SEC325": {},
+	"SEC326": {},
+	"SEC327": {},
+	"SEC328": {},
+}
+
 func authorizeSecurityAssessment(cmd *cobra.Command, app App, opts *options, loaded *loadedPackage) error {
 	if loaded.security == nil || loaded.securityAuthorized {
 		return nil
 	}
 	assessment := *loaded.security
 	if opts.format == "human" {
-		renderSecurityAssessment(cmd, assessment)
+		renderSecurityAssessment(cmd, assessment, opts.securityDetails)
 	}
 	if assessment.Counts.Blocking == 0 || opts.dryRun {
 		loaded.securityAuthorized = true
@@ -49,7 +59,7 @@ func authorizeSecurityAssessment(cmd *cobra.Command, app App, opts *options, loa
 	return nil
 }
 
-func renderSecurityAssessment(cmd *cobra.Command, assessment domain.SecurityAssessment) {
+func renderSecurityAssessment(cmd *cobra.Command, assessment domain.SecurityAssessment, showAll bool) {
 	source := "local scan"
 	switch assessment.Evidence {
 	case domain.SecurityEvidenceSignedIndex:
@@ -57,9 +67,15 @@ func renderSecurityAssessment(cmd *cobra.Command, assessment domain.SecurityAsse
 	case domain.SecurityEvidenceCache:
 		source = "verified cache"
 	}
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Automated security checks: %s (%s %s, exact package revision)\n", securityOutcomeLabel(assessment), assessment.Scanner.ID, assessment.Scanner.Version)
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Evidence: %s. Automated checks are not a guarantee of safety.\n", source)
-	for _, finding := range assessment.Findings {
+	installNotes, maintenanceNotes := splitSecurityFindings(assessment.Findings)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Automated review: %s", securityOutcomeLabel(assessment))
+	if assessment.Counts.Blocking == 0 && assessment.Counts.Warnings > 0 && assessment.Counts.Warnings == len(assessment.Findings) {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), " (%s)", securityNoteBreakdown(len(installNotes), len(maintenanceNotes)))
+	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), ".")
+
+	visible := visibleSecurityFindings(assessment, installNotes, maintenanceNotes, showAll)
+	for _, finding := range visible {
 		location := strings.TrimSpace(finding.Path)
 		if finding.Line > 0 {
 			location = fmt.Sprintf("%s:%d", location, finding.Line)
@@ -67,16 +83,96 @@ func renderSecurityAssessment(cmd *cobra.Command, assessment domain.SecurityAsse
 		if location != "" {
 			location += " - "
 		}
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  [%s] %s %s%s\n", strings.ToUpper(finding.Disposition), finding.Code, location, finding.Message)
+		label := "NOTE"
+		if finding.Disposition == "blocking" {
+			label = "BLOCKING"
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  [%s] %s %s%s\n", label, finding.Code, location, finding.Message)
 	}
+	visibleBlocking, visibleWarnings := findingDispositionCounts(visible)
+	if hiddenBlocking := assessment.Counts.Blocking - visibleBlocking; hiddenBlocking > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%d additional blocking %s are outside the bounded finding preview.\n", hiddenBlocking, plural(hiddenBlocking, "finding", "findings"))
+	}
+	if hiddenWarnings := assessment.Counts.Warnings - visibleWarnings; hiddenWarnings > 0 {
+		if showAll {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%d additional %s are outside the bounded finding preview.\n", hiddenWarnings, plural(hiddenWarnings, "note", "notes"))
+		} else {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%d additional %s hidden. Rerun with --security-details to review all published details.\n", hiddenWarnings, plural(hiddenWarnings, "note", "notes"))
+		}
+	}
+	if showAll || assessment.Counts.Blocking > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Evidence: %s for the exact package revision. Automated checks are not a guarantee of safety.\n", source)
+	}
+}
+
+func findingDispositionCounts(findings []domain.SecurityFinding) (blocking, warnings int) {
+	for _, finding := range findings {
+		if finding.Disposition == "blocking" {
+			blocking++
+		} else {
+			warnings++
+		}
+	}
+	return blocking, warnings
+}
+
+func splitSecurityFindings(findings []domain.SecurityFinding) (install, maintenance []domain.SecurityFinding) {
+	for _, finding := range findings {
+		if _, ok := repositoryMaintenanceSecurityCodes[finding.Code]; ok {
+			maintenance = append(maintenance, finding)
+			continue
+		}
+		install = append(install, finding)
+	}
+	return install, maintenance
+}
+
+func visibleSecurityFindings(assessment domain.SecurityAssessment, install, maintenance []domain.SecurityFinding, showAll bool) []domain.SecurityFinding {
+	if showAll {
+		return append(append([]domain.SecurityFinding(nil), install...), maintenance...)
+	}
+	visible := make([]domain.SecurityFinding, 0, securityFindingPreviewLimit)
+	for _, finding := range install {
+		if finding.Disposition == "blocking" {
+			visible = append(visible, finding)
+		}
+	}
+	if assessment.Counts.Blocking > 0 {
+		return visible
+	}
+	for _, finding := range install {
+		if len(visible) == securityFindingPreviewLimit {
+			break
+		}
+		visible = append(visible, finding)
+	}
+	return visible
+}
+
+func securityNoteBreakdown(install, maintenance int) string {
+	parts := make([]string, 0, 2)
+	if install > 0 {
+		parts = append(parts, fmt.Sprintf("%d install %s", install, plural(install, "note", "notes")))
+	}
+	if maintenance > 0 {
+		parts = append(parts, fmt.Sprintf("%d repository-maintenance %s", maintenance, plural(maintenance, "note", "notes")))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func plural(count int, singular, pluralForm string) string {
+	if count == 1 {
+		return singular
+	}
+	return pluralForm
 }
 
 func securityOutcomeLabel(assessment domain.SecurityAssessment) string {
 	if assessment.Counts.Blocking > 0 {
-		return fmt.Sprintf("%d blocking, %d warning", assessment.Counts.Blocking, assessment.Counts.Warnings)
+		return fmt.Sprintf("%d blocking %s and %d %s", assessment.Counts.Blocking, plural(assessment.Counts.Blocking, "finding", "findings"), assessment.Counts.Warnings, plural(assessment.Counts.Warnings, "note", "notes"))
 	}
 	if assessment.Counts.Warnings > 0 {
-		return fmt.Sprintf("%d warning(s), no blocking findings", assessment.Counts.Warnings)
+		return fmt.Sprintf("no blocking findings; %d %s found", assessment.Counts.Warnings, plural(assessment.Counts.Warnings, "note", "notes"))
 	}
 	return "no blocking findings"
 }

--- a/cli/plugin-kit-ai/internal/agentpluginscli/security_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/security_test.go
@@ -43,6 +43,50 @@ func TestWarningSecurityAssessmentDoesNotPrompt(t *testing.T) {
 	if !loaded.securityAuthorized || strings.Contains(output.String(), "Continue anyway") {
 		t.Fatalf("warning assessment prompted unexpectedly: %s", output.String())
 	}
+	if !strings.Contains(output.String(), "no blocking findings; 3 notes found") || !strings.Contains(output.String(), "3 install notes") {
+		t.Fatalf("warning assessment was not presented calmly: %s", output.String())
+	}
+}
+
+func TestWarningSecurityAssessmentCollapsesRepositoryMaintenanceNoise(t *testing.T) {
+	output := &bytes.Buffer{}
+	assessment := testSecurityAssessment(0, 4)
+	assessment.Findings = []domain.SecurityFinding{
+		{Code: "SEC329", Disposition: "warning", Path: "mcp.json", Message: "mutable package launcher"},
+		{Code: "SEC324", Disposition: "warning", Path: ".github/workflows/ci.yml", Message: "action uses a mutable tag"},
+		{Code: "SEC328", Disposition: "warning", Path: ".github/workflows/release.yml", Message: "write token reaches a third-party action"},
+		{Code: "SEC325", Disposition: "warning", Path: ".github/workflows/docs.yml", Message: "workflow hardening note"},
+	}
+	loaded := loadedPackage{security: assessment}
+	command := securityTestCommand(output, strings.NewReader(""))
+	if err := authorizeSecurityAssessment(command, App{Terminal: true}, &options{format: "human"}, &loaded); err != nil {
+		t.Fatal(err)
+	}
+	text := output.String()
+	if !strings.Contains(text, "1 install note, 3 repository-maintenance notes") || !strings.Contains(text, "SEC329") || strings.Contains(text, "SEC324") {
+		t.Fatalf("maintenance findings were not collapsed: %s", text)
+	}
+	if !strings.Contains(text, "3 additional notes hidden") || !strings.Contains(text, "--security-details") {
+		t.Fatalf("collapsed output omitted detail guidance: %s", text)
+	}
+}
+
+func TestSecurityDetailsShowsEveryPublishedFinding(t *testing.T) {
+	output := &bytes.Buffer{}
+	assessment := testSecurityAssessment(0, 2)
+	assessment.Findings = []domain.SecurityFinding{
+		{Code: "SEC329", Disposition: "warning", Message: "install note"},
+		{Code: "SEC324", Disposition: "warning", Message: "maintenance note"},
+	}
+	loaded := loadedPackage{security: assessment}
+	command := securityTestCommand(output, strings.NewReader(""))
+	if err := authorizeSecurityAssessment(command, App{Terminal: true}, &options{format: "human", securityDetails: true}, &loaded); err != nil {
+		t.Fatal(err)
+	}
+	text := output.String()
+	if !strings.Contains(text, "SEC329") || !strings.Contains(text, "SEC324") || !strings.Contains(text, "Evidence:") || strings.Contains(text, "hidden") {
+		t.Fatalf("detailed output omitted a published finding: %s", text)
+	}
 }
 
 func securityTestCommand(output *bytes.Buffer, input *strings.Reader) *cobra.Command {
@@ -59,9 +103,16 @@ func testSecurityAssessment(blocking, warnings int) *domain.SecurityAssessment {
 	} else if warnings > 0 {
 		outcome = domain.SecurityWarnings
 	}
+	findings := make([]domain.SecurityFinding, 0, blocking+warnings)
+	for index := 0; index < blocking; index++ {
+		findings = append(findings, domain.SecurityFinding{Code: "SEC330", Disposition: "blocking", Path: "mcp.json", Message: "test blocking finding"})
+	}
+	for index := 0; index < warnings; index++ {
+		findings = append(findings, domain.SecurityFinding{Code: "SEC329", Disposition: "warning", Path: "mcp.json", Message: "test review note"})
+	}
 	return &domain.SecurityAssessment{
 		Scanner: domain.SecurityScanner{ID: domain.SecurityScannerID, Version: domain.SecurityScannerVersion},
 		Outcome: outcome, Counts: domain.SecurityCounts{Blocking: blocking, Warnings: warnings, Total: blocking + warnings},
-		Findings: []domain.SecurityFinding{{Code: "SEC330", Disposition: "blocking", Path: "mcp.json", Message: "test finding"}},
+		Findings: findings,
 	}
 }

--- a/cli/plugin-kit-ai/internal/agentpluginscli/validate.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/validate.go
@@ -64,7 +64,7 @@ func newValidateCommand(app App, opts *options) *cobra.Command {
 				return writeJSONOutput(cmd.OutOrStdout(), "validate", result)
 			}
 			if loaded.security != nil {
-				renderSecurityAssessment(cmd, *loaded.security)
+				renderSecurityAssessment(cmd, *loaded.security, true)
 			}
 			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Valid Agent Plugin: %s %s\nSchema: %s\nSource: %s\nComponents: %d skills, %d MCP servers, %d app bindings\n",
 				result.Name, result.Version, result.SchemaURI, publicPackageSource(loaded.envelope.Source),

--- a/landing/components/registry/RegistryWhy.vue
+++ b/landing/components/registry/RegistryWhy.vue
@@ -7,7 +7,7 @@
   >
     <div class="section-heading section-heading--center">
       <p class="eyebrow">Why it works</p>
-      <h2 id="why-title">One standard. Native delivery.</h2>
+      <h2 id="why-title">One standard<br />Native delivery</h2>
       <p>The package stays portable; the installer handles each client's format and lifecycle.</p>
     </div>
     <div class="registry-benefits__grid">


### PR DESCRIPTION
## Summary

- keep warning-only installs non-blocking and present them as concise review notes
- collapse GitHub Actions findings into repository-maintenance counts by default
- add `--security-details` for the full human-readable finding list
- show all blocking findings before confirmation
- update the landing headline to the requested two-line copy

## Verification

- `go test ./internal/agentpluginscli`
- `go test ./agentplugins/adapters/securityscan ./agentplugins/domain`
- `git diff --check`

The JSON output remains complete and unchanged.