### PR TITLE
fix(landing): clarify catalog source and review UX

### DIFF
--- a/landing/assets/styles/registry.scss
+++ b/landing/assets/styles/registry.scss
@@ -412,6 +412,25 @@ img {
 .hero-quick-start__step .command-snippet {
   min-width: 0;
 }
+.hero-quick-start__command {
+  min-width: 0;
+}
+.hero-quick-start__more-install {
+  width: fit-content;
+  margin-top: 7px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--subtle);
+  font-size: 0.58rem;
+  font-weight: 650;
+  text-decoration-color: color-mix(in srgb, currentcolor 46%, transparent);
+  text-underline-offset: 3px;
+}
+.hero-quick-start__more-install:hover,
+.hero-quick-start__more-install:focus-visible {
+  color: var(--cyan);
+}
 .hero-quick-start__footer {
   padding: 13px 0 0 152px;
   display: grid;
@@ -1632,22 +1651,29 @@ img {
   outline: 2px solid var(--primary);
   outline-offset: 3px;
 }
-.plugin-source-group {
-  min-width: 0;
-}
 .plugin-other-sources {
-  margin-top: 8px;
+  margin: 0 0 12px;
+  padding-top: 9px;
+  border-top: 1px solid var(--line);
 }
 .plugin-other-sources > summary {
-  padding: 8px;
+  width: fit-content;
+  padding: 2px 0;
   color: var(--subtle);
-  font-size: 0.75rem;
+  font-size: 0.68rem;
+  font-weight: 700;
   cursor: pointer;
+}
+.plugin-other-sources[open] > summary {
+  color: var(--primary-bright);
 }
 .plugin-other-sources__list {
   list-style: none;
-  padding: 0 8px;
-  margin: 0;
+  padding: 5px 10px;
+  margin: 7px 0 0;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--surface-raised) 72%, transparent);
 }
 .plugin-other-sources__list li {
   display: grid;
@@ -1794,6 +1820,15 @@ img {
   font-size: 0.66rem;
   font-weight: 700;
 }
+.plugin-card__source-label a {
+  color: inherit;
+  text-decoration-color: color-mix(in srgb, currentcolor 45%, transparent);
+  text-underline-offset: 2px;
+}
+.plugin-card__source-label a:hover,
+.plugin-card__source-label a:focus-visible {
+  color: var(--cyan);
+}
 .plugin-card__security {
   width: fit-content;
   margin: 8px 0 0;
@@ -1852,7 +1887,7 @@ img {
     monospace;
   letter-spacing: 0.045em;
   text-align: center;
-  text-transform: uppercase;
+  text-transform: none;
 }
 .plugin-card__ribbon::after {
   content: none;
@@ -1882,9 +1917,99 @@ img {
 .plugin-card__author a {
   color: var(--primary-bright);
 }
-.plugin-card__popularity span {
+.plugin-card__popularity-trigger > span {
   color: #f5c451;
   text-shadow: 0 0 14px rgba(245, 196, 81, 0.25);
+}
+.plugin-card__popularity-trigger {
+  all: unset;
+  border-radius: 4px;
+  cursor: help;
+}
+.plugin-card__popularity-trigger:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 3px;
+}
+
+.app-tooltip {
+  z-index: 120;
+  width: min(360px, calc(100vw - 24px));
+  padding: 13px 14px;
+  border: 1px solid color-mix(in srgb, var(--primary) 40%, var(--line));
+  border-radius: 11px;
+  color: var(--text);
+  background: color-mix(in srgb, var(--surface-solid) 96%, #080914);
+  box-shadow: 0 18px 52px rgba(0, 0, 0, 0.38);
+  font-size: 0.69rem;
+  line-height: 1.45;
+  animation: app-tooltip-in 0.14s ease-out;
+}
+.app-tooltip__arrow {
+  fill: color-mix(in srgb, var(--primary) 40%, var(--line));
+}
+.app-tooltip p {
+  margin: 0;
+}
+.app-tooltip__review {
+  display: grid;
+  gap: 7px;
+}
+.app-tooltip__eyebrow {
+  color: var(--primary-bright);
+  font:
+    750 0.55rem SFMono-Regular,
+    monospace;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+.app-tooltip__review > strong {
+  font-size: 0.76rem;
+}
+.app-tooltip__review > p:not(.app-tooltip__eyebrow) {
+  color: var(--muted);
+}
+.app-tooltip__review ul {
+  margin: 1px 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+  list-style: none;
+}
+.app-tooltip__review li {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 7px;
+}
+.app-tooltip__review code {
+  color: #f5c451;
+  font-size: 0.61rem;
+}
+.app-tooltip__more,
+.app-tooltip__review small {
+  color: var(--subtle);
+  font-size: 0.61rem;
+}
+.app-tooltip__disclaimer {
+  padding-top: 7px;
+  border-top: 1px solid var(--line);
+}
+.app-tooltip__compact {
+  color: var(--muted);
+}
+@keyframes app-tooltip-in {
+  from {
+    opacity: 0;
+    transform: translateY(3px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .app-tooltip {
+    animation: none;
+  }
 }
 .plugin-card__auth {
   margin: 0;

--- a/landing/components/registry/AppTooltip.vue
+++ b/landing/components/registry/AppTooltip.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import {
+  TooltipArrow,
+  TooltipContent,
+  TooltipPortal,
+  TooltipProvider,
+  TooltipRoot,
+  TooltipTrigger,
+} from 'reka-ui';
+</script>
+
+<template>
+  <TooltipProvider :delay-duration="180" :skip-delay-duration="80">
+    <TooltipRoot>
+      <TooltipTrigger as-child>
+        <slot name="trigger" />
+      </TooltipTrigger>
+      <TooltipPortal>
+        <TooltipContent class="app-tooltip" :side-offset="8">
+          <slot />
+          <TooltipArrow class="app-tooltip__arrow" :width="12" :height="6" />
+        </TooltipContent>
+      </TooltipPortal>
+    </TooltipRoot>
+  </TooltipProvider>
+</template>

--- a/landing/components/registry/PluginCatalog.vue
+++ b/landing/components/registry/PluginCatalog.vue
@@ -340,50 +340,12 @@ watch([query, category, component, source, trust, client, authentication, owner]
       </div>
     </div>
     <div v-if="visible.length" class="plugin-grid">
-      <div
+      <RegistryPluginCard
         v-for="group in displayed"
         :key="group.primary.install_source"
-        class="plugin-source-group"
-      >
-        <RegistryPluginCard :plugin="group.primary" />
-        <details v-if="group.alternatives.length" class="plugin-other-sources">
-          <summary>
-            Other sources ({{ group.alternatives.length }})<span class="sr-only">
-              for {{ group.primary.display_name }}</span
-            >
-          </summary>
-          <ul class="plugin-other-sources__list">
-            <li v-for="alternative in group.alternatives" :key="alternative.install_source">
-              <NuxtLink
-                :to="
-                  alternative.trust_state === 'conformant_unreviewed'
-                    ? { path: '/plugins/community/', query: { source: alternative.install_source } }
-                    : `/plugins/${alternative.name}/`
-                "
-              >
-                {{ alternative.source.repository
-                }}{{ alternative.source.path ? `/${alternative.source.path}` : '' }}
-              </NuxtLink>
-              <span
-                >{{
-                  alternative.trust_state === 'conformant_unreviewed'
-                    ? 'Community listing'
-                    : 'Reviewed listing'
-                }}
-                ·
-                {{
-                  alternative.distributions.find(
-                    (item) => item.id === alternative.default_distribution,
-                  )?.kind === 'upstream'
-                    ? 'Upstream'
-                    : 'Community / direct'
-                }}
-                · {{ alternative.installable ? 'Installable' : 'Unavailable' }}</span
-              >
-            </li>
-          </ul>
-        </details>
-      </div>
+        :plugin="group.primary"
+        :alternatives="group.alternatives"
+      />
     </div>
     <div v-else class="empty-state">
       <h3>No matching plugins</h3>

--- a/landing/components/registry/RegistryHero.vue
+++ b/landing/components/registry/RegistryHero.vue
@@ -184,10 +184,19 @@ function updateTargets(values: string[]) {
                 <span class="hero-quick-start__label"
                   ><strong>Copy and run</strong><small>In your terminal</small></span
                 >
-                <CommandSnippet v-if="command" :command="command" kind="add" inline />
-                <p v-else class="install-panel__notice" role="status">
-                  Plugin data is refreshing. Try again shortly.
-                </p>
+                <div class="hero-quick-start__command">
+                  <CommandSnippet v-if="command" :command="command" kind="add" inline />
+                  <p v-else class="install-panel__notice" role="status">
+                    Plugin data is refreshing. Try again shortly.
+                  </p>
+                  <a
+                    class="hero-quick-start__more-install"
+                    href="https://github.com/777genius/universal-agent-plugins#quick-start"
+                    target="_blank"
+                    rel="noreferrer"
+                    >Other installation methods <span aria-hidden="true">↗</span></a
+                  >
+                </div>
               </li>
             </ol>
             <div class="hero-quick-start__footer">

--- a/landing/components/registry/RegistryPluginCard.vue
+++ b/landing/components/registry/RegistryPluginCard.vue
@@ -13,8 +13,11 @@ import {
 } from '~/utils/registry';
 import { pluginCommands } from '~/utils/commands';
 
-const props = defineProps<{ plugin: RegistryPlugin }>();
-const { asset, pluginIcon } = useSite();
+const props = withDefaults(
+  defineProps<{ plugin: RegistryPlugin; alternatives?: RegistryPlugin[] }>(),
+  { alternatives: () => [] },
+);
+const { asset, pluginIcon, sourceUrl } = useSite();
 const { current, expired, published } = useDirectoryStatus();
 const isDiscovered = computed(() => props.plugin.trust_state === 'conformant_unreviewed');
 const availableClients = computed(() =>
@@ -116,6 +119,12 @@ const securityDetailURL = computed(() =>
     : `/plugins/${props.plugin.name}/#security-review`,
 );
 
+function alternativeDetailURL(alternative: RegistryPlugin) {
+  return alternative.trust_state === 'conformant_unreviewed'
+    ? { path: '/plugins/community/', query: { source: alternative.install_source } }
+    : `/plugins/${alternative.name}/`;
+}
+
 function updateTargets(values: string[]) {
   const allowed = new Set(availableClients.value.map((client) => client.id));
   const next = values.filter((value): value is (typeof clients)[number]['id'] =>
@@ -142,12 +151,12 @@ function updateAutoDetect(value: boolean) {
       :class="{ 'plugin-card__ribbon--muted': !canInstall }"
       >{{
         canInstall
-          ? 'Reviewed listing'
+          ? 'reviewed listing'
           : expired
-            ? 'Temporarily paused'
+            ? 'temporarily paused'
             : !published
-              ? 'Preview only'
-              : 'Not available'
+              ? 'preview only'
+              : 'not available'
       }}</span
     >
     <div
@@ -172,19 +181,28 @@ function updateAutoDetect(value: boolean) {
               ? 'Found on GitHub'
               : 'Currently unavailable'
           }}
-          · {{ plugin.source.repository }}{{ plugin.source.path ? `/${plugin.source.path}` : '' }}
+          ·
+          <a :href="sourceUrl(plugin)" target="_blank" rel="noreferrer">
+            {{ plugin.source.repository }}{{ plugin.source.path ? `/${plugin.source.path}` : '' }}
+          </a>
         </p>
         <p v-else-if="canInstall" class="plugin-card__source-label">
           {{ deliverySummary }}
         </p>
       </div>
     </div>
-    <p
-      v-if="isDiscovered"
-      class="plugin-card__author plugin-card__popularity"
-      title="Stars belong to the GitHub repository, not this individual package"
-    >
-      <span aria-hidden="true">★</span> {{ repositoryStars }} stars on repo · Agent Plugins 1.0
+    <p v-if="isDiscovered" class="plugin-card__author plugin-card__popularity">
+      <AppTooltip>
+        <template #trigger>
+          <button type="button" class="plugin-card__popularity-trigger">
+            <span aria-hidden="true">★</span> {{ repositoryStars }} stars on repo
+          </button>
+        </template>
+        <p class="app-tooltip__compact">
+          This is the GitHub repository's star count, not a rating for this individual plugin.
+        </p>
+      </AppTooltip>
+      <span aria-hidden="true"> · </span>Agent Plugins 1.0
     </p>
     <SecurityAssessmentBadge
       v-if="plugin.security"
@@ -192,6 +210,36 @@ function updateAutoDetect(value: boolean) {
       :details-to="securityDetailURL"
     />
     <p class="plugin-card__description">{{ plugin.description }}</p>
+    <details v-if="alternatives.length" class="plugin-other-sources">
+      <summary>
+        Other sources ({{ alternatives.length }})<span class="sr-only">
+          for {{ plugin.display_name }}</span
+        >
+      </summary>
+      <ul class="plugin-other-sources__list">
+        <li v-for="alternative in alternatives" :key="alternative.install_source">
+          <NuxtLink :to="alternativeDetailURL(alternative)">
+            {{ alternative.source.repository
+            }}{{ alternative.source.path ? `/${alternative.source.path}` : '' }}
+          </NuxtLink>
+          <span
+            >{{
+              alternative.trust_state === 'conformant_unreviewed'
+                ? 'community listing'
+                : 'reviewed listing'
+            }}
+            ·
+            {{
+              alternative.distributions.find((item) => item.id === alternative.default_distribution)
+                ?.kind === 'upstream'
+                ? 'upstream'
+                : 'community / direct'
+            }}
+            · {{ alternative.installable ? 'installable' : 'unavailable' }}</span
+          >
+        </li>
+      </ul>
+    </details>
     <div class="plugin-card__bottom">
       <button
         v-if="canInstall"

--- a/landing/components/registry/SecurityAssessmentBadge.vue
+++ b/landing/components/registry/SecurityAssessmentBadge.vue
@@ -12,20 +12,42 @@ const tooltip = computed(() => securityAssessmentTooltip(props.plugin));
 </script>
 
 <template>
-  <NuxtLink
-    class="plugin-card__security"
-    :class="`plugin-card__security--${assessment.outcome}`"
-    :to="detailsTo"
-    :title="tooltip"
-    :aria-label="`${label}. Open the full review for ${plugin.display_name}`"
-  >
-    <span aria-hidden="true">{{
-      assessment.outcome === 'blocking_findings'
-        ? '!'
-        : assessment.outcome === 'warnings'
-          ? 'i'
-          : '✓'
-    }}</span>
-    {{ label }}
-  </NuxtLink>
+  <AppTooltip>
+    <template #trigger>
+      <NuxtLink
+        class="plugin-card__security"
+        :class="`plugin-card__security--${assessment.outcome}`"
+        :to="detailsTo"
+        :aria-label="`${label}. Open the full review for ${plugin.display_name}`"
+      >
+        <span aria-hidden="true">{{
+          assessment.outcome === 'blocking_findings'
+            ? '!'
+            : assessment.outcome === 'warnings'
+              ? 'i'
+              : '✓'
+        }}</span>
+        {{ label }}
+      </NuxtLink>
+    </template>
+    <div class="app-tooltip__review">
+      <p class="app-tooltip__eyebrow">Automated static review</p>
+      <strong>{{ tooltip.label }}</strong>
+      <p>{{ tooltip.scope }}</p>
+      <ul v-if="tooltip.findings.length">
+        <li
+          v-for="finding in tooltip.findings"
+          :key="`${finding.code}:${finding.path}:${finding.line}`"
+        >
+          <code>{{ finding.code }}</code>
+          <span>{{ finding.message }}</span>
+        </li>
+      </ul>
+      <p v-if="tooltip.remaining" class="app-tooltip__more">
+        +{{ tooltip.remaining }} more in the full review
+      </p>
+      <p class="app-tooltip__disclaimer">{{ tooltip.disclaimer }}</p>
+      <small>Open the plugin page for full details.</small>
+    </div>
+  </AppTooltip>
 </template>

--- a/landing/pages/plugins/[slug].vue
+++ b/landing/pages/plugins/[slug].vue
@@ -42,7 +42,7 @@ const initialTarget =
   supportedClients.find((client) => client.id === 'cursor')?.id ?? supportedClients[0]?.id;
 const targets = ref<ClientID[]>(initialTarget ? [initialTarget] : []);
 const autoDetect = ref(true);
-const trustLabel = 'Reviewed listing';
+const trustLabel = 'reviewed listing';
 const siteUrl = String(config.public.siteUrl).replace(/\/+$/, '');
 const pluginUrl = `${siteUrl}/plugins/${plugin.name}/`;
 const pluginSchemaId = `${pluginUrl}#plugin`;

--- a/landing/tests/browser/catalog-search.spec.ts
+++ b/landing/tests/browser/catalog-search.spec.ts
@@ -14,13 +14,15 @@ test('catalog groups duplicate sources and tolerates a small typo', async ({ pag
   await search.fill('context7');
   await expect(page.getByRole('heading', { name: 'Context7', exact: true })).toHaveCount(1);
   const group = page
-    .locator('.plugin-source-group')
+    .locator('.plugin-card')
     .filter({ has: page.getByRole('heading', { name: 'Context7', exact: true }) });
   await expect(group).toHaveCount(1);
   const alternatives = group.locator('.plugin-other-sources');
   await expect(alternatives).toBeVisible();
+  await expect(group.locator('.plugin-card__ribbon')).toHaveText('reviewed listing');
   await alternatives.locator('summary').click();
   await expect(alternatives.locator('li')).not.toHaveCount(0);
+  await expect(group).not.toContainText('777genius/universal-agent-plugins-registry');
 
   await search.fill('contex7');
   await expect(page.getByRole('heading', { name: 'Context7', exact: true })).toHaveCount(1);
@@ -50,4 +52,26 @@ test('catalog URL preserves filters through detail navigation and Reset is alway
   await expect(page).toHaveURL(/\/plugins\/$/);
   await expect(search).toHaveValue('');
   await expect(reset).toBeDisabled();
+});
+
+test('community source labels link to the exact GitHub source', async ({ page }) => {
+  await page.goto('./plugins/');
+  await waitForDiscovery(page);
+  await page.getByRole('searchbox', { name: 'Search plugins' }).fill('hindsight');
+
+  const card = page
+    .locator('.plugin-card')
+    .filter({ has: page.getByRole('heading', { name: /^hindsight$/i }) });
+  const source = card.locator('.plugin-card__source-label a');
+  await expect(source).toHaveText('vectorize-io/hindsight/hindsight-integrations/agent-plugin');
+  await expect(source).toHaveAttribute(
+    'href',
+    /^https:\/\/github\.com\/vectorize-io\/hindsight\/tree\/[0-9a-f]{40}\/hindsight-integrations\/agent-plugin$/,
+  );
+  const popularity = card.locator('.plugin-card__popularity-trigger');
+  await expect(popularity).not.toHaveAttribute('title');
+  await popularity.focus();
+  await expect(page.locator('.app-tooltip')).toContainText(
+    "GitHub repository's star count, not a rating for this individual plugin",
+  );
 });

--- a/landing/tests/browser/landing.spec.ts
+++ b/landing/tests/browser/landing.spec.ts
@@ -55,7 +55,12 @@ test('homepage installs with auto-detection and exposes the full directory', asy
   await expect(securityBadge).toContainText(
     /Automated review: (?:no blocking findings|\d+ notes?|\d+ blocking findings?)/,
   );
-  await expect(securityBadge).toHaveAttribute('title', /Checked indexed revision [0-9a-f]{12}/);
+  await expect(securityBadge).not.toHaveAttribute('title');
+  await securityBadge.hover();
+  const securityTooltip = page.locator('.app-tooltip');
+  await expect(securityTooltip).toBeVisible();
+  await expect(securityTooltip).toContainText(/exact indexed revision [0-9a-f]{12}/);
+  await expect(securityTooltip).toContainText(/does not run the plugin or guarantee safety/i);
   await expect(page.getByText(/guarantee of safety/i)).toHaveCount(0);
   await expect(page.locator('.catalog-count')).toContainText(/[2-9]\d{3} plugins/, {
     timeout: 15_000,
@@ -284,9 +289,17 @@ test('security badges explain the exact checked revision and open full findings'
   page,
 }) => {
   await page.goto('./');
+  await expect(page.locator('.catalog')).toHaveAttribute('data-discovery-state', /current|cached/, {
+    timeout: 15_000,
+  });
   const badge = page.locator('.plugin-card__security--warnings').first();
   await expect(badge).toBeVisible({ timeout: 15_000 });
-  await expect(badge).toHaveAttribute('title', /SEC\d+:/);
+  await expect(badge).not.toHaveAttribute('title');
+  await badge.focus();
+  const tooltip = page.locator('.app-tooltip');
+  await expect(tooltip).toBeVisible();
+  await expect(tooltip).toContainText(/SEC\d+/);
+  await expect(tooltip).toContainText(/exact indexed revision [0-9a-f]{12}/);
   await expect(badge).toHaveAttribute('href', /plugins\/community.*#security-review/);
 
   await badge.click();

--- a/landing/tests/browser/visual-controls.spec.ts
+++ b/landing/tests/browser/visual-controls.spec.ts
@@ -3,6 +3,10 @@ import { expect, test } from '@playwright/test';
 test('flat filters retain keyboard selection, category search, and reset', async ({ page }) => {
   await page.goto('./');
   await expect(page.getByText('In your terminal', { exact: true })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Other installation methods' })).toHaveAttribute(
+    'href',
+    'https://github.com/777genius/universal-agent-plugins#quick-start',
+  );
   await expect(page.getByText('No target flag means auto-detect')).toHaveCount(0);
   const controls = page.getByRole('search', { name: 'Filter plugins' });
   await controls.scrollIntoViewIfNeeded();

--- a/landing/tests/registry.test.ts
+++ b/landing/tests/registry.test.ts
@@ -326,4 +326,29 @@ describe('unified registry landing', () => {
     assert.equal(skillOnly.installable, true);
     assert.deepEqual(catalogVisiblePlugins([unavailable, unsupported, skillOnly]), [skillOnly]);
   });
+
+  it('keeps retired registry mirrors out of the catalog without removing current sources', () => {
+    const reviewed = registry.plugins[0]!;
+    const current = discoveryPlugin(
+      {
+        ...discoveryRecord,
+        slug: 'discovery:example/current',
+        components: { extensions: 0, mcp: 0, skills: 1 },
+        compatible_clients: ['codex'],
+      },
+      discoverySnapshot,
+    );
+    const retired = {
+      ...current,
+      install_source:
+        'discovery:777genius/universal-agent-plugins-registry//plugins/agent-code-navigator',
+      source: {
+        ...current.source,
+        repository: '777genius/universal-agent-plugins-registry',
+        path: 'plugins/agent-code-navigator',
+      },
+    };
+
+    assert.deepEqual(catalogVisiblePlugins([retired, current, reviewed]), [current, reviewed]);
+  });
 });

--- a/landing/tests/securityPresentation.test.ts
+++ b/landing/tests/securityPresentation.test.ts
@@ -77,10 +77,11 @@ describe('security assessment presentation', () => {
       3,
     );
     const tooltip = securityAssessmentTooltip(subject);
-    assert.match(tooltip, /indexed revision abcdef123456/);
-    assert.match(tooltip, /SEC329: MCP config launches a mutable package/);
-    assert.match(tooltip, /\+2 more/);
-    assert.match(tooltip, /not a guarantee of safety/);
+    assert.match(tooltip.scope, /exact indexed revision abcdef123456/);
+    assert.equal(tooltip.findings[0]?.code, 'SEC329');
+    assert.match(tooltip.findings[0]?.message ?? '', /MCP config launches a mutable package/);
+    assert.equal(tooltip.remaining, 2);
+    assert.match(tooltip.disclaimer, /not run the plugin or guarantee safety/);
     assert.equal(groupSecurityFindings(subject.security!).hidden, 2);
   });
 });

--- a/landing/utils/filter.ts
+++ b/landing/utils/filter.ts
@@ -11,10 +11,17 @@ export interface CatalogFilters {
   owner?: string;
 }
 
-/** Keep metadata-only Discovery records available by direct URL, not in the install catalog. */
+const retiredCatalogRepositories = new Set(['777genius/universal-agent-plugins-registry']);
+
+/** Keep retired and metadata-only Discovery records available by direct URL, not in the catalog. */
 export function catalogVisiblePlugins(plugins: RegistryPlugin[]): RegistryPlugin[] {
   return plugins.filter(
-    (plugin) => plugin.trust_state !== 'conformant_unreviewed' || plugin.installable,
+    (plugin) =>
+      !(
+        plugin.trust_state === 'conformant_unreviewed' &&
+        retiredCatalogRepositories.has(plugin.source.repository.toLowerCase())
+      ) &&
+      (plugin.trust_state !== 'conformant_unreviewed' || plugin.installable),
   );
 }
 

--- a/landing/utils/securityPresentation.ts
+++ b/landing/utils/securityPresentation.ts
@@ -9,6 +9,14 @@ export interface SecurityFindingGroups {
   hidden: number;
 }
 
+export interface SecurityTooltipPresentation {
+  label: string;
+  scope: string;
+  findings: SecurityFinding[];
+  remaining: number;
+  disclaimer: string;
+}
+
 type SecurityAssessment = NonNullable<RegistryPlugin['security']>;
 
 // These findings describe repository automation. The workflows are not copied
@@ -47,21 +55,28 @@ export function securityAssessmentHeading(assessment: SecurityAssessment): strin
   return 'Automated review notes';
 }
 
-export function securityAssessmentTooltip(plugin: RegistryPlugin): string {
+export function securityAssessmentTooltip(plugin: RegistryPlugin): SecurityTooltipPresentation {
   const assessment = plugin.security;
-  if (!assessment) return '';
+  if (!assessment) {
+    return {
+      label: '',
+      scope: '',
+      findings: [],
+      remaining: 0,
+      disclaimer: '',
+    };
+  }
   const groups = groupSecurityFindings(assessment);
   const revision = shortRevision(plugin.source.revision);
-  const lines = [
-    securityAssessmentLabel(assessment),
-    `Checked indexed revision ${revision} with LintAI ${assessment.scanner.version}.`,
-  ];
   const preview = [...groups.installer, ...groups.maintainer].slice(0, 2);
-  lines.push(...preview.map((finding) => `${finding.code}: ${finding.message}`));
-  const remaining = assessment.counts.total - preview.length;
-  if (remaining > 0) lines.push(`+${remaining} more in the full review.`);
-  lines.push('This result applies only to the checked files and is not a guarantee of safety.');
-  return lines.join('\n');
+  return {
+    label: securityAssessmentLabel(assessment),
+    scope: `LintAI ${assessment.scanner.version} checked exact indexed revision ${revision}.`,
+    findings: preview,
+    remaining: Math.max(0, assessment.counts.total - preview.length),
+    disclaimer:
+      'This static check looks for configured patterns. It does not run the plugin or guarantee safety.',
+  };
 }
 
 export function shortRevision(revision: string | null): string {


### PR DESCRIPTION
## What changed

- replace native review and popularity titles with formatted Reka UI tooltips
- link discovered package source labels to their exact GitHub revision
- keep alternate sources inside each plugin card and hide retired registry discovery mirrors
- use lower-case reviewed listing labels
- link the hero command to the remaining installation methods

## Verification

- `pnpm run test:registry` - 33 passed
- `pnpm run lint` - 0 errors (4 existing void-element warnings outside this change)
- `pnpm run generate` - 134 routes generated
- browser suite - 46/48 passed in one concurrent run; the updated security scenario then passed and the unrelated Copilot clipboard flake passed in isolation
- focused catalog browser suite - 3/3 passed
