### PR TITLE
feat: simplify catalog and CLI discovery

### DIFF
--- a/cli/plugin-kit-ai/internal/agentpluginscli/search.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/search.go
@@ -3,6 +3,7 @@ package agentpluginscli
 import (
 	"context"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 
@@ -48,14 +49,17 @@ type searchResponse struct {
 	DiscoverySnapshotSequence uint64         `json:"discovery_snapshot_sequence,omitempty"`
 	DiscoverySnapshotDigest   string         `json:"discovery_snapshot_digest,omitempty"`
 	Results                   []searchResult `json:"results"`
+	typoMatched               bool
 }
 
 type searchOptions struct {
-	trust     string
-	component string
-	client    string
-	auth      string
-	owner     string
+	trust        string
+	component    string
+	client       string
+	auth         string
+	owner        string
+	details      bool
+	typoFallback bool
 }
 
 func newSearchCommand(app App, opts *options) *cobra.Command {
@@ -68,6 +72,7 @@ func newSearchCommand(app App, opts *options) *cobra.Command {
 			if err := validateCommonOptions(opts); err != nil {
 				return err
 			}
+			search.typoFallback = opts.format != "json"
 			response, err := searchReviewedDirectory(cmd.Context(), app, strings.TrimSpace(args[0]), *search)
 			if err != nil {
 				return err
@@ -75,37 +80,7 @@ func newSearchCommand(app App, opts *options) *cobra.Command {
 			if opts.format == "json" {
 				return writeJSONOutput(cmd.OutOrStdout(), "search", response)
 			}
-			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%d results for %q\n", len(response.Results), response.Query); err != nil {
-				return err
-			}
-			installTarget := "YOUR_AGENT"
-			if strings.TrimSpace(search.client) != "" {
-				installTarget = strings.ToLower(strings.TrimSpace(search.client))
-			}
-			for _, result := range response.Results {
-				source := result.Repository + "@" + result.Revision
-				if result.PackagePath != "" {
-					source += "//" + result.PackagePath
-				}
-				runtime := "not reviewed"
-				if result.RuntimeReviewed {
-					runtime = "reviewed"
-				}
-				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  %s - %s [%s, %s]\n    source: %s\n    schema: Agent Plugins 1.0; runtime: %s\n",
-					result.DisplayName, result.Description, result.TrustState, result.Status, source, runtime); err != nil {
-					return err
-				}
-				if result.Status != "available" {
-					if _, err := fmt.Fprintln(cmd.OutOrStdout(), "    install: unavailable at indexed source"); err != nil {
-						return err
-					}
-					continue
-				}
-				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "    npx universal-agent-plugins install %s --target %s\n", result.InstallSelector, installTarget); err != nil {
-					return err
-				}
-			}
-			return nil
+			return writeHumanSearch(cmd.OutOrStdout(), response, *search)
 		},
 	}
 	flags := command.Flags()
@@ -114,6 +89,7 @@ func newSearchCommand(app App, opts *options) *cobra.Command {
 	flags.StringVar(&search.client, "client", "", "compatible client")
 	flags.StringVar(&search.auth, "auth", "all", "authentication: all, required, not_required, or unknown")
 	flags.StringVar(&search.owner, "owner", "", "source repository owner")
+	flags.BoolVar(&search.details, "details", false, "show source, runtime, alternative sources, and unavailable records")
 	return command
 }
 
@@ -146,6 +122,7 @@ func searchReviewedDirectory(ctx context.Context, app App, query string, options
 		return searchResponse{}, err
 	}
 	response := searchResponse{Query: query, TrustFilter: trust, DiscoveryStatus: "not_requested", Results: []searchResult{}}
+	fallback := []searchResult{}
 	products := map[string]domain.DirectoryProduct{}
 	if trust != "unreviewed" {
 		if app.DirectoryClient == nil {
@@ -173,6 +150,10 @@ func searchReviewedDirectory(ctx context.Context, app App, query string, options
 			if ok {
 				result.matchScore = reviewedSearchRank(result.matchScore)
 				response.Results = append(response.Results, result)
+			} else if options.typoFallback && searchIdentityTypo(query, append([]string{product.ID, product.ManifestName}, product.Aliases...)...) {
+				if candidate, matched := directorySearchResult(bundle.Snapshot, product, distribution, *release, *policy, product.ID, options.owner, components, selectedClient, auth); matched {
+					fallback = append(fallback, candidate)
+				}
 			}
 		}
 	}
@@ -197,10 +178,25 @@ func searchReviewedDirectory(ctx context.Context, app App, query string, options
 				for _, record := range discovery.Search.Records {
 					if result, ok := discoverySearchResult(record, query, options.owner, components, selectedClient, auth); ok {
 						response.Results = append(response.Results, result)
+					} else if options.typoFallback && searchIdentityTypo(query, record.Name) {
+						if candidate, matched := discoverySearchResult(record, record.Name, options.owner, components, selectedClient, auth); matched {
+							fallback = append(fallback, candidate)
+						}
 					}
 				}
 			}
 		}
