### PR TITLE
docs: record final public E2E closure

### DIFF
--- a/docs/E2E_AND_COMPETITIVE_LAUNCH_PLAN.md
+++ b/docs/E2E_AND_COMPETITIVE_LAUNCH_PLAN.md
@@ -8,19 +8,20 @@ this page keeps the user-visible evidence and honest limits in one place.
 
 | Area | Evidence | Result |
 | --- | --- | --- |
-| CLI source | `9b1bf99ed5cc5b5bb02a825ed90d5ef07ffa8464` | Security checks, grouped discovery search, typo recovery, URL-backed filters, and route-scoped site data are merged |
+| CLI source | release `aa9e03e4e6bc9eb044aedde8be1d1ff4ea514a2c`; post-release main checkpoint `a281a54c77f618903868008f838858aa3acbf0ca` | The public launch claim is bound to the released commit; later standard-first authoring work on main is not represented as already released |
 | Security scanner | [`lintai v0.1.3`](https://github.com/777genius/lintai/releases/tag/v0.1.3), run [`33974725553`](https://github.com/777genius/lintai/actions/runs/33974725553) | Agent Plugins 1.0 scan contract released for every CLI-supported platform; noisy path and remote-instruction matches narrowed |
-| Native release | [`agentplugins-v0.1.50`](https://github.com/777genius/universal-agent-plugins/releases/tag/agentplugins-v0.1.50), run [`33993393392`](https://github.com/777genius/universal-agent-plugins/actions/runs/33993393392) | Six platform builds and native runtime proofs passed |
-| npm release | [npm workflow `33994016590`](https://github.com/777genius/universal-agent-plugins/actions/runs/33994016590), attempt 2 | Trusted Publisher, provenance, signatures, and public lifecycle verification passed after npm finished processing the published version |
-| Public package | `universal-agent-plugins@0.1.50` | `latest` points to `0.1.50`; registry integrity matches the staged tarball |
-| Lifecycle | Fresh GitHub-hosted sandbox in release CI | `add`, `info`, `update`, and `remove` passed for Codex, Cursor, and Kiro; OpenCode repair passed |
-| Public search | `npx --yes universal-agent-plugins@0.1.50 search contex7` in a fresh disposable home | Typo recovery returned the reviewed Context7 primary and the target-free `npx universal-agent-plugins add context7` command; `--details` retains alternate-source visibility |
+| Native release | [`agentplugins-v0.1.51`](https://github.com/777genius/universal-agent-plugins/releases/tag/agentplugins-v0.1.51), run [`34001219785`](https://github.com/777genius/universal-agent-plugins/actions/runs/34001219785) | Six platform builds, checksums, release manifest, and native runtime proofs passed |
+| npm release | [npm workflow `34001764906`](https://github.com/777genius/universal-agent-plugins/actions/runs/34001764906) | Trusted Publisher, provenance, signatures, and public lifecycle verification passed |
+| Public package | `universal-agent-plugins@0.1.51` | `latest` points to `0.1.51`; registry integrity matches the staged tarball |
+| Lifecycle | Existing isolated Linux test host, fresh disposable `/tmp` sandbox | Public `0.1.51` completed `add`, `info`, `update`, and `remove` for explicit Codex, Cursor, and Kiro targets against the reviewed upstream Context7 distribution; final `doctor` reported zero installations and zero open operations |
+| Public search | `npx --yes universal-agent-plugins@0.1.51 search contex7 --details` in a fresh disposable home | Typo recovery returned the reviewed upstream Context7 primary and the target-free `npx universal-agent-plugins add context7` command; alternate-source provenance remains available only in detailed output |
 | Public warning canary | `npx --yes universal-agent-plugins@0.1.49 add /path/to/disposable-fixture --target codex --dry-run` | Four non-blocking findings returned exit 0 without a confirmation prompt; the default showed three notes plus one hidden count, while `--security-details` showed all four; no client files were changed |
-| Public signed-index canary | `npx --yes universal-agent-plugins@0.1.49 add 'discovery:upstash/context7//plugins/agent-plugins/context7' --target codex --dry-run` | Exact public Context7 revision passed in a fresh disposable home after sequence 4 reached the product mirror; no LintAI binary was downloaded and no client files were changed |
-| Directory | [sequence 35](https://777genius.github.io/universal-agent-plugins-registry/registry/schemas/1/latest.json), run [`33993993072`](https://github.com/777genius/universal-agent-plugins-registry/actions/runs/33993993072) | Exact production observation passed for 28 products and 35 distributions; seven withdrawn revisions remain explicit revocations |
-| Discovery | [sequence 38](https://777genius.github.io/universal-agent-plugins-registry/discovery/latest.json), run [`33966346960`](https://github.com/777genius/universal-agent-plugins-registry/actions/runs/33966346960), 3,024 records | Exact production verification passed; snapshot digest `sha256:9d29e278406b2f10cfbf632ab538bbc675aaeb7f38d0b3bd31dc64409fea96c7` |
-| Security Index | [sequence 4](https://777genius.github.io/universal-agent-plugins-registry/security/latest.json), run [`33975646164`](https://github.com/777genius/universal-agent-plugins-registry/actions/runs/33975646164), 2,752 subjects | 2,747 exact package revisions assessed with LintAI 0.1.3 and policy v2; 5 acquisition or scan checks unavailable; 2,366 have no blocking finding, 381 have warnings, and none are classified as blocking; snapshot digest `sha256:b41e8cd7ae9aaf5f630fcb5bda9bec7f7cb815abc0b758a6f0f40fc9b8c8161b` |
-| Product site | main `9b1bf99ed5cc5b5bb02a825ed90d5ef07ffa8464`, [Pages run `33993369525`](https://github.com/777genius/universal-agent-plugins/actions/runs/33993369525) | Signed feeds load, one primary package is shown per product, alternate distributions stay under `Other sources`, typo search and shareable filters work, and client pages copy a valid command |
+| Public signed-index canary | Public `0.1.51` Context7 lifecycle on Directory sequence 37 | The short alias resolved to `upstash/context7@769c6cd22c3d95462d1f55d789e9532cabefa5a9//plugins/agent-plugins/context7`; the signed identity was preserved through add, info, update, and remove |
+| Directory | [sequence 37](https://777genius.github.io/universal-agent-plugins-registry/registry/schemas/1/latest.json), run [`34014230574`](https://github.com/777genius/universal-agent-plugins-registry/actions/runs/34014230574) | Exact production observation passed for 28 products and 36 distributions; Context7 is official-upstream first for all 10 supported clients and retains the reviewed bridge as fallback; snapshot digest `sha256:f03cbf0e4e12e0f01d59497765ef547e5ed83df9cc11223bf1c9a64d3d06ba7f` |
+| Discovery | [sequence 40](https://777genius.github.io/universal-agent-plugins-registry/discovery/latest.json), run [`34014943629`](https://github.com/777genius/universal-agent-plugins-registry/actions/runs/34014943629), 3,024 records | Exact production verification and an independent portable signature check passed; snapshot digest `sha256:9eba42619f65bd505af0914d5f67c72d0e9ef65a6416306761024d2d02c38605` |
+| Security Index | [sequence 8](https://777genius.github.io/universal-agent-plugins-registry/security/latest.json), run [`34017085675`](https://github.com/777genius/universal-agent-plugins-registry/actions/runs/34017085675), 2,751 subjects | 2,746 exact package revisions were assessed with LintAI 0.1.3 and policy v2; 5 checks were unavailable, 2,365 had no blocking finding, 381 had warnings, and none were classified as blocking; snapshot digest `sha256:7f24057d9e37d9905cc2371621e25dc201000347a95594ec7001d71ea24242a7` |
+| Feed freshness | run [`34017918030`](https://github.com/777genius/universal-agent-plugins-registry/actions/runs/34017918030) | Directory, Discovery, and Security signatures were reacquired from public Pages and all retained more than 48 hours of validity |
+| Product site | main `a281a54c77f618903868008f838858aa3acbf0ca`, [Pages run `34017177213`](https://github.com/777genius/universal-agent-plugins/actions/runs/34017177213) | Production Pages completed successfully; the public landing and Context7 page returned complete HTML, and the landing exposes the target-free `npx universal-agent-plugins add context7` command |
 | Route payload | product PR [`#152`](https://github.com/777genius/universal-agent-plugins/pull/152) | Gzip payload is 58,511 bytes for a plugin page, 55,448 bytes for `/download/`, and 84,185 bytes for the catalog home page |
 | Legacy registry landing | registry PRs [`#272`](https://github.com/777genius/universal-agent-plugins-registry/pull/272) and [`#273`](https://github.com/777genius/universal-agent-plugins-registry/pull/273) | A headless public-browser proof reached the product catalog with no failed requests; signed machine feeds and deep assets remain at their stable URLs |
 
@@ -64,12 +65,13 @@ user choose one or several. Target-specific automation can use
 
 The exact CI evidence is available from the repositories:
 
-- [native release run 33993393392](https://github.com/777genius/universal-agent-plugins/actions/runs/33993393392)
-- [npm publish run 33994016590](https://github.com/777genius/universal-agent-plugins/actions/runs/33994016590)
+- [native release run 34001219785](https://github.com/777genius/universal-agent-plugins/actions/runs/34001219785)
+- [npm publish run 34001764906](https://github.com/777genius/universal-agent-plugins/actions/runs/34001764906)
 - [LintAI release run 33974725553](https://github.com/777genius/lintai/actions/runs/33974725553)
-- [Directory sequence 35](https://777genius.github.io/universal-agent-plugins-registry/registry/schemas/1/latest.json)
-- [Discovery sequence 38](https://777genius.github.io/universal-agent-plugins-registry/discovery/latest.json)
-- [Security sequence 4](https://777genius.github.io/universal-agent-plugins-registry/security/latest.json)
+- [Directory sequence 37](https://777genius.github.io/universal-agent-plugins-registry/registry/schemas/1/latest.json)
+- [Discovery sequence 40](https://777genius.github.io/universal-agent-plugins-registry/discovery/latest.json)
+- [Security sequence 8](https://777genius.github.io/universal-agent-plugins-registry/security/latest.json)
+- [signed-feed freshness run 34017918030](https://github.com/777genius/universal-agent-plugins-registry/actions/runs/34017918030)
 - [public Directory](https://777genius.github.io/universal-agent-plugins-registry/)
 - [public product site with the verified feed mirror](https://777genius.github.io/universal-agent-plugins/)
 
@@ -89,9 +91,10 @@ The exact CI evidence is available from the repositories:
 - LintAI reports known static patterns under a versioned policy. It does not
   execute package code and does not certify a package as safe.
 - No real user project, account, OAuth consent, or private service was used by
-  this security extension. Its final release, signed-index publication, and
-  browser proofs ran in GitHub-hosted CI or fresh disposable local directories;
-  it did not require a VM, LXC instance, or snapshot.
+  this security extension. Release and signed-index publication ran in
+  GitHub-hosted CI; the public CLI lifecycle used only a fresh disposable
+  sandbox on the existing isolated Linux test host. No VM, LXC instance, or
+  snapshot was created.
 
 ## Ongoing release contract
 


### PR DESCRIPTION
Record the exact public 0.1.51 release, Directory sequence 37, Discovery sequence 40, Security sequence 8, freshness proof, production Pages run, and the disposable multi-client Context7 lifecycle. The evidence remains explicit about unreleased post-release main work and does not claim package-specific runtime coverage beyond what was tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated launch evidence to reflect the latest 0.1.51 CLI and package releases.
  - Refreshed references for registry, discovery, security, freshness, and product-site verification.
  - Added post-release checkpoints covering signed-index lifecycle verification, production observations, discovery signature checks, and updated security findings.
  - Updated reproduction links to the latest release runs and feed sequences.
  - Clarified the scope and environment used for public lifecycle testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->