### PR TITLE
fix(docs): harden generated markdown handling

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "docs:clean": "node ./tools/clean.mjs",
+    "docs:test": "node --test ./tools/lib/frontmatter.test.mjs",
     "docs:gen": "node ./tools/generate.mjs",
     "docs:build": "pnpm run docs:gen && vitepress build && node ./tools/postbuild.mjs",
     "docs:dev": "pnpm run docs:gen && vitepress dev",
@@ -29,7 +30,7 @@
     "docs:check-output": "node ./tools/quality/check-output.mjs",
     "docs:smoke-ui": "node ./tools/quality/check-ui.mjs",
     "docs:check-ui": "pnpm run docs:build && pnpm run docs:smoke-ui",
-    "docs:check": "pnpm run docs:gen && pnpm run docs:check-locale && pnpm run docs:check-model && pnpm run docs:check-public-boundary && pnpm run docs:check-drift && vitepress build && node ./tools/postbuild.mjs && pnpm run docs:check-output"
+    "docs:check": "pnpm run docs:test && pnpm run docs:gen && pnpm run docs:check-locale && pnpm run docs:check-model && pnpm run docs:check-public-boundary && pnpm run docs:check-drift && vitepress build && node ./tools/postbuild.mjs && pnpm run docs:check-output"
   },
   "devDependencies": {
     "mermaid": "11.17.0",

--- a/website/tools/extractors/node-runtime.mjs
+++ b/website/tools/extractors/node-runtime.mjs
@@ -193,7 +193,6 @@ function localizeNodeRuntimeBody(locale, body) {
     .replace(/^### Constructor$/gm, "### Конструктор")
     .replace(/^#### Parameters$/gm, "#### Параметры")
     .replace(/^#### Returns$/gm, "#### Возвращает")
-    .replace(/^### event$/gm, "### event")
     .replace("Handler signature for Claude hooks that return an object response or no value.", "Сигнатура обработчика для Claude hooks, который возвращает объект ответа или `void`.")
     .replace("Handler signature for Codex events that return an exit code or no value.", "Сигнатура обработчика для Codex events, который возвращает код выхода или `void`.")
     .replace("JSON-shaped payload used by the runtime helpers when a stricter schema is not known.", "JSON-представление payload, которое используется runtime-хелперами, когда строгая схема неизвестна.")

--- a/website/tools/lib/frontmatter.mjs
+++ b/website/tools/lib/frontmatter.mjs
@@ -1,5 +1,7 @@
-function escapeYaml(value) {
-  return String(value).replace(/"/g, '\\"');
+function yamlString(value) {
+  // JSON strings are valid YAML double-quoted scalars and escape quotes,
+  // backslashes and control characters in one deterministic operation.
+  return JSON.stringify(String(value));
 }
 
 export function renderFrontmatter(meta) {
@@ -11,7 +13,7 @@ export function renderFrontmatter(meta) {
     if (Array.isArray(value)) {
       lines.push(`${key}:`);
       for (const item of value) {
-        lines.push(`  - "${escapeYaml(item)}"`);
+        lines.push(`  - ${yamlString(item)}`);
       }
       continue;
     }
@@ -19,7 +21,7 @@ export function renderFrontmatter(meta) {
       lines.push(`${key}: ${value ? "true" : "false"}`);
       continue;
     }
-    lines.push(`${key}: "${escapeYaml(value)}"`);
+    lines.push(`${key}: ${yamlString(value)}`);
   }
   lines.push("---", "");
   return lines.join("\n");
@@ -34,13 +36,82 @@ export function sanitizeGeneratedMarkdown(body) {
 }
 
 export function stripMarkdownLinks(body) {
-  return body.replace(/\[((?:\\.|[^\]])+)\]\((?:<[^>\n]+>|[^)\n]+)\)/g, "$1");
+  let output = "";
+  let offset = 0;
+  while (offset < body.length) {
+    const open = body.indexOf("[", offset);
+    if (open < 0) {
+      output += body.slice(offset);
+      break;
+    }
+    output += body.slice(offset, open);
+    let close = open + 1;
+    while (close < body.length && body[close] !== "]") {
+      close += body[close] === "\\" && close + 1 < body.length ? 2 : 1;
+    }
+    if (close >= body.length) {
+      output += body.slice(open);
+      break;
+    }
+    if (body[close + 1] !== "(") {
+      output += body.slice(open, close + 1);
+      offset = close + 1;
+      continue;
+    }
+    const targetStart = close + 2;
+    let end = targetStart;
+    if (body[targetStart] === "<") {
+      end = body.indexOf(">", targetStart + 1);
+      if (end <= targetStart + 1 || body.slice(targetStart + 1, end).includes("\n") || body[end + 1] !== ")") {
+        end = -1;
+      } else {
+        end += 1;
+      }
+    } else {
+      while (end < body.length && body[end] !== ")" && body[end] !== "\n") {
+        end += 1;
+      }
+      if (end === targetStart || body[end] !== ")") {
+        end = -1;
+      }
+    }
+    if (end < 0) {
+      output += body.slice(open, close + 1);
+      offset = close + 1;
+      continue;
+    }
+    output += body.slice(open + 1, close);
+    offset = end + 1;
+  }
+  return output;
+}
+
+function stripHtmlComments(body) {
+  let output = "";
+  let offset = 0;
+  while (offset < body.length) {
+    const open = body.indexOf("<!--", offset);
+    if (open < 0) {
+      output += body.slice(offset);
+      break;
+    }
+    const close = body.indexOf("-->", open + 4);
+    if (close < 0) {
+      output += body.slice(offset);
+      break;
+    }
+    output += body.slice(offset, open);
+    offset = close + 3;
+    while (body[offset] === "\n") {
+      offset += 1;
+    }
+  }
+  return output;
 }
 
 export function normalizeGeneratedMarkdown(body) {
   return sanitizeGeneratedMarkdown(
-    stripMarkdownLinks(body)
-      .replace(/<!--[\s\S]*?-->\n*/g, "")
+    stripHtmlComments(stripMarkdownLinks(body))
       .replace(/<a\b[^>]*><\/a>\n*/g, "")
       .replace(/<details><summary>([^<]+)<\/summary>\s*<p>\s*/g, "\n**$1**\n\n")
       .replace(/\s*<\/p>\s*<\/details>/g, "\n")

--- a/website/tools/lib/frontmatter.test.mjs
+++ b/website/tools/lib/frontmatter.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  normalizeGeneratedMarkdown,
+  renderFrontmatter,
+  stripMarkdownLinks
+} from "./frontmatter.mjs";
+
+test("frontmatter quotes untrusted scalar and list values without YAML injection", () => {
+  const rendered = renderFrontmatter({
+    title: 'quoted "value"\\path\nnext: true',
+    tags: ["safe", "line\r\nbreak"]
+  });
+  assert.equal(
+    rendered,
+    '---\ntitle: "quoted \\"value\\"\\\\path\\nnext: true"\ntags:\n  - "safe"\n  - "line\\r\\nbreak"\n---\n'
+  );
+});
+
+test("markdown links are stripped in linear scans while malformed input is preserved", () => {
+  assert.equal(
+    stripMarkdownLinks("Use [plain](https://example.com) and [angle](<https://example.com/a>)."),
+    "Use plain and angle."
+  );
+  assert.equal(stripMarkdownLinks("Keep [broken](target\nand [open"), "Keep [broken](target\nand [open");
+  assert.equal(stripMarkdownLinks("Keep [label] without a target"), "Keep [label] without a target");
+  assert.equal(stripMarkdownLinks("[escaped\\] label](target)"), "escaped\\] label");
+});
+
+test("generated markdown removes complete comments and escapes incomplete HTML", () => {
+  assert.equal(normalizeGeneratedMarkdown("before\n<!-- hidden -->\nafter"), "before\nafter");
+  assert.equal(normalizeGeneratedMarkdown("before <!-- incomplete"), "before &lt;!-- incomplete");
+  assert.equal(normalizeGeneratedMarkdown("<script>alert(1)</script>"), "&lt;script&gt;alert(1)&lt;/script&gt;");
+});


### PR DESCRIPTION
## Summary
- encode generated YAML scalar values with JSON-compatible YAML quoting
- replace the potentially super-linear Markdown link regex with a bounded scanner
- replace comment removal with a deterministic delimiter scan
- remove a no-op replacement and add focused Node regression tests

## Evidence
- `node --test website/tools/lib/frontmatter.test.mjs`
- `corepack pnpm@8.15.1 --dir website run docs:test`
- `git diff --check`

Addresses CodeQL alerts #2, #3, #4, and #5.