### PR TITLE
fix(directory): trust reviewed materialization evidence

### DIFF
--- a/install/integrationctl/agentplugins/domain/directory.go
+++ b/install/integrationctl/agentplugins/domain/directory.go
@@ -218,17 +218,18 @@ func (e DirectoryEvidence) HasTrustedProvenanceAtSequence(sequence uint64) bool 
 }
 
 // HasTrustedEligibilityProvenance applies the schema-1 compatibility rule for
-// evidence that can block or promote a release. Static schema/materialization
-// gates require reproducible workflow provenance; client runtime gates may also
-// use evidence explicitly reviewed by the signed Directory publisher.
+// evidence that can block or promote a release. Static schema gates require
+// reproducible workflow provenance. Materialization and client runtime gates
+// may also use exact evidence explicitly reviewed by the signed Directory
+// publisher.
 func (e DirectoryEvidence) HasTrustedEligibilityProvenance() bool {
 	if !e.HasTrustedProvenance() {
 		return false
 	}
-	if e.Level == "schema" || e.Level == "materialization" {
+	if e.Level == "schema" {
 		return e.Trust.Kind == "github_actions"
 	}
-	return e.Level == "discovery" || e.Level == "runtime" || e.Level == "oauth"
+	return e.Level == "materialization" || e.Level == "discovery" || e.Level == "runtime" || e.Level == "oauth"
 }
 
 // HasTrustedEligibilityProvenanceAtSequence applies the eligibility-level
@@ -237,10 +238,10 @@ func (e DirectoryEvidence) HasTrustedEligibilityProvenanceAtSequence(sequence ui
 	if !e.HasTrustedProvenanceAtSequence(sequence) {
 		return false
 	}
-	if e.Level == "schema" || e.Level == "materialization" {
+	if e.Level == "schema" {
 		return e.Trust == nil || e.Trust.Kind == "github_actions"
 	}
-	return e.Level == "discovery" || e.Level == "runtime" || e.Level == "oauth"
+	return e.Level == "materialization" || e.Level == "discovery" || e.Level == "runtime" || e.Level == "oauth"
 }
 
 type DirectoryRevocation struct {

--- a/install/integrationctl/agentplugins/domain/directory_test.go
+++ b/install/integrationctl/agentplugins/domain/directory_test.go
@@ -425,8 +425,11 @@ func TestResolveDirectoryEligibilityRequiresTrustedEvidence(t *testing.T) {
 		{name: "forged workflow", mutate: func(_ *DirectoryReleasePolicy, e *DirectoryEvidence) {
 			e.Trust.Workflow = "contributor/evidence/.github/workflows/directory.yml"
 		}},
-		{name: "incompatible reviewed trust", mutate: func(_ *DirectoryReleasePolicy, e *DirectoryEvidence) {
+		{name: "publisher-reviewed materialization", wantOK: true, mutate: func(_ *DirectoryReleasePolicy, e *DirectoryEvidence) {
 			e.Trust = &DirectoryEvidenceTrust{Kind: "reviewed_external"}
+		}},
+		{name: "malformed reviewed trust", mutate: func(_ *DirectoryReleasePolicy, e *DirectoryEvidence) {
+			e.Trust = &DirectoryEvidenceTrust{Kind: "reviewed_external", Workflow: "owner/evidence/.github/workflows/forged.yml"}
 		}},
 		{name: "non-current trusted evidence", mutate: func(p *DirectoryReleasePolicy, _ *DirectoryEvidence) { p.CurrentEvidence = nil }},
 	}


### PR DESCRIPTION
## Summary
- align upstream materialization eligibility with the signed Directory publisher's reviewed-external trust lane
- keep schema evidence restricted to reproducible GitHub Actions provenance
- reject malformed reviewed-external provenance

## Verification
- `go test ./install/integrationctl/agentplugins/domain ./install/integrationctl/agentplugins/adapters/directoryv1 ./install/integrationctl/agentplugins/planner`
- `go test ./install/integrationctl/agentplugins/...` (all relevant packages passed; existing macOS case-collision fixture in `adapters/packagedigest` remains platform-limited and is covered by Linux CI)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Materialization-based eligibility evidence is now accepted through the standard trusted-provenance path.
  * Eligibility checks continue to require workflow provenance for schema-level evidence.
  * Reviewed materialization evidence without workflow details is now accepted, while malformed reviewed provenance remains rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->