### PR TITLE
feat(authoring): report compatibility and static readiness

### DIFF
--- a/cli/plugin-kit-ai/internal/authoring/commands/commands.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/commands.go
@@ -13,11 +13,13 @@ import (
 	"strings"
 
 	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/project"
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/readiness"
 	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/report"
 	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/scaffold"
 	"github.com/777genius/plugin-kit-ai/cli/internal/authoringcli"
 	"github.com/777genius/plugin-kit-ai/cli/internal/exitx"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/packageview"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 	"github.com/spf13/cobra"
 )
 
@@ -33,7 +35,13 @@ type App struct {
 	Projects project.Service
 	Revision string
 }
+
+func commandNames() []string {
+	return []string{"init", "validate", "inspect", "test", "compat", "capabilities", "doctor"}
+}
+
 type request struct {
+	targets           []domain.ClientID
 	root              string
 	disclose, release bool
 	template          scaffold.Options
@@ -47,7 +55,7 @@ func (a App) Execute(ctx context.Context, args []string, streams authoringcli.St
 	var human bytes.Buffer
 	factory := authoringcli.Factory(func() (*cobra.Command, error) {
 		factories := make([]authoringcli.Factory, 0, 4)
-		for _, name := range []string{"init", "validate", "inspect", "test"} {
+		for _, name := range commandNames() {
 			factories = append(factories, func() (*cobra.Command, error) { return a.command(name, func(r report.Report) { captured = &r }) })
 		}
 		root, err := build(factories...)
@@ -65,7 +73,7 @@ func (a App) Execute(ctx context.Context, args []string, streams authoringcli.St
 		root.CompletionOptions.DisableDefaultCmd = true
 		for _, group := range root.Commands() {
 			if group.Name() == "author" {
-				group.Long = "Build Agent Plugins packages with init, validate, inspect and static test."
+				group.Long = "Build Agent Plugins packages and inspect static compatibility and toolchain evidence."
 				for _, child := range group.Commands() {
 					child.Long = child.Short + "\n\nInstaller-only inherited flags are rejected. Use agentplugins add for installation policy."
 				}
@@ -91,7 +99,7 @@ func (a App) Execute(ctx context.Context, args []string, streams authoringcli.St
 			return exitx.Wrap(errors.New("authoring output failed"), 1)
 		}
 	} else {
-		if _, e := fmt.Fprintf(streams.Out, "%s: readiness %s; conformance %s; runtime %s\n", captured.Command, captured.Readiness.Status, captured.Conformance.Status, captured.Runtime.Status); e != nil {
+		if _, e := fmt.Fprintf(streams.Out, "%s: readiness %s; conformance %s; host %s; compatibility %s; toolchain %s; runtime %s\n", captured.Command, captured.Readiness.Status, captured.Conformance.Status, captured.HostSafety.Status, captured.Compatibility.Status, captured.Toolchain.Status, captured.Runtime.Status); e != nil {
 			return exitx.Wrap(errors.New("authoring output failed"), 1)
 		}
 		for _, f := range captured.Findings {
@@ -102,6 +110,41 @@ func (a App) Execute(ctx context.Context, args []string, streams authoringcli.St
 		for _, component := range captured.Components {
 			if _, e := fmt.Fprintf(streams.Out, "%s %s: %s; requirements %s\n", component.Type, component.ID, component.Status, strings.Join(component.Requirements, ", ")); e != nil {
 				return exitx.Wrap(errors.New("authoring output failed"), 1)
+			}
+		}
+		if captured.Capabilities != nil {
+			if _, e := fmt.Fprintf(streams.Out, "commands: %s\n", strings.Join(captured.Capabilities.Commands, ", ")); e != nil {
+				return exitx.Wrap(e, 1)
+			}
+			for _, s := range captured.Capabilities.Schemas {
+				if _, e := fmt.Fprintf(streams.Out, "schema: %s; %s\n", s.ID, s.Digest); e != nil {
+					return exitx.Wrap(e, 1)
+				}
+			}
+			for _, p := range captured.Capabilities.Profiles {
+				if _, e := fmt.Fprintf(streams.Out, "profile: %s; revision %s; %s\n", p.ID, p.Revision, p.Digest); e != nil {
+					return exitx.Wrap(e, 1)
+				}
+			}
+			for _, c := range captured.Capabilities.Clients {
+				if _, e := fmt.Fprintf(streams.Out, "client: %s; activation: %s\n", c.ClientID, c.ActivationMode); e != nil {
+					return exitx.Wrap(e, 1)
+				}
+			}
+		}
+		for _, c := range captured.Clients {
+			if _, e := fmt.Fprintf(streams.Out, "target %s: static support only; %s\n", c.ClientID, strings.Join(c.Limitations, ", ")); e != nil {
+				return exitx.Wrap(e, 1)
+			}
+			for _, v := range c.Components {
+				if _, e := fmt.Fprintf(streams.Out, "  %s %d: %s\n", v.Kind, v.Index, v.Support); e != nil {
+					return exitx.Wrap(e, 1)
+				}
+			}
+		}
+		for _, c := range captured.DoctorChecks {
+			if _, e := fmt.Fprintf(streams.Out, "%s: %s; %s\n", c.ID, c.Status, c.Action); e != nil {
+				return exitx.Wrap(e, 1)
 			}
 		}
 		if captured.Error != nil {
@@ -126,10 +169,17 @@ func (a App) Execute(ctx context.Context, args []string, streams authoringcli.St
 	return nil
 }
 func (a App) command(name string, capture func(report.Report)) (*cobra.Command, error) {
-	return authoringcli.NewCommand(authoringcli.Spec[request, report.Report]{Use: name + " <path>", Short: summary(name), Args: cobra.ExactArgs(1),
-		Support: authoringcli.Support{Format: true, NoColor: true},
+	use, args := name+" <path>", cobra.ExactArgs(1)
+	if name == "capabilities" {
+		use, args = name, cobra.NoArgs
+	}
+	return authoringcli.NewCommand(authoringcli.Spec[request, report.Report]{Use: use, Short: summary(name), Args: args,
+		Support: authoringcli.Support{Format: true, NoColor: true, Target: name == "compat" || name == "inspect"},
 		Configure: func(c *cobra.Command) {
 			f := c.Flags()
+			if name == "capabilities" {
+				return
+			}
 			f.Bool("include-root", false, "disclose the explicitly selected root in this report")
 			if name == "init" {
 				for _, v := range []struct{ name, help string }{
@@ -144,10 +194,20 @@ func (a App) command(name string, capture func(report.Report)) (*cobra.Command, 
 				f.Bool("release-policy", false, "also evaluate bounded release hygiene (not publication approval)")
 			}
 		},
-		Decode: func(c *cobra.Command, _ authoringcli.Options, args []string) (request, error) {
+		Decode: func(c *cobra.Command, opts authoringcli.Options, args []string) (request, error) {
+			if name == "capabilities" {
+				return request{}, nil
+			}
 			get := func(n string) string { v, _ := c.Flags().GetString(n); return v }
 			disclose, _ := c.Flags().GetBool("include-root")
 			req := request{root: args[0], disclose: disclose}
+			if name == "compat" || name == "inspect" && (opts.Target != "" || c.Flags().Changed("target")) {
+				ids, err := readiness.Targets(opts.Target)
+				if err != nil {
+					return request{}, err
+				}
+				req.targets = ids
+			}
 			if name == "init" {
 				req.template = scaffold.Options{Template: scaffold.Template(get("template")), Name: get("name"), Description: get("description"), SkillName: get("skill-name"), MCPChoice: scaffold.Template(get("mcp")), Runtime: get("runtime"), RemoteURL: get("url"), AuthorName: get("author-name"), License: get("license"), CopyrightHolder: get("copyright-holder"), CopyrightYear: get("copyright-year")}
 			} else {
@@ -156,6 +216,15 @@ func (a App) command(name string, capture func(report.Report)) (*cobra.Command, 
 			return req, nil
 		},
 		Runner: authoringcli.RunnerFunc[request, report.Report](func(ctx context.Context, req request) (report.Report, error) {
+			if name == "capabilities" {
+				r := report.New(name, a.Revision)
+				c, err := readiness.Engine(commandNames())
+				r.Capabilities = c
+				if err != nil {
+					r.AddError("capabilities_unavailable", "Check the embedded engine metadata.")
+				}
+				return r, err
+			}
 			if name == "init" {
 				return a.init(ctx, req)
 			}
@@ -168,6 +237,17 @@ func (a App) command(name string, capture func(report.Report)) (*cobra.Command, 
 				code, action := failure(e, "read")
 				r.AddError(code, action)
 				return r, e
+			}
+			if len(req.targets) > 0 {
+				clients, err := readiness.Compatibility(p, req.targets)
+				if err != nil {
+					r.AddError("compatibility_unavailable", "Select explicit supported clients.")
+					return r, err
+				}
+				r.AddCompatibility(clients)
+			}
+			if name == "doctor" {
+				r.AddDoctor(readiness.Doctor(p))
 			}
 			if !r.Successful() {
 				return r, errors.New("authoring checks incomplete or failed")
@@ -236,6 +316,12 @@ func summary(name string) string {
 	switch name {
 	case "init":
 		return "Create an offline standard package in an absent destination"
+	case "compat":
+		return "Evaluate explicit --target clients using static adapter support; no installed clients required"
+	case "capabilities":
+		return "Show embedded schemas, profiles, live client metadata and implemented commands"
+	case "doctor":
+		return "Inspect captured native files and executable metadata; no processes or network"
 	case "inspect":
 		return "Inspect captured components and unresolved runtime requirements"
 	case "test":
@@ -274,7 +360,7 @@ func failure(err error, phase string) (string, string) {
 	}
 	switch phase {
 	case "arguments":
-		return "arguments_invalid", "Use init, validate, inspect or test with one explicit path and supported flags; installer-only and runtime flags are rejected."
+		return "arguments_invalid", "Use an implemented command with one explicit path (capabilities takes none); compat requires distinct comma-separated --target clients. Installer-only and runtime flags are rejected."
 	case "template":
 		return "template_options_invalid", "Select a template, exact name and description; remote requires --url, stdio requires --runtime node, hybrid requires --mcp; licenses require explicit holder and year."
 	case "apply", "destination":
@@ -299,7 +385,7 @@ func wantsJSON(args []string) bool {
 }
 func selectedCommand(args []string) string {
 	for _, a := range args {
-		for _, n := range []string{"init", "validate", "inspect", "test"} {
+		for _, n := range commandNames() {
 			if a == n {
 				return n
 			}

--- a/cli/plugin-kit-ai/internal/authoring/commands/readiness_native_linux_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/readiness_native_linux_test.go
@@ -1,0 +1,319 @@
+package commands_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/report"
+)
+
+// Only the harness launches binaries. The optional explicit strace lane observes
+// every syscall in their process trees, rejecting any child exec/network syscall
+// and any access to the newly-created private HOME/profile paths.
+func TestNativeBinaryReadiness(t *testing.T) {
+	_, file, _, _ := runtime.Caller(0)
+	module := filepath.Clean(filepath.Join(filepath.Dir(file), "../../.."))
+	revision := "8d4ca3eedb3afbdd401a87677b97597035f84146+readiness-worktree"
+	bins := t.TempDir()
+	evidence := os.Getenv("UAP_READINESS_EVIDENCE")
+	traceTool := os.Getenv("UAP_READINESS_STRACE")
+	guard := os.Getenv("UAP_READINESS_GUARD")
+	if traceTool != "" && !filepath.IsAbs(traceTool) {
+		t.Fatal("trace tool must be explicit absolute path")
+	}
+	binary := []string{filepath.Join(bins, "plugin-kit-ai"), filepath.Join(bins, "agentplugins")}
+	for i, name := range []string{"plugin-kit-ai", "agentplugins"} {
+		prefix := "github.com/777genius/plugin-kit-ai/cli/internal/authoring/commands"
+		cmd := exec.Command(filepath.Join(runtime.GOROOT(), "bin/go"), "build", "-p", "2", "-ldflags", "-X "+prefix+".Enabled=vertical-slice-v1 -X "+prefix+".Revision="+revision, "-o", binary[i], "./cmd/"+name)
+		cmd.Dir = module
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("build: %v %s", err, out)
+		}
+		b, err := os.ReadFile(binary[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("binary=%s sha256=%x revision=%s toolchain=%s platform=%s/%s", name, sha256.Sum256(b), revision, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	}
+	homes := []string{t.TempDir(), t.TempDir()}
+	scratch := []string{t.TempDir(), t.TempDir()}
+	traps := t.TempDir()
+	effect := filepath.Join(traps, "effect")
+	for _, name := range []string{"node", "npm", "npx", "python", "python3", "go", "git", "curl", "wget", "claude", "codex", "agentplugins", "plugin-kit-ai"} {
+		write(t, traps, name, "#!/bin/sh\nprintf invoked > '"+effect+"'\nexit 79\n")
+		if err := os.Chmod(filepath.Join(traps, name), 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Marker profiles are never needed for explicit clients, even if present.
+	for _, home := range homes {
+		for _, name := range []string{".npmrc", ".gitconfig", ".codex/auth.json", ".config/agentplugins/state.json", ".claude/settings.json"} {
+			write(t, home, name, marker)
+		}
+	}
+	homeBefore := []map[string]string{tree(t, homes[0]), tree(t, homes[1])}
+	invocation := 0
+	run := func(i int, args ...string) (report.Report, int, []byte) {
+		t.Helper()
+		invocation++
+		selected, access := "-", "read"
+		invocationGuard := guard
+		if args[0] == "init" {
+			invocationGuard = ""
+		} // fixture creation is the separately verified baseline mutation
+		if len(args) > 1 && args[0] != "capabilities" {
+			selected = args[1]
+		}
+		leadingFlag := strings.HasPrefix(args[0], "--")
+		if leadingFlag {
+			selected = args[2]
+		}
+		if args[0] == "init" {
+			selected, access = filepath.Dir(selected), "write"
+		}
+		if i == 1 {
+			if leadingFlag {
+				args = append([]string{args[0], "author"}, args[1:]...)
+			} else {
+				args = append([]string{"author"}, args...)
+			}
+		}
+		args = append(args, "--format=json")
+		cmd := exec.Command(binary[i], args...)
+		if invocationGuard != "" {
+			cmd = exec.Command(invocationGuard, append([]string{binary[i], scratch[i], selected, access, "--"}, args...)...)
+		}
+		trace := filepath.Join(t.TempDir(), "trace")
+		if traceTool != "" {
+			traced := []string{"-f", "-qq", "-s", "4096", "-e", "trace=%process,%network,%file", "-o", trace, binary[i]}
+			cmd = exec.Command(traceTool, append(traced, args...)...)
+		}
+		cmd.Dir = bins
+		cmd.Env = []string{"HOME=" + homes[i], "XDG_CONFIG_HOME=" + homes[i], "XDG_CACHE_HOME=" + homes[i], "PATH=" + traps, "TMPDIR=" + scratch[i], "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_NOSYSTEM=1", "AGENTPLUGINS_DIRECTORY_ORIGIN=" + marker, "AGENTPLUGINS_SECURITY_ORIGIN=" + marker}
+		var out, stderr bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &stderr
+		err := cmd.Run()
+		code := 0
+		if err != nil {
+			if e, ok := err.(*exec.ExitError); ok {
+				code = e.ExitCode()
+			} else {
+				t.Fatal(err)
+			}
+		}
+		if stderr.Len() != 0 {
+			t.Fatalf("stderr: %s", stderr.Bytes())
+		}
+		if out.Len() == 0 {
+			t.Fatalf("no report, process exit=%d error=%v", code, err)
+		}
+		r := decodeReport(t, out.Bytes())
+		if r.Revision != revision {
+			t.Fatal("revision drift")
+		}
+		if traceTool != "" {
+			b, err := os.ReadFile(trace)
+			if err != nil {
+				t.Fatal(err)
+			}
+			execs := 0
+			for _, line := range strings.Split(string(b), "\n") {
+				if strings.Contains(line, "execve(") {
+					execs++
+					continue
+				}
+				if strings.Contains(line, "execveat(") || strings.Contains(line, "fork(") || strings.Contains(line, "vfork(") {
+					t.Fatalf("process effect: %s", line)
+				}
+				if strings.Contains(line, "clone(") && !strings.Contains(line, "CLONE_THREAD") || strings.Contains(line, "clone3(") && !strings.Contains(line, "CLONE_THREAD") {
+					t.Fatalf("non-thread clone: %s", line)
+				}
+				for _, call := range []string{"socket(", "socketpair(", "connect(", "bind(", "listen(", "accept(", "sendto(", "sendmsg(", "recvfrom(", "recvmsg("} {
+					if strings.Contains(line, call) {
+						t.Fatalf("network effect: %s", line)
+					}
+				}
+				if strings.Contains(line, homes[i]) {
+					t.Fatalf("profile access: %s", line)
+				}
+			}
+			if execs != 1 {
+				t.Fatalf("expected sole native exec, got %d", execs)
+			}
+			if evidence != "" {
+				if err := os.WriteFile(filepath.Join(evidence, fmt.Sprintf("native-%03d.trace", invocation)), b, 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+		if !reflect.DeepEqual(homeBefore[i], tree(t, homes[i])) || len(tree(t, scratch[i])) != 0 {
+			t.Fatal("home mutation or scratch residue")
+		}
+		if _, err := os.Stat(effect); !os.IsNotExist(err) {
+			t.Fatal("process trap fired")
+		}
+		t.Logf("case=%03d binary=%d command=%s exit=%d output_sha256=%x trace=%t guard=%t", invocation, i, r.Command, code, sha256.Sum256(out.Bytes()), traceTool != "", invocationGuard != "")
+		if evidence != "" {
+			if err := os.WriteFile(filepath.Join(evidence, fmt.Sprintf("native-%03d.json", invocation)), out.Bytes(), 0600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return r, code, out.Bytes()
+	}
+	parity := func(args []string, want int) report.Report {
+		t.Helper()
+		a, ac, ab := run(0, args...)
+		_, bc, bb := run(1, args...)
+		if ac != want || bc != want || !bytes.Equal(ab, bb) {
+			t.Fatalf("parity %v: %d %d want %d\n%s\n%s", args, ac, bc, want, ab, bb)
+		}
+		return a
+	}
+	c := parity([]string{"capabilities"}, 0)
+	if c.Capabilities == nil || len(c.Capabilities.Commands) != 7 || c.Readiness.Status != report.NotEvaluated {
+		t.Fatal("capabilities evidence", c)
+	}
+	for _, lane := range []struct {
+		name   string
+		extra  []string
+		doctor int
+	}{
+		{"skill", nil, 0}, {"mcp-remote", []string{"--url=https://invalid.example/mcp"}, 1},
+		{"mcp-stdio", []string{"--runtime=node"}, 1}, {"hybrid", []string{"--mcp=mcp-remote", "--url=https://invalid.example/mcp"}, 1},
+		{"hybrid", []string{"--mcp=mcp-stdio", "--runtime=node"}, 1},
+	} {
+		root := filepath.Join(t.TempDir(), "fixture")
+		args := append([]string{"init", root, "--name=demo", "--description=Disposable fixture", "--template=" + lane.name}, lane.extra...)
+		if _, code, _ := run(0, args...); code != 0 {
+			t.Fatal("fixture generation")
+		}
+		before := tree(t, root)
+		r := parity([]string{"compat", root, "--target=cursor,codex,claude"}, 0)
+		if len(r.Clients) != 3 || r.Compatibility.Status != report.Pass || r.Runtime.Status != report.NotEvaluated {
+			t.Fatal("compat invented runtime", r)
+		}
+		parity([]string{"inspect", root, "--target=cursor,codex,claude"}, 0)
+		r = parity([]string{"doctor", root}, lane.doctor)
+		if r.Runtime.Status != report.NotEvaluated || lane.doctor == 1 && r.Toolchain.Status == report.Pass {
+			t.Fatal("doctor fake proof", r)
+		}
+		if !reflect.DeepEqual(before, tree(t, root)) {
+			t.Fatal("source changed")
+		}
+	}
+	root := t.TempDir()
+	write(t, root, "plugin.json", plugin(""))
+	parity([]string{"--target=codex", "inspect", root}, 0)
+	if _, code, _ := run(1, "--scope=user", "doctor", root); code != 2 {
+		t.Fatal("installer flag before author accepted")
+	}
+	write(t, root, "mcp.json", mcp(`{"local":{"type":"stdio","command":"./bin/fixture"}}`))
+	write(t, root, "bin/fixture", "#!/bin/sh\nprintf invoked > '"+effect+"'\n")
+	r := parity([]string{"doctor", root}, 1)
+	if r.Toolchain.Status != report.Fail || r.Conformance.Status != report.Pass {
+		t.Fatal("mode conflated with conformance", r)
+	}
+	if err := os.Chmod(filepath.Join(root, "bin/fixture"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	r = parity([]string{"doctor", root}, 1)
+	if r.Toolchain.Status != report.NotEvaluated {
+		t.Fatal("mode proves runtime", r)
+	}
+	if err := os.Remove(filepath.Join(root, "bin/fixture")); err != nil {
+		t.Fatal(err)
+	}
+	parity([]string{"doctor", root}, 1)
+	write(t, root, "plugin.json", plugin(`,"extensions":{"dev.example":{"secret":"`+marker+`"}}`))
+	write(t, root, "mcp.json", mcp(`{"good":{"type":"streamable-http","url":"https://invalid.example/mcp","headers":{"Authorization":"`+marker+`"}},"bad":{"type":"invalid","command":"`+marker+`"}}`))
+	parity([]string{"compat", root, "--target=cursor,chatgpt,windsurf"}, 1)
+	parity([]string{"doctor", root}, 1)
+	write(t, root, "plugin.json", `{"$schema":"https://invalid.example/future","name":"demo"}`)
+	r = parity([]string{"compat", root, "--target=codex"}, 1)
+	if len(r.Clients) != 0 || r.Compatibility.Status != report.NotEvaluated {
+		t.Fatal("unknown schema guessed")
+	}
+	r = parity([]string{"doctor", root}, 1)
+	if len(r.DoctorChecks) != 0 {
+		t.Fatal("future doctor guessed")
+	}
+	for _, args := range [][]string{
+		{"compat", root}, {"compat", root, "--target=codex,codex"}, {"compat", root, "--target=" + marker},
+		{"compat", root, "--target=codex", "--dry-run=false"}, {"inspect", root, "--target="},
+		{"doctor", root, "--target=codex"}, {"doctor", root, "--runtime"}, {"capabilities", "unexpected"},
+	} {
+		parity(args, 2)
+	}
+	for _, flag := range []string{"--scope=user", "--accept-security-risk=false", "--security-details=false"} {
+		if r, code, _ := run(1, "compat", root, "--target=codex", flag); code != 2 || r.Error.Code != "arguments_invalid" {
+			t.Fatal("installer-only flag accepted")
+		}
+	}
+	t.Logf("verified invocations=%d process_trap_hits=0 home_changes=0 scratch_residue=0 syscall_tracing=%t confinement=%t", invocation, traceTool != "", guard != "")
+}
+
+// Calibrate the optional kernel guard against effects, rather than assuming a
+// clean command result proves that the external harness actually confines it.
+func TestReadinessGuardTraps(t *testing.T) {
+	guard := os.Getenv("UAP_READINESS_GUARD")
+	if guard == "" {
+		t.Log("kernel guard calibration not requested")
+		return
+	}
+	root, home, scratch := t.TempDir(), t.TempDir(), t.TempDir()
+	source := filepath.Join(root, "probe.c")
+	probe := filepath.Join(root, "probe")
+	body := `#include <sys/socket.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+int main(int argc,char **argv) {
+ if(argc!=3) return 99;
+ if(argv[1][0]=='n') return socket(AF_INET,SOCK_STREAM,0)<0?98:97;
+ if(argv[1][0]=='e') { execl("/bin/true","true",(char*)0); return 96; }
+ if(argv[1][0]=='f') { fork(); return 95; }
+ int fd=open(argv[2],argv[1][0]=='w'?O_WRONLY:O_RDONLY);
+ return fd<0 && errno==EACCES?0:94;
+}`
+	if err := os.WriteFile(source, []byte(body), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cc := os.Getenv("UAP_READINESS_CC")
+	if cc == "" || !filepath.IsAbs(cc) {
+		t.Fatal("guard calibration requires explicit UAP_READINESS_CC")
+	}
+	if out, err := exec.Command(cc, "-Wall", "-Wextra", "-Werror", "-o", probe, source).CombinedOutput(); err != nil {
+		t.Fatalf("compile guard probe: %v %s", err, out)
+	}
+	write(t, home, "credentials", marker)
+	write(t, root, "source", marker)
+	for _, mode := range []string{"network", "exec", "fork", "profile", "write"} {
+		path := filepath.Join(home, "credentials")
+		if mode == "write" {
+			path = filepath.Join(root, "source")
+		}
+		cmd := exec.Command(guard, probe, scratch, root, "read", "--", mode, path)
+		cmd.Env = []string{"HOME=" + home, "PATH=" + root}
+		out, err := cmd.CombinedOutput()
+		if mode == "profile" || mode == "write" {
+			if err != nil {
+				t.Fatalf("guard did not deny %s file access: %v %s", mode, err, out)
+			}
+		} else {
+			e, ok := err.(*exec.ExitError)
+			if !ok || !strings.Contains(e.String(), "bad system call") {
+				t.Fatalf("guard did not trap %s: %v %s", mode, err, out)
+			}
+		}
+		t.Logf("calibration=%s enforced=true", mode)
+	}
+}

--- a/cli/plugin-kit-ai/internal/authoring/commands/readiness_review_probe_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/readiness_review_probe_test.go
@@ -1,0 +1,117 @@
+package commands_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/commands"
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/project"
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/report"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+func TestReadinessReviewEmptyMCPName(t *testing.T) {
+	for _, badName := range []string{"bad", ""} {
+		t.Run("invalid-name="+badName, func(t *testing.T) {
+			root, scratch := t.TempDir(), t.TempDir()
+			write(t, root, "plugin.json", plugin(""))
+			key, _ := json.Marshal(badName)
+			write(t, root, "mcp.json", mcp(`{`+string(key)+`:{"type":"stdio","command":7},"good":{"type":"stdio","command":"node"}}`))
+			app := commands.App{Projects: project.Service{Scratch: scratch}, Revision: "0e74767e09169f58145d56f5d3e10b4038171e3a"}
+			args := []string{"compat", root, "--target=cursor", "--format=json"}
+			r, code, raw := execute(t, app, args, false)
+			_, mountedCode, mountedRaw := execute(t, app, args, true)
+			if code != 1 || mountedCode != code || !bytes.Equal(raw, mountedRaw) {
+				t.Fatal("entrypoint parity or failed conformance exit changed")
+			}
+			good := 0
+			for _, c := range r.Components {
+				if c.Status == report.Pass {
+					good++
+				}
+			}
+			if good != 1 {
+				t.Fatalf("control lost its valid sibling: %+v", r.Components)
+			}
+			if len(r.Clients) != 1 {
+				t.Fatal("expected Cursor compatibility")
+			}
+			summary, _ := json.Marshal(r.Clients[0].Components)
+			t.Logf("badName=%q reportComponents=%d validSiblings=%d compatibility=%s conformance=%s exit=%d decisions=%s", badName, len(r.Components), good, r.Compatibility.Status, r.Conformance.Status, code, summary)
+			if len(r.Clients[0].Components) != 2 {
+				t.Errorf("invalid MCP entry vanished: got %d compatibility entries; want 2", len(r.Clients[0].Components))
+			}
+			supported := 0
+			for _, c := range r.Clients[0].Components {
+				if c.Kind == domain.ComponentMCPServer && c.Support == domain.SupportNative {
+					supported++
+				}
+			}
+			if supported != 1 {
+				t.Errorf("invalid sibling poisoned valid server support: got %d native MCP decisions; want 1", supported)
+			}
+			if len(tree(t, scratch)) != 0 {
+				t.Fatal("scratch residue")
+			}
+		})
+	}
+}
+
+func TestReadinessReviewMCPBoundaries(t *testing.T) {
+	for _, tc := range []struct {
+		name, body          string
+		code, count, native int
+	}{
+		{"empty-invalid", mcp(`{"":{"type":"stdio","command":7},"good":{"type":"stdio","command":"node"}}`), 1, 2, 1},
+		{"ordinary-invalid", mcp(`{"bad":{"type":"stdio","command":7},"good":{"type":"stdio","command":"node"}}`), 1, 2, 1},
+		{"empty-valid", mcp(`{"":{"type":"stdio","command":"node"},"good":{"type":"stdio","command":"node"}}`), 0, 2, 2},
+		{"document-invalid", `{"$schema":"https://agent-plugins.org/schemas/1.0.0/mcp.schema.json","unexpected":true,"mcpServers":{"good":{"type":"stdio","command":"node"}}}`, 1, 0, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root, scratch := t.TempDir(), t.TempDir()
+			write(t, root, "plugin.json", plugin(""))
+			write(t, root, "mcp.json", tc.body)
+			app := commands.App{Projects: project.Service{Scratch: scratch}}
+			for _, command := range []string{"compat", "inspect"} {
+				args := []string{command, root, "--target=cursor", "--format=json"}
+				r, code, raw := execute(t, app, args, false)
+				_, mountedCode, mountedRaw := execute(t, app, args, true)
+				if code != tc.code || mountedCode != code || !bytes.Equal(raw, mountedRaw) {
+					t.Fatal("exit or mount parity")
+				}
+				if len(r.Clients) != 1 || len(r.Clients[0].Components) != tc.count {
+					t.Fatalf("inventory: %+v", r.Clients)
+				}
+				native := 0
+				for i, c := range r.Clients[0].Components {
+					if c.Index != i+1 || c.Kind != domain.ComponentMCPServer {
+						t.Fatal("opaque ordering")
+					}
+					if c.Support == domain.SupportNative {
+						native++
+					}
+				}
+				if native != tc.native {
+					t.Fatalf("native=%d want=%d", native, tc.native)
+				}
+				want := report.Pass
+				if tc.code == 1 {
+					want = report.Fail
+				}
+				if r.Conformance.Status != want {
+					t.Fatal("conformance changed")
+				}
+				if tc.count == 2 && r.Compatibility.Status != want {
+					t.Fatal("compatibility aggregate changed")
+				}
+				if bytes.Contains(raw, []byte(`"good"`)) || bytes.Contains(raw, []byte(`"bad"`)) || bytes.Contains(raw, []byte(root)) {
+					t.Fatal("raw identity disclosure")
+				}
+			}
+			if len(tree(t, scratch)) != 0 {
+				t.Fatal("scratch residue")
+			}
+		})
+	}
+}

--- a/cli/plugin-kit-ai/internal/authoring/commands/readiness_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/readiness_test.go
@@ -1,0 +1,153 @@
+package commands_test
+
+import (
+	"bytes"
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/commands"
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/project"
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/report"
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoringcli"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/planner"
+)
+
+func TestReadinessComposition(t *testing.T) {
+	root, scratch := t.TempDir(), t.TempDir()
+	write(t, root, "plugin.json", plugin(`,"extensions":{"dev.example":{"secret":"`+marker+`"}}`))
+	write(t, root, "mcp.json", mcp(`{"good":{"type":"stdio","command":"node","env":{"SECRET":"`+marker+`"}},"bad":{"type":"future-transport","url":"`+marker+`"}}`))
+	app := commands.App{Projects: project.Service{Scratch: scratch}, Revision: "readiness-test"}
+	p, err := app.Projects.Read(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := planner.Compatibility(*p.Facts.Package, domain.SupportedClientIDs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ids []string
+	for _, id := range domain.SupportedClientIDs() {
+		ids = append(ids, string(id))
+	}
+	before := tree(t, root)
+	for _, name := range []string{"compat", "inspect"} {
+		args := []string{name, root, "--target=" + strings.Join(ids, ","), "--format=json"}
+		a, ac, ab := execute(t, app, args, false)
+		b, bc, bb := execute(t, app, args, true)
+		if ac != 1 || ac != bc || !bytes.Equal(ab, bb) || !reflect.DeepEqual(a.Clients, want) || !reflect.DeepEqual(a, b) {
+			t.Fatalf("%s parity/planner mismatch: %d %d", name, ac, bc)
+		}
+		if a.Compatibility.Status != report.Fail || a.Runtime.Status != report.NotEvaluated || a.Conformance.Status != report.Fail {
+			t.Fatal("conflated assessments", a)
+		}
+	}
+	for _, mounted := range []bool{false, true} {
+		r, code, _ := execute(t, app, []string{"doctor", root, "--format=json"}, mounted)
+		if code != 1 || r.Toolchain.Status == report.Pass || len(r.DoctorChecks) == 0 {
+			t.Fatal("fake doctor readiness", r)
+		}
+		r, code, _ = execute(t, app, []string{"capabilities", "--format=json"}, mounted)
+		if code != 0 || r.Capabilities == nil || r.Readiness.Status != report.NotEvaluated || r.Runtime.Status != report.NotEvaluated {
+			t.Fatal("capabilities is not package readiness", r)
+		}
+	}
+	if !reflect.DeepEqual(before, tree(t, root)) || len(tree(t, scratch)) != 0 {
+		t.Fatal("read changed source or retained scratch")
+	}
+}
+
+func TestReadinessArgumentIsolation(t *testing.T) {
+	app := commands.App{Projects: project.Service{Scratch: "/must-not-be-opened"}}
+	for _, args := range [][]string{
+		{"compat", "/must-not-be-opened"}, {"compat", "/must-not-be-opened", "--target=codex,codex"},
+		{"compat", "/must-not-be-opened", "--target=" + marker}, {"inspect", "/must-not-be-opened", "--target="},
+		{"doctor", "/must-not-be-opened", "--target=codex"}, {"capabilities", "extra"},
+		{"capabilities", "--release-policy"}, {"capabilities", "--target=codex"},
+		{"compat", "/must-not-be-opened", "--target=codex", "--dry-run=false"},
+		{"doctor", "/must-not-be-opened", "--runtime"},
+	} {
+		args = append(args, "--format=json")
+		_, ac, a := execute(t, app, args, false)
+		r, bc, b := execute(t, app, args, true)
+		if ac != 2 || bc != 2 || !bytes.Equal(a, b) || r.Error.Code != "arguments_invalid" {
+			t.Fatalf("argument mismatch %v: %d %d %s", args, ac, bc, b)
+		}
+	}
+	for _, flag := range []string{"--scope=user", "--accept-security-risk=false", "--security-details=false"} {
+		for _, name := range []string{"compat", "doctor", "capabilities"} {
+			args := []string{name}
+			if name != "capabilities" {
+				args = append(args, "/must-not-be-opened")
+			}
+			if name == "compat" {
+				args = append(args, "--target=codex")
+			}
+			args = append(args, flag, "--format=json")
+			r, code, _ := execute(t, app, args, true)
+			if code != 2 || r.Error.Code != "arguments_invalid" {
+				t.Fatal("installer flag reached read", r)
+			}
+		}
+	}
+}
+
+func TestReadinessUnknownSchemaAndFreshFactories(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "plugin.json", `{"$schema":"https://invalid.example/future","name":"demo"}`)
+	write(t, root, "package.json", `{"secret":"`+marker+`"}`)
+	app := commands.App{Projects: project.Service{Scratch: t.TempDir()}}
+	for _, name := range []string{"compat", "inspect", "doctor"} {
+		args := []string{name, root, "--format=json"}
+		if name != "doctor" {
+			args = append(args, "--target=codex")
+		}
+		r, code, _ := execute(t, app, args, false)
+		if code != 1 || len(r.Clients) != 0 || len(r.DoctorChecks) != 0 || r.Capabilities != nil || r.Compatibility.Status != report.NotEvaluated {
+			t.Fatal("future schema guesses", r)
+		}
+	}
+	for i := 0; i < 4; i++ {
+		r, code, _ := execute(t, app, []string{"capabilities", "--format=json"}, i%2 == 0)
+		if code != 0 || len(r.Capabilities.Commands) != 7 {
+			t.Fatal("factory state leak")
+		}
+	}
+	var out bytes.Buffer
+	if err := app.Execute(context.Background(), []string{"doctor", "--help"}, authoringcli.Streams{Out: &out, Err: &out}, authoringcli.NewPluginKitRoot); err != nil || !strings.Contains(out.String(), "no processes or network") {
+		t.Fatal("doctor help", err, out.String())
+	}
+}
+
+func TestReadinessHumanOutput(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "plugin.json", plugin(`,"extensions":{"dev.example":{"secret":"`+marker+`"}}`))
+	write(t, root, "mcp.json", mcp(`{"`+marker+`":{"type":"stdio","command":"`+marker+`","env":{"SECRET":"`+marker+`"}}}`))
+	app := commands.App{Projects: project.Service{Scratch: t.TempDir()}}
+	for _, args := range [][]string{{"compat", root, "--target=cursor"}, {"doctor", root}, {"capabilities"}} {
+		for _, mount := range []bool{false, true} {
+			var out, stderr bytes.Buffer
+			builder := commands.RootBuilder(authoringcli.NewPluginKitRoot)
+			input := append([]string{}, args...)
+			if mount {
+				builder = mounted
+				input = append([]string{"author"}, input...)
+			}
+			_ = app.Execute(context.Background(), input, authoringcli.Streams{Out: &out, Err: &stderr}, builder)
+			if stderr.Len() != 0 || strings.Contains(out.String(), marker) || strings.Contains(out.String(), root) {
+				t.Fatalf("human disclosure: %s", out.String())
+			}
+			if args[0] == "doctor" && !strings.Contains(out.String(), "no PATH lookup") {
+				t.Fatal("doctor lacks actionable uncertainty")
+			}
+			if args[0] == "capabilities" && !strings.Contains(out.String(), "schema: https://agent-plugins.org/") {
+				t.Fatal("human schemas missing")
+			}
+			if args[0] == "compat" && !strings.Contains(out.String(), "static support only") {
+				t.Fatal("human compatibility scope missing")
+			}
+		}
+	}
+}

--- a/cli/plugin-kit-ai/internal/authoring/commands/testdata/readiness_guard.c
+++ b/cli/plugin-kit-ai/internal/authoring/commands/testdata/readiness_guard.c
@@ -1,0 +1,90 @@
+// Linux test harness only. Fail closed if confinement cannot be installed.
+// The initial exec uses the exact pre-exec pathname pointer; every subsequent
+// exec in the Go image is killed. This is a test trap, not a hostile-code sandbox.
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/audit.h>
+#include <linux/filter.h>
+#include <linux/landlock.h>
+#include <linux/seccomp.h>
+#include <sched.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#define RO (LANDLOCK_ACCESS_FS_READ_FILE | LANDLOCK_ACCESS_FS_READ_DIR)
+#define RW (RO | LANDLOCK_ACCESS_FS_WRITE_FILE | LANDLOCK_ACCESS_FS_REMOVE_DIR | LANDLOCK_ACCESS_FS_REMOVE_FILE | LANDLOCK_ACCESS_FS_MAKE_DIR | LANDLOCK_ACCESS_FS_MAKE_REG | LANDLOCK_ACCESS_FS_MAKE_SYM | LANDLOCK_ACCESS_FS_REFER | LANDLOCK_ACCESS_FS_TRUNCATE)
+static void die(const char *what) { perror(what); exit(125); }
+static void allow(int rules, const char *path, uint64_t access) {
+ int fd = open(path, O_PATH | O_CLOEXEC);
+ if (fd < 0) die("guard path");
+ struct landlock_path_beneath_attr rule = {.allowed_access=access,.parent_fd=fd};
+ if (syscall(SYS_landlock_add_rule,rules,LANDLOCK_RULE_PATH_BENEATH,&rule,0)) die("guard rule");
+ close(fd);
+}
+#define KILL SECCOMP_RET_KILL_PROCESS
+#define DENY(n) BPF_JUMP(BPF_JMP|BPF_JEQ|BPF_K,n,0,1), BPF_STMT(BPF_RET|BPF_K,KILL)
+int main(int argc,char **argv) {
+ // guard binary scratch project-or-dash read|write -- command args...
+ if (argc<7) return 125;
+ if (prctl(PR_SET_NO_NEW_PRIVS,1,0,0,0)) die("guard no-new-privileges");
+ struct landlock_ruleset_attr attr = {.handled_access_fs=RW | LANDLOCK_ACCESS_FS_EXECUTE};
+ int rules=syscall(SYS_landlock_create_ruleset,&attr,sizeof(attr),0);
+ if(rules<0) die("guard ruleset");
+ allow(rules,argv[1],LANDLOCK_ACCESS_FS_READ_FILE|LANDLOCK_ACCESS_FS_EXECUTE);
+ allow(rules,argv[2],RW);
+ if(argv[3][0]!='-') allow(rules,argv[3],argv[4][0]=='w'?RW:RO);
+ allow(rules,"/dev/null",LANDLOCK_ACCESS_FS_READ_FILE|LANDLOCK_ACCESS_FS_WRITE_FILE);
+ // Native cgo binaries may need the system ELF interpreter and libraries.
+ allow(rules,"/lib",RO|LANDLOCK_ACCESS_FS_EXECUTE);
+ allow(rules,"/lib64",RO|LANDLOCK_ACCESS_FS_EXECUTE);
+ allow(rules,"/etc/ld.so.cache",LANDLOCK_ACCESS_FS_READ_FILE);
+ allow(rules,"/proc",RO);
+ allow(rules,"/sys",RO);
+ if(syscall(SYS_landlock_restrict_self,rules,0)) die("guard restrict");
+ close(rules);
+ uintptr_t executable=(uintptr_t)argv[1];
+ struct sock_filter filter[]={
+  BPF_STMT(BPF_LD|BPF_W|BPF_ABS,offsetof(struct seccomp_data,arch)),
+#if defined(__x86_64__)
+  BPF_JUMP(BPF_JMP|BPF_JEQ|BPF_K,AUDIT_ARCH_X86_64,1,0),
+#elif defined(__aarch64__)
+  BPF_JUMP(BPF_JMP|BPF_JEQ|BPF_K,AUDIT_ARCH_AARCH64,1,0),
+#else
+#error Unsupported guard architecture
+#endif
+  BPF_STMT(BPF_RET|BPF_K,KILL),
+  BPF_STMT(BPF_LD|BPF_W|BPF_ABS,offsetof(struct seccomp_data,nr)),
+  DENY(SYS_socket),DENY(SYS_socketpair),DENY(SYS_connect),DENY(SYS_bind),DENY(SYS_listen),
+  DENY(SYS_sendto),DENY(SYS_sendmsg),DENY(SYS_recvfrom),DENY(SYS_recvmsg),DENY(SYS_execveat),
+#ifdef SYS_fork
+  DENY(SYS_fork),DENY(SYS_vfork),
+#endif
+  BPF_JUMP(BPF_JMP|BPF_JEQ|BPF_K,SYS_clone,0,4),
+  BPF_STMT(BPF_LD|BPF_W|BPF_ABS,offsetof(struct seccomp_data,args[0])),
+  BPF_JUMP(BPF_JMP|BPF_JSET|BPF_K,CLONE_THREAD,1,0),
+  BPF_STMT(BPF_RET|BPF_K,KILL),
+  BPF_STMT(BPF_RET|BPF_K,SECCOMP_RET_ALLOW),
+  // Go uses clone for threads. No clone3 flags pointer inspection is attempted.
+  BPF_JUMP(BPF_JMP|BPF_JEQ|BPF_K,SYS_clone3,0,1),
+  BPF_STMT(BPF_RET|BPF_K,SECCOMP_RET_ERRNO|ENOSYS),
+  BPF_JUMP(BPF_JMP|BPF_JEQ|BPF_K,SYS_execve,0,6),
+  BPF_STMT(BPF_LD|BPF_W|BPF_ABS,offsetof(struct seccomp_data,args[0])),
+  BPF_JUMP(BPF_JMP|BPF_JEQ|BPF_K,(uint32_t)executable,0,3),
+  BPF_STMT(BPF_LD|BPF_W|BPF_ABS,offsetof(struct seccomp_data,args[0])+4),
+  BPF_JUMP(BPF_JMP|BPF_JEQ|BPF_K,(uint32_t)(executable>>32),0,1),
+  BPF_STMT(BPF_RET|BPF_K,SECCOMP_RET_ALLOW),
+  BPF_STMT(BPF_RET|BPF_K,KILL),
+  BPF_STMT(BPF_RET|BPF_K,SECCOMP_RET_ALLOW),
+ };
+ struct sock_fprog program={.len=sizeof(filter)/sizeof(filter[0]),.filter=filter};
+ if(prctl(PR_SET_SECCOMP,SECCOMP_MODE_FILTER,&program)) die("guard seccomp");
+ argv[5]=argv[1];
+ execv(argv[1],argv+5);
+ die("guard exec");
+}

--- a/cli/plugin-kit-ai/internal/authoring/readiness/doctor.go
+++ b/cli/plugin-kit-ai/internal/authoring/readiness/doctor.go
@@ -1,0 +1,173 @@
+package readiness
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/project"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/packageview"
+)
+
+// Check is an allowlisted static observation. Pass applies only to the named
+// metadata check, never execution, dependency validity, or toolchain readiness.
+type Check struct {
+	ID     string `json:"id"`
+	ItemID string `json:"item_id,omitempty"`
+	Status string `json:"status"`
+	Action string `json:"action"`
+}
+
+func itemID(value string) string { return fmt.Sprintf("sha256:%x", sha256.Sum256([]byte(value))) }
+
+func Doctor(p project.Result) []Check {
+	checks := []Check{}
+	add := func(id, item, status, action string) { checks = append(checks, Check{id, item, status, action}) }
+	if p.Facts.Package == nil {
+		return checks
+	}
+	entries := map[string]packageview.Observation{}
+	for _, o := range p.Input.Inventory {
+		entries[o.Path] = o
+	}
+	// The reader captures these files into the scope digest, but exports metadata
+	// rather than their bytes. Do not reopen a mutable source or parse scripts.
+	for _, lane := range []struct {
+		file, language string
+		locks          []string
+	}{
+		{"package.json", "node", []string{"package-lock.json", "npm-shrinkwrap.json", "pnpm-lock.yaml", "yarn.lock", "bun.lock", "bun.lockb"}},
+		{"pyproject.toml", "python", []string{"uv.lock", "poetry.lock", "Pipfile.lock"}},
+		{"go.mod", "go", []string{"go.sum"}},
+	} {
+		o, exists := entries[lane.file]
+		if !exists {
+			continue
+		}
+		status := "not_evaluated"
+		if o.Captured && o.State == packageview.Present && o.Kind == "file" {
+			status = "pass"
+		}
+		add(lane.language+"_project_file", "", status, "Inspect the language-native project file; contents and build scripts are not interpreted.")
+		lockStatus := "not_evaluated"
+		count := 0
+		for _, file := range lane.locks {
+			if o, ok := entries[file]; ok && o.Captured && o.State == packageview.Present && o.Kind == "file" {
+				count++
+			}
+		}
+		if count == 1 {
+			lockStatus = "pass"
+		}
+		action := "Review native dependency inputs and supply the selected manager's lock/checksum file where required; no dependencies were installed."
+		if count > 1 {
+			action = "Multiple manager lockfiles are present; explicitly select and reconcile dependency inputs."
+		}
+		add(lane.language+"_lockfile_presence", "", lockStatus, action)
+		add(lane.language+"_dependency_consistency", "", "not_evaluated", "Verify dependency versions, lockfile consistency and build outputs with the selected native toolchain separately.")
+	}
+	for name, skill := range p.Facts.Package.Skills {
+		if skill.Compatibility != "" || skill.AllowedTools != "" {
+			add("skill_host_requirements", itemID("skill:"+name), "not_evaluated", "Review declared Skill compatibility and tool requirements in the intended host; declarations do not prove availability.")
+		}
+	}
+	names := make([]string, 0, len(p.Facts.Package.MCP.Servers))
+	for name := range p.Facts.Package.MCP.Servers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		s := p.Facts.Package.MCP.Servers[name]
+		id := itemID("mcp:" + name)
+		if s.Type != "stdio" {
+			add("remote_connection", id, "not_evaluated", "Remote endpoint and authentication requirements have not been tested.")
+			add("oauth", id, "not_evaluated", "Determine authentication requirements separately; no credential stores were inspected.")
+			continue
+		}
+		command, _ := s.Decoded["command"].(string)
+		if strings.ContainsAny(command, `/\`) {
+			o, status := resolve(entries, command, p.Input.Coverage.InventoryComplete)
+			add("bundled_executable_presence", id, status, "Provide the referenced bundled file inside the package; no command was executed.")
+			mode := "not_evaluated"
+			if status == "pass" && runtime.GOOS != "windows" {
+				mode = "fail"
+				if o.Executable {
+					mode = "pass"
+				}
+			}
+			add("bundled_executable_mode", id, mode, "Ensure the bundled executable has appropriate executable permissions for the target OS.")
+		} else {
+			add("path_executable_availability", id, "not_evaluated", "Confirm the declared executable is available in the intended host PATH; this command performs no PATH lookup.")
+		}
+		add("executable_version", id, "not_evaluated", "Verify the required executable version separately; version probes are not run.")
+		add("runtime", id, "not_evaluated", "Static evidence does not prove process startup, MCP handshake or runtime dependencies.")
+	}
+	sort.Slice(checks, func(i, j int) bool {
+		if checks[i].ID != checks[j].ID {
+			return checks[i].ID < checks[j].ID
+		}
+		return checks[i].ItemID < checks[j].ItemID
+	})
+	return checks
+}
+
+// resolve traverses retained observations, including contained links, without
+// lexical cleaning away intermediates or opening any source/host path.
+func resolve(entries map[string]packageview.Observation, value string, complete bool) (packageview.Observation, string) {
+	unknown := func() (packageview.Observation, string) { return packageview.Observation{}, "not_evaluated" }
+	if strings.HasPrefix(value, "${PLUGIN_DATA}") || strings.Contains(value, `\`) {
+		return unknown()
+	}
+	value = strings.TrimPrefix(value, "${PLUGIN_ROOT}/")
+	if strings.HasPrefix(value, "/") || strings.Contains(value, "${") {
+		return unknown()
+	}
+	todo := strings.Split(value, "/")
+	var stack []string
+	var last packageview.Observation
+	links := 0
+	for len(todo) > 0 {
+		part := todo[0]
+		todo = todo[1:]
+		if part == "" || part == "." {
+			continue
+		}
+		if part == ".." {
+			if len(stack) == 0 {
+				return packageview.Observation{}, "fail"
+			}
+			stack = stack[:len(stack)-1]
+			continue
+		}
+		key := strings.Join(append(append([]string{}, stack...), part), "/")
+		o, ok := entries[key]
+		if !ok {
+			if complete {
+				return o, "fail"
+			}
+			return unknown()
+		}
+		if !o.Captured || o.State != packageview.Present {
+			return unknown()
+		}
+		if o.Kind == "symlink" {
+			links++
+			if links > 40 || strings.HasPrefix(o.Target, "/") || strings.Contains(o.Target, `\`) {
+				return unknown()
+			}
+			todo = append(strings.Split(o.Target, "/"), todo...)
+			continue
+		}
+		if len(todo) > 0 && o.Kind != "directory" {
+			return o, "fail"
+		}
+		stack = append(stack, part)
+		last = o
+	}
+	if last.Kind != "file" {
+		return last, "fail"
+	}
+	return last, "pass"
+}

--- a/cli/plugin-kit-ai/internal/authoring/readiness/readiness.go
+++ b/cli/plugin-kit-ai/internal/authoring/readiness/readiness.go
@@ -1,0 +1,86 @@
+// Package readiness evaluates retained project evidence without host discovery,
+// filesystem access, process execution, or installer lifecycle dependencies.
+package readiness
+
+import (
+	"errors"
+	"sort"
+	"strings"
+
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/project"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/specregistry"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/conformance"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/planner"
+)
+
+var ErrTargets = errors.New("select distinct explicit registry clients")
+
+// Targets rejects ambiguous selections before any project read. Neither aliases
+// nor 'all' imply ambient detection. Limits bound even malicious CLI input.
+func Targets(value string) ([]domain.ClientID, error) {
+	if value == "" || len(value) > 4096 {
+		return nil, ErrTargets
+	}
+	parts := strings.Split(value, ",")
+	if len(parts) > len(domain.ClientDefinitions()) {
+		return nil, ErrTargets
+	}
+	seen := map[domain.ClientID]bool{}
+	ids := make([]domain.ClientID, 0, len(parts))
+	for _, part := range parts {
+		id := domain.ClientID(part)
+		if seen[id] || !domain.IsSupportedClient(id) {
+			return nil, ErrTargets
+		}
+		seen[id] = true
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids, nil
+}
+
+// Compatibility does not turn unusable/unknown-schema input into an empty,
+// successful package. Valid siblings remain available on partial input.
+func Compatibility(p project.Result, ids []domain.ClientID) ([]planner.ClientCompatibility, error) {
+	if p.Facts.Package == nil {
+		return nil, nil
+	}
+	return planner.Compatibility(*p.Facts.Package, ids)
+}
+
+type Schema struct {
+	ID     string `json:"id"`
+	Digest string `json:"digest"`
+}
+type Capabilities struct {
+	Schemas  []Schema                      `json:"schemas"`
+	Profiles []conformance.ProfileIdentity `json:"profiles"`
+	Clients  []domain.ClientCapabilities   `json:"clients"`
+	Commands []string                      `json:"commands"`
+	Evidence []string                      `json:"evidence_limits"`
+}
+
+// Engine uses embedded schema checksums, shared profiles and the live registry.
+// Commands must come from the actual registration table, never a roadmap list.
+func Engine(commands []string) (*Capabilities, error) {
+	registry, err := specregistry.New()
+	if err != nil {
+		return nil, err
+	}
+	c := &Capabilities{Profiles: conformance.ProfileIdentities(), Commands: append([]string{}, commands...),
+		Evidence: []string{"static_only", "no_path_lookup", "no_executable_version_probe", "no_runtime_or_oauth_evidence", "native_files_metadata_only"}}
+	for _, id := range []string{domain.PluginSchemaV1, domain.MCPSchemaV1} {
+		digest, ok := registry.Digest(id)
+		if !ok || !registry.Supports(id) {
+			return nil, errors.New("embedded schema unavailable")
+		}
+		c.Schemas = append(c.Schemas, Schema{id, digest})
+	}
+	for _, def := range domain.ClientDefinitions() {
+		c.Clients = append(c.Clients, def.Capabilities)
+	}
+	sort.Strings(c.Commands)
+	sort.Slice(c.Clients, func(i, j int) bool { return c.Clients[i].ClientID < c.Clients[j].ClientID })
+	return c, nil
+}

--- a/cli/plugin-kit-ai/internal/authoring/readiness/readiness_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/readiness/readiness_test.go
@@ -1,0 +1,132 @@
+package readiness
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/project"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/packageview"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/conformance"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/planner"
+)
+
+func TestTargetsRegistryAndBounds(t *testing.T) {
+	for _, def := range domain.ClientDefinitions() {
+		ids, err := Targets(string(def.ID))
+		if err != nil || !reflect.DeepEqual(ids, []domain.ClientID{def.ID}) {
+			t.Fatalf("registry %s: %v", def.ID, err)
+		}
+	}
+	for _, bad := range []string{"", "all", "codex,codex", "codex,", ",codex", "Codex", " codex", "codex,secret-value", strings.Repeat("x", 4097)} {
+		if _, err := Targets(bad); err != ErrTargets {
+			t.Fatalf("expected fixed error for bounded invalid selection")
+		}
+	}
+	ids, err := Targets("cursor,codex")
+	if err != nil || ids[0] != domain.ClientCodex {
+		t.Fatal(ids, err)
+	}
+}
+
+func TestEngineSharedMetadataCopies(t *testing.T) {
+	names := []string{"inspect", "capabilities"}
+	c, err := Engine(names)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(c.Profiles, conformance.ProfileIdentities()) {
+		t.Fatal("profile drift")
+	}
+	if len(c.Clients) != len(domain.ClientDefinitions()) {
+		t.Fatal("frozen registry")
+	}
+	for _, v := range c.Clients {
+		want, ok := planner.Capabilities(v.ClientID)
+		if !ok || !reflect.DeepEqual(v, want) {
+			t.Fatal("client metadata drift")
+		}
+	}
+	c.Commands[0] = "changed"
+	c.Clients[0].MCPTransports["stdio"] = "changed"
+	again, err := Engine(names)
+	if err != nil || again.Commands[0] == "changed" || again.Clients[0].MCPTransports["stdio"] == "changed" || names[0] != "inspect" {
+		t.Fatal("mutable metadata shared")
+	}
+	if len(c.Schemas) != 2 || c.Schemas[0].Digest == "" {
+		t.Fatal("missing embedded metadata")
+	}
+}
+
+func TestCompatibilityUnknownAndPlannerParity(t *testing.T) {
+	got, err := Compatibility(project.Result{}, []domain.ClientID{domain.ClientCursor})
+	if err != nil || got != nil {
+		t.Fatal("guessed capabilities for unavailable schema")
+	}
+	p := project.Result{Facts: conformance.Facts{Package: &domain.PackageEnvelope{}}}
+	ids := domain.SupportedClientIDs()
+	got, err = Compatibility(p, ids)
+	want, e := planner.Compatibility(*p.Facts.Package, ids)
+	if err != nil || e != nil || !reflect.DeepEqual(got, want) {
+		t.Fatal("second compatibility semantics")
+	}
+}
+
+func TestRetainedExecutableTraversal(t *testing.T) {
+	entries := map[string]packageview.Observation{}
+	for _, o := range []packageview.Observation{
+		{Path: "bin", Kind: "directory", State: packageview.Present, Captured: true},
+		{Path: "bin/server", Kind: "file", State: packageview.Present, Captured: true, Executable: true},
+		{Path: "link", Kind: "symlink", Target: "bin/server", State: packageview.Present, Captured: true},
+		{Path: "escape", Kind: "symlink", Target: "../outside", State: packageview.Present, Captured: true},
+		{Path: "loop", Kind: "symlink", Target: "loop", State: packageview.Present, Captured: true},
+		{Path: "blocked", Kind: "file", State: packageview.Blocked},
+	} {
+		entries[o.Path] = o
+	}
+	for _, tt := range []struct{ path, status string }{
+		{"${PLUGIN_ROOT}/bin/server", "pass"}, {"./link", "pass"}, {"bin/../bin/server", "pass"},
+		{"missing/../bin/server", "fail"}, {"bin/server/../server", "fail"}, {"./escape", "fail"},
+		{"./loop", "not_evaluated"}, {"./blocked", "not_evaluated"}, {"${PLUGIN_DATA}/server", "not_evaluated"},
+		{"/outside", "not_evaluated"}, {"C:\\outside", "not_evaluated"}, {"bin", "fail"},
+	} {
+		_, s := resolve(entries, tt.path, true)
+		if s != tt.status {
+			t.Fatalf("%s: %s != %s", tt.path, s, tt.status)
+		}
+	}
+	if _, s := resolve(entries, "missing", false); s != "not_evaluated" {
+		t.Fatal("incomplete absence invented")
+	}
+}
+
+func TestDoctorMetadataOnlyAndNoLeak(t *testing.T) {
+	p := project.Result{Facts: conformance.Facts{Package: &domain.PackageEnvelope{}}, Input: packageview.Input{Inventory: []packageview.Observation{
+		{Path: "package.json", Kind: "file", State: packageview.Present, Captured: true},
+		{Path: "package-lock.json", Kind: "file", State: packageview.Present, Captured: true},
+		{Path: "secret-marker", Kind: "file", State: packageview.Present, Captured: true},
+	}}}
+	checks := Doctor(p)
+	statuses := map[string]string{}
+	for _, c := range checks {
+		statuses[c.ID] = c.Status
+	}
+	if statuses["node_project_file"] != "pass" || statuses["node_lockfile_presence"] != "pass" || statuses["node_dependency_consistency"] != "not_evaluated" {
+		t.Fatal(checks)
+	}
+	p.Input.Inventory = append(p.Input.Inventory, packageview.Observation{Path: "yarn.lock", Kind: "file", State: packageview.Present, Captured: true})
+	for _, c := range Doctor(p) {
+		if c.ID == "node_lockfile_presence" && c.Status != "not_evaluated" {
+			t.Fatal("ambiguous manager passed")
+		}
+	}
+	b, _ := json.Marshal(checks)
+	if strings.Contains(string(b), "secret-marker") {
+		t.Fatal("raw inventory leaked")
+	}
+	if len(Doctor(project.Result{Input: p.Input})) != 0 {
+		t.Fatal("unknown schema native guesses")
+	}
+}

--- a/cli/plugin-kit-ai/internal/authoring/report/report.go
+++ b/cli/plugin-kit-ai/internal/authoring/report/report.go
@@ -9,10 +9,12 @@ import (
 	"sort"
 
 	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/project"
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/readiness"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/pathpolicy"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/packageview"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/conformance"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/planner"
 )
 
 type State string
@@ -76,34 +78,39 @@ type Error struct {
 	Action string `json:"action"`
 }
 type Report struct {
-	Schema      string      `json:"schema"`
-	Engine      string      `json:"engine"`
-	Revision    string      `json:"revision"`
-	Command     string      `json:"command"`
-	Mode        string      `json:"mode"`
-	Root        string      `json:"root,omitempty"`
-	Identity    Identity    `json:"identity"`
-	Coverage    Coverage    `json:"coverage"`
-	Profiles    []Profile   `json:"profiles"`
-	SchemaIDs   []string    `json:"schema_ids"`
-	Loadability Assessment  `json:"loadability"`
-	Conformance Assessment  `json:"normative_conformance"`
-	HostSafety  Assessment  `json:"host_safety"`
-	Readiness   Assessment  `json:"authoring_readiness"`
-	Release     Assessment  `json:"release_policy"`
-	Runtime     Assessment  `json:"runtime_evidence"`
-	Findings    []Finding   `json:"findings"`
-	Components  []Component `json:"components"`
-	Checks      []Check     `json:"checks"`
-	Committed   bool        `json:"committed"`
-	Paths       []string    `json:"affected_paths"`
-	Error       *Error      `json:"error,omitempty"`
+	Compatibility Assessment                    `json:"compatibility"`
+	Clients       []planner.ClientCompatibility `json:"clients,omitempty"`
+	Capabilities  *readiness.Capabilities       `json:"capabilities,omitempty"`
+	Toolchain     Assessment                    `json:"toolchain"`
+	DoctorChecks  []readiness.Check             `json:"doctor_checks,omitempty"`
+	Schema        string                        `json:"schema"`
+	Engine        string                        `json:"engine"`
+	Revision      string                        `json:"revision"`
+	Command       string                        `json:"command"`
+	Mode          string                        `json:"mode"`
+	Root          string                        `json:"root,omitempty"`
+	Identity      Identity                      `json:"identity"`
+	Coverage      Coverage                      `json:"coverage"`
+	Profiles      []Profile                     `json:"profiles"`
+	SchemaIDs     []string                      `json:"schema_ids"`
+	Loadability   Assessment                    `json:"loadability"`
+	Conformance   Assessment                    `json:"normative_conformance"`
+	HostSafety    Assessment                    `json:"host_safety"`
+	Readiness     Assessment                    `json:"authoring_readiness"`
+	Release       Assessment                    `json:"release_policy"`
+	Runtime       Assessment                    `json:"runtime_evidence"`
+	Findings      []Finding                     `json:"findings"`
+	Components    []Component                   `json:"components"`
+	Checks        []Check                       `json:"checks"`
+	Committed     bool                          `json:"committed"`
+	Paths         []string                      `json:"affected_paths"`
+	Error         *Error                        `json:"error,omitempty"`
 }
 
 func assessment(s State) Assessment { return Assessment{Status: s, FindingIDs: []string{}} }
 func New(command, revision string) Report {
 	return Report{Schema: "agentplugins-authoring-report/v1", Engine: "standard-first-slice/1", Revision: revision,
-		Command: command, Mode: "read", Coverage: Coverage{Plugin: NotEvaluated, MCP: NotEvaluated, Skills: NotEvaluated, Filesystem: NotEvaluated}, Profiles: []Profile{}, SchemaIDs: []string{}, Findings: []Finding{}, Components: []Component{}, Checks: []Check{}, Paths: []string{},
+		Compatibility: assessment(NotEvaluated), Toolchain: assessment(NotEvaluated), Command: command, Mode: "read", Coverage: Coverage{Plugin: NotEvaluated, MCP: NotEvaluated, Skills: NotEvaluated, Filesystem: NotEvaluated}, Profiles: []Profile{}, SchemaIDs: []string{}, Findings: []Finding{}, Components: []Component{}, Checks: []Check{}, Paths: []string{},
 		Loadability: assessment(NotEvaluated), Conformance: assessment(NotEvaluated), HostSafety: assessment(NotEvaluated), Readiness: assessment(NotEvaluated), Release: assessment(NotEvaluated), Runtime: assessment(NotEvaluated)}
 }
 func opaque(s string) string {
@@ -338,7 +345,7 @@ func (r *Report) finish() {
 	sort.Slice(r.Findings, func(i, j int) bool { return r.Findings[i].ID < r.Findings[j].ID })
 	sort.Slice(r.Components, func(i, j int) bool { return r.Components[i].ID < r.Components[j].ID })
 	r.SchemaIDs = unique(r.SchemaIDs)
-	for _, a := range []*Assessment{&r.Loadability, &r.Conformance, &r.HostSafety, &r.Readiness, &r.Release, &r.Runtime} {
+	for _, a := range []*Assessment{&r.Loadability, &r.Conformance, &r.HostSafety, &r.Readiness, &r.Release, &r.Runtime, &r.Compatibility, &r.Toolchain} {
 		a.FindingIDs = unique(a.FindingIDs)
 	}
 	for i := range r.Checks {
@@ -356,5 +363,52 @@ func unique(v []string) []string {
 	return out
 }
 func (r Report) Successful() bool {
-	return r.Error == nil && r.Readiness.Status == Pass && r.Release.Status != Fail
+	if r.Command == "capabilities" {
+		return r.Error == nil && r.Capabilities != nil
+	}
+	return r.Error == nil && r.Readiness.Status == Pass && r.Release.Status != Fail && r.Compatibility.Status != Fail && (r.Command != "doctor" || r.Toolchain.Status == Pass)
+}
+
+// AddCompatibility attaches only the planner's explicitly sanitized static DTO.
+func (r *Report) AddCompatibility(clients []planner.ClientCompatibility) {
+	r.Clients = clients
+	if clients == nil {
+		return
+	}
+	r.Compatibility = assessment(Pass)
+	for _, c := range clients {
+		for _, component := range c.Components {
+			if component.Support == "unsupported" {
+				id := r.add(Finding{Code: "target_component_unsupported", Layer: "compatibility", Rule: "planner/static-support", ItemID: opaque(string(c.ClientID) + ":" + string(component.Kind)), Severity: "error"})
+				r.Compatibility.Status = Fail
+				r.Compatibility.FindingIDs = append(r.Compatibility.FindingIDs, id)
+			}
+		}
+	}
+	r.finish()
+}
+
+// Doctor readiness is distinct from valid package authoring and from execution.
+// Unknown runtime proof must never become a passed toolchain assessment.
+func (r *Report) AddDoctor(checks []readiness.Check) {
+	r.DoctorChecks = checks
+	r.Toolchain = assessment(NotEvaluated)
+	if r.Loadability.Status == Pass && r.Readiness.Status == Pass {
+		r.Toolchain.Status = Pass
+	}
+	for _, check := range checks {
+		if check.Status == "pass" {
+			continue
+		}
+		severity := "warning"
+		if check.Status == "fail" {
+			severity = "error"
+			r.Toolchain.Status = Fail
+		} else if r.Toolchain.Status == Pass {
+			r.Toolchain.Status = NotEvaluated
+		}
+		id := r.add(Finding{Code: check.ID, Layer: "toolchain", Rule: "authoring/static-evidence", ItemID: check.ItemID, Severity: severity})
+		r.Toolchain.FindingIDs = append(r.Toolchain.FindingIDs, id)
+	}
+	r.finish()
 }

--- a/install/integrationctl/agentplugins/planner/compatibility.go
+++ b/install/integrationctl/agentplugins/planner/compatibility.go
@@ -90,6 +90,10 @@ func compatibilityFor(envelope domain.PackageEnvelope, capabilities domain.Clien
 	// bounds. No detected client or DeliveryPlan is constructed.
 	decisions := componentDecisions(envelope, capabilities)
 	invalid := make(map[domain.ComponentKind]map[string]bool)
+	// Empty names are exact item identities, never a kind-wide sentinel.
+	invalidKind := map[domain.ComponentKind]bool{
+		domain.ComponentSkill: envelope.Inventory.InvalidSkillsRoot,
+	}
 	mark := func(kind domain.ComponentKind, name string) {
 		if invalid[kind] == nil {
 			invalid[kind] = make(map[string]bool)
@@ -114,7 +118,11 @@ func compatibilityFor(envelope domain.PackageEnvelope, capabilities domain.Clien
 		switch diagnostic.Boundary {
 		case domain.BoundarySkill:
 			kind = domain.ComponentSkill
-		case domain.BoundaryMCP, domain.BoundaryMCPServer:
+		case domain.BoundaryMCP:
+			// This boundary describes the MCP document, not a server key.
+			invalidKind[domain.ComponentMCPServer] = true
+			continue
+		case domain.BoundaryMCPServer:
 			kind = domain.ComponentMCPServer
 		case domain.BoundaryApp:
 			kind = domain.ComponentApp
@@ -127,9 +135,6 @@ func compatibilityFor(envelope domain.PackageEnvelope, capabilities domain.Clien
 	}
 	for kind, names := range invalid {
 		for name := range names {
-			if name == "" {
-				continue
-			}
 			found := false
 			for _, item := range decisions {
 				if item.Kind == kind && item.Name == name {
@@ -159,17 +164,13 @@ func compatibilityFor(envelope domain.PackageEnvelope, capabilities domain.Clien
 		if item.Reason != "" {
 			component.Limitations = append(component.Limitations, item.Reason)
 		}
-		if invalid[item.Kind][item.Name] || invalid[item.Kind][""] {
+		if invalid[item.Kind][item.Name] || invalidKind[item.Kind] {
 			reject("invalid_component")
 		}
 		switch item.Kind {
 		case domain.ComponentExtension:
 			// The registry has no namespace-specific interpreter contract.
 			reject("extension_semantics_not_established")
-		case domain.ComponentSkill:
-			if envelope.Inventory.InvalidSkillsRoot {
-				reject("invalid_component")
-			}
 		case domain.ComponentMCPServer:
 			if envelope.MCP.Present && !envelope.MCP.Enabled {
 				reject("component_disabled")

--- a/install/integrationctl/agentplugins/planner/compatibility.go
+++ b/install/integrationctl/agentplugins/planner/compatibility.go
@@ -1,0 +1,200 @@
+package planner
+
+import (
+	"errors"
+	"sort"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+// ErrUnknownCompatibilityClient is deliberately independent of the supplied
+// target text, which may contain secrets or an arbitrarily large string.
+var ErrUnknownCompatibilityClient = errors.New("unknown compatibility client")
+
+// ComponentCompatibility describes static adapter support, never activation.
+// Index is one-based within Kind, ordered by the input's component map keys
+// (including invalid inventory entries). Names are intentionally not returned:
+// even malformed component keys and diagnostic items can contain secrets/paths.
+type ComponentCompatibility struct {
+	Kind        domain.ComponentKind `json:"kind"`
+	Index       int                  `json:"index"`
+	Support     domain.SupportLevel  `json:"support"`
+	Limitations []string             `json:"limitations,omitempty"`
+}
+
+// ClientCompatibility separates registry metadata from conservative decisions
+// about this envelope. Capabilities are an independent copy of the registry;
+// its generic extension support does not establish any namespace's semantics.
+// Limitations are fixed codes, never raw diagnostics or configuration data.
+type ClientCompatibility struct {
+	ClientID     domain.ClientID           `json:"client_id"`
+	Capabilities domain.ClientCapabilities `json:"capabilities"`
+	Components   []ComponentCompatibility  `json:"components"`
+	Limitations  []string                  `json:"limitations"`
+}
+
+// Compatibility evaluates explicitly requested clients without host discovery,
+// I/O, lifecycle planning, or catalog/trust evaluation. Duplicate targets are
+// collapsed and results sorted by ClientID; an empty list returns an empty
+// result. Any unknown target fails the whole request with a fixed error.
+//
+// The envelope is already interpreted input, not a request to decode or validate
+// a package. Component-only envelopes are accepted. Known component errors are
+// retained without suppressing valid siblings. Neither a support level nor
+// registry activation metadata is evidence of installation, authentication,
+// OAuth, runtime readiness, client version compatibility, or publication.
+func Compatibility(envelope domain.PackageEnvelope, clients []domain.ClientID) ([]ClientCompatibility, error) {
+	targets := make(map[domain.ClientID]domain.ClientCapabilities)
+	for _, id := range clients {
+		if _, exists := targets[id]; exists {
+			continue
+		}
+		capabilities, ok := Capabilities(id)
+		if !ok {
+			return nil, ErrUnknownCompatibilityClient
+		}
+		targets[id] = capabilities
+	}
+	result := make([]ClientCompatibility, 0, len(targets))
+	ids := make([]domain.ClientID, 0, len(targets))
+	for id := range targets {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	for _, id := range ids {
+		capabilities := targets[id]
+		result = append(result, compatibilityFor(envelope, capabilities))
+	}
+	return result, nil
+}
+
+func compatibilityFor(envelope domain.PackageEnvelope, capabilities domain.ClientCapabilities) ClientCompatibility {
+	result := ClientCompatibility{
+		ClientID: capabilities.ClientID, Capabilities: capabilities,
+		Components:  make([]ComponentCompatibility, 0),
+		Limitations: []string{"static_adapter_support_only", "installation_not_checked", "authentication_not_checked", "runtime_not_checked", "client_version_not_checked", "catalog_publication_not_checked"},
+	}
+	if capabilities.ActivationMode == domain.ActivationByUser {
+		result.Limitations = append(result.Limitations, "manual_activation_required")
+	}
+	if capabilities.ClientID == domain.ClientChatGPT {
+		result.Limitations = append(result.Limitations, "chatgpt_manual_preparation_only", "remote_app_registration_not_checked")
+		if (!envelope.App.Enabled && (len(envelope.MCP.Servers) > 0 || envelope.App.Present || envelope.App.Declared)) || len(missingChatGPTAppBindings(envelope)) > 0 {
+			result.Limitations = append(result.Limitations, "chatgpt_app_binding_required")
+		}
+	}
+	if capabilities.ClientID == domain.ClientWindsurf {
+		result.Limitations = append(result.Limitations, "windsurf_channel_selection_required", "windsurf_skills_prepared_only")
+	}
+	// Reuse lifecycle component choices, then apply authoring-only uncertainty
+	// bounds. No detected client or DeliveryPlan is constructed.
+	decisions := componentDecisions(envelope, capabilities)
+	invalid := make(map[domain.ComponentKind]map[string]bool)
+	mark := func(kind domain.ComponentKind, name string) {
+		if invalid[kind] == nil {
+			invalid[kind] = make(map[string]bool)
+		}
+		invalid[kind][name] = true
+	}
+	for name := range envelope.MCP.InvalidServer {
+		mark(domain.ComponentMCPServer, name)
+	}
+	for _, name := range envelope.Inventory.InvalidMCPServer {
+		mark(domain.ComponentMCPServer, name)
+	}
+	for _, name := range envelope.Inventory.InvalidSkills {
+		mark(domain.ComponentSkill, name)
+	}
+	for _, diagnostic := range envelope.Diagnostics {
+		if diagnostic.Severity != domain.SeverityError {
+			continue
+		}
+		result.Limitations = appendUnique(result.Limitations, "input_has_errors")
+		var kind domain.ComponentKind
+		switch diagnostic.Boundary {
+		case domain.BoundarySkill:
+			kind = domain.ComponentSkill
+		case domain.BoundaryMCP, domain.BoundaryMCPServer:
+			kind = domain.ComponentMCPServer
+		case domain.BoundaryApp:
+			kind = domain.ComponentApp
+		case domain.BoundaryExtension:
+			kind = domain.ComponentExtension
+		}
+		if kind != "" {
+			mark(kind, diagnostic.Item)
+		}
+	}
+	for kind, names := range invalid {
+		for name := range names {
+			if name == "" {
+				continue
+			}
+			found := false
+			for _, item := range decisions {
+				if item.Kind == kind && item.Name == name {
+					found = true
+					break
+				}
+			}
+			if !found {
+				decisions = append(decisions, decision(kind, name, domain.SupportUnsupported))
+			}
+		}
+	}
+	sort.Slice(decisions, func(i, j int) bool {
+		if decisions[i].Kind != decisions[j].Kind {
+			return decisions[i].Kind < decisions[j].Kind
+		}
+		return decisions[i].Name < decisions[j].Name
+	})
+	counts := make(map[domain.ComponentKind]int)
+	for _, item := range decisions {
+		counts[item.Kind]++
+		component := ComponentCompatibility{Kind: item.Kind, Index: counts[item.Kind], Support: item.Support}
+		reject := func(code string) {
+			component.Support = domain.SupportUnsupported
+			component.Limitations = appendUnique(component.Limitations, code)
+		}
+		if item.Reason != "" {
+			component.Limitations = append(component.Limitations, item.Reason)
+		}
+		if invalid[item.Kind][item.Name] || invalid[item.Kind][""] {
+			reject("invalid_component")
+		}
+		switch item.Kind {
+		case domain.ComponentExtension:
+			// The registry has no namespace-specific interpreter contract.
+			reject("extension_semantics_not_established")
+		case domain.ComponentSkill:
+			if envelope.Inventory.InvalidSkillsRoot {
+				reject("invalid_component")
+			}
+		case domain.ComponentMCPServer:
+			if envelope.MCP.Present && !envelope.MCP.Enabled {
+				reject("component_disabled")
+			}
+			if capabilities.ClientID == domain.ClientChatGPT {
+				server := envelope.MCP.Servers[item.Name]
+				binding, mapped := envelope.App.Bindings[item.Name]
+				if !envelope.App.Enabled || !mapped || binding.ID == "" {
+					reject("chatgpt_app_binding_required")
+				} else if server.Type != "streamable-http" && server.Type != "sse" {
+					reject("chatgpt_remote_mcp_required")
+				} else {
+					component.Limitations = append(component.Limitations, "remote_app_registration_not_checked")
+				}
+			}
+		case domain.ComponentApp:
+			if !envelope.App.Enabled || envelope.App.Bindings[item.Name].ID == "" {
+				reject("invalid_component")
+			}
+			if capabilities.ClientID == domain.ClientChatGPT {
+				component.Limitations = append(component.Limitations, "remote_app_registration_not_checked")
+			}
+		}
+		result.Components = append(result.Components, component)
+	}
+	sort.Strings(result.Limitations)
+	return result
+}

--- a/install/integrationctl/agentplugins/planner/compatibility_test.go
+++ b/install/integrationctl/agentplugins/planner/compatibility_test.go
@@ -1,0 +1,237 @@
+package planner
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestCompatibilityRegistryMatrix(t *testing.T) {
+	e := domain.PackageEnvelope{Skills: map[string]domain.Skill{"skill": {}}, MCP: domain.MCPComponent{Servers: map[string]domain.MCPServer{"http": {Type: "streamable-http"}, "sse": {Type: "sse"}, "stdio": {Type: "stdio"}, "unknown": {Type: "future"}}}, Manifest: domain.PluginManifest{Extensions: map[string]json.RawMessage{"future.namespace": json.RawMessage(`{}`)}}}
+	for _, def := range domain.ClientDefinitions() {
+		t.Run(string(def.ID), func(t *testing.T) {
+			got, err := Compatibility(e, []domain.ClientID{def.ID})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got[0].Capabilities, def.Capabilities) {
+				t.Fatal("registry metadata differs")
+			}
+			base := componentDecisions(e, def.Capabilities)
+			for _, c := range got[0].Components {
+				if c.Kind == domain.ComponentExtension {
+					if c.Support != domain.SupportUnsupported {
+						t.Fatal("opaque extension claimed supported")
+					}
+					continue
+				}
+				var same []domain.ComponentDecision
+				for _, b := range base {
+					if b.Kind == c.Kind {
+						same = append(same, b)
+					}
+				}
+				if c.Support != same[c.Index-1].Support {
+					t.Fatalf("shared decisions diverged: %+v", c)
+				}
+			}
+			if def.Capabilities.ActivationMode == domain.ActivationByUser && !compatContains(got[0].Limitations, "manual_activation_required") {
+				t.Fatal("manual limitation missing")
+			}
+		})
+	}
+}
+
+func TestCompatibilityChatGPT(t *testing.T) {
+	for _, tc := range []struct {
+		name, transport string
+		enabled, mapped bool
+		want            domain.SupportLevel
+	}{
+		{"unmapped", "streamable-http", true, false, domain.SupportUnsupported},
+		{"disabled", "streamable-http", false, true, domain.SupportUnsupported},
+		{"remote", "streamable-http", true, true, domain.SupportProjected},
+		{"sse", "sse", true, true, domain.SupportProjected},
+		{"stdio", "stdio", true, true, domain.SupportUnsupported},
+		{"unknown", "future", true, true, domain.SupportUnsupported},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := domain.PackageEnvelope{MCP: domain.MCPComponent{Servers: map[string]domain.MCPServer{"server": {Type: tc.transport}}}, App: domain.AppComponent{Enabled: tc.enabled, Bindings: map[string]domain.AppBinding{}}}
+			if tc.mapped {
+				e.App.Bindings["server"] = domain.AppBinding{ID: "registered-reference"}
+			}
+			got, err := Compatibility(e, []domain.ClientID{domain.ClientChatGPT})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, c := range got[0].Components {
+				if c.Kind == domain.ComponentMCPServer && c.Support != tc.want {
+					t.Fatalf("wrong support: %+v", c)
+				}
+			}
+			for _, code := range []string{"chatgpt_manual_preparation_only", "remote_app_registration_not_checked"} {
+				if !compatContains(got[0].Limitations, code) {
+					t.Fatal(code)
+				}
+			}
+		})
+	}
+}
+
+func TestCompatibilityInvalidSiblings(t *testing.T) {
+	e := domain.PackageEnvelope{Skills: map[string]domain.Skill{"good": {}}, Inventory: domain.ComponentInventory{InvalidSkills: []string{"bad"}}, MCP: domain.MCPComponent{Servers: map[string]domain.MCPServer{"good": {Type: "stdio"}}, InvalidServer: map[string]domain.Diagnostic{"bad": {Message: "fixture-diagnostic"}}}, Diagnostics: []domain.Diagnostic{{Severity: domain.SeverityError, Boundary: domain.BoundarySkill, Item: "bad", Message: "fixture-diagnostic"}}}
+	got, err := Compatibility(e, []domain.ClientID{domain.ClientCursor})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got[0].Components) != 4 {
+		t.Fatal("invalid inventory lost")
+	}
+	for _, c := range got[0].Components {
+		want := domain.SupportNative
+		if c.Index == 1 {
+			want = domain.SupportUnsupported
+		}
+		if c.Support != want {
+			t.Fatalf("invalid sibling isolation: %+v", c)
+		}
+	}
+}
+
+func TestCompatibilityTargetsAndOwnership(t *testing.T) {
+	e := domain.PackageEnvelope{Skills: map[string]domain.Skill{"only": {}}}
+	a, err := Compatibility(e, []domain.ClientID{domain.ClientCursor, domain.ClientCodex, domain.ClientCursor})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, _ := Compatibility(e, []domain.ClientID{domain.ClientCodex, domain.ClientCursor})
+	if !reflect.DeepEqual(a, b) {
+		t.Fatal("duplicates/order affect output")
+	}
+	a[0].Capabilities.MCPTransports["stdio"] = domain.SupportUnsupported
+	a[0].Capabilities.Scopes[0] = domain.ScopeProject
+	c, _ := Compatibility(e, []domain.ClientID{domain.ClientCodex, domain.ClientCursor})
+	if !reflect.DeepEqual(b, c) {
+		t.Fatal("registry mutated")
+	}
+	for _, id := range []domain.ClientID{"", "CODEX", domain.ClientID(strings.Repeat("fixture-client\n/", 10000))} {
+		got, err := Compatibility(e, []domain.ClientID{domain.ClientCursor, id})
+		if got != nil || !errors.Is(err, ErrUnknownCompatibilityClient) || err.Error() != "unknown compatibility client" {
+			t.Fatal("unbounded or partial error")
+		}
+	}
+	empty, err := Compatibility(e, nil)
+	if err != nil || empty == nil || len(empty) != 0 {
+		t.Fatal("empty targets")
+	}
+}
+
+func TestCompatibilityEmptyHostAndNoSensitiveEvidence(t *testing.T) {
+	const fixtureMarker = "fixture-private-value"
+	const fixturePath = "fixtures/client/config.json"
+	e := domain.PackageEnvelope{
+		SnapshotRoot: fixturePath,
+		Source:       domain.SourceIdentity{RequestedSource: fixturePath},
+		Manifest: domain.PluginManifest{Extensions: map[string]json.RawMessage{
+			fixtureMarker: json.RawMessage(`{"opaque_note":"fixture-private-value"}`),
+		}},
+		Skills: map[string]domain.Skill{
+			fixtureMarker: {RelativePath: fixturePath, Raw: []byte(fixtureMarker)},
+		},
+		MCP: domain.MCPComponent{Servers: map[string]domain.MCPServer{
+			fixtureMarker: {
+				Type: "stdio",
+				Decoded: map[string]any{
+					"env":     map[string]string{"FIXTURE_NOTE": fixtureMarker},
+					"headers": map[string]string{"X-Fixture-Note": fixtureMarker},
+					"args":    []string{fixtureMarker, fixturePath},
+				},
+				StdioRequirement: &domain.StdioRequirement{Command: fixturePath},
+			},
+		}},
+		Diagnostics: []domain.Diagnostic{{
+			Severity: domain.SeverityError, Boundary: domain.BoundaryApp,
+			Item: fixtureMarker, Code: fixtureMarker, Path: fixturePath, Message: fixtureMarker,
+		}},
+		CatalogEvidence: &domain.CatalogEvidence{},
+	}
+	before, _ := json.Marshal(e)
+	a, err := Compatibility(e, domain.SupportedClientIDs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", home)
+	t.Setenv("XDG_CONFIG_HOME", home)
+	t.Setenv("USERPROFILE", home)
+	b, err := Compatibility(e, domain.SupportedClientIDs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(a, b) {
+		t.Fatal("host affected output")
+	}
+	entries, err := os.ReadDir(home)
+	if err != nil || len(entries) != 0 {
+		t.Fatal("host write")
+	}
+	after, _ := json.Marshal(e)
+	if string(before) != string(after) {
+		t.Fatal("input mutated")
+	}
+	raw, _ := json.Marshal(b)
+	if strings.Contains(string(raw), fixtureMarker) || strings.Contains(string(raw), fixturePath) {
+		t.Fatalf("sensitive output: %s", raw)
+	}
+	e.CatalogEvidence = nil
+	without, _ := Compatibility(e, domain.SupportedClientIDs())
+	if !reflect.DeepEqual(b, without) {
+		t.Fatal("catalog influenced static output")
+	}
+	for _, client := range b {
+		for _, code := range []string{"installation_not_checked", "authentication_not_checked", "runtime_not_checked", "client_version_not_checked", "catalog_publication_not_checked"} {
+			if !compatContains(client.Limitations, code) {
+				t.Fatal(code)
+			}
+		}
+	}
+}
+
+func compatContains(items []string, want string) bool {
+	for _, s := range items {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCompatibilityDisabledAndComponentOnly(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		envelope domain.PackageEnvelope
+		want     domain.SupportLevel
+	}{
+		{"skill-only", domain.PackageEnvelope{Skills: map[string]domain.Skill{"one": {}}}, domain.SupportNative},
+		{"mcp-only", domain.PackageEnvelope{MCP: domain.MCPComponent{Servers: map[string]domain.MCPServer{"one": {Type: "stdio"}}}}, domain.SupportNative},
+		{"disabled-mcp", domain.PackageEnvelope{MCP: domain.MCPComponent{Present: true, Servers: map[string]domain.MCPServer{"one": {Type: "stdio"}}}}, domain.SupportUnsupported},
+		{"invalid-root", domain.PackageEnvelope{Skills: map[string]domain.Skill{"one": {}}, Inventory: domain.ComponentInventory{InvalidSkillsRoot: true}}, domain.SupportUnsupported},
+		{"app-other-client", domain.PackageEnvelope{App: domain.AppComponent{Enabled: true, Bindings: map[string]domain.AppBinding{"one": {ID: "reference"}}}}, domain.SupportUnsupported},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Compatibility(tc.envelope, []domain.ClientID{domain.ClientCursor})
+			if err != nil || len(got[0].Components) != 1 || got[0].Components[0].Support != tc.want {
+				t.Fatalf("got %+v, %v", got, err)
+			}
+		})
+	}
+	got, err := Compatibility(domain.PackageEnvelope{}, []domain.ClientID{domain.ClientChatGPT})
+	if err != nil || len(got[0].Components) != 0 {
+		t.Fatal("empty package invented components")
+	}
+}

--- a/install/integrationctl/agentplugins/planner/compatibility_test.go
+++ b/install/integrationctl/agentplugins/planner/compatibility_test.go
@@ -235,3 +235,73 @@ func TestCompatibilityDisabledAndComponentOnly(t *testing.T) {
 		t.Fatal("empty package invented components")
 	}
 }
+
+// Exact keys, even empty ones, are identities in every item-level source.
+func TestCompatibilityEmptyInvalidIdentity(t *testing.T) {
+	for _, source := range []string{"map", "inventory", "diagnostic", "overlap"} {
+		for _, name := range []string{"", "a-private-invalid-name", "z-private-invalid-name"} {
+			t.Run(source+"/"+name, func(t *testing.T) {
+				e := domain.PackageEnvelope{MCP: domain.MCPComponent{Servers: map[string]domain.MCPServer{"good": {Type: "stdio"}}}}
+				switch source {
+				case "map":
+					e.MCP.InvalidServer = map[string]domain.Diagnostic{name: {}}
+				case "inventory":
+					e.Inventory.InvalidMCPServer = []string{name}
+				case "overlap":
+					e.MCP.Servers[name] = domain.MCPServer{Type: "stdio"}
+					fallthrough
+				case "diagnostic":
+					e.Diagnostics = []domain.Diagnostic{{Severity: domain.SeverityError, Boundary: domain.BoundaryMCPServer, Item: name}}
+				}
+				var first []byte
+				for repeat := 0; repeat < 10; repeat++ {
+					got, err := Compatibility(e, []domain.ClientID{domain.ClientCursor})
+					if err != nil || len(got[0].Components) != 2 {
+						t.Fatalf("inventory: %+v, %v", got, err)
+					}
+					for i, c := range got[0].Components {
+						invalid := (i == 0) == (name < "good")
+						want := domain.SupportNative
+						if invalid {
+							want = domain.SupportUnsupported
+						}
+						if c.Kind != domain.ComponentMCPServer || c.Index != i+1 || c.Support != want || compatContains(c.Limitations, "invalid_component") != invalid {
+							t.Fatalf("identity boundary: %+v", c)
+						}
+					}
+					raw, _ := json.Marshal(got)
+					if strings.Contains(string(raw), "private-invalid-name") || strings.Contains(string(raw), `"good"`) {
+						t.Fatal("name disclosure")
+					}
+					if repeat > 0 && string(raw) != string(first) {
+						t.Fatal("unstable indexes")
+					}
+					first = raw
+				}
+			})
+		}
+	}
+}
+
+func TestCompatibilityDocumentBoundary(t *testing.T) {
+	for _, item := range []string{"", "document-private-marker"} {
+		e := domain.PackageEnvelope{
+			Skills:      map[string]domain.Skill{"good": {}},
+			MCP:         domain.MCPComponent{Servers: map[string]domain.MCPServer{"": {Type: "stdio"}, "good": {Type: "stdio"}}},
+			Diagnostics: []domain.Diagnostic{{Severity: domain.SeverityError, Boundary: domain.BoundaryMCP, Item: item}},
+		}
+		got, err := Compatibility(e, []domain.ClientID{domain.ClientCursor})
+		if err != nil || len(got[0].Components) != 3 {
+			t.Fatalf("document boundary invented inventory: %+v, %v", got, err)
+		}
+		for _, c := range got[0].Components {
+			want := domain.SupportNative
+			if c.Kind == domain.ComponentMCPServer {
+				want = domain.SupportUnsupported
+			}
+			if c.Support != want {
+				t.Fatalf("document boundary: %+v", c)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds explicit client compatibility, engine capabilities and static source-project doctor commands through both internal authoring entrypoints. Compatibility uses the existing client registry without installed clients; doctor uses captured metadata and leaves executable versions, dependency consistency, runtime and OAuth unproven.

Follows merged #157. Based on main at e92f40976fd06ed96eefa87d655f13ad7b9a2e23. This is Phase 4, not the Phase 6 public cutover; default v1 builds stay unchanged.

Validation at 783ab8d794c93c08bc46757ed80d2fa51688efb5 (tree identical to tested 3cc9dccb):
- Authoring, factory and planner suites passed after rebasing onto the first PR fixes.
- Both actual native binaries passed compatibility/capabilities/doctor E2E. Added commands ran under a calibrated Linux Landlock/seccomp fixture that denies network, child execution, HOME file access and source writes while allowing private reader scratch. This proves denial, not a trace of every attempted access.
- Independent review found one P2 involving empty MCP server names. The correction separates item identities from document-wide invalidity; baseline-failing regressions now pass through compat and inspect at both mounts. Post-commit planner/commands and confined native checks passed. Earlier focused/race/vet and CLI regression checks also passed.
- Final required CI, CodeQL, security checks, documentation checks and Linux/Windows installer smoke passed on this head. The draft CodeRabbit check is a skip, not independent review evidence.

The bounded diff includes the pure compatibility API and tests. Native platform support, Skills authoring and release packaging remain separate gates. Revert this PR independently to remove these read-only commands while retaining #157.
