### PR TITLE
fix(cli): close dev watch baseline race

### DIFF
--- a/cli/plugin-kit-ai/internal/app/dev.go
+++ b/cli/plugin-kit-ai/internal/app/dev.go
@@ -47,15 +47,25 @@ func (svc PluginService) Dev(ctx context.Context, opts PluginDevOptions, emit fu
 		return update.Passed, nil
 	}
 
-	lastPassed, err := runCycle("initial", nil)
-	if err != nil {
-		return PluginDevSummary{}, err
-	}
+	cycle++
+	initialUpdate := svc.runDevCycle(ctx, root, selectedPlatform, opts, cycle, "initial", nil)
+	lastPassed := initialUpdate.Passed
 	if opts.Once {
+		emit(initialUpdate)
 		return PluginDevSummary{Cycles: cycle, LastPassed: lastPassed}, nil
 	}
 
-	return svc.runDevWatchLoop(ctx, root, interval, &cycle, &lastPassed, runCycle, emit)
+	// Capture the generated baseline before publishing the initial update. A caller
+	// may edit a fixture as soon as it receives that update; taking the baseline
+	// afterward can absorb that edit and leave the watch loop waiting forever.
+	snapshot, err := takeDevSnapshot(root)
+	if err != nil {
+		emit(initialUpdate)
+		return PluginDevSummary{}, err
+	}
+	emit(initialUpdate)
+
+	return svc.runDevWatchLoop(ctx, root, interval, snapshot, &cycle, &lastPassed, runCycle, emit)
 }
 
 func normalizeDevRoot(root string) string {

--- a/cli/plugin-kit-ai/internal/app/dev_loop.go
+++ b/cli/plugin-kit-ai/internal/app/dev_loop.go
@@ -5,12 +5,7 @@ import (
 	"time"
 )
 
-func (svc PluginService) runDevWatchLoop(ctx context.Context, root string, interval time.Duration, cycle *int, lastPassed *bool, runCycle func(string, []string) (bool, error), emit func(PluginDevUpdate)) (PluginDevSummary, error) {
-	snapshot, err := takeDevSnapshot(root)
-	if err != nil {
-		return PluginDevSummary{}, err
-	}
-
+func (svc PluginService) runDevWatchLoop(ctx context.Context, root string, interval time.Duration, snapshot devSnapshot, cycle *int, lastPassed *bool, runCycle func(string, []string) (bool, error), emit func(PluginDevUpdate)) (PluginDevSummary, error) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 

--- a/cli/plugin-kit-ai/internal/app/dev_test.go
+++ b/cli/plugin-kit-ai/internal/app/dev_test.go
@@ -73,15 +73,14 @@ func TestPluginServiceDevWatchRerunsOnFixtureChange(t *testing.T) {
 		errCh <- err
 	}()
 
-	first := <-updatesCh
+	first := receiveDevUpdate(t, updatesCh)
 	if first.Cycle != 1 {
 		t.Fatalf("first cycle = %d", first.Cycle)
 	}
-	time.Sleep(60 * time.Millisecond)
 	if err := os.WriteFile(fixturePath, []byte(`{"session_id":"s2","cwd":"/tmp","hook_event_name":"Stop"}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	second := <-updatesCh
+	second := receiveDevUpdate(t, updatesCh)
 	if second.Cycle != 2 {
 		t.Fatalf("second cycle = %d", second.Cycle)
 	}
@@ -92,8 +91,30 @@ func TestPluginServiceDevWatchRerunsOnFixtureChange(t *testing.T) {
 	if !strings.Contains(output, "fixtures/claude/Stop.json") {
 		t.Fatalf("output = %s", output)
 	}
-	if err := <-errCh; err != nil {
+	if err := receiveDevError(t, errCh); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func receiveDevUpdate(t *testing.T, updates <-chan PluginDevUpdate) PluginDevUpdate {
+	t.Helper()
+	select {
+	case update := <-updates:
+		return update
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for dev update")
+		return PluginDevUpdate{}
+	}
+}
+
+func receiveDevError(t *testing.T, errors <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-errors:
+		return err
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for dev completion")
+		return nil
 	}
 }
 


### PR DESCRIPTION
## Summary

- capture the generated watch baseline before publishing the initial callback
- prevent immediate caller edits from being absorbed into the baseline
- make the regression fail fast instead of hanging the package suite

## Evidence

- affected watch tests passed 50 consecutive iterations
- full `internal/app` package passed
- `git diff --check` passed
- the final E2E evidence PR exposed the race in Required run 34018097935

Related: #162