### PR TITLE
perf: scope registry data to each page

### DIFF
--- a/landing/composables/useRegistry.ts
+++ b/landing/composables/useRegistry.ts
@@ -1,76 +1,136 @@
+import type { DiscoveryBundle } from '~/types/discovery';
 import type { RegistryIndex } from '~/types/registry';
+import type { SecuritySnapshot } from '~/types/security';
 import { BrowserDiscoveryCache, discoveryPlugin, loadDiscovery } from '~/utils/discovery';
 import { applySecurityAssessment, loadSecurity } from '~/utils/security';
+import type { RegistryProjection } from '~/utils/registryProjection';
 
-export function useRegistry(): RegistryIndex {
+interface RegistryPageOptions {
+  projection?: RegistryProjection;
+  discovery?: boolean;
+}
+
+let discoveryPromise: Promise<DiscoveryBundle> | undefined;
+let securityPromise: Promise<SecuritySnapshot | undefined> | undefined;
+
+export async function useRegistryPage(options: RegistryPageOptions = {}): Promise<RegistryIndex> {
+  const projection = options.projection ?? { kind: 'catalog' };
+  const endpoint = registryEndpoint(projection);
+  const key = `registry-page:${endpoint}`;
   const config = useRuntimeConfig();
-  const registry = useState<RegistryIndex>('registry-index', () =>
-    structuredClone(config.public.registryIndex as unknown as RegistryIndex),
-  );
-  const started = useState('discovery-started', () => false);
+  const registry = useState<RegistryIndex | undefined>('registry-index');
+  const activeKey = useState('registry-page-key', () => '');
   const status = useDiscoveryStatus();
+  const seed = shallowRef<RegistryIndex>();
 
-  if (import.meta.client) {
-    onMounted(async () => {
-      if (started.value) return;
-      started.value = true;
-      status.value = { state: 'loading', count: 0 };
-      const baseURL = String(config.public.baseURL).replace(/\/?$/, '/');
-      const origin = new URL(`${baseURL}discovery/`, location.origin);
-      const security = loadSecurity({
-        origin: new URL(`${baseURL}security/`, location.origin),
-        trust: {
-          keyID: String(config.public.discoveryKeyID),
-          publicKeyBase64: String(config.public.discoveryPublicKey),
-        },
-      }).catch(() => undefined);
-      try {
-        const bundle = await loadDiscovery({
-          origin,
-          trust: {
-            keyID: String(config.public.discoveryKeyID),
-            publicKeyBase64: String(config.public.discoveryPublicKey),
-          },
-          cache: new BrowserDiscoveryCache(origin),
-        });
-        await waitForCatalogInteractionToFinish();
-        const reviewed = registry.value.plugins.filter(
-          (plugin) => plugin.trust_state !== 'conformant_unreviewed',
-        );
-        const discovered = bundle.search.records.map((record) =>
-          discoveryPlugin(record, bundle.snapshot),
-        );
-        registry.value.plugins = [...reviewed, ...discovered];
-        status.value = {
-          state: bundle.source === 'remote' ? 'current' : 'cached',
-          count: discovered.length,
-          sequence: bundle.snapshot.sequence,
-          generatedAt: bundle.snapshot.generated_at,
-        };
-        const securityBundle = await security;
-        if (securityBundle) {
-          await waitForCatalogInteractionToFinish();
-          registry.value.plugins = registry.value.plugins.map((plugin) =>
-            applySecurityAssessment(plugin, securityBundle.snapshot),
-          );
-        }
-      } catch (error) {
-        registry.value.plugins = registry.value.plugins.filter(
-          (plugin) => plugin.trust_state !== 'conformant_unreviewed',
-        );
-        status.value = {
-          state:
-            error instanceof Error && /stale|expired/i.test(error.message)
-              ? 'stale'
-              : 'unavailable',
-          count: 0,
-          message: error instanceof Error ? error.message : 'Signed Discovery Index is unavailable',
-        };
+  if (import.meta.client && options.discovery) {
+    onMounted(() => {
+      if (seed.value) {
+        void augmentWithDiscovery(registry, seed.value, key, activeKey, status, config);
       }
     });
   }
 
+  const { data, error } = await useAsyncData<RegistryIndex>(
+    key,
+    () => $fetch<RegistryIndex>(endpoint),
+    { deep: false },
+  );
+  if (error.value || !data.value) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Plugin directory is unavailable',
+      cause: error.value,
+    });
+  }
+
+  seed.value = structuredClone(data.value);
+  activeKey.value = key;
+  registry.value = seed.value;
   return registry.value;
+}
+
+export function useRegistry(): RegistryIndex {
+  const registry = useState<RegistryIndex | undefined>('registry-index');
+  if (!registry.value) {
+    throw createError({ statusCode: 500, statusMessage: 'Plugin directory is not initialized' });
+  }
+  return registry.value;
+}
+
+export function registryEndpoint(projection: RegistryProjection): string {
+  if (projection.kind === 'plugin') {
+    return `/api/registry/plugin/${encodeURIComponent(projection.value)}`;
+  }
+  if (projection.kind === 'client') {
+    return `/api/registry/client/${encodeURIComponent(projection.value)}`;
+  }
+  return `/api/registry/${projection.kind}`;
+}
+
+async function augmentWithDiscovery(
+  registry: Ref<RegistryIndex | undefined>,
+  seed: RegistryIndex,
+  key: string,
+  activeKey: Ref<string>,
+  status: ReturnType<typeof useDiscoveryStatus>,
+  config: ReturnType<typeof useRuntimeConfig>,
+) {
+  status.value = { state: 'loading', count: 0 };
+  const baseURL = String(config.public.baseURL).replace(/\/?$/, '/');
+  const discoveryOrigin = new URL(`${baseURL}discovery/`, location.origin);
+  const securityOrigin = new URL(`${baseURL}security/`, location.origin);
+  discoveryPromise ??= loadDiscovery({
+    origin: discoveryOrigin,
+    trust: {
+      keyID: String(config.public.discoveryKeyID),
+      publicKeyBase64: String(config.public.discoveryPublicKey),
+    },
+    cache: new BrowserDiscoveryCache(discoveryOrigin),
+  });
+  securityPromise ??= loadSecurity({
+    origin: securityOrigin,
+    trust: {
+      keyID: String(config.public.discoveryKeyID),
+      publicKeyBase64: String(config.public.discoveryPublicKey),
+    },
+  })
+    .then((bundle) => bundle.snapshot)
+    .catch(() => undefined);
+
+  try {
+    const bundle = await discoveryPromise;
+    if (activeKey.value !== key || !registry.value) return;
+    await waitForCatalogInteractionToFinish();
+    if (activeKey.value !== key || !registry.value) return;
+    const discovered = bundle.search.records.map((record) =>
+      discoveryPlugin(record, bundle.snapshot),
+    );
+    registry.value.plugins = [...seed.plugins, ...discovered];
+    status.value = {
+      state: bundle.source === 'remote' ? 'current' : 'cached',
+      count: discovered.length,
+      sequence: bundle.snapshot.sequence,
+      generatedAt: bundle.snapshot.generated_at,
+    };
+
+    const security = await securityPromise;
+    if (!security || activeKey.value !== key || !registry.value) return;
+    await waitForCatalogInteractionToFinish();
+    if (activeKey.value !== key || !registry.value) return;
+    registry.value.plugins = registry.value.plugins.map((plugin) =>
+      applySecurityAssessment(plugin, security),
+    );
+  } catch (error) {
+    if (activeKey.value !== key || !registry.value) return;
+    registry.value.plugins = [...seed.plugins];
+    status.value = {
+      state:
+        error instanceof Error && /stale|expired/i.test(error.message) ? 'stale' : 'unavailable',
+      count: 0,
+      message: error instanceof Error ? error.message : 'Signed Discovery Index is unavailable',
+    };
+  }
 }
 
 function waitForCatalogInteractionToFinish(): Promise<void> {

--- a/landing/nuxt.config.ts
+++ b/landing/nuxt.config.ts
@@ -118,6 +118,10 @@ export default defineNuxtConfig({
         '/plugins',
         '/plugins/community',
         ...registryIndex.plugins.map((plugin) => `/plugins/${plugin.name}`),
+        '/api/registry/catalog',
+        '/api/registry/empty',
+        ...clientLandingPages.map((client) => `/api/registry/client/${client.id}`),
+        ...registryIndex.plugins.map((plugin) => `/api/registry/plugin/${plugin.name}`),
         '/api/releases/latest',
         '/sitemap.xml',
         '/robots.txt',
@@ -149,6 +153,9 @@ export default defineNuxtConfig({
     name: productName,
   },
   runtimeConfig: {
+    // The complete reviewed Directory is server/build-only. Route-scoped API
+    // projections keep unrelated plugin records out of every page payload.
+    registryIndex,
     seo: {
       sitemapRoutes,
     },
@@ -165,7 +172,6 @@ export default defineNuxtConfig({
       docsSitemapUrl,
       baseURL,
       repositoryUrl: registryRepositoryUrl,
-      registryIndex,
       discoveryKeyID,
       discoveryPublicKey,
     },

--- a/landing/pages/agents/[client].vue
+++ b/landing/pages/agents/[client].vue
@@ -3,7 +3,6 @@ import { mdiArrowLeft, mdiOpenInNew } from '@mdi/js';
 import { clientLandingBySlug } from '~/data/clients';
 
 const route = useRoute();
-const registry = useRegistry();
 const config = useRuntimeConfig();
 const { asset, pluginIcon } = useSite();
 const client = clientLandingBySlug.get(String(route.params.client));
@@ -11,6 +10,8 @@ const client = clientLandingBySlug.get(String(route.params.client));
 if (!client) {
   throw createError({ statusCode: 404, statusMessage: 'Agent not found' });
 }
+
+const registry = await useRegistryPage({ projection: { kind: 'client', value: client.id } });
 
 const reviewedPlugins = registry.plugins.filter(
   (plugin) =>

--- a/landing/pages/index.vue
+++ b/landing/pages/index.vue
@@ -2,7 +2,7 @@
 import { registryFaqItems } from '~/data/registryFaq';
 import { productSoftwareSchema } from '~/utils/seo';
 
-const registry = useRegistry();
+const registry = await useRegistryPage({ discovery: true });
 const config = useRuntimeConfig();
 const description =
   'Install, update, repair, and remove Agent Plugins 1.0 across supported AI agents with one CLI.';

--- a/landing/pages/plugins/[slug].vue
+++ b/landing/pages/plugins/[slug].vue
@@ -5,10 +5,11 @@ import { seoDescription, spdxLicenseUrl } from '~/utils/seo';
 import type { ClientID } from '~/types/registry';
 
 const route = useRoute();
-const registry = useRegistry();
+const slug = String(route.params.slug);
+const registry = await useRegistryPage({ projection: { kind: 'plugin', value: slug } });
 const config = useRuntimeConfig();
 const { asset, pluginIcon, sourceUrl } = useSite();
-const plugin = registry.plugins.find((item) => item.name === String(route.params.slug));
+const plugin = registry.plugins.find((item) => item.name === slug);
 
 if (!plugin || plugin.trust_state === 'conformant_unreviewed') {
   throw createError({ statusCode: 404, statusMessage: 'Plugin not found' });

--- a/landing/pages/plugins/community.vue
+++ b/landing/pages/plugins/community.vue
@@ -2,7 +2,10 @@
 import type { ClientID } from '~/types/registry';
 
 const route = useRoute();
-const registry = useRegistry();
+const registry = await useRegistryPage({
+  projection: { kind: 'empty' },
+  discovery: true,
+});
 const discovery = useDiscoveryStatus();
 const { pluginIcon, sourceUrl } = useSite();
 const requestedSource = computed(() => String(route.query.source ?? ''));

--- a/landing/pages/plugins/index.vue
+++ b/landing/pages/plugins/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const registry = useRegistry();
+const registry = await useRegistryPage({ discovery: true });
 const config = useRuntimeConfig();
 const description =
   'Search reviewed and community Agent Plugins 1.0 for Codex, Claude Code, Cursor, Gemini CLI, OpenCode, and more.';

--- a/landing/server/api/registry/catalog.get.ts
+++ b/landing/server/api/registry/catalog.get.ts
@@ -1,0 +1,8 @@
+import type { RegistryIndex } from '~/types/registry';
+import { projectRegistry } from '~/utils/registryProjection';
+
+export default defineEventHandler((event) =>
+  projectRegistry(useRuntimeConfig(event).registryIndex as unknown as RegistryIndex, {
+    kind: 'catalog',
+  }),
+);

--- a/landing/server/api/registry/client/[client].get.ts
+++ b/landing/server/api/registry/client/[client].get.ts
@@ -1,0 +1,16 @@
+import type { ClientID, RegistryIndex } from '~/types/registry';
+import { clients } from '~/data/clients';
+import { projectRegistry } from '~/utils/registryProjection';
+
+const supportedClients = new Set<ClientID>(clients.map((client) => client.id));
+
+export default defineEventHandler((event) => {
+  const client = String(getRouterParam(event, 'client') ?? '') as ClientID;
+  if (!supportedClients.has(client)) {
+    throw createError({ statusCode: 404, statusMessage: 'Agent not found' });
+  }
+  return projectRegistry(useRuntimeConfig(event).registryIndex as unknown as RegistryIndex, {
+    kind: 'client',
+    value: client,
+  });
+});

--- a/landing/server/api/registry/empty.get.ts
+++ b/landing/server/api/registry/empty.get.ts
@@ -1,0 +1,8 @@
+import type { RegistryIndex } from '~/types/registry';
+import { projectRegistry } from '~/utils/registryProjection';
+
+export default defineEventHandler((event) =>
+  projectRegistry(useRuntimeConfig(event).registryIndex as unknown as RegistryIndex, {
+    kind: 'empty',
+  }),
+);

--- a/landing/server/api/registry/plugin/[slug].get.ts
+++ b/landing/server/api/registry/plugin/[slug].get.ts
@@ -1,0 +1,14 @@
+import type { RegistryIndex } from '~/types/registry';
+import { projectRegistry } from '~/utils/registryProjection';
+
+export default defineEventHandler((event) => {
+  const slug = String(getRouterParam(event, 'slug') ?? '');
+  const projected = projectRegistry(
+    useRuntimeConfig(event).registryIndex as unknown as RegistryIndex,
+    { kind: 'plugin', value: slug },
+  );
+  if (projected.plugins.length !== 1) {
+    throw createError({ statusCode: 404, statusMessage: 'Plugin not found' });
+  }
+  return projected;
+});

--- a/landing/tests/browser/payload-scoping.spec.ts
+++ b/landing/tests/browser/payload-scoping.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+
+test('static pages receive only their route-scoped reviewed registry data', async ({ request }) => {
+  const [detail, download, pluginApi, emptyApi] = await Promise.all([
+    request.get('./plugins/context7/'),
+    request.get('./download/'),
+    request.get('./api/registry/plugin/context7'),
+    request.get('./api/registry/empty'),
+  ]);
+  for (const response of [detail, download, pluginApi, emptyApi]) expect(response.ok()).toBe(true);
+
+  const detailHtml = await detail.text();
+  const downloadHtml = await download.text();
+  expect(Buffer.byteLength(detailHtml)).toBeLessThan(450_000);
+  expect(Buffer.byteLength(downloadHtml)).toBeLessThan(450_000);
+  expect(detailHtml).not.toContain('registryIndex');
+  expect(downloadHtml).not.toContain('registryIndex');
+  expect(detailHtml).not.toContain('Community package for the official Atlassian');
+
+  const plugin = (await pluginApi.json()) as { plugins: Array<{ name: string }> };
+  const empty = (await emptyApi.json()) as { plugins: unknown[] };
+  expect(plugin.plugins.map((item) => item.name)).toEqual(['context7']);
+  expect(empty.plugins).toEqual([]);
+});

--- a/landing/tests/registry.test.ts
+++ b/landing/tests/registry.test.ts
@@ -13,6 +13,7 @@ import {
   restoreCatalogQuery,
 } from '../utils/filter.ts';
 import { mirroredIconPath, parseDirectoryData } from '../utils/registry.ts';
+import { projectRegistry } from '../utils/registryProjection.ts';
 import type { DiscoveryRecord, DiscoverySnapshot } from '../types/discovery.ts';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -54,6 +55,27 @@ const discoveryRecord = {
 } satisfies DiscoveryRecord;
 
 describe('unified registry landing', () => {
+  it('projects only the registry data required by each static route', () => {
+    const plugin = registry.plugins[0]!;
+    const client = plugin.client_support.clients[0]!;
+    assert.deepEqual(projectRegistry(registry, { kind: 'empty' }).plugins, []);
+    assert.deepEqual(
+      projectRegistry(registry, { kind: 'plugin', value: plugin.name }).plugins.map(
+        (item) => item.name,
+      ),
+      [plugin.name],
+    );
+    assert.ok(
+      projectRegistry(registry, { kind: 'client', value: client }).plugins.every((item) =>
+        item.client_support.clients.includes(client),
+      ),
+    );
+    assert.equal(
+      projectRegistry(registry, { kind: 'catalog' }).plugins.length,
+      registry.plugins.filter((item) => item.trust_state !== 'conformant_unreviewed').length,
+    );
+  });
+
   it('groups alternate sources with a deterministic reviewed primary', () => {
     const reviewed = registry.plugins[0]!;
     const other = {

--- a/landing/utils/registryProjection.ts
+++ b/landing/utils/registryProjection.ts
@@ -1,0 +1,28 @@
+import type { ClientID, RegistryIndex } from '../types/registry';
+
+export type RegistryProjection =
+  | { kind: 'catalog' }
+  | { kind: 'empty' }
+  | { kind: 'plugin'; value: string }
+  | { kind: 'client'; value: ClientID };
+
+export function projectRegistry(
+  registry: RegistryIndex,
+  projection: RegistryProjection,
+): RegistryIndex {
+  const reviewed = registry.plugins.filter(
+    (plugin) => plugin.trust_state !== 'conformant_unreviewed',
+  );
+  const plugins =
+    projection.kind === 'empty'
+      ? []
+      : projection.kind === 'plugin'
+        ? reviewed.filter((plugin) => plugin.name === projection.value)
+        : projection.kind === 'client'
+          ? reviewed.filter((plugin) => plugin.client_support.clients.includes(projection.value))
+          : reviewed;
+  return {
+    ...registry,
+    plugins,
+  };
+}

--- a/repotests/landing_contract_integration_test.go
+++ b/repotests/landing_contract_integration_test.go
@@ -251,7 +251,7 @@ func TestLandingSurface_LocalesLinksAndBrandingStayAligned(t *testing.T) {
 		t.Fatal(err)
 	}
 	pluginsPage := string(pluginsPageBody)
-	mustContain(t, pluginsPage, `const registry = useRegistry()`)
+	mustContain(t, pluginsPage, `const registry = await useRegistryPage({ discovery: true })`)
 	mustContain(t, pluginsPage, `usePageSeo('Agent Plugins 1.0 Directory | Search 2,500+ Plugins'`)
 	mustContain(t, pluginsPage, `'@type': 'ItemList'`)
 	mustContain(t, pluginsPage, `<PluginCatalog`)
@@ -263,6 +263,7 @@ func TestLandingSurface_LocalesLinksAndBrandingStayAligned(t *testing.T) {
 	}
 	pluginDetailPage := string(pluginDetailPageBody)
 	mustContain(t, pluginDetailPage, `registry.plugins.find`)
+	mustContain(t, pluginDetailPage, `projection: { kind: 'plugin', value: slug }`)
 	mustContain(t, pluginDetailPage, `usePageSeo(`)
 	mustContain(t, pluginDetailPage, `'@type': 'SoftwareSourceCode'`)
 	mustContain(t, pluginDetailPage, `'@type': 'BreadcrumbList'`)
@@ -275,6 +276,7 @@ func TestLandingSurface_LocalesLinksAndBrandingStayAligned(t *testing.T) {
 	}
 	agentPage := string(agentPageBody)
 	mustContain(t, agentPage, `clientLandingBySlug.get`)
+	mustContain(t, agentPage, `projection: { kind: 'client', value: client.id }`)
 	mustContain(t, agentPage, `'@type': 'ItemList'`)
 	mustContain(t, agentPage, `'@type': 'BreadcrumbList'`)
 	mustContain(t, agentPage, `npx universal-agent-plugins add context7 --target`)


### PR DESCRIPTION
## Summary
- keep the complete reviewed registry server-side at build time
- prerender catalog, client, and plugin-specific JSON projections
- preserve live Discovery and Security augmentation on catalog surfaces
- add route payload budgets and projection contracts

## Measured impact
- plugin detail HTML gzip: 90.5 KB -> 58.5 KB
- download HTML gzip: 67.2 KB -> 55.5 KB
- home HTML gzip: 95.2 KB -> 84.1 KB

## Verification
- pnpm test:registry (32 passed)
- pnpm generate
- playwright test --workers=3 (48 passed)
- pnpm lint (0 errors)
- focused Go landing contract