+	}
+	hasVisibleMatch := false
+	for _, result := range response.Results {
+		if result.Status == "available" || options.details {
+			hasVisibleMatch = true
+			break
+		}
+	}
+	if options.typoFallback && !hasVisibleMatch {
+		response.Results = append(response.Results, fallback...)
+		response.typoMatched = len(fallback) > 0
 	}
 	sort.SliceStable(response.Results, func(i, j int) bool {
 		left, right := response.Results[i], response.Results[j]
@@ -230,6 +226,126 @@ func searchReviewedDirectory(ctx context.Context, app App, query string, options
 		response.Results[index].matchScore = 0
 	}
 	return response, nil
+}
+
+// Human grouping is a presentation view, never an assertion that sources are
+// interchangeable. JSON retains every record and its original identity.
+func writeHumanSearch(out io.Writer, response searchResponse, options searchOptions) error {
+	groups := [][]searchResult{}
+	positions := map[string]int{}
+	for _, result := range response.Results {
+		if result.Status != "available" && !options.details {
+			continue
+		}
+		identity := strings.ToLower(strings.TrimSpace(result.ManifestName))
+		if identity == "" {
+			identity = strings.ToLower(result.ProductID)
+		}
+		if identity == "" {
+			identity = result.InstallSelector
+		}
+		if index, ok := positions[identity]; ok {
+			groups[index] = append(groups[index], result)
+		} else {
+			positions[identity] = len(groups)
+			groups = append(groups, []searchResult{result})
+		}
+	}
+	var output strings.Builder
+	fmt.Fprintf(&output, "%d results for %q\n", len(groups), response.Query)
+	if response.typoMatched && len(groups) > 0 {
+		fmt.Fprintln(&output, "Showing close name matches (check the plugin name before adding).")
+	}
+	for _, group := range groups {
+		// Preserve search relevance between groups, but prefer an available,
+		// reviewed and upstream record as the group's primary source.
+		sort.SliceStable(group, func(i, j int) bool {
+			left, right := group[i], group[j]
+			if (left.Status == "available") != (right.Status == "available") {
+				return left.Status == "available"
+			}
+			leftShort := left.TrustState == "reviewed" && left.InstallSelector == left.ProductID
+			rightShort := right.TrustState == "reviewed" && right.InstallSelector == right.ProductID
+			if leftShort != rightShort {
+				return leftShort
+			}
+			if left.TrustState != right.TrustState {
+				return left.TrustState == "reviewed"
+			}
+			return left.DistributionKind == domain.DistributionUpstream && right.DistributionKind != domain.DistributionUpstream
+		})
+		result := group[0]
+		fmt.Fprintf(&output, "  %s - %s [%s]\n", result.DisplayName, result.Description, result.TrustState)
+		if result.Status == "available" {
+			fmt.Fprintf(&output, "    npx universal-agent-plugins add %s", result.InstallSelector)
+			if client := strings.ToLower(strings.TrimSpace(options.client)); client != "" {
+				fmt.Fprintf(&output, " --target %s", client)
+			}
+			fmt.Fprintln(&output)
+		} else {
+			fmt.Fprintln(&output, "    install: unavailable at indexed source")
+		}
+		if options.details {
+			runtime := "not reviewed"
+			if result.RuntimeReviewed {
+				runtime = "reviewed"
+			}
+			fmt.Fprintf(&output, "    source: %s\n    schema: %s; runtime: %s; status: %s\n", humanSearchSource(result), result.SchemaURI, runtime, result.Status)
+			if len(group) > 1 {
+				fmt.Fprintf(&output, "    Other sources (%d):\n", len(group)-1)
+				for _, alternative := range group[1:] {
+					fmt.Fprintf(&output, "      %s [%s, %s] - %s\n", alternative.InstallSelector, alternative.TrustState, alternative.Status, humanSearchSource(alternative))
+				}
+			}
+		}
+	}
+	_, err := io.WriteString(out, output.String())
+	return err
+}
+
+func humanSearchSource(result searchResult) string {
+	source := result.Repository + "@" + result.Revision
+	if result.PackagePath != "" {
+		source += "//" + result.PackagePath
+	}
+	return source
+}
+
+// Limit fallback to one edit in a name of at least four characters. Short
+// queries and repository selectors retain their precise matching semantics.
+func searchIdentityTypo(query string, identities ...string) bool {
+	query = strings.ToLower(strings.TrimSpace(query))
+	if len(query) < 4 || strings.ContainsAny(query, " /:\t\n") {
+		return false
+	}
+	for _, identity := range identities {
+		left, right := []rune(query), []rune(strings.ToLower(identity))
+		if len(left)-len(right) > 1 || len(right)-len(left) > 1 {
+			continue
+		}
+		i, j, edits := 0, 0, 0
+		for i < len(left) && j < len(right) {
+			if left[i] == right[j] {
+				i++
+				j++
+				continue
+			}
+			edits++
+			if edits > 1 {
+				break
+			}
+			if len(left) >= len(right) {
+				i++
+			}
+			if len(right) >= len(left) {
+				j++
+			}
+		}
+		if edits+len(left)-i+len(right)-j == 1 {
+			return true
+		}
+	}
+	return false
 }
 
 func reviewedSearchRank(score int) int {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/search_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/search_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/discoveryv1"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 )
 
 type fixedDiscoveryClient struct {
@@ -115,15 +116,15 @@ func TestHumanSearchShowsExactProvenanceTrustAndRunnableInstallCommand(t *testin
 	fixture := newCLIFixture(t, nil)
 	fixture.app.DirectoryClient = &fixedDirectoryClient{bundle: readModelBundle()}
 	fixture.app.DiscoveryClient = &fixedDiscoveryClient{bundle: discoverySearchBundle()}
-	stdout, _, err := fixture.execute(false, "search", "upstream/demo", "--trust", "unreviewed", "--client", "cursor")
+	stdout, _, err := fixture.execute(false, "search", "upstream/demo", "--trust", "unreviewed", "--client", "cursor", "--details")
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, want := range []string{
-		"[unreviewed, available]",
+		"[unreviewed]",
 		"source: upstream/demo@" + strings.Repeat("a", 40) + "//plugin",
-		"schema: Agent Plugins 1.0; runtime: not reviewed",
-		"npx universal-agent-plugins install discovery:upstream/demo//plugin --target cursor",
+		"schema: https://agent-plugins.org/schemas/1.0.0/plugin.schema.json; runtime: not reviewed",
+		"npx universal-agent-plugins add discovery:upstream/demo//plugin --target cursor",
 	} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("human search omitted %q:\n%s", want, stdout)
@@ -131,7 +132,7 @@ func TestHumanSearchShowsExactProvenanceTrustAndRunnableInstallCommand(t *testin
 	}
 }
 
-func TestHumanSearchUsesShellSafeTargetPlaceholderWithoutClient(t *testing.T) {
+func TestHumanSearchOmitsTargetAndTechnicalDetailsWithoutClient(t *testing.T) {
 	t.Parallel()
 	fixture := newCLIFixture(t, nil)
 	fixture.app.DirectoryClient = &fixedDirectoryClient{bundle: readModelBundle()}
@@ -140,9 +141,9 @@ func TestHumanSearchUsesShellSafeTargetPlaceholderWithoutClient(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "npx universal-agent-plugins install discovery:upstream/demo//plugin --target YOUR_AGENT"
-	if !strings.Contains(stdout, want) || strings.Contains(stdout, "--target <agent>") {
-		t.Fatalf("human search target placeholder is not shell-safe:\n%s", stdout)
+	want := "npx universal-agent-plugins add discovery:upstream/demo//plugin\n"
+	if !strings.Contains(stdout, want) || strings.Contains(stdout, "--target") || strings.Contains(stdout, "source:") || strings.Contains(stdout, "runtime:") {
+		t.Fatalf("human search is not compact:\n%s", stdout)
 	}
 }
 
@@ -157,8 +158,111 @@ func TestHumanSearchDoesNotOfferInstallForUnavailablePackage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(stdout, "install: unavailable at indexed source") || strings.Contains(stdout, "npx universal-agent-plugins install") {
+	if !strings.Contains(stdout, "0 results") || strings.Contains(stdout, "npx universal-agent-plugins") {
 		t.Fatalf("human search offered installation for an unavailable package:\n%s", stdout)
+	}
+	details, _, err := fixture.execute(false, "search", "upstream/demo", "--trust", "unreviewed", "--details")
+	if err != nil || !strings.Contains(details, "install: unavailable at indexed source") || strings.Contains(details, "npx universal-agent-plugins") {
+		t.Fatalf("unavailable details = %q, err = %v", details, err)
+	}
+	jsonOutput, _, err := fixture.execute(false, "search", "upstream/demo", "--trust", "unreviewed", "--format", "json")
+	if err != nil || !strings.Contains(jsonOutput, `"status":"unavailable"`) {
+		t.Fatalf("JSON lost unavailable result: %q, err = %v", jsonOutput, err)
+	}
+}
+
+func TestHumanSearchGroupsSourcesWhileJSONRetainsRecords(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, nil)
+	fixture.app.DirectoryClient = &fixedDirectoryClient{bundle: readModelBundle()}
+	fixture.app.DiscoveryClient = &fixedDiscoveryClient{bundle: discoverySearchBundle()}
+	compact, _, err := fixture.execute(false, "search", "demo")
+	if err != nil || !strings.HasPrefix(compact, "1 results") || strings.Count(compact, "npx universal-agent-plugins add ") != 1 || !strings.Contains(compact, "add demo\n") {
+		t.Fatalf("compact grouping = %q, err = %v", compact, err)
+	}
+	details, _, err := fixture.execute(false, "search", "demo", "--details")
+	if err != nil || !strings.Contains(details, "Other sources (") || !strings.Contains(details, "discovery:upstream/demo//plugin") {
+		t.Fatalf("details = %q, err = %v", details, err)
+	}
+	first, _, err := fixture.execute(false, "search", "demo", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, _, err := fixture.execute(false, "search", "demo", "--format", "json", "--details")
+	if err != nil || first != second || !strings.Contains(first, "discovery:upstream/demo//plugin") {
+		t.Fatalf("JSON changed with presentation flag: %q vs %q, err=%v", first, second, err)
+	}
+}
+
+func TestHumanSearchTypoFallbackRespectsFiltersAndJSON(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, nil)
+	fixture.app.DirectoryClient = &fixedDirectoryClient{bundle: readModelBundle()}
+	bundle := discoverySearchBundle()
+	bundle.Search.Records[0].Name = "context7"
+	bundle.Search.Records[0].Slug = "discovery:upstream/context7//plugin"
+	fixture.app.DiscoveryClient = &fixedDiscoveryClient{bundle: bundle}
+	stdout, _, err := fixture.execute(false, "search", "contex7", "--trust", "unreviewed")
+	if err != nil || !strings.Contains(stdout, "context7") || !strings.Contains(stdout, "close name matches") {
+		t.Fatalf("typo fallback = %q, err=%v", stdout, err)
+	}
+	for _, filters := range [][]string{{"--owner", "other"}, {"--component", "skills"}, {"--client", "kiro"}, {"--auth", "required"}} {
+		args := append([]string{"search", "contex7", "--trust", "unreviewed"}, filters...)
+		output, _, err := fixture.execute(false, args...)
+		if err != nil || !strings.HasPrefix(output, "0 results") {
+			t.Fatalf("filters %v: %q err=%v", filters, output, err)
+		}
+	}
+	jsonOutput, _, err := fixture.execute(false, "search", "contex7", "--trust", "unreviewed", "--format", "json")
+	if err != nil || !strings.Contains(jsonOutput, `"results":[]`) {
+		t.Fatalf("JSON typo behavior changed: %q err=%v", jsonOutput, err)
+	}
+}
+
+func TestSearchIdentityTypoIsBounded(t *testing.T) {
+	for _, test := range []struct {
+		query string
+		want  bool
+	}{{"contex7", true}, {"contextt7", true}, {"contexx7", true}, {"context7", false}, {"ctx", false}, {"cntex", false}, {"owner/contex7", false}} {
+		if got := searchIdentityTypo(test.query, "context7"); got != test.want {
+			t.Errorf("%q = %v, want %v", test.query, got, test.want)
+		}
+	}
+}
+
+func TestHumanSearchPrimarySourcePreference(t *testing.T) {
+	t.Parallel()
+	base := searchResult{ManifestName: "context7", ProductID: "context7", DisplayName: "Context7", TrustState: "unreviewed", Status: "available", InstallSelector: "copy"}
+	community := base
+	community.TrustState, community.InstallSelector = "reviewed", "context7"
+	upstream := community
+	upstream.DistributionKind, upstream.InstallSelector = domain.DistributionUpstream, "upstream"
+	unavailable := upstream
+	unavailable.Status, unavailable.InstallSelector = "unavailable", "unavailable"
+	var output strings.Builder
+	if err := writeHumanSearch(&output, searchResponse{Query: "context7", Results: []searchResult{base, unavailable, community, upstream}}, searchOptions{details: true}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output.String(), "add context7\n") || strings.Count(output.String(), "npx universal-agent-plugins") != 1 || !strings.Contains(output.String(), "Other sources (3)") {
+		t.Fatalf("primary preference: %s", output.String())
+	}
+}
+
+func TestHumanSearchReviewedTypoAndExactMatchPrecedence(t *testing.T) {
+	t.Parallel()
+	fixture := newCLIFixture(t, nil)
+	fixture.app.DirectoryClient = &fixedDirectoryClient{bundle: readModelBundle()}
+	fixture.app.DiscoveryClient = &fixedDiscoveryClient{bundle: discoverySearchBundle()}
+	output, _, err := fixture.execute(false, "search", "demoo", "--trust", "reviewed")
+	if err != nil || !strings.Contains(output, "add demo\n") || !strings.Contains(output, "close name matches") {
+		t.Fatalf("reviewed typo: %q err=%v", output, err)
+	}
+	bundle := discoverySearchBundle()
+	bundle.Search.Records[0].Name = "demoo"
+	fixture.app.DiscoveryClient = &fixedDiscoveryClient{bundle: bundle}
+	output, _, err = fixture.execute(false, "search", "demoo")
+	if err != nil || strings.Contains(output, "close name matches") || strings.Contains(output, "add demo\n") || !strings.HasPrefix(output, "1 results") {
+		t.Fatalf("exact match precedence: %q err=%v", output, err)
 	}
 }
 

--- a/landing/assets/styles/registry.scss
+++ b/landing/assets/styles/registry.scss
@@ -1604,6 +1604,62 @@ img {
   justify-content: space-between;
   gap: 15px;
 }
+.catalog-active-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+}
+.catalog-filter-chip,
+.catalog-filter-reset {
+  padding: 7px 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.72rem;
+  cursor: pointer;
+}
+.catalog-filter-reset:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+.catalog-filter-chip:focus-visible,
+.catalog-filter-reset:focus-visible,
+.plugin-other-sources > summary:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 3px;
+}
+.plugin-source-group {
+  min-width: 0;
+}
+.plugin-other-sources {
+  margin-top: 8px;
+}
+.plugin-other-sources > summary {
+  padding: 8px;
+  color: var(--subtle);
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+.plugin-other-sources__list {
+  list-style: none;
+  padding: 0 8px;
+  margin: 0;
+}
+.plugin-other-sources__list li {
+  display: grid;
+  gap: 4px;
+  padding: 10px 0;
+  border-top: 1px solid var(--line);
+  overflow-wrap: anywhere;
+  font-size: 0.72rem;
+}
+.plugin-other-sources__list span {
+  color: var(--subtle);
+}
 .catalog-count {
   color: var(--subtle);
   font-size: 0.72rem;
@@ -2689,9 +2745,17 @@ img {
     margin: 0;
   }
   .hero-quick-start__step .command-snippet--inline pre {
-    font-size: 0.72rem;
+    font-size: 0.86rem;
     white-space: normal;
     overflow-wrap: anywhere;
+  }
+  .command-snippet pre,
+  .command-snippet--compact pre {
+    font-size: 0.84rem;
+  }
+  .command-snippet__header,
+  .command-snippet button {
+    font-size: 0.7rem;
   }
   .install-command-row {
     grid-template-columns: 1fr;

--- a/landing/components/registry/ClientStrip.vue
+++ b/landing/components/registry/ClientStrip.vue
@@ -7,10 +7,10 @@ const { asset } = useSite();
 <template>
   <ul class="client-strip" aria-label="Supported agents">
     <li v-for="client in clients" :key="client.id">
-      <NuxtLink :to="`/agents/${clientLandingById.get(client.id)?.slug}`">
+      <NuxtLink :to="`/agents/${clientLandingById.get(client.id)?.slug}/`">
         <span class="client-strip__icon"
           ><img :src="asset(`client-icons/${client.icon}`)" alt="" width="24" height="24"
-        ></span>
+        /></span>
         <span class="client-strip__copy"
           ><strong>{{ client.name }}</strong
           ><small>{{ client.status }}</small></span

--- a/landing/components/registry/InstallPanel.vue
+++ b/landing/components/registry/InstallPanel.vue
@@ -39,8 +39,7 @@ const targetOptions = computed(() =>
 const commands = computed(() =>
   props.plugin.installable &&
   current.value &&
-  targets.value.length &&
-  (autoDetect.value || hasCompleteSource.value)
+  (autoDetect.value || (targets.value.length > 0 && hasCompleteSource.value))
     ? pluginCommands(props.plugin, autoDetect.value ? undefined : targets.value)
     : undefined,
 );
@@ -57,7 +56,7 @@ const chatgptSelected = computed(
     selectedTargets.value.some((target) => target.client === 'chatgpt' && target.app_binding),
 );
 const unavailableDiscoveryReason = computed(() => {
-  if (props.plugin.trust_state !== 'conformant_unreviewed' || props.plugin.installable) return '';
+  if (props.plugin.installable) return '';
   if (props.plugin.discovery?.availability === 'unavailable')
     return 'This package is no longer available from its source.';
   if (!props.plugin.components.length)
@@ -145,6 +144,7 @@ watch(availableClients, (next) => {
     <p
       v-else-if="!unavailableDiscoveryReason && !autoDetect && !hasCompleteSource"
       class="install-panel__notice"
+      role="status"
     >
       <strong>Commands unavailable.</strong> {{ resolution.unavailable_reason }}
     </p>
@@ -158,11 +158,17 @@ watch(availableClients, (next) => {
       {{ plugin.display_name }} in Apps or Plugins, connect it, and start a new chat. Availability
       depends on your account and workspace.
     </p>
-    <p v-if="!autoDetect && resolution.fallback_reason && current" class="install-panel__notice">
+    <p
+      v-if="!unavailableDiscoveryReason && !autoDetect && resolution.fallback_reason && current"
+      class="install-panel__notice"
+    >
       <strong>Expected source fallback: {{ expectedSource?.label }}.</strong>
       {{ resolution.fallback_reason }}
     </p>
-    <p v-else-if="!autoDetect && !hasCompleteSource && current" class="install-panel__notice">
+    <p
+      v-else-if="!unavailableDiscoveryReason && !autoDetect && !hasCompleteSource && current"
+      class="install-panel__notice"
+    >
       <strong>No single source serves this target set.</strong> The CLI will fail before mutation
       and suggest compatible target/source combinations; it never mixes distributions across
       clients.
@@ -173,3 +179,23 @@ watch(availableClients, (next) => {
     </p>
   </aside>
 </template>
+
+<style scoped>
+.install-panel {
+  min-width: 0;
+  width: 100%;
+}
+
+.target-select :deep(.app-multiselect__trigger) {
+  padding-block: 10px;
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+.target-select :deep(.app-multiselect__value > span:last-child) {
+  overflow: visible;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  text-align: left;
+}
+</style>

--- a/landing/components/registry/PluginCatalog.vue
+++ b/landing/components/registry/PluginCatalog.vue
@@ -1,6 +1,15 @@
 <script setup lang="ts">
-import { availableFilters, catalogVisiblePlugins, filterPlugins } from '~/utils/filter';
+import {
+  availableFilters,
+  catalogVisiblePlugins,
+  filterPlugins,
+  groupCatalogPlugins,
+  catalogQuery,
+  restoreCatalogQuery,
+} from '~/utils/filter';
+import type { LocationQueryRaw } from 'vue-router';
 import type { RegistryPlugin } from '~/types/registry';
+import { canonicalPath } from '~/utils/seo';
 
 const props = withDefaults(
   defineProps<{ plugins: RegistryPlugin[]; heading?: string; intro?: string }>(),
@@ -18,11 +27,22 @@ const trust = ref('all');
 const client = ref('all');
 const authentication = ref('all');
 const owner = ref('all');
+const route = useRoute();
+const router = useRouter();
+const filterRefs = [query, category, component, source, trust, client, authentication, owner];
+function restoreFilters() {
+  restoreCatalogQuery(route.query).forEach((value, index) => {
+    filterRefs[index]!.value = value;
+  });
+}
+restoreFilters();
+watch(() => route.query, restoreFilters);
 const mobileFiltersOpen = ref(false);
 const pageSize = 48;
 const displayLimit = ref(pageSize);
 const discovery = useDiscoveryStatus();
 const catalogPlugins = computed(() => catalogVisiblePlugins(props.plugins));
+const catalogTotal = computed(() => groupCatalogPlugins(catalogPlugins.value).length);
 const filters = computed(() => availableFilters(catalogPlugins.value));
 type FilterOption = { value: string; label: string };
 let previousCategoryOptions: FilterOption[] = [];
@@ -61,7 +81,7 @@ const sourceOptions = [
 ];
 const trustOptions = [
   { value: 'all', label: 'All trust levels' },
-  { value: 'reviewed', label: 'Reviewed plugins' },
+  { value: 'reviewed', label: 'Reviewed listings' },
   { value: 'conformant_unreviewed', label: 'Community discovery' },
 ];
 const clientOptions = [
@@ -82,19 +102,21 @@ const ownerOptions = computed(() => [
   ...filters.value.owners.map((item) => ({ value: item, label: item })),
 ]);
 const visible = computed(() =>
-  filterPlugins(catalogPlugins.value, {
-    query: query.value,
-    category: category.value === 'all' ? '' : category.value,
-    component:
-      component.value === 'all'
-        ? undefined
-        : (component.value as RegistryPlugin['components'][number]),
-    source: source.value as 'all' | 'upstream' | 'community_bridge' | 'community' | 'direct',
-    trust: trust.value as 'all' | 'reviewed' | 'conformant_unreviewed',
-    client: client.value as 'all' | RegistryPlugin['client_support']['clients'][number],
-    authentication: authentication.value as 'all' | 'none' | 'required_or_unknown',
-    owner: owner.value === 'all' ? '' : owner.value,
-  }),
+  groupCatalogPlugins(
+    filterPlugins(catalogPlugins.value, {
+      query: query.value,
+      category: category.value === 'all' ? '' : category.value,
+      component:
+        component.value === 'all'
+          ? undefined
+          : (component.value as RegistryPlugin['components'][number]),
+      source: source.value as 'all' | 'upstream' | 'community_bridge' | 'community' | 'direct',
+      trust: trust.value as 'all' | 'reviewed' | 'conformant_unreviewed',
+      client: client.value as 'all' | RegistryPlugin['client_support']['clients'][number],
+      authentication: authentication.value as 'all' | 'none' | 'required_or_unknown',
+      owner: owner.value === 'all' ? '' : owner.value,
+    }),
+  ),
 );
 const displayed = computed(() => visible.value.slice(0, displayLimit.value));
 const remaining = computed(() => Math.max(0, visible.value.length - displayed.value.length));
@@ -104,8 +126,40 @@ const activeFilterCount = computed(
       (filter) => filter.value !== 'all',
     ).length,
 );
+const activeChips = computed(() => {
+  const labels = [
+    'Search',
+    'Category',
+    'Component',
+    'Source',
+    'Trust',
+    'Agent',
+    'Authentication',
+    'Owner',
+  ];
+  const options = [
+    [],
+    stableCategoryOptions.value,
+    stableComponentOptions.value,
+    sourceOptions,
+    trustOptions,
+    clientOptions,
+    authenticationOptions,
+    ownerOptions.value,
+  ];
+  return filterRefs.flatMap((filter, index) =>
+    filter.value !== (index === 0 ? '' : 'all')
+      ? [
+          {
+            index,
+            label: `${labels[index]}: ${options[index]?.find((option) => option.value === filter.value)?.label ?? filter.value}`,
+          },
+        ]
+      : [],
+  );
+});
 const catalogSummary = computed(() => {
-  const total = catalogPlugins.value.length;
+  const total = catalogTotal.value;
   if (!visible.value.length) return `No matches · ${total} total`;
   if (visible.value.length === total) return `${displayed.value.length} shown · ${total} plugins`;
   if (displayed.value.length < visible.value.length)
@@ -127,15 +181,19 @@ function clearFilters() {
 
 watch([query, category, component, source, trust, client, authentication, owner], () => {
   displayLimit.value = pageSize;
+  const values = filterRefs.map((filter) => filter.value);
+  if (JSON.stringify(values) !== JSON.stringify(restoreCatalogQuery(route.query))) {
+    void router.replace({
+      path: canonicalPath(route.path),
+      query: catalogQuery(values, route.query) as LocationQueryRaw,
+      hash: route.hash,
+    });
+  }
 });
 </script>
 
 <template>
-  <section
-    class="catalog"
-    aria-labelledby="catalog-title"
-    :data-discovery-state="discovery.state"
-  >
+  <section class="catalog" aria-labelledby="catalog-title" :data-discovery-state="discovery.state">
     <div class="section-heading">
       <p class="eyebrow">Plugin directory</p>
       <div class="catalog-heading-row">
@@ -164,7 +222,7 @@ watch([query, category, component, source, trust, client, authentication, owner]
           type="search"
           aria-label="Search plugins"
           placeholder="Search by name, author, or capability…"
-        >
+        />
         <button
           v-if="query"
           class="search-field__clear"
@@ -240,6 +298,26 @@ watch([query, category, component, source, trust, client, authentication, owner]
         />
       </div>
     </div>
+    <div class="catalog-active-filters" aria-label="Active filters">
+      <button
+        v-for="chip in activeChips"
+        :key="chip.index"
+        type="button"
+        class="catalog-filter-chip"
+        :aria-label="`Remove ${chip.label}`"
+        @click="filterRefs[chip.index]!.value = chip.index === 0 ? '' : 'all'"
+      >
+        {{ chip.label }} <span aria-hidden="true">×</span>
+      </button>
+      <button
+        type="button"
+        class="catalog-filter-reset"
+        :disabled="!activeChips.length"
+        @click="clearFilters"
+      >
+        Reset filters
+      </button>
+    </div>
     <div class="catalog-meta">
       <div>
         <div class="catalog-count" aria-live="polite">{{ catalogSummary }}</div>
@@ -252,21 +330,60 @@ watch([query, category, component, source, trust, client, authentication, owner]
             >Finding more community plugins on GitHub…</template
           >
           <template v-else-if="discovery.state === 'stale'"
-            >Community results are refreshing. Reviewed plugins remain available.</template
+            >Community results are refreshing. Reviewed listings remain available.</template
           >
           <template v-else-if="discovery.state === 'unavailable'"
-            >Community results are temporarily unavailable. Reviewed plugins remain
+            >Community results are temporarily unavailable. Reviewed listings remain
             available.</template
           >
         </p>
       </div>
     </div>
     <div v-if="visible.length" class="plugin-grid">
-      <RegistryPluginCard
-        v-for="plugin in displayed"
-        :key="plugin.install_source"
-        :plugin="plugin"
-      />
+      <div
+        v-for="group in displayed"
+        :key="group.primary.install_source"
+        class="plugin-source-group"
+      >
+        <RegistryPluginCard :plugin="group.primary" />
+        <details v-if="group.alternatives.length" class="plugin-other-sources">
+          <summary>
+            Other sources ({{ group.alternatives.length }})<span class="sr-only">
+              for {{ group.primary.display_name }}</span
+            >
+          </summary>
+          <ul class="plugin-other-sources__list">
+            <li v-for="alternative in group.alternatives" :key="alternative.install_source">
+              <NuxtLink
+                :to="
+                  alternative.trust_state === 'conformant_unreviewed'
+                    ? { path: '/plugins/community/', query: { source: alternative.install_source } }
+                    : `/plugins/${alternative.name}/`
+                "
+              >
+                {{ alternative.source.repository
+                }}{{ alternative.source.path ? `/${alternative.source.path}` : '' }}
+              </NuxtLink>
+              <span
+                >{{
+                  alternative.trust_state === 'conformant_unreviewed'
+                    ? 'Community listing'
+                    : 'Reviewed listing'
+                }}
+                ·
+                {{
+                  alternative.distributions.find(
+                    (item) => item.id === alternative.default_distribution,
+                  )?.kind === 'upstream'
+                    ? 'Upstream'
+                    : 'Community / direct'
+                }}
+                · {{ alternative.installable ? 'Installable' : 'Unavailable' }}</span
+              >
+            </li>
+          </ul>
+        </details>
+      </div>
     </div>
     <div v-else class="empty-state">
       <h3>No matching plugins</h3>

--- a/landing/components/registry/RegistryHero.vue
+++ b/landing/components/registry/RegistryHero.vue
@@ -2,7 +2,7 @@
 import type { ClientID, RegistryIndex } from '~/types/registry';
 import { pluginCommands } from '~/utils/commands';
 import { countAtElapsed, PLUGIN_COUNT_ANIMATION_MS } from '~/utils/countAnimation';
-import { catalogVisiblePlugins } from '~/utils/filter';
+import { catalogVisiblePlugins, groupCatalogPlugins } from '~/utils/filter';
 import { deliveryLabel, expectedDistribution, resolveDistribution } from '~/utils/registry';
 
 const props = defineProps<{ registry: RegistryIndex }>();
@@ -27,7 +27,7 @@ if (import.meta.client) {
     (state) => {
       if (state !== 'current' && state !== 'cached') return;
 
-      const target = catalogVisiblePlugins(props.registry.plugins).length;
+      const target = groupCatalogPlugins(catalogVisiblePlugins(props.registry.plugins)).length;
       if (
         countAnimationCompleted.value ||
         window.matchMedia('(prefers-reduced-motion: reduce)').matches
@@ -132,7 +132,7 @@ function updateTargets(values: string[]) {
   <section class="hero-shell">
     <div class="hero container">
       <div class="hero__copy">
-        <h1>One plugin<br ><em>All your agents</em></h1>
+        <h1>One plugin<br /><em>All your agents</em></h1>
         <p class="hero__lead">
           Install, update, repair, and remove Agent Plugins 1.0 across supported AI agents with one
           command. Let the CLI detect installed agents, or choose exactly where the plugin goes.
@@ -182,8 +182,7 @@ function updateTargets(values: string[]) {
               <li class="hero-quick-start__step">
                 <span class="hero-quick-start__number hero-quick-start__number--run">2</span>
                 <span class="hero-quick-start__label"
-                  ><strong>Copy and run</strong
-                  ><small>In your terminal</small></span
+                  ><strong>Copy and run</strong><small>In your terminal</small></span
                 >
                 <CommandSnippet v-if="command" :command="command" kind="add" inline />
                 <p v-else class="install-panel__notice" role="status">

--- a/landing/components/registry/RegistryPluginCard.vue
+++ b/landing/components/registry/RegistryPluginCard.vue
@@ -20,6 +20,18 @@ const isDiscovered = computed(() => props.plugin.trust_state === 'conformant_unr
 const availableClients = computed(() =>
   clients.filter((client) => props.plugin.client_support.clients.includes(client.id)),
 );
+const deliverySummary = computed(() => {
+  const delivery = props.plugin.client_support.delivery;
+  const managed = availableClients.value.filter(
+    (client) => delivery[client.id] === 'managed',
+  ).length;
+  const prepared = availableClients.value.filter((client) =>
+    ['prepared', 'manual_activation'].includes(delivery[client.id] ?? ''),
+  ).length;
+  if (managed + prepared < availableClients.value.length || !availableClients.value.length)
+    return 'Agent compatibility checked when you run the command';
+  return `${managed} installed automatically · ${prepared} require one final step`;
+});
 const initialTarget =
   availableClients.value.find((client) => client.id === 'cursor')?.id ??
   availableClients.value[0]?.id;
@@ -91,17 +103,17 @@ const provenanceURL = computed(() => {
 });
 const detailURL = computed(() =>
   isDiscovered.value
-    ? { path: '/plugins/community', query: { source: props.plugin.install_source } }
-    : `/plugins/${props.plugin.name}`,
+    ? { path: '/plugins/community/', query: { source: props.plugin.install_source } }
+    : `/plugins/${props.plugin.name}/`,
 );
 const securityDetailURL = computed(() =>
   isDiscovered.value
     ? {
-        path: '/plugins/community',
+        path: '/plugins/community/',
         query: { source: props.plugin.install_source },
         hash: '#security-review',
       }
-    : `/plugins/${props.plugin.name}#security-review`,
+    : `/plugins/${props.plugin.name}/#security-review`,
 );
 
 function updateTargets(values: string[]) {
@@ -130,7 +142,7 @@ function updateAutoDetect(value: boolean) {
       :class="{ 'plugin-card__ribbon--muted': !canInstall }"
       >{{
         canInstall
-          ? 'Reviewed plugin'
+          ? 'Reviewed listing'
           : expired
             ? 'Temporarily paused'
             : !published
@@ -160,10 +172,10 @@ function updateAutoDetect(value: boolean) {
               ? 'Found on GitHub'
               : 'Currently unavailable'
           }}
+          · {{ plugin.source.repository }}{{ plugin.source.path ? `/${plugin.source.path}` : '' }}
         </p>
         <p v-else-if="canInstall" class="plugin-card__source-label">
-          Ready for {{ availableClients.length }} supported
-          {{ availableClients.length === 1 ? 'agent' : 'agents' }}
+          {{ deliverySummary }}
         </p>
       </div>
     </div>

--- a/landing/components/sections/DownloadSection.vue
+++ b/landing/components/sections/DownloadSection.vue
@@ -1,13 +1,21 @@
 <script setup lang="ts">
 import CommandSnippetCard from '~/components/shared/CommandSnippetCard.vue';
+import { clientLandingPages } from '~/data/clients';
 import { applyCliInvocation, getCliInvocation } from '~/utils/cliInvocation';
+
+withDefaults(defineProps<{ headingTag?: 'h1' | 'h2' }>(), { headingTag: 'h2' });
 
 const { content } = useLandingContent();
 const { t, locale } = useI18n();
 const { data: releaseData, fallbackUrl } = useReleaseDownloads();
 const { quickstartUrl, supportBoundaryUrl } = useDocsLinks();
 
-const releaseVersion = computed(() => releaseData.value?.version || null);
+const releaseVersion = computed(() => {
+  const version = releaseData.value?.version;
+  return (
+    version?.match(/^(?:agentplugins-)?v?(\d+\.\d+\.\d+(?:-[\w.-]+)?(?:\+[\w.-]+)?)$/)?.[1] || null
+  );
+});
 const releaseDate = computed(() => {
   if (!releaseData.value?.pubDate) {
     return '';
@@ -92,7 +100,9 @@ const quickstartSteps = computed(() => {
   <section id="download" class="download-section section anchor-offset">
     <v-container>
       <div class="download-section__header">
-        <h2 class="download-section__title">{{ content.download.title }}</h2>
+        <component :is="headingTag" class="download-section__title">{{
+          content.download.title
+        }}</component>
         <p class="download-section__subtitle">{{ content.download.note }}</p>
         <p v-if="releaseVersion" class="download-section__release-info">
           {{ t('download.latestRelease') }} ·
@@ -194,16 +204,18 @@ const quickstartSteps = computed(() => {
 
         <div class="download-section__support-list">
           <div
-            v-for="(lane, index) in content.supportLanes"
-            :key="lane.id"
+            v-for="(client, index) in clientLandingPages"
+            :key="client.id"
             class="download-section__support-item"
             :style="{ '--accent': supportAccent[index % supportAccent.length] }"
           >
             <div class="download-section__support-main">
-              <h4 class="download-section__support-name">{{ lane.name }}</h4>
-              <span class="download-section__support-status">{{ lane.status }}</span>
+              <h4 class="download-section__support-name">
+                <NuxtLink :to="`/agents/${client.slug}/`">{{ client.name }}</NuxtLink>
+              </h4>
+              <span class="download-section__support-status">{{ client.status }}</span>
             </div>
-            <p class="download-section__support-note">{{ lane.note }}</p>
+            <p class="download-section__support-note">{{ client.note }}. {{ client.activation }}</p>
           </div>
         </div>
 
@@ -501,6 +513,11 @@ const quickstartSteps = computed(() => {
   font-size: 0.96rem;
   font-weight: 700;
   color: #e0e6ff;
+}
+
+.download-section__support-name a {
+  color: inherit;
+  text-underline-offset: 3px;
 }
 
 .download-section__support-status {

--- a/landing/locales/en.json
+++ b/landing/locales/en.json
@@ -85,8 +85,8 @@
       "linux": "Linux",
       "other": "your device"
     },
-    "supportTitle": "Support snapshot",
-    "supportSubtitle": "Real support depth today, based on the current support policy and target matrix.",
+    "supportTitle": "Supported agents",
+    "supportSubtitle": "Compatibility depends on the plugin. The CLI checks each selected agent and prints any activation or sign-in steps that remain.",
     "supportLink": "Read the support boundary"
   },
   "common": {

--- a/landing/pages/agents/[client].vue
+++ b/landing/pages/agents/[client].vue
@@ -22,12 +22,12 @@ const pageUrl = `${siteUrl}/agents/${client.slug}/`;
 const breadcrumbId = `${pageUrl}#breadcrumb`;
 const listId = `${pageUrl}#plugin-list`;
 const title = `Agent Plugins for ${client.name} | Universal Agent Plugins`;
-const installCommand = `npx universal-agent-plugins add <plugin> --target ${client.id}`;
+const installCommand = `npx universal-agent-plugins add context7 --target ${client.id}`;
 
 usePageSeo(title, client.intro, {
   translate: false,
   pageType: 'CollectionPage',
-  canonicalPath: `/agents/${client.slug}`,
+  canonicalPath: `/agents/${client.slug}/`,
   pageProperties: {
     breadcrumb: { '@id': breadcrumbId },
     mainEntity: { '@id': listId },
@@ -100,8 +100,8 @@ usePageSeo(title, client.intro, {
             <h2 id="agent-install-title">Choose a plugin and install it</h2>
             <CommandSnippet :command="installCommand" kind="add" label="Install" />
             <p>
-              Replace <code>&lt;plugin&gt;</code> with a reviewed short name or a pinned GitHub
-              package source.
+              Try Context7, or replace <code>context7</code> with another compatible plugin's
+              reviewed short name or pinned GitHub package source.
             </p>
           </aside>
         </div>
@@ -157,7 +157,7 @@ usePageSeo(title, client.intro, {
         </div>
         <ul class="agent-page__plugin-grid">
           <li v-for="plugin in reviewedPlugins" :key="plugin.name">
-            <NuxtLink :to="`/plugins/${plugin.name}`">
+            <NuxtLink :to="`/plugins/${plugin.name}/`">
               <span class="agent-page__plugin-icon">
                 <img
                   v-if="pluginIcon(plugin)"
@@ -176,7 +176,7 @@ usePageSeo(title, client.intro, {
             </NuxtLink>
           </li>
         </ul>
-        <NuxtLink class="button button--secondary agent-page__directory-link" to="/plugins">
+        <NuxtLink class="button button--secondary agent-page__directory-link" to="/plugins/">
           Explore the full plugin directory <span aria-hidden="true">→</span>
         </NuxtLink>
       </v-container>

--- a/landing/pages/download.vue
+++ b/landing/pages/download.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { productSoftwareSchema } from '~/utils/seo';
 
-const { content } = useLandingContent();
 const config = useRuntimeConfig();
 const description =
   'Install the Universal Agent Plugins CLI on macOS, Linux, or Windows and manage Agent Plugins 1.0 from one command.';
@@ -24,9 +23,7 @@ usePageSeo('Download Universal Agent Plugins CLI', description, {
 </script>
 
 <template>
-  <v-container class="section">
-    <h1 class="text-h4 section-title">{{ content.download.title }}</h1>
-    <p class="text-body-2 mb-6">{{ content.download.note }}</p>
-    <DownloadSection />
-  </v-container>
+  <div class="download-page">
+    <DownloadSection heading-tag="h1" />
+  </div>
 </template>

--- a/landing/pages/plugins/[slug].vue
+++ b/landing/pages/plugins/[slug].vue
@@ -19,11 +19,29 @@ const iconURL = pluginIcon(plugin);
 const supportedClients = clients.filter((client) =>
   plugin.client_support.clients.includes(client.id),
 );
+const clientGroups = [
+  {
+    label: 'Managed by CLI',
+    clients: supportedClients.filter(
+      (client) => plugin.client_support.delivery[client.id] === 'managed',
+    ),
+  },
+  {
+    label: 'Requires a final step in the app',
+    clients: supportedClients.filter((client) =>
+      ['prepared', 'manual_activation'].includes(plugin.client_support.delivery[client.id] ?? ''),
+    ),
+  },
+  {
+    label: 'Delivery details not specified',
+    clients: supportedClients.filter((client) => !plugin.client_support.delivery[client.id]),
+  },
+].filter((group) => group.clients.length > 0);
 const initialTarget =
   supportedClients.find((client) => client.id === 'cursor')?.id ?? supportedClients[0]?.id;
 const targets = ref<ClientID[]>(initialTarget ? [initialTarget] : []);
 const autoDetect = ref(true);
-const trustLabel = 'Reviewed package';
+const trustLabel = 'Reviewed listing';
 const siteUrl = String(config.public.siteUrl).replace(/\/+$/, '');
 const pluginUrl = `${siteUrl}/plugins/${plugin.name}/`;
 const pluginSchemaId = `${pluginUrl}#plugin`;
@@ -93,7 +111,7 @@ usePageSeo(`${plugin.display_name} Agent Plugin | Universal Agent Plugins`, desc
       <v-container>
         <div class="plugin-detail__hero-topbar">
           <v-btn
-            to="/plugins"
+            to="/plugins/"
             variant="text"
             icon
             aria-label="Back to plugin directory"
@@ -102,7 +120,7 @@ usePageSeo(`${plugin.display_name} Agent Plugin | Universal Agent Plugins`, desc
             <v-icon :icon="mdiArrowLeft" size="22" />
           </v-btn>
           <nav class="breadcrumbs" aria-label="Breadcrumb">
-            <NuxtLink to="/plugins">Plugins</NuxtLink><span aria-hidden="true">/</span
+            <NuxtLink to="/plugins/">Plugins</NuxtLink><span aria-hidden="true">/</span
             ><span>{{ plugin.display_name }}</span>
           </nav>
         </div>
@@ -137,6 +155,11 @@ usePageSeo(`${plugin.display_name} Agent Plugin | Universal Agent Plugins`, desc
               >
             </div>
 
+            <p class="plugin-detail__summary">
+              The listing and metadata were reviewed. An automated security assessment, when
+              present, applies only to the exact scanned revision. Runtime behavior is not audited.
+            </p>
+
             <div class="plugin-detail__actions">
               <v-btn size="x-large" class="plugin-detail__install-cta" @click="openInstallSection">
                 Install plugin <v-icon :icon="mdiDownload" end size="20" />
@@ -155,13 +178,17 @@ usePageSeo(`${plugin.display_name} Agent Plugin | Universal Agent Plugins`, desc
 
           <div class="plugin-detail__summary-card">
             <p class="plugin-detail__summary-eyebrow">Plugin overview</p>
-            <div class="plugin-detail__summary-block">
-              <div class="plugin-detail__summary-title">Supported clients</div>
+            <div
+              v-for="group in clientGroups"
+              :key="group.label"
+              class="plugin-detail__summary-block"
+            >
+              <div class="plugin-detail__summary-title">{{ group.label }}</div>
               <div class="plugin-detail__client-list">
                 <NuxtLink
-                  v-for="client in supportedClients"
+                  v-for="client in group.clients"
                   :key="client.id"
-                  :to="`/agents/${clientLandingById.get(client.id)?.slug}`"
+                  :to="`/agents/${clientLandingById.get(client.id)?.slug}/`"
                   class="plugin-detail__client"
                 >
                   <img :src="asset(`client-icons/${client.icon}`)" alt="" width="22" height="22" >

--- a/landing/pages/plugins/community.vue
+++ b/landing/pages/plugins/community.vue
@@ -20,9 +20,7 @@ const availableClients = computed(() =>
     ? clients.filter((client) => plugin.value!.client_support.clients.includes(client.id))
     : [],
 );
-const sourceUnavailable = computed(
-  () => plugin.value?.discovery?.availability === 'unavailable',
-);
+const sourceUnavailable = computed(() => plugin.value?.discovery?.availability === 'unavailable');
 const targets = ref<ClientID[]>([]);
 const autoDetect = ref(true);
 
@@ -50,11 +48,11 @@ usePageSeo(
 </script>
 
 <template>
-  <div class="registry-surface plugin-page">
+  <div class="registry-surface plugin-page community-plugin-page">
     <PageBackground />
     <div class="container">
       <nav class="breadcrumbs" aria-label="Breadcrumb">
-        <NuxtLink to="/plugins">Plugins</NuxtLink><span aria-hidden="true">/</span
+        <NuxtLink to="/plugins/">Plugins</NuxtLink><span aria-hidden="true">/</span
         ><span>{{ plugin?.display_name ?? 'Community plugin' }}</span>
       </nav>
 
@@ -76,7 +74,7 @@ usePageSeo(
           <dl class="plugin-facts">
             <div>
               <dt>Author</dt>
-              <dd>{{ plugin.author.name }}</dd>
+              <dd>{{ plugin.author.name || 'Not declared' }}</dd>
             </div>
             <div>
               <dt>{{ sourceUnavailable ? 'Last known agents' : 'Works with' }}</dt>
@@ -84,14 +82,16 @@ usePageSeo(
                 {{
                   availableClients.length
                     ? availableClients.map((client) => client.name).join(', ')
-                    : 'No supported agents yet'
+                    : plugin.client_support.resolution === 'install_time' && plugin.installable
+                      ? 'Detected at install time'
+                      : 'Not declared'
                 }}
               </dd>
             </div>
             <div>
               <dt>{{ sourceUnavailable ? 'Last known components' : 'Components' }}</dt>
               <dd>
-                {{ plugin.components.length ? plugin.components.join(', ') : 'No installable tools' }}
+                {{ plugin.components.length ? plugin.components.join(', ') : 'Not declared' }}
               </dd>
             </div>
             <div>
@@ -115,8 +115,27 @@ usePageSeo(
       <div v-else class="community-plugin-state">
         <h1>Plugin not found</h1>
         <p>This package is no longer available in the current directory.</p>
-        <NuxtLink class="button button--primary" to="/plugins">Explore plugins</NuxtLink>
+        <NuxtLink class="button button--primary" to="/plugins/">Explore plugins</NuxtLink>
       </div>
     </div>
   </div>
 </template>
+
+<style scoped>
+.community-plugin-page .plugin-page__grid {
+  grid-template-columns: minmax(0, 1fr);
+  max-width: 960px;
+  margin-inline: auto;
+  gap: 32px;
+}
+
+.community-plugin-page :deep(.install-panel) {
+  position: static;
+}
+
+.plugin-profile,
+.plugin-facts dd {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+</style>

--- a/landing/tests/browser/catalog-search.spec.ts
+++ b/landing/tests/browser/catalog-search.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+
+async function waitForDiscovery(page: import('@playwright/test').Page) {
+  await expect(page.locator('.catalog')).toHaveAttribute('data-discovery-state', /current|cached/, {
+    timeout: 15_000,
+  });
+}
+
+test('catalog groups duplicate sources and tolerates a small typo', async ({ page }) => {
+  await page.goto('./plugins/');
+  await waitForDiscovery(page);
+  const search = page.getByRole('searchbox', { name: 'Search plugins' });
+
+  await search.fill('context7');
+  await expect(page.getByRole('heading', { name: 'Context7', exact: true })).toHaveCount(1);
+  const group = page
+    .locator('.plugin-source-group')
+    .filter({ has: page.getByRole('heading', { name: 'Context7', exact: true }) });
+  await expect(group).toHaveCount(1);
+  const alternatives = group.locator('.plugin-other-sources');
+  await expect(alternatives).toBeVisible();
+  await alternatives.locator('summary').click();
+  await expect(alternatives.locator('li')).not.toHaveCount(0);
+
+  await search.fill('contex7');
+  await expect(page.getByRole('heading', { name: 'Context7', exact: true })).toHaveCount(1);
+});
+
+test('catalog URL preserves filters through detail navigation and Reset is always available', async ({
+  page,
+}) => {
+  await page.goto('./plugins/');
+  await waitForDiscovery(page);
+  const search = page.getByRole('searchbox', { name: 'Search plugins' });
+  const reset = page.getByRole('button', { name: 'Reset filters', exact: true });
+  await expect(reset).toBeDisabled();
+
+  await search.fill('gitlab');
+  await expect(page).toHaveURL(/\?q=gitlab$/);
+  await expect(reset).toBeEnabled();
+  await expect(page.getByRole('button', { name: 'Remove Search: gitlab' })).toBeVisible();
+
+  await page.getByRole('heading', { name: 'GitLab', exact: true }).getByRole('link').click();
+  await expect(page).toHaveURL(/\/plugins\/gitlab\/$/);
+  await page.goBack();
+  await expect(page).toHaveURL(/\/plugins\/\?q=gitlab$/);
+  await expect(search).toHaveValue('gitlab');
+
+  await reset.click();
+  await expect(page).toHaveURL(/\/plugins\/$/);
+  await expect(search).toHaveValue('');
+  await expect(reset).toBeDisabled();
+});

--- a/landing/tests/browser/community-install.spec.ts
+++ b/landing/tests/browser/community-install.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test';
+
+test('community installer is centered, full-width, and readable at desktop/tablet/mobile', async ({
+  page,
+}) => {
+  await page.goto(
+    './plugins/community/?source=discovery%3Avectorize-io%2Fhindsight%2F%2Fhindsight-integrations%2Fagent-plugin',
+  );
+  const panel = page.locator('.install-panel');
+  await expect(panel.locator('.command-snippet')).toHaveCount(4, { timeout: 15_000 });
+  await expect(page.locator('.breadcrumbs a')).toHaveAttribute('href', /\/plugins\/$/);
+  await expect(page.locator('#security-review')).toBeVisible();
+
+  for (const width of [1280, 980, 390]) {
+    await page.setViewportSize({ width, height: 900 });
+    const grid = (await page.locator('.plugin-page__grid').boundingBox())!;
+    const box = (await panel.boundingBox())!;
+    expect(Math.abs(grid.x - box.x)).toBeLessThanOrEqual(1);
+    expect(Math.abs(grid.width - box.width)).toBeLessThanOrEqual(1);
+    expect(Math.abs(box.x + box.width / 2 - width / 2)).toBeLessThanOrEqual(1);
+    const label = panel.locator('.app-multiselect__value > span:last-child');
+    await expect(label).toHaveText('All installed agents');
+    expect(await label.evaluate((node) => node.scrollWidth <= node.clientWidth)).toBe(true);
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(
+      true,
+    );
+    for (const snippet of await panel.locator('.command-snippet').all()) {
+      await expect(snippet).not.toContainText('--target');
+    }
+  }
+});
+
+test('targetless metadata-only community fixture explains missing installation support', async ({
+  page,
+}) => {
+  await page.goto(
+    './plugins/community/?source=discovery%3Aremotion-dev%2Fremotion%2F%2Fpackages%2Fagent-plugin',
+  );
+  const panel = page.locator('.install-panel');
+  await expect(panel.getByRole('status')).toContainText("doesn't include any tools", {
+    timeout: 15_000,
+  });
+  await expect(panel.locator('.command-snippet')).toHaveCount(0);
+  await expect(page.locator('.plugin-facts dd').filter({ hasText: /^Not declared$/ })).toHaveCount(
+    2,
+  );
+});

--- a/landing/tests/browser/hero-orbit.spec.ts
+++ b/landing/tests/browser/hero-orbit.spec.ts
@@ -15,11 +15,22 @@ test('CSS background works without JavaScript and keeps unique logos on the circ
     for (const client of uniqueLogos) {
       const logo = field.locator(`[data-client-id="${client.id}"] img`);
       await expect(logo).toHaveAttribute('src', new RegExp(`/client-icons/${client.icon}$`));
-      await expect.poll(() => logo.evaluate((image: HTMLImageElement) => image.complete && image.naturalWidth > 0)).toBe(true);
     }
+    await expect
+      .poll(() =>
+        field
+          .locator('[data-client-id] img')
+          .evaluateAll((images: HTMLImageElement[]) =>
+            images.every((image) => image.complete && image.naturalWidth > 0),
+          ),
+      )
+      .toBe(true);
     // Flatten the camera only; retain the historical spoke/circumference geometry.
     await field.locator('.hero-agent-field__plane').evaluate((node: HTMLElement) => {
-      node.style.transform = 'none';
+      // CSS animations outrank ordinary inline declarations while they are
+      // settling. Important keeps this geometry probe deterministic even when
+      // the full browser suite starts several contexts at once.
+      node.style.setProperty('transform', 'none', 'important');
     });
     await expect.poll(() => field.locator('.hero-agent-field__plane')
       .evaluate((node) => getComputedStyle(node).transform)).toBe('none');

--- a/landing/tests/browser/landing.spec.ts
+++ b/landing/tests/browser/landing.spec.ts
@@ -115,22 +115,22 @@ test('scroll reveals respect reduced motion', async ({ page }) => {
   ).toBeLessThanOrEqual(0.00001);
 });
 
-test(
-  'below-fold content stays visible when JavaScript is disabled',
-  async ({ browser, baseURL }) => {
-    const context = await browser.newContext({ javaScriptEnabled: false });
-    try {
-      const page = await context.newPage();
-      await page.goto(baseURL!);
-      const section = page.locator('#why');
-      await expect(section).toBeVisible();
-      await expect(section).not.toHaveClass(/scroll-reveal/);
-      await expect(section).toHaveCSS('opacity', '1');
-    } finally {
-      await context.close();
-    }
-  },
-);
+test('below-fold content stays visible when JavaScript is disabled', async ({
+  browser,
+  baseURL,
+}) => {
+  const context = await browser.newContext({ javaScriptEnabled: false });
+  try {
+    const page = await context.newPage();
+    await page.goto(baseURL!);
+    const section = page.locator('#why');
+    await expect(section).toBeVisible();
+    await expect(section).not.toHaveClass(/scroll-reveal/);
+    await expect(section).toHaveCSS('opacity', '1');
+  } finally {
+    await context.close();
+  }
+});
 
 test('plugin counter stays inside the hero on a narrow screen', async ({ page }) => {
   await page.setViewportSize({ width: 280, height: 844 });
@@ -202,7 +202,7 @@ test('homepage publishes canonical social metadata and complete product schema',
 
 test('supported client links open crawlable client-specific landing pages', async ({ page }) => {
   await page.goto('./');
-  await page.locator('.client-strip a[href$="/agents/codex"]').click();
+  await page.locator('.client-strip a[href$="/agents/codex/"]').click();
   await expect(page).toHaveURL(/\/agents\/codex\/?$/);
   await expect(page).toHaveTitle('Agent Plugins for Codex | Universal Agent Plugins');
   await expect(
@@ -213,7 +213,7 @@ test('supported client links open crawlable client-specific landing pages', asyn
     'https://777genius.github.io/universal-agent-plugins/agents/codex/',
   );
   await expect(page.locator('.command-snippet')).toContainText(
-    'npx universal-agent-plugins add <plugin> --target codex',
+    'npx universal-agent-plugins add context7 --target codex',
   );
   const graph = await parseJsonLd(page);
   expect(graph.map((item) => item['@type'])).toEqual(
@@ -271,9 +271,9 @@ test('community plugin titles open an installable plugin page instead of GitHub'
   await expect(communityCard).toBeVisible({ timeout: 15_000 });
   const title = communityCard.locator('.plugin-card__title-link');
   const pluginName = (await title.textContent())?.trim();
-  await expect(title).toHaveAttribute('href', /\/plugins\/community\?source=/);
+  await expect(title).toHaveAttribute('href', /\/plugins\/community\/\?source=/);
   await title.click();
-  await expect(page).toHaveURL(/\/plugins\/community\?source=/);
+  await expect(page).toHaveURL(/\/plugins\/community\/\?source=/);
   await expect(page.getByRole('heading', { name: pluginName, exact: true })).toBeVisible({
     timeout: 15_000,
   });
@@ -316,7 +316,7 @@ test('metadata-only community direct links explain why installation is unavailab
   page,
 }) => {
   await page.goto(
-    './plugins/community?source=discovery%3Aremotion-dev%2Fremotion%2F%2Fpackages%2Fagent-plugin',
+    './plugins/community/?source=discovery%3Aremotion-dev%2Fremotion%2F%2Fpackages%2Fagent-plugin',
   );
   await expect(page.getByRole('heading', { name: 'remotion', exact: true })).toBeVisible({
     timeout: 15_000,
@@ -324,14 +324,13 @@ test('metadata-only community direct links explain why installation is unavailab
   await expect(page.getByRole('heading', { name: 'Not ready to install' })).toBeVisible();
   await expect(page.getByRole('status')).toContainText('This plugin is not installable yet');
   await expect(page.getByRole('status')).toContainText("doesn't include any tools");
-  await expect(page.getByText('No supported agents yet')).toBeVisible();
-  await expect(page.getByText('No installable tools')).toBeVisible();
+  await expect(page.getByText('Not declared')).toHaveCount(2);
   await expect(page.locator('.command-snippet')).toHaveCount(0);
 });
 
 test('unavailable community sources never expose stale install guidance', async ({ page }) => {
   await page.goto(
-    './plugins/community?source=discovery%3A777genius%2Funiversal-agent-plugins%2F%2Fbridges%2Fchrome-devtools%2Foverlay',
+    './plugins/community/?source=discovery%3A777genius%2Funiversal-agent-plugins%2F%2Fbridges%2Fchrome-devtools%2Foverlay',
   );
   await expect(page.getByRole('heading', { name: 'Not ready to install' })).toBeVisible({
     timeout: 15_000,

--- a/landing/tests/browser/migration-copy.spec.ts
+++ b/landing/tests/browser/migration-copy.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@playwright/test';
+import { clientLandingPages } from '../../data/clients';
+
+test('download has one title, a readable version, and current client support', async ({ page }) => {
+  await page.route('https://api.github.com/repos/**/releases/latest', (route) =>
+    route.fulfill({
+      json: { tag_name: 'agentplugins-v1.2.3', published_at: '2026-09-01T00:00:00Z', assets: [] },
+    }),
+  );
+  await page.goto('./download/');
+  await expect(
+    page.getByRole('heading', { name: 'Install your first plugin', exact: true }),
+  ).toHaveCount(1);
+  await expect(page.locator('h1')).toHaveText('Install your first plugin');
+  await expect(page.locator('.download-section__release-info a')).toHaveText('v1.2.3');
+  await expect(page.getByRole('main')).not.toContainText(
+    /vagentplugins|runtime lane|packaging-only/i,
+  );
+  const support = page.locator('.download-section__support-list');
+  await expect(support.locator('.download-section__support-item')).toHaveCount(
+    clientLandingPages.length,
+  );
+  for (const client of clientLandingPages) {
+    await expect(support.getByRole('link', { name: client.name, exact: true })).toHaveAttribute(
+      'href',
+      new RegExp(`/agents/${client.slug}/$`),
+    );
+  }
+  await expect(support).toContainText('Setup in app');
+  await expect(support).toContainText('Prepared by CLI');
+});
+
+for (const client of clientLandingPages) {
+  test(`${client.name} copies a runnable example and uses canonical catalog links`, async ({ page }) => {
+    await page.addInitScript(() => {
+      let copied = '';
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: {
+          writeText: async (value: string) => {
+            copied = value;
+          },
+          readText: async () => copied,
+        },
+      });
+    });
+    await page.goto(`./agents/${client.slug}/`);
+    const command = `npx universal-agent-plugins add context7 --target ${client.id}`;
+    const install = page.locator('.agent-page__install');
+    await expect(install.locator('code').first()).toHaveText(command);
+    await install.getByRole('button', { name: 'Copy command', exact: true }).click();
+    await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(command);
+    await expect(page.locator('.agent-page__directory-link')).toHaveAttribute(
+      'href',
+      /\/plugins\/$/,
+    );
+    for (const link of await page.locator('.agent-page__plugin-grid a').all()) {
+      await expect(link).toHaveAttribute('href', /\/plugins\/[^/]+\/$/);
+    }
+  });
+}

--- a/landing/tests/browser/visual-controls.spec.ts
+++ b/landing/tests/browser/visual-controls.spec.ts
@@ -8,19 +8,21 @@ test('flat filters retain keyboard selection, category search, and reset', async
   await controls.scrollIntoViewIfNeeded();
   await expect(controls).toHaveCSS('border-top-width', '0px');
   await expect(controls).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
-  for (const field of await controls.locator('.search-field input, .app-select__trigger, .app-combobox__anchor').all()) {
+  for (const field of await controls
+    .locator('.search-field input, .app-select__trigger, .app-combobox__anchor')
+    .all()) {
     await expect(field).toHaveCSS('border-radius', '0px');
     await expect(field).toHaveCSS('border-top-width', '0px');
     await expect(field).toHaveCSS('background-image', 'none');
     await expect(field).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
-    expect((await field.boundingBox())!.height).toBeGreaterThanOrEqual(44);
+    expect((await field.boundingBox())!.height).toBeGreaterThanOrEqual(43.5);
     await field.hover();
     await expect(field).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
   }
   const trust = page.getByRole('combobox', { name: 'Filter by trust level', exact: true });
   await trust.focus();
   await page.keyboard.press('Enter');
-  await page.getByRole('option', { name: 'Reviewed plugins', exact: true }).click();
+  await page.getByRole('option', { name: 'Reviewed listings', exact: true }).click();
   await expect(trust).toBeFocused();
   await expect(page.locator('.plugin-card[data-trust="community"]')).toHaveCount(0);
   await expect(page.locator('.plugin-card').first()).toBeVisible();
@@ -38,7 +40,9 @@ test('flat filters retain keyboard selection, category search, and reset', async
   await expect(page.getByRole('searchbox', { name: 'Search plugins' })).toHaveValue('');
 });
 
-test('numbered benefits remain readable in both themes and responsive layouts', async ({ page }) => {
+test('numbered benefits remain readable in both themes and responsive layouts', async ({
+  page,
+}) => {
   await page.goto('./');
   const cards = page.locator('.registry-benefits__card');
   await expect(cards).toHaveCount(4);
@@ -50,17 +54,22 @@ test('numbered benefits remain readable in both themes and responsive layouts', 
     for (const width of [1440, 800, 390, 280]) {
       await page.setViewportSize({ width, height: 1000 });
       await cards.first().scrollIntoViewIfNeeded();
-      const columns = await page.locator('.registry-benefits__grid').evaluate((node) =>
-        getComputedStyle(node).gridTemplateColumns.split(' ').length);
+      const columns = await page
+        .locator('.registry-benefits__grid')
+        .evaluate((node) => getComputedStyle(node).gridTemplateColumns.split(' ').length);
       expect(columns).toBe(width > 980 ? 4 : width > 720 ? 2 : 1);
       for (const [index, card] of (await cards.all()).entries()) {
-        await expect(card.getByRole('heading', { name: headings[index], exact: true })).toBeVisible();
+        await expect(
+          card.getByRole('heading', { name: headings[index], exact: true }),
+        ).toBeVisible();
         const box = (await card.boundingBox())!;
         expect(box.x).toBeGreaterThanOrEqual(0);
         expect(box.x + box.width).toBeLessThanOrEqual(width);
         expect(await card.evaluate((node) => node.scrollWidth <= node.clientWidth)).toBe(true);
       }
-      expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+      expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(
+        true,
+      );
     }
     // The desktop theme control is intentionally absent from the compact mobile header.
     await page.setViewportSize({ width: 1440, height: 1000 });

--- a/landing/tests/community-install.test.ts
+++ b/landing/tests/community-install.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripTypeScriptTypes } from 'node:module';
+import { test } from 'node:test';
+import { runInNewContext } from 'node:vm';
+import { pluginCommands } from '../utils/commands.ts';
+
+// Exercise the actual setup expressions, with Nuxt/Vue state supplied by this
+// isolated harness. No signed production data or installer is mutated.
+const component = readFileSync(
+  new URL('../components/registry/InstallPanel.vue', import.meta.url),
+  'utf8',
+);
+const setup = component
+  .match(/<script setup lang="ts">([\s\S]*?)<\/script>/)![1]!
+  .replace(/^import .*;\n/gm, '');
+const script = stripTypeScriptTypes(setup) + '\n({ commands, unavailableDiscoveryReason });';
+
+const targetlessFixture = {
+  name: 'targetless-fixture',
+  install_source: 'discovery:example/targetless-fixture',
+  installable: true,
+  components: [],
+  trust_state: 'conformant_unreviewed',
+  client_support: { resolution: 'install_time', clients: [] },
+  discovery: { availability: 'available' },
+};
+
+function panelState({ installable = true, autoDetect = true, current = true } = {}) {
+  return runInNewContext(script, {
+    defineProps: () => ({ plugin: { ...targetlessFixture, installable } }),
+    defineModel: (name: string) => ({ value: name === 'targets' ? [] : autoDetect }),
+    computed: (read: () => unknown) => ({
+      get value() {
+        return read();
+      },
+    }),
+    useSite: () => ({ asset: (path: string) => path, sourceUrl: () => '' }),
+    useDirectoryStatus: () => ({
+      current: { value: current },
+      expired: { value: !current },
+      published: { value: true },
+    }),
+    clients: [{ id: 'codex', name: 'Codex', icon: 'codex.svg' }],
+    resolveDistribution: () => ({ unavailable_reason: 'No compatible source.' }),
+    expectedDistribution: () => undefined,
+    deliveryLabel: () => '',
+    pluginCommands,
+    watch: () => {},
+  });
+}
+
+test('installable install-time fixture with no targets exposes all four automatic commands', () => {
+  const state = panelState();
+  for (const action of ['add', 'update', 'repair', 'remove']) {
+    assert.equal(
+      state.commands.value[action],
+      `npx universal-agent-plugins ${action} ${action === 'add' ? targetlessFixture.install_source : targetlessFixture.name}`,
+    );
+    assert.equal(state.commands.value[action].includes('--target'), false);
+  }
+  assert.equal(state.unavailableDiscoveryReason.value, '');
+});
+
+test('targetless fixture cannot bypass explicit selection or snapshot authority', () => {
+  assert.equal(panelState({ autoDetect: false }).commands.value, undefined);
+  assert.equal(panelState({ current: false }).commands.value, undefined);
+});
+
+test('non-installable targetless fixture has an explicit reason and no commands', () => {
+  const state = panelState({ installable: false });
+  assert.equal(state.commands.value, undefined);
+  assert.match(state.unavailableDiscoveryReason.value, /doesn't include any tools/);
+});

--- a/landing/tests/registry.test.ts
+++ b/landing/tests/registry.test.ts
@@ -5,7 +5,13 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { pluginCommands } from '../utils/commands.ts';
 import { discoveryPlugin } from '../utils/discovery.ts';
-import { catalogVisiblePlugins, filterPlugins } from '../utils/filter.ts';
+import {
+  catalogVisiblePlugins,
+  filterPlugins,
+  groupCatalogPlugins,
+  catalogQuery,
+  restoreCatalogQuery,
+} from '../utils/filter.ts';
 import { mirroredIconPath, parseDirectoryData } from '../utils/registry.ts';
 import type { DiscoveryRecord, DiscoverySnapshot } from '../types/discovery.ts';
 
@@ -48,6 +54,125 @@ const discoveryRecord = {
 } satisfies DiscoveryRecord;
 
 describe('unified registry landing', () => {
+  it('groups alternate sources with a deterministic reviewed primary', () => {
+    const reviewed = registry.plugins[0]!;
+    const other = {
+      ...reviewed,
+      install_source: 'discovery:other/plugin',
+      trust_state: 'conformant_unreviewed' as const,
+      source: { ...reviewed.source, repository: 'other/plugin' },
+    };
+    const groups = groupCatalogPlugins([other, reviewed]);
+    assert.equal(groups.length, 1);
+    assert.equal(groups[0]?.primary, reviewed);
+    assert.deepEqual(groups[0]?.alternatives, [other]);
+    assert.equal(groupCatalogPlugins([reviewed, other])[0]?.primary, reviewed);
+  });
+
+  it('prefers upstream, available, non-test sources before stars', () => {
+    const base = registry.plugins[0]!;
+    const candidate = (id: string, upstream: boolean, installable: boolean, path: string) => ({
+      ...base,
+      install_source: id,
+      trust_state: 'conformant_unreviewed' as const,
+      installable,
+      source: { ...base.source, repository: `${id}/plugin`, path },
+      distributions: base.distributions.map((item) => ({
+        ...item,
+        kind: upstream ? ('upstream' as const) : ('community' as const),
+      })),
+    });
+    const community = candidate('a', false, true, '');
+    const unavailable = candidate('b', true, false, '');
+    const test = candidate('c', true, true, 'fixtures/example');
+    const real = candidate('d', true, true, 'plugin');
+    assert.equal(groupCatalogPlugins([community, unavailable, test, real])[0]?.primary, real);
+    assert.equal(groupCatalogPlugins([real, test, unavailable, community])[0]?.primary, real);
+  });
+
+  it('keeps different monorepo packages separate and groups canonical source aliases', () => {
+    const base = { ...registry.plugins[0]!, trust_state: 'conformant_unreviewed' as const };
+    const first = { ...base, name: 'first', source: { ...base.source, path: 'first' } };
+    const second = {
+      ...base,
+      name: 'second',
+      install_source: 'second',
+      source: { ...base.source, path: 'second' },
+    };
+    const alias = { ...first, name: 'alias', install_source: 'alias' };
+    assert.equal(groupCatalogPlugins([first, second, alias]).length, 2);
+  });
+
+  it('uses repository stars then install source as a stable primary tiebreaker', () => {
+    const base = discoveryPlugin(discoveryRecord, discoverySnapshot);
+    const popular = { ...base, install_source: 'z', discovery: { ...base.discovery!, stars: 100 } };
+    const sameStars = { ...popular, install_source: 'a' };
+    assert.equal(groupCatalogPlugins([base, popular])[0]?.primary, popular);
+    assert.equal(groupCatalogPlugins([popular, sameStars])[0]?.primary, sameStars);
+    assert.equal(groupCatalogPlugins([sameStars, popular])[0]?.primary, sameStars);
+  });
+
+  it('joins canonical aliases transitively without losing any source', () => {
+    const base = { ...registry.plugins[0]!, trust_state: 'conformant_unreviewed' as const };
+    const first = {
+      ...base,
+      name: 'first',
+      install_source: 'first',
+      source: { ...base.source, path: 'first' },
+    };
+    const second = {
+      ...base,
+      name: 'second',
+      install_source: 'second',
+      source: { ...base.source, path: 'second' },
+    };
+    const bridge = { ...first, name: 'second', install_source: 'bridge' };
+    const groups = groupCatalogPlugins([first, second, bridge]);
+    assert.equal(groups.length, 1);
+    assert.equal(groups[0]?.alternatives.length, 2);
+  });
+
+  it('uses typo fallback only when exact search has no results, retaining filters', () => {
+    const plugin = {
+      ...registry.plugins[0]!,
+      name: 'calendar',
+      display_name: 'Calendar',
+      categories: ['productivity'],
+    };
+    for (const query of ['calndar', 'calender', 'calenadr', 'callendar']) {
+      assert.deepEqual(filterPlugins([plugin], { query }), [plugin]);
+      assert.deepEqual(filterPlugins([plugin], { query, category: 'other' }), []);
+    }
+    const exact = {
+      ...plugin,
+      name: 'calender',
+      display_name: 'Calender',
+      install_source: 'exact',
+    };
+    assert.deepEqual(filterPlugins([plugin, exact], { query: 'calender' }), [exact]);
+    assert.deepEqual(filterPlugins([plugin], { query: 'xyz' }), []);
+  });
+
+  it('round-trips every filter, preserves unrelated queries and clears only catalog state', () => {
+    const values = [
+      'calendar',
+      'productivity',
+      'mcp',
+      'upstream',
+      'reviewed',
+      'codex',
+      'none',
+      'example',
+    ];
+    const query = catalogQuery(values, { campaign: 'launch' });
+    assert.deepEqual(restoreCatalogQuery(query), values);
+    assert.equal(query.campaign, 'launch');
+    assert.deepEqual(catalogQuery(['', ...Array(7).fill('all')], query), { campaign: 'launch' });
+    assert.deepEqual(restoreCatalogQuery({ q: ['calendar', 'ignored'], owner: null }), [
+      'calendar',
+      ...Array(7).fill('all'),
+    ]);
+  });
   it('loads the signed reviewed directory used by the site', () => {
     assert.ok(registry.plugins.length >= 20);
     assert.ok(registry.plugins.every((plugin) => plugin.trust_state !== 'conformant_unreviewed'));

--- a/landing/utils/filter.ts
+++ b/landing/utils/filter.ts
@@ -22,6 +22,113 @@ function normalized(value: string): string {
   return value.trim().toLowerCase();
 }
 
+export const catalogQueryKeys = [
+  'q',
+  'category',
+  'component',
+  'source',
+  'trust',
+  'client',
+  'auth',
+  'owner',
+] as const;
+
+/** Only the catalog's keys are changed; unrelated route state is preserved. */
+export function catalogQuery(values: string[], existing: Record<string, unknown> = {}) {
+  const result = { ...existing };
+  catalogQueryKeys.forEach((key, index) => {
+    const value = values[index]?.trim();
+    if (value && (key === 'q' || value !== 'all')) result[key] = value;
+    else Reflect.deleteProperty(result, key);
+  });
+  return result;
+}
+
+export function restoreCatalogQuery(query: Record<string, unknown>): string[] {
+  return catalogQueryKeys.map((key) => {
+    const value = Array.isArray(query[key]) ? query[key][0] : query[key];
+    return typeof value === 'string' && value.trim() ? value.trim() : key === 'q' ? '' : 'all';
+  });
+}
+
+function primaryPriority(plugin: RegistryPlugin): number[] {
+  return [
+    plugin.trust_state === 'conformant_unreviewed' ? 1 : 0,
+    plugin.distributions.some((item) => item.kind === 'upstream') ? 0 : 1,
+    plugin.installable && plugin.discovery?.availability !== 'unavailable' ? 0 : 1,
+    /(^|[/_.-])(tests?|fixtures?|examples?|demo)([/_.-]|$)/i.test(
+      `${plugin.source.repository}/${plugin.source.path}`,
+    )
+      ? 1
+      : 0,
+    -(plugin.discovery?.stars ?? 0),
+  ];
+}
+
+export function groupCatalogPlugins(plugins: RegistryPlugin[]) {
+  type SourceGroup = { members: RegistryPlugin[]; keys: Set<string>; order: number };
+  const groups = new Set<SourceGroup>();
+  const byIdentity = new Map<string, SourceGroup>();
+  for (const [order, plugin] of plugins.entries()) {
+    const keys = new Set([
+      `name:${normalized(plugin.name)}`,
+      `source:${normalized(plugin.source.repository)}/${plugin.source.path.replace(/^\/+|\/+$/g, '')}`,
+      ...(plugin.discovery?.reviewed_distribution_id
+        ? [`distribution:${plugin.discovery.reviewed_distribution_id}`]
+        : []),
+      ...((plugin.trust_state ?? 'reviewed') === 'reviewed'
+        ? plugin.distributions.map((item) => `distribution:${item.id}`)
+        : []),
+    ]);
+    const overlapping = [
+      ...new Set([...keys].flatMap((key) => (byIdentity.has(key) ? [byIdentity.get(key)!] : []))),
+    ];
+    const group = {
+      members: [plugin, ...overlapping.flatMap((item) => item.members)],
+      keys: new Set([...keys, ...overlapping.flatMap((item) => [...item.keys])]),
+      order: Math.min(order, ...overlapping.map((item) => item.order)),
+    };
+    overlapping.forEach((item) => groups.delete(item));
+    groups.add(group);
+    group.keys.forEach((key) => byIdentity.set(key, group));
+  }
+  return [...groups]
+    .sort((left, right) => left.order - right.order)
+    .map((group) => {
+      group.members.sort((left, right) => {
+        const a = primaryPriority(left);
+        const b = primaryPriority(right);
+        return (
+          a.map((value, index) => value - b[index]!).find((value) => value !== 0) ??
+          compareText(left.install_source, right.install_source)
+        );
+      });
+      return { primary: group.members[0]!, alternatives: group.members.slice(1) };
+    });
+}
+
+/** One insertion/deletion/substitution or adjacent transposition, for meaningful words only. */
+function typoMatch(value: string, query: string): boolean {
+  if (query.length < 4) return false;
+  return normalized(value)
+    .split(/[^\p{L}\p{N}]+/u)
+    .some((word) => {
+      if (Math.abs(word.length - query.length) > 1) return false;
+      let index = 0;
+      while (index < Math.min(word.length, query.length) && word[index] === query[index]) index++;
+      if (word.length === query.length)
+        return (
+          word.slice(index + 1) === query.slice(index + 1) ||
+          (word[index] === query[index + 1] &&
+            word[index + 1] === query[index] &&
+            word.slice(index + 2) === query.slice(index + 2))
+        );
+      return word.length > query.length
+        ? word.slice(index + 1) === query.slice(index)
+        : word.slice(index) === query.slice(index + 1);
+    });
+}
+
 function sourceOwner(plugin: RegistryPlugin): string {
   return plugin.source.repository.split('/', 1)[0] ?? plugin.source.repository;
 }
@@ -96,19 +203,8 @@ export function filterPlugins(
   filters: CatalogFilters,
 ): RegistryPlugin[] {
   const query = normalized(filters.query ?? '');
-  const matches = plugins.filter((plugin) => {
-    const searchable = [
-      plugin.name,
-      plugin.display_name,
-      plugin.description,
-      plugin.author.name,
-      plugin.source.repository,
-      ...plugin.categories,
-      ...plugin.keywords,
-      ...plugin.components,
-    ];
+  const eligible = plugins.filter((plugin) => {
     return (
-      (!query || searchable.some((value) => normalized(value).includes(query))) &&
       (!filters.category || plugin.categories.includes(filters.category)) &&
       (!filters.component || plugin.components.includes(filters.component)) &&
       (!filters.source ||
@@ -129,6 +225,25 @@ export function filterPlugins(
       (!filters.owner || normalized(sourceOwner(plugin)) === normalized(filters.owner))
     );
   });
+  const searchable = (plugin: RegistryPlugin) => [
+    plugin.name,
+    plugin.display_name,
+    plugin.description,
+    plugin.author.name,
+    plugin.source.repository,
+    ...plugin.categories,
+    ...plugin.keywords,
+    ...plugin.components,
+  ];
+  let matches = eligible.filter(
+    (plugin) => !query || searchable(plugin).some((value) => normalized(value).includes(query)),
+  );
+  if (query && !matches.length)
+    matches = eligible.filter((plugin) =>
+      [plugin.name, plugin.display_name, ...plugin.keywords].some((value) =>
+        typoMatch(value, query),
+      ),
+    );
   if (!query) {
     const reviewed = matches
       .filter((plugin) => (plugin.trust_state ?? 'reviewed') === 'reviewed')

--- a/npm/agentplugins/README.md
+++ b/npm/agentplugins/README.md
@@ -23,7 +23,7 @@ verified scripts in the [project README](https://github.com/777genius/universal-
 3. Follow any activation or sign-in instruction printed by the CLI.
 4. Start a new agent session and use the plugin.
 
-[Browse 2,500+ plugins](https://777genius.github.io/universal-agent-plugins-registry/)
+[Browse 2,500+ plugins](https://777genius.github.io/universal-agent-plugins/plugins/)
 
 ## What it does
 
@@ -104,7 +104,7 @@ and caches it locally. Native release tests cover x64 and arm64 on all three
 operating systems.
 
 - [Source and documentation](https://github.com/777genius/universal-agent-plugins)
-- [Browse the registry](https://777genius.github.io/universal-agent-plugins-registry/)
+- [Browse the plugin catalog](https://777genius.github.io/universal-agent-plugins/plugins/)
 - [Client E2E evidence](https://github.com/777genius/universal-agent-plugins/blob/main/docs/AGENTPLUGINS_CLIENT_E2E.md)
 
 Universal Agent Plugins is an independent community project. It is not

--- a/repotests/landing_contract_integration_test.go
+++ b/repotests/landing_contract_integration_test.go
@@ -277,7 +277,7 @@ func TestLandingSurface_LocalesLinksAndBrandingStayAligned(t *testing.T) {
 	mustContain(t, agentPage, `clientLandingBySlug.get`)
 	mustContain(t, agentPage, `'@type': 'ItemList'`)
 	mustContain(t, agentPage, `'@type': 'BreadcrumbList'`)
-	mustContain(t, agentPage, `npx universal-agent-plugins add <plugin> --target`)
+	mustContain(t, agentPage, `npx universal-agent-plugins add context7 --target`)
 
 	enContentBody, err := os.ReadFile(filepath.Join(landingRoot, "content", "en.json"))
 	if err != nil {


### PR DESCRIPTION
## Summary
- group duplicate catalog and CLI results behind one recommended source
- preserve catalog filters in URLs with active chips and a persistent reset
- simplify reviewed, delivery, migration, and runnable command copy
- add typo fallback and compact human CLI search with optional details

## Verification
- go test ./... -count=1
- pnpm test:registry (31 passed)
- pnpm generate
- playwright test --workers=3 (47 passed)
- pnpm lint (0 errors)
- real CLI search for context7, contex7, details, and JSON

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added typo-tolerant catalog and CLI search with close-match suggestions.
  - Added detailed search output showing availability, source, runtime, status, and alternatives.
  - Catalog now groups duplicate listings, displays alternative sources, and preserves filters in URL parameters.
  - Added active-filter chips and a reset control.
  - Install panels now provide clearer client-specific commands and delivery information.

- **Improvements**
  - Updated registry labels, trust messaging, compatibility details, links, and installation guidance.
  - Improved responsive styling and readability across catalog and installation views.
  - Updated download and agent pages with clearer supported-client information and current catalog links.

- **Tests**
  - Expanded browser and integration coverage for search, filtering, installation, navigation, and responsive layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->