### PR TITLE
feat(authoring): add native Linux and Windows arm64 gates

### DIFF
--- a/.github/workflows/authoring-native.yml
+++ b/.github/workflows/authoring-native.yml
@@ -19,6 +19,10 @@ jobs:
         include:
           - {runner: ubuntu-24.04, os: linux, arch: amd64}
           - {runner: windows-2022, os: windows, arch: amd64}
+          # github/docs ec3629a841129ae28189d7bb2274a7b3d40c5095:
+          # data/reusables/actions/supported-github-runners.md (standard public runners).
+          - {runner: ubuntu-24.04-arm, os: linux, arch: arm64}
+          - {runner: windows-11-arm, os: windows, arch: arm64}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 25
     defaults:
@@ -43,6 +47,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # ci.yml
         with:
           go-version: '1.25.13'
+          architecture: ${{ matrix.arch == 'amd64' && 'x64' || matrix.arch }}
           cache: false
       - name: Native offline tests and actual entrypoint builds
         run: |
@@ -97,8 +102,9 @@ jobs:
           suffix=""; if [[ "$EXPECTED_OS" == windows ]]; then suffix=.exe; fi
           command_package=github.com/777genius/plugin-kit-ai/cli/internal/authoring/commands
           for entry in agentplugins plugin-kit-ai; do
-            go build -p 2 -trimpath -ldflags "-X $command_package.Enabled=vertical-slice-v1 -X $command_package.Revision=$EXPECTED_HEAD" \
+            go build -p 2 -buildvcs=true -trimpath -ldflags "-X $command_package.Enabled=vertical-slice-v1 -X $command_package.Revision=$EXPECTED_HEAD" \
               -o "$AUTHORING_NATIVE_BIN_DIR/$entry$suffix" "./cli/plugin-kit-ai/cmd/$entry"
+            go version -m -json "$AUTHORING_NATIVE_BIN_DIR/$entry$suffix" > "$NATIVE_ROOT/evidence/$entry-build.json"
           done
           go test -p 2 -json -list '^Test' "${packages[@]}" > "$NATIVE_ROOT/evidence/test-discovery.json"
           # Only packageview's owned disposable filesystem fixtures run privileged

--- a/.github/workflows/authoring-native.yml
+++ b/.github/workflows/authoring-native.yml
@@ -3,6 +3,11 @@ name: Authoring native offline
 on:
   pull_request:
   workflow_dispatch:
+    inputs:
+      windows_arm64_diagnostics:
+        description: Capture same-invocation native errors (diagnostic builds cannot qualify as release proof)
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -49,6 +54,10 @@ jobs:
           go-version: '1.25.13'
           architecture: ${{ matrix.arch == 'amd64' && 'x64' || matrix.arch }}
           cache: false
+      - name: Prepare disposable second NTFS filesystem on Windows ARM64
+        if: matrix.os == 'windows' && matrix.arch == 'arm64'
+        shell: pwsh
+        run: ./cli/plugin-kit-ai/internal/authoring/commands/testdata/windows_arm64_volume.ps1 -Mode Setup
       - name: Native offline tests and actual entrypoint builds
         run: |
           set -euo pipefail
@@ -100,9 +109,19 @@ jobs:
           go list -p 2 -deps -test "${packages[@]}" ./cli/plugin-kit-ai/cmd/{agentplugins,plugin-kit-ai} > "$NATIVE_ROOT/evidence/dependencies.txt"
           export GOPROXY=off GOSUMDB=off
           suffix=""; if [[ "$EXPECTED_OS" == windows ]]; then suffix=.exe; fi
+          build_vcs=true
+          if [[ "$EXPECTED_OS/$EXPECTED_ARCH" == windows/arm64 && "${{ github.event_name == 'pull_request' || inputs.windows_arm64_diagnostics }}" == true ]]; then
+            # Generate outside checkout; apply to these actual binaries and tests,
+            # never to a post-failure rerun. Preserve exact overlay with evidence.
+            go run ./cli/plugin-kit-ai/internal/authoring/commands/testdata/native_diagnostics.go "$GITHUB_WORKSPACE" "$NATIVE_ROOT/evidence/diagnostics"
+            export GOFLAGS="-overlay=$NATIVE_ROOT/evidence/diagnostics/overlay.json"
+            # Fail the existing clean-VCS proof gate transparently for diagnostic
+            # builds; an overlay must never masquerade as clean production proof.
+            build_vcs=false
+          fi
           command_package=github.com/777genius/plugin-kit-ai/cli/internal/authoring/commands
           for entry in agentplugins plugin-kit-ai; do
-            go build -p 2 -buildvcs=true -trimpath -ldflags "-X $command_package.Enabled=vertical-slice-v1 -X $command_package.Revision=$EXPECTED_HEAD" \
+            go build -p 2 -buildvcs="$build_vcs" -trimpath -ldflags "-X $command_package.Enabled=vertical-slice-v1 -X $command_package.Revision=$EXPECTED_HEAD" \
               -o "$AUTHORING_NATIVE_BIN_DIR/$entry$suffix" "./cli/plugin-kit-ai/cmd/$entry"
             go version -m -json "$AUTHORING_NATIVE_BIN_DIR/$entry$suffix" > "$NATIVE_ROOT/evidence/$entry-build.json"
           done
@@ -134,6 +153,21 @@ jobs:
           fi
           printf '%s\n' "$result" > "$NATIVE_ROOT/evidence/test-exit.txt"
           exit "$result"
+      - name: Detach and remove only the owned Windows ARM64 VHDX
+        if: always() && matrix.os == 'windows' && matrix.arch == 'arm64'
+        shell: pwsh
+        run: ./cli/plugin-kit-ai/internal/authoring/commands/testdata/windows_arm64_volume.ps1 -Mode Cleanup
+      - name: Preserve disposable volume setup and cleanup evidence
+        if: always() && matrix.os == 'windows' && matrix.arch == 'arm64' && env.AUTHORING_VOLUME_FIXTURE != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: authoring-volume-arm64-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ env.AUTHORING_VOLUME_FIXTURE }}/*.json
+            ${{ env.AUTHORING_VOLUME_FIXTURE }}/*.txt
+            ${{ env.AUTHORING_VOLUME_FIXTURE }}/*.log
+          if-no-files-found: error
+          retention-days: 14
       - name: Require structured native evidence (including skips and offline E2E)
         if: always()
         run: python scripts/check-authoring-native-results.py "$NATIVE_ROOT"

--- a/.github/workflows/authoring-native.yml
+++ b/.github/workflows/authoring-native.yml
@@ -7,7 +7,7 @@ on:
       windows_diagnostics:
         description: Capture same-invocation native errors (diagnostic builds cannot qualify as release proof)
         type: boolean
-        default: true
+        default: false
 
 permissions:
   contents: read
@@ -110,7 +110,7 @@ jobs:
           export GOPROXY=off GOSUMDB=off
           suffix=""; if [[ "$EXPECTED_OS" == windows ]]; then suffix=.exe; fi
           build_vcs=true
-          if [[ "$EXPECTED_OS" == windows && "${{ github.event_name == 'pull_request' || inputs.windows_diagnostics }}" == true ]]; then
+          if [[ "$EXPECTED_OS" == windows && "${{ inputs.windows_diagnostics }}" == true ]]; then
             # Generate outside checkout; apply to these actual binaries and tests,
             # never to a post-failure rerun. Preserve exact overlay with evidence.
             go run ./cli/plugin-kit-ai/internal/authoring/commands/testdata/native_diagnostics.go "$GITHUB_WORKSPACE" "$NATIVE_ROOT/evidence/diagnostics"

--- a/.github/workflows/authoring-native.yml
+++ b/.github/workflows/authoring-native.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
-      windows_arm64_diagnostics:
+      windows_diagnostics:
         description: Capture same-invocation native errors (diagnostic builds cannot qualify as release proof)
         type: boolean
         default: true
@@ -110,7 +110,7 @@ jobs:
           export GOPROXY=off GOSUMDB=off
           suffix=""; if [[ "$EXPECTED_OS" == windows ]]; then suffix=.exe; fi
           build_vcs=true
-          if [[ "$EXPECTED_OS/$EXPECTED_ARCH" == windows/arm64 && "${{ github.event_name == 'pull_request' || inputs.windows_arm64_diagnostics }}" == true ]]; then
+          if [[ "$EXPECTED_OS" == windows && "${{ github.event_name == 'pull_request' || inputs.windows_diagnostics }}" == true ]]; then
             # Generate outside checkout; apply to these actual binaries and tests,
             # never to a post-failure rerun. Preserve exact overlay with evidence.
             go run ./cli/plugin-kit-ai/internal/authoring/commands/testdata/native_diagnostics.go "$GITHUB_WORKSPACE" "$NATIVE_ROOT/evidence/diagnostics"

--- a/cli/plugin-kit-ai/internal/authoring/commands/installer_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/installer_test.go
@@ -27,8 +27,8 @@ import (
 // existing add command constructs its real planner. Detection and scanner are
 // no-effect test inputs; no real user profile, runtime or provider is executed.
 func TestGeneratedPackagesReachExistingInstallerPlanner(t *testing.T) {
-	if runtime.GOOS != "linux" && !(runtime.GOOS == "windows" && runtime.GOARCH == "amd64") {
-		t.Skip("writable native authoring requires Linux or Windows amd64")
+	if runtime.GOOS != "linux" && !(runtime.GOOS == "windows" && (runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64")) {
+		t.Skip("writable native authoring requires Linux or Windows amd64/arm64")
 	}
 	author := commands.App{Projects: project.Service{Scratch: t.TempDir()}, Revision: baseline}
 	registry, e := specregistry.New()

--- a/cli/plugin-kit-ai/internal/authoring/commands/lifecycle_native_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/lifecycle_native_test.go
@@ -1,4 +1,4 @@
-//go:build (linux || windows) && amd64
+//go:build (linux || windows) && (amd64 || arm64)
 
 package commands_test
 

--- a/cli/plugin-kit-ai/internal/authoring/commands/path_fix_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/path_fix_test.go
@@ -78,7 +78,11 @@ func (b pathFixBinaries) run(t *testing.T, i int, cwd, scratch string, args ...s
 	cmd.Env = append(nativeEnvironment(t.TempDir(), scratch, t.TempDir()), "GOMAXPROCS=2")
 	var out, errout bytes.Buffer
 	cmd.Stdout, cmd.Stderr = &out, &errout
+	started := time.Now().UnixNano()
 	err := cmd.Run()
+	if runtime.GOOS == "windows" && cmd.Process != nil {
+		t.Logf("native invocation binary=%d pid=%d started_ns=%d ended_ns=%d", i, cmd.Process.Pid, started, time.Now().UnixNano())
+	}
 	code := 0
 	if err != nil {
 		if exit, ok := err.(*exec.ExitError); ok {

--- a/cli/plugin-kit-ai/internal/authoring/commands/path_fix_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/path_fix_test.go
@@ -1,4 +1,4 @@
-//go:build linux || (windows && amd64)
+//go:build linux || (windows && (amd64 || arm64))
 
 package commands_test
 

--- a/cli/plugin-kit-ai/internal/authoring/commands/path_fix_windows_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/path_fix_windows_test.go
@@ -1,4 +1,4 @@
-//go:build windows && amd64
+//go:build windows && (amd64 || arm64)
 
 package commands_test
 

--- a/cli/plugin-kit-ai/internal/authoring/commands/slice_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/slice_test.go
@@ -218,8 +218,8 @@ func tree(t *testing.T, root string) map[string]string {
 }
 
 func TestReportsAndFreshFactory(t *testing.T) {
-	if runtime.GOOS != "linux" && !(runtime.GOOS == "windows" && runtime.GOARCH == "amd64") {
-		t.Skip("writable native authoring requires Linux or Windows amd64")
+	if runtime.GOOS != "linux" && !(runtime.GOOS == "windows" && (runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64")) {
+		t.Skip("writable native authoring requires Linux or Windows amd64/arm64")
 	}
 	scratch := t.TempDir()
 	a := commands.App{Projects: project.Service{Scratch: scratch}, Revision: baseline}
@@ -343,8 +343,8 @@ func TestArgumentFailuresBeforeEffects(t *testing.T) {
 }
 
 func TestInitValidationAndFailurePolicy(t *testing.T) {
-	if runtime.GOOS != "linux" && !(runtime.GOOS == "windows" && runtime.GOARCH == "amd64") {
-		t.Skip("writable native authoring requires Linux or Windows amd64")
+	if runtime.GOOS != "linux" && !(runtime.GOOS == "windows" && (runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64")) {
+		t.Skip("writable native authoring requires Linux or Windows amd64/arm64")
 	}
 	scratch := t.TempDir()
 	a := commands.App{Projects: project.Service{Scratch: scratch}, Revision: baseline}
@@ -399,8 +399,8 @@ func TestInitValidationAndFailurePolicy(t *testing.T) {
 }
 
 func TestConcurrentInitAndCanceledInvocation(t *testing.T) {
-	if runtime.GOOS != "linux" && !(runtime.GOOS == "windows" && runtime.GOARCH == "amd64") {
-		t.Skip("writable native authoring requires Linux or Windows amd64")
+	if runtime.GOOS != "linux" && !(runtime.GOOS == "windows" && (runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64")) {
+		t.Skip("writable native authoring requires Linux or Windows amd64/arm64")
 	}
 	parent, scratch := t.TempDir(), t.TempDir()
 	a := commands.App{Projects: project.Service{Scratch: scratch}, Revision: baseline}
@@ -451,8 +451,8 @@ type faultContext struct {
 func (c faultContext) Err() error { c.check(); return c.Context.Err() }
 
 func TestCleanupFailureSurvivesCancellation(t *testing.T) {
-	if runtime.GOOS != "linux" && !(runtime.GOOS == "windows" && runtime.GOARCH == "amd64") {
-		t.Skip("writable native authoring requires Linux or Windows amd64")
+	if runtime.GOOS != "linux" && !(runtime.GOOS == "windows" && (runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64")) {
+		t.Skip("writable native authoring requires Linux or Windows amd64/arm64")
 	}
 	root, scratch := t.TempDir(), t.TempDir()
 	write(t, root, "plugin.json", plugin(""))
@@ -530,8 +530,8 @@ func TestCleanupFailureSurvivesCancellation(t *testing.T) {
 }
 
 func TestNativeBinaryVerticalSlice(t *testing.T) {
-	if runtime.GOOS != "linux" && !(runtime.GOOS == "windows" && runtime.GOARCH == "amd64") {
-		t.Skip("writable native authoring requires Linux or Windows amd64")
+	if runtime.GOOS != "linux" && !(runtime.GOOS == "windows" && (runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64")) {
+		t.Skip("writable native authoring requires Linux or Windows amd64/arm64")
 	}
 	_, file, _, _ := runtime.Caller(0)
 	module := filepath.Clean(filepath.Join(filepath.Dir(file), "../../.."))

--- a/cli/plugin-kit-ai/internal/authoring/commands/slice_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/slice_test.go
@@ -78,8 +78,9 @@ func execute(t *testing.T, a commands.App, args []string, mount bool) (report.Re
 
 // Workers capture bytes and errors; only the parent may decode or fail a test.
 type rawExecution struct {
-	out, errout []byte
-	err         error
+	out, errout         []byte
+	err                 error
+	diagnosticGoroutine string
 }
 
 func executeRaw(a commands.App, args []string, mount bool) rawExecution {
@@ -90,7 +91,9 @@ func executeRaw(a commands.App, args []string, mount bool) rawExecution {
 		args = append([]string{"author"}, args...)
 	}
 	e := a.Execute(context.Background(), args, authoringcli.Streams{Out: &out, Err: &errout}, builder)
-	return rawExecution{out.Bytes(), errout.Bytes(), e}
+	var stack [64]byte
+	gid := strings.Fields(string(stack[:runtime.Stack(stack[:], false)]))[1]
+	return rawExecution{out.Bytes(), errout.Bytes(), e, gid}
 }
 
 func decodeExecution(t *testing.T, result rawExecution) (report.Report, int, []byte) {
@@ -416,7 +419,7 @@ func TestConcurrentInitAndCanceledInvocation(t *testing.T) {
 		if r.Committed {
 			wins++
 		} else if r.Error == nil || r.Error.Code != "destination_exists" {
-			t.Fatalf("unexpected race failure: %+v", r)
+			t.Fatalf("unexpected race failure pid=%d goroutine=%s: %+v", os.Getpid(), result.diagnosticGoroutine, r)
 		}
 	}
 	if wins != 1 {

--- a/cli/plugin-kit-ai/internal/authoring/commands/testdata/native_diagnostics.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/testdata/native_diagnostics.go
@@ -96,7 +96,7 @@ func main() {
 						if c, ok := n.Results[i].(*ast.CallExpr); ok {
 							if id, ok := c.Fun.(*ast.Ident); ok && id.Name == "fail" && len(c.Args) == 1 {
 								if code, ok := c.Args[0].(*ast.BasicLit); ok && code.Value == strconv.Quote("source_changed") {
-									pairs := []string{"[]any{meta, after}", "[]any{meta, locked}"}
+									pairs := []string{`[]any{meta, after, map[string]any{"outside_root": outsideRoot, "selected_root_depth": s.selectionDepth}}`, `[]any{meta, locked, map[string]any{"outside_root": outsideRoot, "selected_root_depth": s.selectionDepth}}`}
 									observation, err := parser.ParseExpr(pairs[changes])
 									must(err)
 									observations = append(observations, observation)

--- a/cli/plugin-kit-ai/internal/authoring/commands/testdata/native_diagnostics.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/testdata/native_diagnostics.go
@@ -47,7 +47,7 @@ func main() {
 		"cli/plugin-kit-ai/internal/authoring/scaffold":            "scaffold",
 	}
 	files := map[string][]string{
-		"packageview": {"source_windows.go"},
+		"packageview": {"source_windows.go", "scratch_windows.go"},
 		"scaffold":    {"apply.go", "rename_windows.go", "stage_windows.go"},
 	}
 	for dir, pkg := range packages {

--- a/cli/plugin-kit-ai/internal/authoring/commands/testdata/native_diagnostics.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/testdata/native_diagnostics.go
@@ -1,0 +1,226 @@
+//go:build ignore
+
+// This CI-only overlay observes the actual Windows test/entrypoint invocation.
+// It never edits checked-in production sources. Instrumented binaries are
+// diagnostic artifacts, not uninstrumented native release proof.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+func literal(s string) ast.Expr { return &ast.BasicLit{Kind: token.STRING, Value: strconv.Quote(s)} }
+func errorResult(t *ast.FuncType) bool {
+	if t.Results == nil {
+		return false
+	}
+	r := t.Results.List
+	id, ok := r[len(r)-1].Type.(*ast.Ident)
+	return ok && id.Name == "error"
+}
+func main() {
+	if len(os.Args) != 3 {
+		panic("usage: native_diagnostics.go checkout evidence-directory")
+	}
+	root, err := filepath.Abs(os.Args[1])
+	must(err)
+	out, err := filepath.Abs(os.Args[2])
+	must(err)
+	must(os.MkdirAll(out, 0700))
+	replacements := map[string]string{}
+	packages := map[string]string{
+		"install/integrationctl/agentplugins/adapters/packageview": "packageview",
+		"cli/plugin-kit-ai/internal/authoring/scaffold":            "scaffold",
+	}
+	files := map[string][]string{
+		"packageview": {"source_windows.go"},
+		"scaffold":    {"apply.go", "rename_windows.go", "stage_windows.go"},
+	}
+	for dir, pkg := range packages {
+		for _, base := range files[pkg] {
+			path := filepath.Join(root, dir, base)
+			fs := token.NewFileSet()
+			f, err := parser.ParseFile(fs, path, nil, parser.ParseComments)
+			must(err)
+			// Wrap returned errors without replacing or unwrapping them. The site refers
+			// to the original source line, and never contains an input pathname/value.
+			arity := 0
+			function := ""
+			changes := 0
+			var visit func(ast.Node) bool
+			visit = func(n ast.Node) bool {
+				switch n := n.(type) {
+				case *ast.FuncDecl:
+					function = n.Name.Name
+					if errorResult(n.Type) {
+						previous := arity
+						arity = n.Type.Results.NumFields()
+						ast.Inspect(n.Body, visit)
+						arity = previous
+					}
+					return false
+				case *ast.FuncLit:
+					if errorResult(n.Type) {
+						previous := arity
+						arity = n.Type.Results.NumFields()
+						ast.Inspect(n.Body, visit)
+						arity = previous
+					}
+					return false
+				case *ast.ReturnStmt:
+					if len(n.Results) != arity {
+						return false
+					}
+					i := len(n.Results) - 1
+					if id, ok := n.Results[i].(*ast.Ident); ok && id.Name == "nil" {
+						return false
+					}
+					site := fmt.Sprintf("%s:%d", base, fs.Position(n.Pos()).Line)
+					ast.Inspect(n.Results[i], visit)
+					var observations []ast.Expr
+					if function == "remember" {
+						if c, ok := n.Results[i].(*ast.CallExpr); ok {
+							if id, ok := c.Fun.(*ast.Ident); ok && id.Name == "fail" && len(c.Args) == 1 {
+								if code, ok := c.Args[0].(*ast.BasicLit); ok && code.Value == strconv.Quote("source_changed") {
+									pairs := []string{"[]any{meta, after}", "[]any{meta, locked}"}
+									observation, err := parser.ParseExpr(pairs[changes])
+									must(err)
+									observations = append(observations, observation)
+									changes++
+								}
+							}
+						}
+					}
+					n.Results[i] = &ast.CallExpr{Fun: ast.NewIdent("uapDiagnosticError"), Args: append([]ast.Expr{n.Results[i], literal(site)}, observations...)}
+					return false
+				case *ast.CallExpr:
+					if s, ok := n.Fun.(*ast.SelectorExpr); ok {
+						if x, ok := s.X.(*ast.Ident); ok && x.Name == "windows" && s.Sel.Name == "NtCreateFile" {
+							// Capture the raw returned NTSTATUS and IOSB before winReopen maps it.
+							site := literal(fmt.Sprintf("%s:%d/NtCreateFile", base, fs.Position(n.Pos()).Line))
+							n.Fun = ast.NewIdent("uapDiagnosticNtCreateFile")
+							n.Args = append(n.Args, site)
+						} else if x, ok := s.X.(*ast.Ident); ok && x.Name == "windows" {
+							site := literal(fmt.Sprintf("%s:%d/%s", base, fs.Position(n.Pos()).Line, s.Sel.Name))
+							switch s.Sel.Name {
+							case "NtSetInformationFile":
+								n.Fun = ast.NewIdent("uapDiagnosticNtSetInformationFile")
+								n.Args = append(n.Args, site)
+							case "GetFileType":
+								n.Fun = ast.NewIdent("uapDiagnosticGetFileType")
+								n.Args = append(n.Args, site)
+							case "GetFileInformationByHandle", "GetFileInformationByHandleEx", "GetVolumeInformationByHandle":
+								original := *n
+								n.Fun = ast.NewIdent("uapDiagnosticError")
+								n.Args = []ast.Expr{&original, site}
+								return false
+							}
+						}
+					}
+				}
+				return true
+			}
+			ast.Inspect(f, visit)
+			// Named result observations run after existing cleanup defers.
+			for _, decl := range f.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || (fn.Name.Name != "apply" && fn.Name.Name != "openSource") {
+					continue
+				}
+				deferred, err := parser.ParseExpr("func() { uapDiagnosticError(err, " + strconv.Quote(fn.Name.Name+".final") + ") }")
+				must(err)
+				fn.Body.List = append([]ast.Stmt{&ast.DeferStmt{Call: &ast.CallExpr{Fun: deferred}}}, fn.Body.List...)
+			}
+			var b bytes.Buffer
+			must(format.Node(&b, fs, f))
+			generated := filepath.Join(out, pkg+"-"+base)
+			must(os.WriteFile(generated, b.Bytes(), 0600))
+			replacements[path] = generated
+		}
+		safeCode := ""
+		if pkg == "packageview" {
+			safeCode = `var safe *Error; if errors.As(err, &safe) { row["code"] = safe.Code }`
+		}
+		helper := fmt.Sprintf(helperSource, pkg, out, pkg, safeCode)
+		formatted, err := format.Source([]byte(helper))
+		must(err)
+		generated := filepath.Join(out, pkg+"-diagnostic_windows.go")
+		must(os.WriteFile(generated, formatted, 0600))
+		replacements[filepath.Join(root, dir, "uap_diagnostic_windows.go")] = generated
+	}
+	b, err := json.MarshalIndent(map[string]any{"Replace": replacements}, "", "  ")
+	must(err)
+	must(os.WriteFile(filepath.Join(out, "overlay.json"), b, 0600))
+	must(os.WriteFile(filepath.Join(out, "DIAGNOSTIC_ONLY.txt"), []byte("CI-only error observations in the actual invocation. Overlay sources are preserved here. Instrumented binaries are not uninstrumented native release proof. No retries or public error changes.\n"), 0600))
+}
+
+const helperSource = `//go:build windows
+package %s
+import (
+ "encoding/json"
+ "errors"
+ "fmt"
+ "os"
+ "path/filepath"
+ "runtime"
+ "strconv"
+ "strings"
+ "sync"
+ "syscall"
+ "time"
+ "golang.org/x/sys/windows"
+)
+var uapDiagnosticMu sync.Mutex
+// The destination is baked into CI-only files: subprocess profile isolation
+// cannot drop it, and no user environment can enable it in a normal build.
+const uapDiagnosticDirectory = %q
+const uapDiagnosticPackage = %q
+func uapDiagnosticError(err error, stage string, observations ...any) error {
+ if err != nil { uapDiagnosticRecord(err, stage, nil, observations...) }; return err
+}
+func uapDiagnosticRecord(err error, stage string, native map[string]uint64, observations ...any) {
+ if err == nil { return }
+ // Only the numeric goroutine identifier is retained; no stack/argument text.
+ var stack [64]byte
+ fields := strings.Fields(string(stack[:runtime.Stack(stack[:], false)]))
+ gid, _ := strconv.ParseUint(fields[1], 10, 64)
+ row := map[string]any{"time_unix_nano": time.Now().UnixNano(), "pid": os.Getpid(), "goroutine": gid, "stage": stage, "type": fmt.Sprintf("%%T", err), "native": native, "observations": observations}
+ var status windows.NTStatus; var errno syscall.Errno
+ if errors.As(err, &status) { row["ntstatus"] = uint32(status); row["win32"] = uint32(status.Errno()) }
+ if errors.As(err, &errno) { row["errno"] = uint32(errno) }
+ %s
+ // No Error(), pathname, SID, content, environment, or handle value is logged.
+ uapDiagnosticMu.Lock(); defer uapDiagnosticMu.Unlock()
+ f, e := os.OpenFile(filepath.Join(uapDiagnosticDirectory, fmt.Sprintf("%%s-%%d.jsonl", uapDiagnosticPackage, os.Getpid())), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+ if e != nil { panic("CI diagnostic sink unavailable") }
+ e = json.NewEncoder(f).Encode(row); closeErr := f.Close()
+ if e != nil || closeErr != nil { panic("CI diagnostic sink write failed") }
+}
+func uapDiagnosticNtSetInformationFile(h windows.Handle, iosb *windows.IO_STATUS_BLOCK, data *byte, size, class uint32, stage string) error {
+ err := windows.NtSetInformationFile(h, iosb, data, size, class)
+ if err != nil { uapDiagnosticRecord(err, stage, map[string]uint64{"class": uint64(class), "iosb_status": uint64(uint32(iosb.Status)), "iosb_information": uint64(iosb.Information)}) }
+ return err
+}
+func uapDiagnosticGetFileType(h windows.Handle, stage string) (uint32, error) {
+ kind, err := windows.GetFileType(h); uapDiagnosticRecord(err, stage, nil); return kind, err
+}
+func uapDiagnosticNtCreateFile(h *windows.Handle, access uint32, oa *windows.OBJECT_ATTRIBUTES, iosb *windows.IO_STATUS_BLOCK, allocation *int64, attributes, share, disposition, options uint32, ea uintptr, eaLength uint32, stage string) error {
+ err := windows.NtCreateFile(h, access, oa, iosb, allocation, attributes, share, disposition, options, ea, eaLength)
+ if err != nil { uapDiagnosticRecord(err, stage, map[string]uint64{"access": uint64(access), "share": uint64(share), "options": uint64(options), "disposition": uint64(disposition), "iosb_status": uint64(uint32(iosb.Status)), "iosb_information": uint64(iosb.Information)}) }
+ return err
+}
+`

--- a/cli/plugin-kit-ai/internal/authoring/commands/testdata/windows_arm64_volume.ps1
+++ b/cli/plugin-kit-ai/internal/authoring/commands/testdata/windows_arm64_volume.ps1
@@ -52,7 +52,7 @@ $create = Join-Path $fixture 'create.txt'
 "create vdisk file=`"$vhd`" maximum=256 type=expandable`nexit" | Set-Content -LiteralPath $create -Encoding ascii
 & diskpart.exe /s $create | Out-File (Join-Path $fixture 'create.log')
 if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $vhd)) { throw 'Fresh VHDX creation failed' }
-$image = Mount-DiskImage -ImagePath $vhd -StorageType VHD -Access ReadWrite -PassThru
+$image = Mount-DiskImage -ImagePath $vhd -StorageType VHDX -Access ReadWrite -PassThru
 $disks = @($image | Get-Disk)
 if ($disks.Count -ne 1) { throw 'Fresh image must map to exactly one disk' }
 $disk = $disks[0]

--- a/cli/plugin-kit-ai/internal/authoring/commands/testdata/windows_arm64_volume.ps1
+++ b/cli/plugin-kit-ai/internal/authoring/commands/testdata/windows_arm64_volume.ps1
@@ -1,0 +1,92 @@
+param([Parameter(Mandatory)][ValidateSet('Setup','Cleanup')][string]$Mode)
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+# Never run on developer hosts or self-hosted runners. No existing disk is selected.
+if ($env:GITHUB_ACTIONS -ne 'true' -or $env:RUNNER_ENVIRONMENT -ne 'github-hosted' -or
+    $env:RUNNER_OS -ne 'Windows' -or $env:RUNNER_ARCH -ne 'ARM64' -or
+    [Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString() -ne 'Arm64') {
+    throw 'Disposable GitHub-hosted native Windows ARM64 runner required'
+}
+$tempRoot = [IO.Path]::GetFullPath($env:RUNNER_TEMP).TrimEnd('\') + '\'
+if ($Mode -eq 'Setup') {
+    $fixture = Join-Path $tempRoot ('uap-arm64-volume-' + [guid]::NewGuid().ToString('N'))
+    # New-Item fails on a collision; record this unique container before disk work.
+    New-Item -ItemType Directory -Path $fixture | Out-Null
+    "AUTHORING_VOLUME_FIXTURE=$fixture" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+} else {
+    if (-not $env:AUTHORING_VOLUME_FIXTURE) { return }
+    $fixture = [IO.Path]::GetFullPath($env:AUTHORING_VOLUME_FIXTURE)
+}
+if ([IO.Path]::GetDirectoryName($fixture) + '\' -ne $tempRoot -or
+    [IO.Path]::GetFileName($fixture) -notmatch '^uap-arm64-volume-[0-9a-f]{32}$' -or
+    ((Get-Item -LiteralPath $fixture).Attributes -band [IO.FileAttributes]::ReparsePoint)) {
+    throw 'Fixture container identity refused'
+}
+$vhd = Join-Path $fixture 'fresh.vhdx'
+$journal = Join-Path $fixture 'ownership.json'
+if ($vhd -match '["\r\n]') { throw 'Unsafe diskpart path encoding' }
+if ($Mode -eq 'Cleanup') {
+    if (-not (Test-Path -LiteralPath $journal)) { return } # Setup never reached creation.
+    $owner = Get-Content -Raw -LiteralPath $journal | ConvertFrom-Json
+    if ($owner.path -ne $vhd -or $owner.run -ne $env:GITHUB_RUN_ID -or $owner.attempt -ne $env:GITHUB_RUN_ATTEMPT) {
+        throw 'VHD ownership journal mismatch'
+    }
+    if (Test-Path -LiteralPath $vhd) {
+        # A partially created/corrupt file may be unqueryable: fail closed and
+        # retain it for runner disposal, never guess an existing disk number.
+        $image = Get-DiskImage -ImagePath $vhd
+        if ($image.Attached) { Dismount-DiskImage -ImagePath $vhd }
+        if ((Get-DiskImage -ImagePath $vhd).Attached) { throw 'VHD remains attached' }
+        Remove-Item -LiteralPath $vhd
+    }
+    'Detached and removed only owned fresh.vhdx' | Set-Content (Join-Path $fixture 'cleanup.txt')
+    return
+}
+foreach ($command in @('diskpart.exe','Get-DiskImage','Mount-DiskImage','Dismount-DiskImage','Get-Disk',
+    'Initialize-Disk','New-Partition','Format-Volume','Get-Volume')) { Get-Command $command | Out-Null }
+if (Test-Path -LiteralPath $vhd) { throw 'Fresh VHD path already exists' }
+@{path=$vhd; run=$env:GITHUB_RUN_ID; attempt=$env:GITHUB_RUN_ATTEMPT} |
+    ConvertTo-Json | Set-Content -LiteralPath $journal
+# diskpart creates this one new file only: no select disk, clean, online, or format.
+$create = Join-Path $fixture 'create.txt'
+"create vdisk file=`"$vhd`" maximum=256 type=expandable`nexit" | Set-Content -LiteralPath $create -Encoding ascii
+& diskpart.exe /s $create | Out-File (Join-Path $fixture 'create.log')
+if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $vhd)) { throw 'Fresh VHDX creation failed' }
+$image = Mount-DiskImage -ImagePath $vhd -StorageType VHD -Access ReadWrite -PassThru
+$disks = @($image | Get-Disk)
+if ($disks.Count -ne 1) { throw 'Fresh image must map to exactly one disk' }
+$disk = $disks[0]
+$system = Get-Partition -DriveLetter C | Get-Disk
+if ($disk.IsBoot -or $disk.IsSystem -or $disk.Number -eq $system.Number -or
+    $disk.PartitionStyle -ne 'RAW' -or $disk.Size -ne 256MB -or -not $disk.UniqueId) {
+    throw 'Fresh disk identity/RAW/size/system exclusion failed'
+}
+$diskId = $disk.UniqueId
+function Assert-OwnedDisk {
+    $current = @((Get-DiskImage -ImagePath $vhd) | Get-Disk)
+    if ($current.Count -ne 1 -or $current[0].UniqueId -ne $diskId -or
+        $current[0].Number -ne $disk.Number -or $current[0].IsBoot -or $current[0].IsSystem) {
+        throw 'Fresh image disk identity changed'
+    }
+}
+Assert-OwnedDisk
+Initialize-Disk -InputObject $disk -PartitionStyle GPT | Out-Null
+$used = @((Get-Volume).DriveLetter) + @((Get-PSDrive -PSProvider FileSystem).Name)
+$free = @([char[]](90..68) | Where-Object { $_.ToString() -notin $used })
+if ($free.Count -eq 0) { throw 'No free drive letter' }
+$letter = $free[0]
+Assert-OwnedDisk
+$partition = New-Partition -InputObject ((Get-DiskImage -ImagePath $vhd) | Get-Disk) -UseMaximumSize -DriveLetter $letter
+Assert-OwnedDisk
+if ($partition.DiskNumber -ne $disk.Number -or $partition.DriveLetter -ne $letter) { throw 'New partition identity mismatch' }
+$volume = Format-Volume -Partition $partition -FileSystem NTFS -NewFileSystemLabel UAPDisposable -Confirm:$false
+$systemVolume = Get-Volume -DriveLetter C
+if ($volume.FileSystem -ne 'NTFS' -or $volume.DriveType -ne 'Fixed' -or
+    $volume.UniqueId -notmatch '^\\\\\?\\Volume\{[0-9a-f-]+\}\\$' -or
+    $volume.UniqueId -eq $systemVolume.UniqueId) { throw 'Distinct fixed NTFS GUID proof failed' }
+@{image=$vhd; disk_unique_id=$diskId; disk_number=$disk.Number; drive=$letter.ToString();
+  volume_guid=$volume.UniqueId; c_volume_guid=$systemVolume.UniqueId; filesystem=$volume.FileSystem;
+  invariant='Distinct filesystem identities, not separate physical hardware'} |
+    ConvertTo-Json | Set-Content (Join-Path $fixture 'volume-proof.json')
+# Existing required tests discover this fixed drive and verify GUID identity.
+Get-Content (Join-Path $fixture 'volume-proof.json')

--- a/cli/plugin-kit-ai/internal/authoring/project/project_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/project/project_test.go
@@ -35,8 +35,8 @@ func empty(t *testing.T, root string) {
 }
 func writableNative(t *testing.T) {
 	t.Helper()
-	if runtime.GOOS != "linux" && !(runtime.GOOS == "windows" && runtime.GOARCH == "amd64") {
-		t.Skip("writable native authoring requires Linux or Windows amd64")
+	if runtime.GOOS != "linux" && !(runtime.GOOS == "windows" && (runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64")) {
+		t.Skip("writable native authoring requires Linux or Windows amd64/arm64")
 	}
 }
 

--- a/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows.go
+++ b/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows.go
@@ -4,6 +4,8 @@ package scaffold
 
 import (
 	"errors"
+	"fmt"
+	"io/fs"
 	"os"
 	"runtime"
 	"unsafe"
@@ -17,17 +19,48 @@ import (
 // POSIX_SEMANTICS. Unsupported filesystems fail without a weaker fallback.
 func renameExclusive(from *os.File, old string, to *os.File, new string) error {
 	err := renameWindows(from, old, to, new)
+	if err != nil {
+		err = windowsRenameError(err, to, new)
+	}
 	runtime.KeepAlive(from)
 	runtime.KeepAlive(to)
+	if err != nil {
+		return &os.LinkError{Op: "rename-exclusive", Old: old, New: new, Err: err}
+	}
+	return nil
+}
+
+func windowsRenameError(err error, to *os.File, new string) error {
 	// Both NT calls return NTStatus, which lacks Is/Unwrap in pinned x/sys.
 	// Retain the native cause and expose its Win32 errno for Go classification.
 	if status, ok := err.(windows.NTStatus); ok {
 		err = errors.Join(status, status.Errno())
 	}
-	if err != nil {
-		return &os.LinkError{Op: "rename-exclusive", Old: old, New: new, Err: err}
+	if !errors.Is(err, windows.STATUS_SHARING_VIOLATION) {
+		return err
 	}
-	return nil
+	// A winner's delete-denying data handle can make sharing failure precede
+	// name collision. Observe existence only after failure; never retry rename.
+	// Metadata access avoids data opens, and the single rooted component is
+	// opened as a reparse point so even a dangling/outside link counts as existing.
+	name, e := windows.NewNTUnicodeString(new)
+	if e != nil {
+		return err
+	}
+	oa := windows.OBJECT_ATTRIBUTES{RootDirectory: windows.Handle(to.Fd()), ObjectName: name, Attributes: windows.OBJ_CASE_INSENSITIVE}
+	oa.Length = uint32(unsafe.Sizeof(oa))
+	var handle windows.Handle
+	e = windows.NtCreateFile(&handle, windows.FILE_READ_ATTRIBUTES|windows.SYNCHRONIZE, &oa, &windows.IO_STATUS_BLOCK{}, nil, 0,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE, windows.FILE_OPEN,
+		windows.FILE_OPEN_REPARSE_POINT|windows.FILE_SYNCHRONOUS_IO_NONALERT, 0, 0)
+	runtime.KeepAlive(to)
+	if e != nil {
+		return err // Missing or unobservable destination: no new existence claim.
+	}
+	if e = windows.CloseHandle(handle); e != nil {
+		return errors.Join(err, e)
+	}
+	return errors.Join(err, fmt.Errorf("destination already exists: %w", fs.ErrExist))
 }
 func renameWindows(from *os.File, old string, to *os.File, new string) error {
 	name, err := windows.NewNTUnicodeString(old)

--- a/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows.go
+++ b/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows.go
@@ -3,6 +3,7 @@
 package scaffold
 
 import (
+	"errors"
 	"os"
 	"runtime"
 	"unsafe"
@@ -18,6 +19,11 @@ func renameExclusive(from *os.File, old string, to *os.File, new string) error {
 	err := renameWindows(from, old, to, new)
 	runtime.KeepAlive(from)
 	runtime.KeepAlive(to)
+	// Both NT calls return NTStatus, which lacks Is/Unwrap in pinned x/sys.
+	// Retain the native cause and expose its Win32 errno for Go classification.
+	if status, ok := err.(windows.NTStatus); ok {
+		err = errors.Join(status, status.Errno())
+	}
 	if err != nil {
 		return &os.LinkError{Op: "rename-exclusive", Old: old, New: new, Err: err}
 	}

--- a/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows_test.go
@@ -1,0 +1,116 @@
+//go:build windows
+
+package scaffold
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestWindowsRenameNativeClassification(t *testing.T) {
+	for _, kind := range []string{"empty", "nonempty", "missing-source", "sharing-violation"} {
+		t.Run(kind, func(t *testing.T) {
+			parent := tempRoot(t)
+			for _, name := range []string{"source", "dest"} {
+				if err := os.Mkdir(filepath.Join(parent, name), 0700); err != nil {
+					t.Fatal(err)
+				}
+				if name == "source" || kind == "nonempty" {
+					if err := os.WriteFile(filepath.Join(parent, name, "sentinel"), []byte(name), 0600); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			old, want := "source", windows.STATUS_OBJECT_NAME_COLLISION
+			if kind == "missing-source" {
+				old, want = "missing", windows.STATUS_OBJECT_NAME_NOT_FOUND
+			}
+			if kind == "sharing-violation" {
+				name, err := windows.UTF16PtrFromString(filepath.Join(parent, old))
+				if err != nil {
+					t.Fatal(err)
+				}
+				handle, err := windows.CreateFile(name, windows.FILE_READ_ATTRIBUTES, windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE, nil, windows.OPEN_EXISTING, windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer windows.CloseHandle(handle)
+				want = windows.STATUS_SHARING_VIOLATION
+			}
+			root, err := os.Open(parent)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer root.Close()
+			before := skillTree(t, parent)
+			// Invoke the native no-replace primitive directly; no absent() shortcut.
+			err = renameExclusive(root, old, root, "dest")
+			collision := want == windows.STATUS_OBJECT_NAME_COLLISION
+			var link *os.LinkError
+			var status windows.NTStatus
+			if !errors.As(err, &link) || link.Old != old || link.New != "dest" || !errors.As(err, &status) || status != want || !errors.Is(err, want.Errno()) || errors.Is(err, os.ErrExist) != collision {
+				t.Fatalf("native %s: want status=%#x exists=%v; got %v", kind, uint32(want), collision, err)
+			}
+			if !reflect.DeepEqual(before, skillTree(t, parent)) {
+				t.Fatal("failed rename changed source/destination paths or contents")
+			}
+		})
+	}
+	// Old red reproducer: LinkError and cleanup joins cannot classify raw NTStatus.
+	if errors.Is(errors.Join(&os.LinkError{Err: windows.STATUS_OBJECT_NAME_COLLISION}), os.ErrExist) {
+		t.Fatal("pinned NTStatus classification changed; re-evaluate the boundary fix")
+	}
+	for _, status := range []windows.NTStatus{windows.STATUS_ACCESS_DENIED, windows.STATUS_SHARING_VIOLATION} {
+		if errors.Is(errors.Join(status, status.Errno()), os.ErrExist) {
+			t.Fatalf("noncollision status %#x classified as exists", uint32(status))
+		}
+	}
+}
+
+func TestWindowsApplyNativeCollisionCleanup(t *testing.T) {
+	for _, retain := range []bool{false, true} {
+		parent := tempRoot(t)
+		dest := filepath.Join(parent, "dest")
+		var container string
+		called := false
+		ops := applyOps{write: writeTree, rename: func(from *os.File, old string, to *os.File, new string) error {
+			called = true
+			container = from.Name()
+			// Calibrate at the actual rename seam, after Apply's final absent check.
+			if err := os.Mkdir(dest, 0700); err != nil {
+				t.Fatal(err)
+			}
+			before := skillTree(t, parent)
+			err := renameExclusive(from, old, to, new)
+			if !reflect.DeepEqual(before, skillTree(t, parent)) {
+				t.Fatal("native collision changed staged payload or destination")
+			}
+			if retain {
+				if e := os.WriteFile(filepath.Join(from.Name(), "retained"), []byte("retain"), 0600); e != nil {
+					t.Fatal(e)
+				}
+			}
+			return err
+		}}
+		result, err := apply(context.Background(), planFor(t, "skill"), ApplyOptions{Destination: dest, Validate: realValidation(t)}, ops)
+		var cleanup *CleanupError
+		if !called || result.Committed || !errors.Is(err, os.ErrExist) || !errors.Is(err, windows.STATUS_OBJECT_NAME_COLLISION) || errors.As(err, &cleanup) != retain {
+			t.Fatalf("retain=%v called=%v result=%+v err=%v", retain, called, result, err)
+		}
+		assertOnly(t, dest)
+		if !retain {
+			assertOnly(t, parent, "dest")
+		} else {
+			assertOnly(t, container, "retained")
+			if b, e := os.ReadFile(filepath.Join(container, "retained")); e != nil || string(b) != "retain" {
+				t.Fatalf("cleanup changed unrelated container entry: %q %v", b, e)
+			}
+		}
+	}
+}

--- a/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows_test.go
@@ -18,6 +18,9 @@ func TestWindowsRenameNativeClassification(t *testing.T) {
 		t.Run(kind, func(t *testing.T) {
 			parent := tempRoot(t)
 			for _, name := range []string{"source", "dest"} {
+				if kind == "sharing-violation" && name == "dest" {
+					continue
+				}
 				if err := os.Mkdir(filepath.Join(parent, name), 0700); err != nil {
 					t.Fatal(err)
 				}
@@ -36,7 +39,7 @@ func TestWindowsRenameNativeClassification(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				handle, err := windows.CreateFile(name, windows.FILE_READ_ATTRIBUTES, windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE, nil, windows.OPEN_EXISTING, windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
+				handle, err := windows.CreateFile(name, windows.FILE_LIST_DIRECTORY, windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE, nil, windows.OPEN_EXISTING, windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows_test.go
@@ -5,6 +5,7 @@ package scaffold
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -14,7 +15,7 @@ import (
 )
 
 func TestWindowsRenameNativeClassification(t *testing.T) {
-	for _, kind := range []string{"empty", "nonempty", "missing-source", "sharing-violation"} {
+	for _, kind := range []string{"empty", "nonempty", "missing-source", "sharing-violation", "destination-sharing", "destination-metadata"} {
 		t.Run(kind, func(t *testing.T) {
 			parent := tempRoot(t)
 			for _, name := range []string{"source", "dest"} {
@@ -34,17 +35,18 @@ func TestWindowsRenameNativeClassification(t *testing.T) {
 			if kind == "missing-source" {
 				old, want = "missing", windows.STATUS_OBJECT_NAME_NOT_FOUND
 			}
-			if kind == "sharing-violation" {
-				name, err := windows.UTF16PtrFromString(filepath.Join(parent, old))
-				if err != nil {
-					t.Fatal(err)
+			if kind == "sharing-violation" || kind == "destination-sharing" || kind == "destination-metadata" {
+				held, access := "dest", uint32(windows.FILE_READ_ATTRIBUTES|windows.FILE_LIST_DIRECTORY)
+				if kind == "sharing-violation" {
+					held = old
 				}
-				handle, err := windows.CreateFile(name, windows.FILE_LIST_DIRECTORY, windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE, nil, windows.OPEN_EXISTING, windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
-				if err != nil {
-					t.Fatal(err)
+				if kind == "destination-metadata" {
+					access = windows.FILE_READ_ATTRIBUTES
+				} else {
+					want = windows.STATUS_SHARING_VIOLATION
 				}
+				handle := holdRenameDirectory(t, filepath.Join(parent, held), access)
 				defer windows.CloseHandle(handle)
-				want = windows.STATUS_SHARING_VIOLATION
 			}
 			root, err := os.Open(parent)
 			if err != nil {
@@ -54,12 +56,13 @@ func TestWindowsRenameNativeClassification(t *testing.T) {
 			before := skillTree(t, parent)
 			// Invoke the native no-replace primitive directly; no absent() shortcut.
 			err = renameExclusive(root, old, root, "dest")
-			collision := want == windows.STATUS_OBJECT_NAME_COLLISION
+			collision := want == windows.STATUS_OBJECT_NAME_COLLISION || kind == "destination-sharing"
 			var link *os.LinkError
 			var status windows.NTStatus
 			if !errors.As(err, &link) || link.Old != old || link.New != "dest" || !errors.As(err, &status) || status != want || !errors.Is(err, want.Errno()) || errors.Is(err, os.ErrExist) != collision {
 				t.Fatalf("native %s: want status=%#x exists=%v; got %v", kind, uint32(want), collision, err)
 			}
+			t.Logf("%s: status=%#x win32=%d exists=%v", kind, uint32(status), want.Errno(), collision)
 			if !reflect.DeepEqual(before, skillTree(t, parent)) {
 				t.Fatal("failed rename changed source/destination paths or contents")
 			}
@@ -76,44 +79,157 @@ func TestWindowsRenameNativeClassification(t *testing.T) {
 	}
 }
 
+// FILE_LIST_DIRECTORY participates in sharing; READ_ATTRIBUTES alone does not.
+// Deny WRITE and DELETE exactly as packageview's protected directory lease does.
+func holdRenameDirectory(t *testing.T, path string, access uint32) windows.Handle {
+	t.Helper()
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h, err := windows.CreateFile(name, access, windows.FILE_SHARE_READ, nil, windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS|windows.FILE_FLAG_OPEN_REPARSE_POINT, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
+}
+
 func TestWindowsApplyNativeCollisionCleanup(t *testing.T) {
-	for _, retain := range []bool{false, true} {
-		parent := tempRoot(t)
-		dest := filepath.Join(parent, "dest")
-		var container string
-		called := false
-		ops := applyOps{write: writeTree, rename: func(from *os.File, old string, to *os.File, new string) error {
-			called = true
-			container = from.Name()
-			// Calibrate at the actual rename seam, after Apply's final absent check.
-			if err := os.Mkdir(dest, 0700); err != nil {
-				t.Fatal(err)
-			}
-			before := skillTree(t, parent)
-			err := renameExclusive(from, old, to, new)
-			if !reflect.DeepEqual(before, skillTree(t, parent)) {
-				t.Fatal("native collision changed staged payload or destination")
-			}
-			if retain {
-				if e := os.WriteFile(filepath.Join(from.Name(), "retained"), []byte("retain"), 0600); e != nil {
-					t.Fatal(e)
+	for _, kind := range []string{"collision", "destination-sharing", "destination-removed", "source-sharing"} {
+		for _, retain := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/retain=%v", kind, retain), func(t *testing.T) {
+				parent := tempRoot(t)
+				dest := filepath.Join(parent, "dest")
+				var container string
+				var held windows.Handle
+				defer func() {
+					if held != 0 {
+						if err := windows.CloseHandle(held); err != nil {
+							t.Error(err)
+						}
+					}
+				}()
+				calls := 0
+				ops := applyOps{write: writeTree, rename: func(from *os.File, old string, to *os.File, new string) error {
+					calls++
+					container = from.Name()
+					// Winner appears after Apply's final absence check, without timing.
+					if kind != "source-sharing" {
+						if err := os.Mkdir(dest, 0700); err != nil {
+							t.Fatal(err)
+						}
+					}
+					if kind != "collision" {
+						path := dest
+						if kind == "source-sharing" {
+							path = filepath.Join(from.Name(), old)
+						}
+						held = holdRenameDirectory(t, path, windows.FILE_READ_ATTRIBUTES|windows.FILE_LIST_DIRECTORY)
+					}
+					before := skillTree(t, parent)
+					var err error
+					if kind == "destination-removed" {
+						// One real NtSetInformationFile, then remove the winner before
+						// the diagnostic observation. Never retry the source rename.
+						err = renameWindows(from, old, to, new)
+						if !errors.Is(err, windows.STATUS_SHARING_VIOLATION) {
+							t.Fatalf("raw destination sharing: %v", err)
+						}
+						if !reflect.DeepEqual(before, skillTree(t, parent)) {
+							t.Fatal("failed native rename changed trees")
+						}
+						if e := windows.CloseHandle(held); e != nil {
+							t.Fatal(e)
+						}
+						held = 0
+						if e := os.Remove(dest); e != nil {
+							t.Fatal(e)
+						}
+						err = &os.LinkError{Op: "rename-exclusive", Old: old, New: new, Err: windowsRenameError(err, to, new)}
+					} else {
+						err = renameExclusive(from, old, to, new)
+						if !reflect.DeepEqual(before, skillTree(t, parent)) {
+							t.Fatal("native collision changed staged payload or destination")
+						}
+					}
+					if kind == "source-sharing" {
+						if e := windows.CloseHandle(held); e != nil {
+							t.Fatal(e)
+						}
+						held = 0 // Allow normal owned payload cleanup.
+					}
+					if retain {
+						if e := os.WriteFile(filepath.Join(container, "retained"), []byte("retain"), 0600); e != nil {
+							t.Fatal(e)
+						}
+					}
+					return err
+				}}
+				result, err := apply(context.Background(), planFor(t, "skill"), ApplyOptions{Destination: dest, Validate: realValidation(t)}, ops)
+				want := windows.STATUS_SHARING_VIOLATION
+				if kind == "collision" {
+					want = windows.STATUS_OBJECT_NAME_COLLISION
 				}
-			}
-			return err
-		}}
-		result, err := apply(context.Background(), planFor(t, "skill"), ApplyOptions{Destination: dest, Validate: realValidation(t)}, ops)
-		var cleanup *CleanupError
-		if !called || result.Committed || !errors.Is(err, os.ErrExist) || !errors.Is(err, windows.STATUS_OBJECT_NAME_COLLISION) || errors.As(err, &cleanup) != retain {
-			t.Fatalf("retain=%v called=%v result=%+v err=%v", retain, called, result, err)
+				exists := kind == "collision" || kind == "destination-sharing"
+				var cleanup *CleanupError
+				var link *os.LinkError
+				if calls != 1 || result.Committed || errors.Is(err, os.ErrExist) != exists || !errors.Is(err, want) || !errors.Is(err, want.Errno()) || !errors.As(err, &link) || errors.As(err, &cleanup) != retain {
+					t.Fatalf("calls=%d result=%+v err=%v", calls, result, err)
+				}
+				names := []string{}
+				if exists {
+					assertOnly(t, dest)
+					names = append(names, "dest")
+				}
+				if retain {
+					names = append(names, filepath.Base(container))
+					assertOnly(t, container, "retained")
+					if b, e := os.ReadFile(filepath.Join(container, "retained")); e != nil || string(b) != "retain" {
+						t.Fatalf("cleanup changed unrelated entry: %q %v", b, e)
+					}
+				}
+				assertOnly(t, parent, names...)
+			})
 		}
-		assertOnly(t, dest)
-		if !retain {
-			assertOnly(t, parent, "dest")
-		} else {
-			assertOnly(t, container, "retained")
-			if b, e := os.ReadFile(filepath.Join(container, "retained")); e != nil || string(b) != "retain" {
-				t.Fatalf("cleanup changed unrelated container entry: %q %v", b, e)
-			}
+	}
+}
+
+func TestWindowsRenameObservationFailureAndReparse(t *testing.T) {
+	parent := tempRoot(t)
+	root, err := os.Open(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+	cause := windows.STATUS_SHARING_VIOLATION
+	if err := windowsRenameError(windows.STATUS_ACCESS_DENIED, root, "."); errors.Is(err, os.ErrExist) || !errors.Is(err, windows.STATUS_ACCESS_DENIED) {
+		t.Fatalf("unrelated failure must not gain existence classification: %v", err)
+	}
+	closed, err := os.Open(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := closed.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := windowsRenameError(cause, closed, "."); errors.Is(err, os.ErrExist) || !errors.Is(err, cause) || !errors.Is(err, cause.Errno()) {
+		t.Fatalf("failed native observation lost cause or claimed existence: %v", err)
+	}
+	// Invalid name forces the rooted metadata probe to fail, not report exists.
+	if err := windowsRenameError(cause, root, "invalid\x00name"); errors.Is(err, os.ErrExist) || !errors.Is(err, cause) || !errors.Is(err, cause.Errno()) {
+		t.Fatalf("failed observation lost cause or claimed existence: %v", err)
+	}
+	for _, target := range []string{filepath.Join(tempRoot(t), "missing"), tempRoot(t)} {
+		link := filepath.Join(parent, "link")
+		if err := os.Symlink(target, link); err != nil {
+			t.Skipf("native symlink prerequisite: %v", err)
+		}
+		if err := windowsRenameError(cause, root, "link"); !errors.Is(err, os.ErrExist) || !errors.Is(err, cause) {
+			t.Fatalf("reparse entry must count without following target: %v", err)
+		}
+		if err := os.Remove(link); err != nil {
+			t.Fatal(err)
 		}
 	}
 }

--- a/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows_test.go
@@ -9,13 +9,14 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"golang.org/x/sys/windows"
 )
 
 func TestWindowsRenameNativeClassification(t *testing.T) {
-	for _, kind := range []string{"empty", "nonempty", "missing-source", "sharing-violation", "destination-sharing", "destination-metadata"} {
+	for _, kind := range []string{"empty", "nonempty", "missing-source", "sharing-violation", "source-sharing-existing", "destination-sharing", "destination-metadata"} {
 		t.Run(kind, func(t *testing.T) {
 			parent := tempRoot(t)
 			for _, name := range []string{"source", "dest"} {
@@ -35,14 +36,15 @@ func TestWindowsRenameNativeClassification(t *testing.T) {
 			if kind == "missing-source" {
 				old, want = "missing", windows.STATUS_OBJECT_NAME_NOT_FOUND
 			}
-			if kind == "sharing-violation" || kind == "destination-sharing" || kind == "destination-metadata" {
+			sourceSharing := kind == "sharing-violation" || kind == "source-sharing-existing"
+			if sourceSharing || kind == "destination-sharing" || kind == "destination-metadata" {
 				held, access := "dest", uint32(windows.FILE_READ_ATTRIBUTES|windows.FILE_LIST_DIRECTORY)
-				if kind == "sharing-violation" {
+				if sourceSharing {
 					held = old
 				}
 				if kind == "destination-metadata" {
 					access = windows.FILE_READ_ATTRIBUTES
-				} else {
+				} else if sourceSharing {
 					want = windows.STATUS_SHARING_VIOLATION
 				}
 				handle := holdRenameDirectory(t, filepath.Join(parent, held), access)
@@ -54,9 +56,15 @@ func TestWindowsRenameNativeClassification(t *testing.T) {
 			}
 			defer root.Close()
 			before := skillTree(t, parent)
-			// Invoke the native no-replace primitive directly; no absent() shortcut.
-			err = renameExclusive(root, old, root, "dest")
-			collision := want == windows.STATUS_OBJECT_NAME_COLLISION || kind == "destination-sharing"
+			// Held destination data access is a collision control on native NTFS.
+			// Source delete denial fails NtCreateFile, before NtSetInformationFile;
+			// an independent destination tests only the diagnostic contract.
+			raw := renameWindows(root, old, root, "dest")
+			if raw != want {
+				t.Fatalf("native %s: raw=%v (%T), want %#x", kind, raw, raw, uint32(want))
+			}
+			err = &os.LinkError{Op: "rename-exclusive", Old: old, New: "dest", Err: windowsRenameError(raw, root, "dest")}
+			collision := want == windows.STATUS_OBJECT_NAME_COLLISION || kind == "source-sharing-existing"
 			var link *os.LinkError
 			var status windows.NTStatus
 			if !errors.As(err, &link) || link.Old != old || link.New != "dest" || !errors.As(err, &status) || status != want || !errors.Is(err, want.Errno()) || errors.Is(err, os.ErrExist) != collision {
@@ -95,8 +103,40 @@ func holdRenameDirectory(t *testing.T, path string, access uint32) windows.Handl
 	return h
 }
 
+// Root.Open(".").Name() is ".", not a physical container pathname.
+// Resolve the held identity only among this fixture's immediate children.
+func renameFixtureContainer(t *testing.T, parent string, from *os.File) string {
+	t.Helper()
+	held, err := from.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	matches := []string{}
+	for _, entry := range entries {
+		path := filepath.Join(parent, entry.Name())
+		info, err := os.Lstat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if os.SameFile(held, info) {
+			if !filepath.IsAbs(path) || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || !strings.HasPrefix(entry.Name(), ".authoring-") {
+				t.Fatalf("held container is not an owned stage: %q", path)
+			}
+			matches = append(matches, path)
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("want exactly one owned stage matching held identity, got %v", matches)
+	}
+	return matches[0]
+}
+
 func TestWindowsApplyNativeCollisionCleanup(t *testing.T) {
-	for _, kind := range []string{"collision", "destination-sharing", "destination-removed", "source-sharing"} {
+	for _, kind := range []string{"collision", "destination-sharing", "source-sharing-existing", "destination-removed", "source-sharing"} {
 		for _, retain := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s/retain=%v", kind, retain), func(t *testing.T) {
 				parent := tempRoot(t)
@@ -113,7 +153,12 @@ func TestWindowsApplyNativeCollisionCleanup(t *testing.T) {
 				calls := 0
 				ops := applyOps{write: writeTree, rename: func(from *os.File, old string, to *os.File, new string) error {
 					calls++
-					container = from.Name()
+					container = renameFixtureContainer(t, parent, from)
+					assertOnly(t, parent, filepath.Base(container))
+					if old != "payload" || new != filepath.Base(dest) {
+						t.Fatalf("unexpected rename components: %q -> %q", old, new)
+					}
+					sourceSharing := kind == "source-sharing" || kind == "source-sharing-existing" || kind == "destination-removed"
 					// Winner appears after Apply's final absence check, without timing.
 					if kind != "source-sharing" {
 						if err := os.Mkdir(dest, 0700); err != nil {
@@ -122,38 +167,38 @@ func TestWindowsApplyNativeCollisionCleanup(t *testing.T) {
 					}
 					if kind != "collision" {
 						path := dest
-						if kind == "source-sharing" {
-							path = filepath.Join(from.Name(), old)
+						if sourceSharing {
+							path = filepath.Join(container, old)
 						}
 						held = holdRenameDirectory(t, path, windows.FILE_READ_ATTRIBUTES|windows.FILE_LIST_DIRECTORY)
 					}
 					before := skillTree(t, parent)
 					var err error
 					if kind == "destination-removed" {
-						// One real NtSetInformationFile, then remove the winner before
-						// the diagnostic observation. Never retry the source rename.
+						// Source NtCreateFile really fails sharing. Remove only our empty
+						// destination before one probe, keeping the same source lease.
 						err = renameWindows(from, old, to, new)
-						if !errors.Is(err, windows.STATUS_SHARING_VIOLATION) {
-							t.Fatalf("raw destination sharing: %v", err)
+						if err != windows.STATUS_SHARING_VIOLATION {
+							t.Fatalf("raw source sharing: %v", err)
 						}
 						if !reflect.DeepEqual(before, skillTree(t, parent)) {
 							t.Fatal("failed native rename changed trees")
 						}
-						if e := windows.CloseHandle(held); e != nil {
-							t.Fatal(e)
-						}
-						held = 0
 						if e := os.Remove(dest); e != nil {
 							t.Fatal(e)
 						}
 						err = &os.LinkError{Op: "rename-exclusive", Old: old, New: new, Err: windowsRenameError(err, to, new)}
+						delete(before, "dest")
+						if !reflect.DeepEqual(before, skillTree(t, parent)) {
+							t.Fatal("removal/probe changed entries beyond owned destination")
+						}
 					} else {
 						err = renameExclusive(from, old, to, new)
 						if !reflect.DeepEqual(before, skillTree(t, parent)) {
 							t.Fatal("native collision changed staged payload or destination")
 						}
 					}
-					if kind == "source-sharing" {
+					if sourceSharing {
 						if e := windows.CloseHandle(held); e != nil {
 							t.Fatal(e)
 						}
@@ -168,15 +213,19 @@ func TestWindowsApplyNativeCollisionCleanup(t *testing.T) {
 				}}
 				result, err := apply(context.Background(), planFor(t, "skill"), ApplyOptions{Destination: dest, Validate: realValidation(t)}, ops)
 				want := windows.STATUS_SHARING_VIOLATION
-				if kind == "collision" {
+				if kind == "collision" || kind == "destination-sharing" {
 					want = windows.STATUS_OBJECT_NAME_COLLISION
 				}
-				exists := kind == "collision" || kind == "destination-sharing"
+				exists := kind == "collision" || kind == "destination-sharing" || kind == "source-sharing-existing"
 				var cleanup *CleanupError
 				var link *os.LinkError
-				if calls != 1 || result.Committed || errors.Is(err, os.ErrExist) != exists || !errors.Is(err, want) || !errors.Is(err, want.Errno()) || !errors.As(err, &link) || errors.As(err, &cleanup) != retain {
+				var status windows.NTStatus
+				// ENOTEMPTY in CleanupError also matches ErrExist. Classify the
+				// original LinkError separately; commands still prioritize cleanup.
+				if calls != 1 || result.Committed || !errors.As(err, &link) || link.Old != "payload" || link.New != "dest" || errors.Is(link.Err, os.ErrExist) != exists || !errors.As(link.Err, &status) || status != want || !errors.Is(link.Err, want) || !errors.Is(link.Err, want.Errno()) || errors.As(err, &cleanup) != retain {
 					t.Fatalf("calls=%d result=%+v err=%v", calls, result, err)
 				}
+				t.Logf("%s: status=%#x win32=%d exists=%v cleanup=%v", kind, uint32(status), status.Errno(), exists, retain)
 				names := []string{}
 				if exists {
 					assertOnly(t, dest)
@@ -223,7 +272,10 @@ func TestWindowsRenameObservationFailureAndReparse(t *testing.T) {
 	for _, target := range []string{filepath.Join(tempRoot(t), "missing"), tempRoot(t)} {
 		link := filepath.Join(parent, "link")
 		if err := os.Symlink(target, link); err != nil {
-			t.Skipf("native symlink prerequisite: %v", err)
+			if errors.Is(err, windows.ERROR_PRIVILEGE_NOT_HELD) {
+				t.Skipf("UNPROVEN: native symlink privilege prerequisite: %v", err)
+			}
+			t.Fatal(err)
 		}
 		if err := windowsRenameError(cause, root, "link"); !errors.Is(err, os.ErrExist) || !errors.Is(err, cause) {
 			t.Fatalf("reparse entry must count without following target: %v", err)

--- a/install/integrationctl/agentplugins/adapters/packageview/ancestor_epoch_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/ancestor_epoch_windows_test.go
@@ -7,12 +7,13 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"golang.org/x/sys/windows"
 )
 
 // One synchronous sibling creation, selected by held object identity, occurs
-// exactly between the two metadata observations. No sleep, race loop, timestamp
+// exactly between the two metadata observations. No race loop, timestamp
 // write or mocked metadata. An unchanged native epoch is a fixture failure.
 func TestWindowsAncestorEpochBoundary(t *testing.T) {
 	for _, boundary := range []string{"outside", "root", "descendant"} {
@@ -41,6 +42,7 @@ func TestWindowsAncestorEpochBoundary(t *testing.T) {
 						mutationErr = err
 						return
 					}
+					windowsAwaitDirectoryClock(t, a)
 					mutationErr = os.Mkdir(filepath.Join(target, "unrelated-sibling"), 0700)
 					if mutationErr != nil {
 						return
@@ -140,7 +142,17 @@ func TestWindowsAncestorEpochOrderedRoot(t *testing.T) {
 					return
 				}
 				fired = true
+				before, e := winMeta(f)
+				bootstrapCheck(t, "ordered root pre-mutation", e)
+				windowsAwaitDirectoryClock(t, before)
 				mutationErr = os.Mkdir(filepath.Join(root, "late"), 0700)
+				after, e := winMeta(f)
+				bootstrapCheck(t, "ordered root post-mutation", e)
+				x, y := before, after
+				x.Write, x.Change, y.Write, y.Change = 0, 0, 0, 0
+				if x != y || before == after {
+					t.Fatal("ordered root fixture did not isolate directory epoch mutation")
+				}
 			})
 			if s != nil {
 				s.close()
@@ -221,5 +233,27 @@ func TestWindowsAncestorEpochReplacementRejected(t *testing.T) {
 	var safe *Error
 	if !fired || mutationErr != nil || !errors.As(err, &safe) || safe.Code != "root_unreadable" {
 		t.Fatalf("ancestor replacement accepted: fired=%t mutation=%v acquisition=%v", fired, mutationErr, err)
+	}
+}
+
+// NTFS can stamp two consecutive directory mutations with the same kernel clock
+// tick. Wait for an observed coarse-clock advance before the SINGLE mutation;
+// never retry acquisition/mutation or modify source timestamps. A stopped clock
+// fails the fixture after a bounded deadline, and each caller still proves the
+// actual filesystem epoch changed without any other metadata changing.
+func windowsAwaitDirectoryClock(t *testing.T, snapshot winSnapshot) {
+	t.Helper()
+	clock := func() int64 {
+		var now windows.Filetime
+		windows.GetSystemTimeAsFileTime(&now)
+		return int64(uint64(now.HighDateTime)<<32 | uint64(now.LowDateTime))
+	}
+	threshold := max(snapshot.Write, snapshot.Change, clock())
+	deadline := time.Now().Add(2 * time.Second)
+	for clock() <= threshold {
+		if time.Now().After(deadline) {
+			t.Fatal("native coarse clock did not advance for directory mutation")
+		}
+		time.Sleep(time.Millisecond)
 	}
 }

--- a/install/integrationctl/agentplugins/adapters/packageview/ancestor_epoch_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/ancestor_epoch_windows_test.go
@@ -1,0 +1,225 @@
+//go:build windows && (amd64 || arm64)
+
+package packageview
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// One synchronous sibling creation, selected by held object identity, occurs
+// exactly between the two metadata observations. No sleep, race loop, timestamp
+// write or mocked metadata. An unchanged native epoch is a fixture failure.
+func TestWindowsAncestorEpochBoundary(t *testing.T) {
+	for _, boundary := range []string{"outside", "root", "descendant"} {
+		for _, stage := range []string{"stat", "protect"} {
+			t.Run(boundary+"/"+stage, func(t *testing.T) {
+				before := winRecordCount()
+				parent := t.TempDir()
+				nativeWrite(t, parent, "source/sub/original", "original")
+				root := filepath.Join(parent, "source")
+				target := map[string]string{"outside": parent, "root": root, "descendant": filepath.Join(root, "sub")}[boundary]
+				identity, err := os.Stat(target)
+				bootstrapCheck(t, "fixture identity", err)
+				fired := false
+				var mutationErr error
+				hook := func(f *os.File, at string) {
+					if fired || at != stage {
+						return
+					}
+					info, err := f.Stat()
+					if err != nil || !os.SameFile(identity, info) {
+						return
+					}
+					fired = true
+					a, err := winMeta(f)
+					if err != nil {
+						mutationErr = err
+						return
+					}
+					mutationErr = os.Mkdir(filepath.Join(target, "unrelated-sibling"), 0700)
+					if mutationErr != nil {
+						return
+					}
+					b, err := winMeta(f)
+					if err != nil {
+						mutationErr = err
+						return
+					}
+					// Compare every non-epoch field without depending on the fix helper.
+					x, y := a, b
+					x.Write, x.Change, y.Write, y.Change = 0, 0, 0, 0
+					if x != y || a == b {
+						mutationErr = errors.New("native fixture did not isolate a same-object directory epoch change")
+					}
+					t.Logf("stage=%s boundary=%s before=%+v after=%+v", stage, boundary, a, b)
+				}
+				s, err := openSourceWithMetadataStage(root, hook)
+				if s != nil {
+					defer s.close()
+				}
+				if boundary == "descendant" {
+					bootstrapCheck(t, "source acquisition", err)
+					p, e := s.pin("sub", false)
+					if p != nil {
+						p.file.Close()
+					}
+					err = e
+				}
+				if !fired || mutationErr != nil {
+					t.Fatalf("mutation fired=%t error=%v", fired, mutationErr)
+				}
+				if boundary == "outside" {
+					bootstrapCheck(t, "outside-root sibling must not invalidate acquisition", err)
+					// All retained records still participate in global verification.
+					for _, o := range s.records {
+						if os.SameFile(identity, o.info) {
+							data, e := (&pinned{file: o.file, info: o.info}).reopen(true)
+							if data != nil {
+								data.Close()
+							}
+							if e == nil {
+								t.Fatal("outside identity pin authorized a data upgrade")
+							}
+						}
+						if !same(o.info, o.info) {
+							t.Fatal("retained record failed verification")
+						}
+					}
+					p, err := s.pin("sub/original", false)
+					bootstrapCheck(t, "contained pin", err)
+					data, err := p.reopen(false)
+					p.file.Close()
+					bootstrapCheck(t, "contained same-object data upgrade", err)
+					data.Close()
+					if _, err := s.pin("../unrelated-sibling", false); err == nil {
+						t.Fatal("ancestry escaped source")
+					}
+					if err := nativeSharedRename(parent, parent+"-moved"); !errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
+						t.Fatalf("outside ancestor lost delete protection: %v", err)
+					}
+				} else {
+					var safe *Error
+					want := "source_changed"
+					if boundary == "root" {
+						want = "root_unreadable"
+					}
+					if !errors.As(err, &safe) || safe.Code != want {
+						t.Fatalf("inside mutation accepted: %v", err)
+					}
+				}
+				if s != nil {
+					bootstrapCheck(t, "source close", s.close())
+				}
+				if got := winRecordCount(); got != before {
+					t.Fatalf("record leak: before=%d after=%d", before, got)
+				}
+			})
+		}
+	}
+}
+
+// Trailing '.' and a real descent followed by '..' must retain strict epochs
+// for the actual root from its first acquisition, not just its final spelling.
+func TestWindowsAncestorEpochOrderedRoot(t *testing.T) {
+	for _, suffix := range []string{`\.`, `\sub\..`} {
+		t.Run(suffix, func(t *testing.T) {
+			root := t.TempDir()
+			nativeWrite(t, root, "sub/original", "original")
+			identity, err := os.Stat(root)
+			bootstrapCheck(t, "root identity", err)
+			fired := false
+			var mutationErr error
+			s, err := openSourceWithMetadataStage(root+suffix, func(f *os.File, stage string) {
+				info, e := f.Stat()
+				if fired || stage != "protect" || e != nil || !os.SameFile(identity, info) {
+					return
+				}
+				fired = true
+				mutationErr = os.Mkdir(filepath.Join(root, "late"), 0700)
+			})
+			if s != nil {
+				s.close()
+			}
+			if !fired || mutationErr != nil || err == nil {
+				t.Fatalf("ordered root epoch weakened: fired=%t mutation=%v acquisition=%v", fired, mutationErr, err)
+			}
+		})
+	}
+}
+
+func TestWindowsAncestorEpochMetadataGuards(t *testing.T) {
+	a := winSnapshot{Volume: 1, High: 2, Low: 3, Links: 1, Attributes: windows.FILE_ATTRIBUTE_DIRECTORY, Size: 4096, Creation: 4, Write: 5, Change: 6}
+	for _, mutate := range []func(*winSnapshot){
+		func(b *winSnapshot) { b.Volume++ }, func(b *winSnapshot) { b.High++ },
+		func(b *winSnapshot) { b.Low++ }, func(b *winSnapshot) { b.Links++ },
+		func(b *winSnapshot) { b.Attributes |= windows.FILE_ATTRIBUTE_REPARSE_POINT },
+		func(b *winSnapshot) { b.Attributes |= windows.FILE_ATTRIBUTE_OFFLINE },
+		func(b *winSnapshot) { b.Attributes |= windows.FILE_ATTRIBUTE_RECALL_ON_OPEN },
+		func(b *winSnapshot) { b.Size++ }, func(b *winSnapshot) { b.Creation++ },
+	} {
+		b := a
+		mutate(&b)
+		if winUnchanged(a, b, true) {
+			t.Fatalf("ancestor metadata guard weakened: %+v", b)
+		}
+	}
+	b := a
+	b.Write++
+	b.Change++
+	if !winUnchanged(a, b, true) || winUnchanged(a, b, false) {
+		t.Fatal("directory role lost epoch boundary")
+	}
+	a.Attributes, b.Attributes = 0, 0
+	if winUnchanged(a, b, true) {
+		t.Fatal("regular file gained ancestor exception")
+	}
+}
+
+// A rename changes ChangeTime too. The exception must not permit a path ancestor
+// to move between its metadata probe and delete-protected HANDLE upgrade.
+func TestWindowsAncestorEpochReplacementRejected(t *testing.T) {
+	parent := t.TempDir()
+	nativeWrite(t, parent, "ancestor/source/original", "original")
+	ancestor := filepath.Join(parent, "ancestor")
+	identity, err := os.Stat(ancestor)
+	bootstrapCheck(t, "ancestor identity", err)
+	fired := false
+	var mutationErr error
+	s, err := openSourceWithMetadataStage(filepath.Join(ancestor, "source"), func(f *os.File, stage string) {
+		info, e := f.Stat()
+		if fired || stage != "protect" || e != nil || !os.SameFile(identity, info) {
+			return
+		}
+		fired = true
+		a, e := winMeta(f)
+		if e != nil {
+			mutationErr = e
+			return
+		}
+		mutationErr = nativeSharedRename(ancestor, filepath.Join(parent, "moved"))
+		if mutationErr == nil {
+			mutationErr = os.MkdirAll(filepath.Join(ancestor, "source"), 0700)
+		}
+		b, e := winMeta(f)
+		if e != nil {
+			mutationErr = e
+			return
+		}
+		a.Write, a.Change, b.Write, b.Change = 0, 0, 0, 0
+		if a != b {
+			mutationErr = errors.New("rename fixture changed non-epoch metadata")
+		}
+	})
+	if s != nil {
+		s.close()
+	}
+	var safe *Error
+	if !fired || mutationErr != nil || !errors.As(err, &safe) || safe.Code != "root_unreadable" {
+		t.Fatalf("ancestor replacement accepted: fired=%t mutation=%v acquisition=%v", fired, mutationErr, err)
+	}
+}

--- a/install/integrationctl/agentplugins/adapters/packageview/bootstrap_directory_guard_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/bootstrap_directory_guard_windows_test.go
@@ -1,4 +1,4 @@
-//go:build windows && amd64
+//go:build windows && (amd64 || arm64)
 
 package packageview
 

--- a/install/integrationctl/agentplugins/adapters/packageview/bootstrap_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/bootstrap_windows_test.go
@@ -1,4 +1,4 @@
-//go:build windows && amd64
+//go:build windows && (amd64 || arm64)
 
 package packageview
 

--- a/install/integrationctl/agentplugins/adapters/packageview/final_cleanup_stages_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/final_cleanup_stages_windows_test.go
@@ -72,7 +72,11 @@ func windowsFinalCleanupStage(t *testing.T, stage string, err error) error {
 // Observe the actual production resolver. A copied walker can silently diverge
 // from source-root role and namespace protection, invalidating this diagnostic.
 func windowsFinalCleanupSource(t *testing.T, role, name string) (*source, error) {
-	s, err := openSourceWithMetadataStage(name, func(f *os.File, stage string) {
+	open := openSourceWithMetadataStage
+	if role == "scratch" {
+		open = openTrustedScratchWithMetadataStage
+	}
+	s, err := open(name, func(f *os.File, stage string) {
 		snapshot, e := winMeta(f)
 		t.Logf("stage=%s.%s observation=%+v err=%v (not internal comparison evidence)", role, stage, snapshot, e)
 	})

--- a/install/integrationctl/agentplugins/adapters/packageview/final_cleanup_stages_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/final_cleanup_stages_windows_test.go
@@ -1,4 +1,4 @@
-//go:build windows && amd64
+//go:build windows && (amd64 || arm64)
 
 package packageview
 

--- a/install/integrationctl/agentplugins/adapters/packageview/final_cleanup_stages_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/final_cleanup_stages_windows_test.go
@@ -7,8 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
 	"syscall"
 	"testing"
 
@@ -16,9 +14,9 @@ import (
 )
 
 // This is an independent, bounded diagnostic, not a retry of Reader.Open.
-// Stage acquisition uses production primitives before openSource/scratchParent
-// sanitize their errors. The fixture has only literal directory components;
-// this helper is not a replacement resolver or an alternate reader profile.
+// Acquisition calls the production resolver with metadata-only observations.
+// Sanitized errors are reported as such; optional native overlays supply deeper
+// causality without maintaining a second resolver in this test.
 // Native codes are logged only when the called primitive actually returns one.
 func TestWindowsFinalCleanupAcquisitionStages(t *testing.T) {
 	root := nativeFixture(t, func(root string) { nativeWrite(t, root, "plugin.json", "core") })
@@ -71,99 +69,14 @@ func windowsFinalCleanupStage(t *testing.T, stage string, err error) error {
 	return fmt.Errorf("%s: %w", stage, err)
 }
 
-func windowsFinalCleanupSource(t *testing.T, role, name string) (_ *source, err error) {
-	name = strings.ReplaceAll(name, "/", `\`)
-	if len(name) < 3 || name[1] != ':' || name[2] != '\\' || !((name[0] >= 'A' && name[0] <= 'Z') || (name[0] >= 'a' && name[0] <= 'z')) {
-		return nil, windowsFinalCleanupStage(t, role+".literal-drive", fail("root_unreadable"))
-	}
-	u, e := windows.UTF16PtrFromString(name[:3])
-	if err = windowsFinalCleanupStage(t, role+".drive-utf16", e); err != nil {
-		return nil, err
-	}
-	kind := windows.GetDriveType(u)
-	t.Logf("stage=%s.drive-type kind=%d", role, kind)
-	if kind != windows.DRIVE_FIXED {
-		return nil, windowsFinalCleanupStage(t, role+".drive-type", fail("filesystem_unavailable"))
-	}
-	f, e := winOpen(0, `\??\`+name[:3], true)
-	if err = windowsFinalCleanupStage(t, role+".bootstrap.winOpen", e); err != nil {
-		return nil, err
-	}
-	s := &source{anchor: f, records: make(map[winSnapshot]*winObservation)}
-	defer func() {
-		if err != nil {
-			if e := s.close(); e != nil {
-				t.Errorf("%s acquisition cleanup: %v", role, e)
-			}
-		}
-	}()
-	var fs [32]uint16
-	e = windows.GetVolumeInformationByHandle(windows.Handle(f.Fd()), nil, 0, &s.volume, nil, nil, &fs[0], uint32(len(fs)))
-	if err = windowsFinalCleanupStage(t, role+".volume-information", e); err != nil {
-		return nil, err
-	}
-	t.Logf("stage=%s.filesystem type=%q volume=%08x", role, windows.UTF16ToString(fs[:]), s.volume)
-	if windows.UTF16ToString(fs[:]) != "NTFS" {
-		return nil, windowsFinalCleanupStage(t, role+".filesystem", fail("filesystem_unavailable"))
-	}
-	p, err := windowsFinalCleanupRemember(t, role+".bootstrap.remember", s, f)
-	if err != nil {
-		return nil, err
-	}
-	if e = winCheckDirectory(p.file); e != nil {
-		p.file.Close()
-		return nil, windowsFinalCleanupStage(t, role+".bootstrap.protected-directory", e)
-	}
-	s.anchor.Close()
-	s.anchor = p.file
-	rest := strings.TrimRight(name[3:], `\`)
-	if rest == "" {
-		return s, nil
-	}
-	parts, e := winParts(rest)
-	if err = windowsFinalCleanupStage(t, role+".parts", e); err != nil {
-		return nil, err
-	}
-	for i, part := range parts {
-		// Only the fresh fixture's simple components may use staged walking.
-		if part == "" || part == "." || part == ".." {
-			return nil, windowsFinalCleanupStage(t, role+".fixture-component", syscall.EXDEV)
-		}
-		stage := fmt.Sprintf("%s.component[%d]=%q", role, i, part)
-		// Match walk's root-selection validation for literal fixture names.
-		if !filepath.IsLocal(part) || strings.HasSuffix(part, ".") || strings.HasSuffix(part, " ") || strings.ContainsAny(part, "<>|") {
-			return nil, windowsFinalCleanupStage(t, stage+".name", syscall.EXDEV)
-		}
-		f, e := winOpen(windows.Handle(s.anchor.Fd()), part, false)
-		if err = windowsFinalCleanupStage(t, stage+".winOpen", e); err != nil {
-			return nil, err
-		}
-		p, e = windowsFinalCleanupRemember(t, stage+".remember", s, f)
-		f.Close()
-		if e != nil {
-			return nil, e
-		}
-		if p.info.Mode()&os.ModeSymlink != 0 || !p.info.IsDir() {
-			p.file.Close()
-			return nil, windowsFinalCleanupStage(t, stage+".directory", fail("root_wrong_kind"))
-		}
-		s.anchor.Close()
-		s.anchor = p.file
-	}
-	return s, nil
-}
-
-// These snapshots surround the real remember call. They are NOT its internal
-// snapshots and do not establish which comparison failed. No path is reopened
-// to obtain them, and the diagnostic never retries remember after failure.
-func windowsFinalCleanupRemember(t *testing.T, stage string, s *source, f *os.File) (*pinned, error) {
-	before, beforeErr := winMeta(f)
-	p, err := s.rememberMustDuplicate(f)
-	if err != nil {
-		after, afterErr := winMeta(f)
-		t.Logf("stage=%s surrounding snapshots before=%+v err=%v after=%+v err=%v (not internal comparison evidence)", stage, before, beforeErr, after, afterErr)
-	}
-	return p, windowsFinalCleanupStage(t, stage, err)
+// Observe the actual production resolver. A copied walker can silently diverge
+// from source-root role and namespace protection, invalidating this diagnostic.
+func windowsFinalCleanupSource(t *testing.T, role, name string) (*source, error) {
+	s, err := openSourceWithMetadataStage(name, func(f *os.File, stage string) {
+		snapshot, e := winMeta(f)
+		t.Logf("stage=%s.%s observation=%+v err=%v (not internal comparison evidence)", role, stage, snapshot, e)
+	})
+	return s, windowsFinalCleanupStage(t, role+".openSource", err)
 }
 
 func windowsFinalCleanupAttempt(t *testing.T, root, scratch string) (err error) {

--- a/install/integrationctl/agentplugins/adapters/packageview/nt_self_reopen_regression_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/nt_self_reopen_regression_windows_test.go
@@ -1,4 +1,4 @@
-//go:build windows && amd64
+//go:build windows && (amd64 || arm64)
 
 package packageview
 

--- a/install/integrationctl/agentplugins/adapters/packageview/pure_namespace_replacement_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/pure_namespace_replacement_windows_test.go
@@ -1,4 +1,4 @@
-//go:build windows && amd64
+//go:build windows && (amd64 || arm64)
 
 package packageview
 

--- a/install/integrationctl/agentplugins/adapters/packageview/reopen_parameters_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/reopen_parameters_windows_test.go
@@ -1,4 +1,4 @@
-//go:build windows && amd64
+//go:build windows && (amd64 || arm64)
 
 package packageview
 

--- a/install/integrationctl/agentplugins/adapters/packageview/scratch_alias_stages_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/scratch_alias_stages_windows_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -51,6 +52,8 @@ func TestWindowsScratchAliasResolutionStages(t *testing.T) {
 			if e != nil {
 				t.Fatal("scratch resolution stage:", e)
 			}
+			var stack [64]byte
+			t.Logf("resolved acquisition pid=%d goroutine=%s", os.Getpid(), strings.Fields(string(stack[:runtime.Stack(stack[:], false)]))[1])
 			scratch, e := openSource(resolved)
 			t.Logf("resolved openSource err=%v", e)
 			if e != nil {

--- a/install/integrationctl/agentplugins/adapters/packageview/scratch_alias_stages_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/scratch_alias_stages_windows_test.go
@@ -54,8 +54,8 @@ func TestWindowsScratchAliasResolutionStages(t *testing.T) {
 			}
 			var stack [64]byte
 			t.Logf("resolved acquisition pid=%d goroutine=%s", os.Getpid(), strings.Fields(string(stack[:runtime.Stack(stack[:], false)]))[1])
-			scratch, e := openSource(resolved)
-			t.Logf("resolved openSource err=%v", e)
+			scratch, e := openTrustedScratchWithMetadataStage(resolved, nil)
+			t.Logf("resolved trusted scratch acquisition err=%v", e)
 			if e != nil {
 				t.Fatal("protected acquisition stage:", e)
 			}

--- a/install/integrationctl/agentplugins/adapters/packageview/scratch_alias_stages_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/scratch_alias_stages_windows_test.go
@@ -1,4 +1,4 @@
-//go:build windows && amd64
+//go:build windows && (amd64 || arm64)
 
 package packageview
 

--- a/install/integrationctl/agentplugins/adapters/packageview/scratch_other.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/scratch_other.go
@@ -1,4 +1,4 @@
-//go:build !windows || !amd64
+//go:build !windows || !(amd64 || arm64)
 
 package packageview
 

--- a/install/integrationctl/agentplugins/adapters/packageview/scratch_windows.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/scratch_windows.go
@@ -20,7 +20,7 @@ func scratchParent(s *source, _ string, tempDir string) (_ string, release func(
 	if e != nil {
 		return "", nil, fail("scratch_unavailable")
 	}
-	scratch, e := openSource(tmp)
+	scratch, e := openTrustedScratchWithMetadataStage(tmp, nil)
 	if e != nil {
 		return "", nil, fail("scratch_unavailable")
 	}
@@ -37,11 +37,17 @@ func scratchParent(s *source, _ string, tempDir string) (_ string, release func(
 	return tmp, scratch.close, nil
 }
 
+// Only trusted scratch configuration may select this purpose. The ordinary
+// source APIs remain strict even when a source happens to live in a temp path.
+func openTrustedScratchWithMetadataStage(name string, stage func(*os.File, string)) (*source, error) {
+	return openWindowsRoot(name, winTrustedScratch, stage)
+}
+
 // winResolveScratch is only for the trusted, cleanable scratch configuration.
 // Go 1.23+ reports junctions as ModeIrregular, so EvalSymlinks leaves a leaf
-// junction unresolved (and rejects one in an ancestor). openSource must still
+// junction unresolved (and rejects one in an ancestor). Acquisition must still
 // reject those reparse points. Resolve known links here using metadata only,
-// then let openSource acquire and protect the entire resolved directory ancestry.
+// then acquire and protect the entire resolved directory ancestry.
 // Never use this resolver for a source path or as physical identity evidence.
 func winResolveScratch(name string) (string, error) {
 	name, e := filepath.Abs(name)

--- a/install/integrationctl/agentplugins/adapters/packageview/scratch_windows.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/scratch_windows.go
@@ -1,4 +1,4 @@
-//go:build windows && amd64
+//go:build windows && (amd64 || arm64)
 
 package packageview
 

--- a/install/integrationctl/agentplugins/adapters/packageview/scratch_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/scratch_windows_test.go
@@ -1,4 +1,4 @@
-//go:build windows && amd64
+//go:build windows && (amd64 || arm64)
 
 package packageview
 

--- a/install/integrationctl/agentplugins/adapters/packageview/shared_scratch_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/shared_scratch_windows_test.go
@@ -1,0 +1,209 @@
+//go:build windows && (amd64 || arm64)
+
+package packageview
+
+import (
+	"encoding/binary"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// Mutate the selected leaf once, synchronously, between real metadata queries.
+// Both roles see the same operation, with the existing native clock calibration.
+func TestWindowsSharedScratchEpochBoundary(t *testing.T) {
+	for _, role := range []string{"scratch", "source"} {
+		for _, stage := range []string{"stat", "protect"} {
+			t.Run(role+"/"+stage, func(t *testing.T) {
+				before := winRecordCount()
+				root := t.TempDir()
+				identity, err := os.Stat(root)
+				bootstrapCheck(t, "leaf identity", err)
+				fired := false
+				var mutationErr error
+				var probe *os.File
+				open := openSourceWithMetadataStage
+				if role == "scratch" {
+					open = openTrustedScratchWithMetadataStage
+				}
+				s, err := open(root, func(f *os.File, at string) {
+					info, e := f.Stat()
+					if fired || at != stage || e != nil || !os.SameFile(identity, info) {
+						return
+					}
+					fired, probe = true, f
+					directoryGuardMetadataAccess(t, f)
+					a, e := winMeta(f)
+					if e != nil {
+						mutationErr = e
+						return
+					}
+					windowsAwaitDirectoryClock(t, a)
+					mutationErr = os.Mkdir(filepath.Join(root, "other-init-private"), 0700)
+					b, e := winMeta(f)
+					if e != nil {
+						mutationErr = e
+					}
+					x, y := a, b
+					x.Write, x.Change, y.Write, y.Change = 0, 0, 0, 0
+					if x != y || a == b {
+						mutationErr = errors.New("fixture did not isolate a directory epoch change")
+					}
+					t.Logf("role=%s stage=%s before=%+v after=%+v", role, stage, a, b)
+				})
+				if s != nil {
+					defer s.close()
+				}
+				if !fired || mutationErr != nil {
+					t.Fatalf("single mutation fired=%t err=%v", fired, mutationErr)
+				}
+				if _, e := winMeta(probe); e == nil {
+					t.Fatal("metadata probe leaked")
+				}
+				if role == "source" {
+					var safe *Error
+					if s != nil || !errors.As(err, &safe) || safe.Code != "root_unreadable" {
+						t.Fatalf("source epoch accepted: %v", err)
+					}
+				} else {
+					bootstrapCheck(t, "trusted scratch leaf acquisition", err)
+					if s.selectionDepth != winSelectionDepth(root[3:]) {
+						t.Fatal("scratch role changed path depth")
+					}
+					leaf := false
+					var handles []*os.File
+					for _, o := range s.records {
+						handles = append(handles, o.file)
+						leaf = leaf || os.SameFile(identity, o.info)
+						if !o.traversalOnly || !same(o.info, o.info) {
+							t.Fatal("scratch observation lost traversal-only identity")
+						}
+						data, e := (&pinned{file: o.file, info: o.info}).reopen(true)
+						if data != nil {
+							data.Close()
+						}
+						if e == nil {
+							t.Fatal("scratch authorized a data upgrade")
+						}
+					}
+					if !leaf {
+						t.Fatal("scratch leaf not retained")
+					}
+					p, e := s.pin("other-init-private", false)
+					if p != nil {
+						p.file.Close()
+					}
+					if e == nil {
+						t.Fatal("scratch authorized source capture")
+					}
+					if e := nativeSharedRename(root, root+"-moved"); !errors.Is(e, windows.ERROR_SHARING_VIOLATION) {
+						t.Fatalf("protected scratch allowed DELETE: %v", e)
+					}
+					u, e := windows.UTF16PtrFromString(root)
+					bootstrapCheck(t, "scratch spelling", e)
+					h, e := windows.CreateFile(u, windows.GENERIC_WRITE, winShare, nil, windows.OPEN_EXISTING,
+						windows.FILE_FLAG_OPEN_REPARSE_POINT|windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
+					if e == nil {
+						windows.CloseHandle(h)
+					}
+					if !errors.Is(e, windows.ERROR_SHARING_VIOLATION) {
+						t.Fatalf("protected scratch allowed reparse setter access: %v", e)
+					}
+					handles = append(handles, s.anchor)
+					bootstrapCheck(t, "scratch close", s.close())
+					if s.records != nil || s.anchor != nil {
+						t.Fatal("scratch retained ownership after close")
+					}
+					for _, f := range handles {
+						if _, e := winMeta(f); e == nil {
+							t.Fatal("scratch handle leaked")
+						}
+					}
+				}
+				if winRecordCount() != before {
+					t.Fatal("scratch/source metadata map leaked")
+				}
+				bootstrapCheck(t, "released leaf rename", nativeSharedRename(root, root+"-moved"))
+				bootstrapCheck(t, "restore leaf", nativeSharedRename(root+"-moved", root))
+			})
+		}
+	}
+}
+
+// The epoch exception also covers rename, so the protected parent-relative name
+// check must reject a different directory OR a junction installed at the leaf.
+func TestWindowsSharedScratchReplacementRejected(t *testing.T) {
+	for _, kind := range []string{"directory", "junction", "reparse"} {
+		for _, stage := range []string{"stat", "protect"} {
+			t.Run(kind+"/"+stage, func(t *testing.T) {
+				before := winRecordCount()
+				parent := t.TempDir()
+				root, spare, moved := filepath.Join(parent, "scratch"), filepath.Join(parent, "spare"), filepath.Join(parent, "moved")
+				bootstrapCheck(t, "scratch fixture", os.Mkdir(root, 0700))
+				if kind != "directory" {
+					nativeJunction(t, spare, t.TempDir())
+				} else {
+					bootstrapCheck(t, "replacement fixture", os.Mkdir(spare, 0700))
+				}
+				var reparseData []byte
+				if kind == "reparse" {
+					f, e := winOpen(0, `\??\`+spare, false)
+					bootstrapCheck(t, "inert junction metadata", e)
+					buf := make([]byte, 16*1024)
+					var n uint32
+					e = windows.DeviceIoControl(windows.Handle(f.Fd()), windows.FSCTL_GET_REPARSE_POINT, nil, 0, &buf[0], uint32(len(buf)), &n, nil)
+					f.Close()
+					bootstrapCheck(t, "inert junction record", e)
+					if n < 8 || n > uint32(len(buf)) || binary.LittleEndian.Uint32(buf) != windows.IO_REPARSE_TAG_MOUNT_POINT || int(binary.LittleEndian.Uint16(buf[4:])) != int(n)-8 {
+						t.Fatal("invalid inert junction record")
+					}
+					reparseData = buf[8:n]
+				}
+				identity, err := os.Stat(root)
+				bootstrapCheck(t, "scratch identity", err)
+				fired := false
+				var mutationErr error
+				s, err := openTrustedScratchWithMetadataStage(root, func(f *os.File, at string) {
+					info, e := f.Stat()
+					if fired || at != stage || e != nil || !os.SameFile(identity, info) {
+						return
+					}
+					fired = true
+					if kind == "reparse" {
+						setNativeReparse(t, root, windows.IO_REPARSE_TAG_MOUNT_POINT, reparseData)
+						return
+					}
+					a, e := winMeta(f)
+					bootstrapCheck(t, "old leaf metadata", e)
+					mutationErr = nativeSharedRename(root, moved)
+					if mutationErr == nil {
+						mutationErr = nativeSharedRename(spare, root)
+					}
+					b, e := winMeta(f)
+					bootstrapCheck(t, "renamed leaf metadata", e)
+					a.Write, a.Change, b.Write, b.Change = 0, 0, 0, 0
+					if a != b {
+						mutationErr = errors.New("rename changed non-epoch metadata")
+					}
+				})
+				if s != nil {
+					s.close()
+				}
+				var safe *Error
+				if !fired || mutationErr != nil || s != nil || !errors.As(err, &safe) || safe.Code != "root_unreadable" {
+					t.Fatalf("replacement accepted: fired=%t mutation=%v acquisition=%v", fired, mutationErr, err)
+				}
+				if winRecordCount() != before {
+					t.Fatal("replacement rejection leaked records")
+				}
+				if kind != "reparse" {
+					bootstrapCheck(t, "released old leaf", nativeSharedRename(moved, spare))
+				}
+				bootstrapCheck(t, "released replacement", nativeSharedRename(root, moved))
+			})
+		}
+	}
+}

--- a/install/integrationctl/agentplugins/adapters/packageview/source_native_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_native_test.go
@@ -1,4 +1,4 @@
-//go:build (darwin && arm64) || (windows && amd64)
+//go:build (darwin && arm64) || (windows && (amd64 || arm64))
 
 package packageview
 

--- a/install/integrationctl/agentplugins/adapters/packageview/source_unsupported.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_unsupported.go
@@ -1,4 +1,4 @@
-//go:build !linux && !(darwin && arm64) && !(windows && amd64)
+//go:build !linux && !(darwin && arm64) && !(windows && (amd64 || arm64))
 
 package packageview
 

--- a/install/integrationctl/agentplugins/adapters/packageview/source_unsupported_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_unsupported_test.go
@@ -1,4 +1,4 @@
-//go:build !linux && !(darwin && arm64) && !(windows && amd64)
+//go:build !linux && !(darwin && arm64) && !(windows && (amd64 || arm64))
 
 package packageview
 

--- a/install/integrationctl/agentplugins/adapters/packageview/source_windows.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_windows.go
@@ -33,9 +33,20 @@ type source struct {
 	volume         uint32
 	records        map[winSnapshot]*winObservation
 	selectionDepth int
+	purpose        winAcquisitionPurpose
 	// Operation-local native test seam; nil in production. No pathname is passed.
 	metadataStage func(*os.File, string)
 }
+
+// The zero value preserves strict captured-source acquisition. Trusted scratch
+// is a directory traversal capability, including its leaf, never captured data.
+type winAcquisitionPurpose uint8
+
+const (
+	winCapturedSource winAcquisitionPurpose = iota
+	winTrustedScratch
+)
+
 type pinned struct {
 	file *os.File
 	info os.FileInfo
@@ -62,10 +73,10 @@ type winSnapshot struct {
 	Creation, Write, Change              int64
 }
 type winObservation struct {
-	file        *os.File
-	info        os.FileInfo
-	meta        winSnapshot
-	outsideRoot bool
+	file          *os.File
+	info          os.FileInfo
+	meta          winSnapshot
+	traversalOnly bool
 }
 
 const winShare = windows.FILE_SHARE_READ | windows.FILE_SHARE_WRITE | windows.FILE_SHARE_DELETE
@@ -183,11 +194,12 @@ func winDup(f *os.File) (*os.File, error) {
 	return os.NewFile(uintptr(h), "source-pin"), nil
 }
 
-// winUnchanged excludes only the write/change epoch of a proven outside-root
-// directory. Its identity, creation, size, attributes and link count stay pinned.
-// Captured root/descendant observations always require the complete snapshot.
-func winUnchanged(a, b winSnapshot, outsideRoot bool) bool {
-	if outsideRoot && a.Attributes&windows.FILE_ATTRIBUTE_DIRECTORY != 0 && a.Attributes&windows.FILE_ATTRIBUTE_REPARSE_POINT == 0 {
+// winUnchanged excludes only the write/change epoch of a proven traversal-only
+// directory (outside-source ancestry or trusted scratch, including its leaf).
+// Identity, creation, size, attributes and links stay pinned. Captured source
+// root/descendant observations always require the complete snapshot.
+func winUnchanged(a, b winSnapshot, traversalOnly bool) bool {
+	if traversalOnly && a.Attributes&windows.FILE_ATTRIBUTE_DIRECTORY != 0 && a.Attributes&windows.FILE_ATTRIBUTE_REPARSE_POINT == 0 {
 		a.Write, a.Change = b.Write, b.Change
 	}
 	return a == b
@@ -197,6 +209,12 @@ func (s *source) remember(f *os.File, outside ...bool) (*pinned, error) {
 	// Takes ownership on all paths; hard bounds include root-selection ancestors.
 	defer f.Close()
 	outsideRoot := len(outside) == 1 && outside[0]
+	traversalOnly := outsideRoot || s.purpose == winTrustedScratch
+	if s.purpose == winTrustedScratch {
+		if e := winCheckDirectory(f); e != nil {
+			return nil, e
+		}
+	}
 	meta, e := winMeta(f)
 	if e != nil {
 		return nil, e
@@ -216,7 +234,7 @@ func (s *source) remember(f *os.File, outside ...bool) (*pinned, error) {
 		return nil, e
 	}
 	after, e := winMeta(f)
-	if e != nil || !winUnchanged(meta, after, outsideRoot) {
+	if e != nil || !winUnchanged(meta, after, traversalOnly) {
 		return nil, fail("source_changed")
 	}
 	if meta.Attributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
@@ -231,11 +249,11 @@ func (s *source) remember(f *os.File, outside ...bool) (*pinned, error) {
 		// A strict observation of this exact epoch may promote an identity pin;
 		// never downgrade a captured observation on a root-selection revisit.
 		winInfos.Lock()
-		if o.outsideRoot && !outsideRoot {
+		if o.traversalOnly && !traversalOnly {
 			// The ancestor's Stat may have observed a newer permitted epoch.
 			// Bind promotion to this fresh, fully checked Stat instead.
 			delete(winInfos.m, o.info)
-			o.info, o.outsideRoot = info, false
+			o.info, o.traversalOnly = info, false
 			winInfos.m[info] = o
 		}
 		winInfos.Unlock()
@@ -269,7 +287,7 @@ func (s *source) remember(f *os.File, outside ...bool) (*pinned, error) {
 		return nil, e
 	}
 	locked, e := winMeta(held)
-	if e != nil || !winUnchanged(meta, locked, outsideRoot) {
+	if e != nil || !winUnchanged(meta, locked, traversalOnly) {
 		held.Close()
 		return nil, fail("source_changed")
 	}
@@ -278,7 +296,7 @@ func (s *source) remember(f *os.File, outside ...bool) (*pinned, error) {
 		held.Close()
 		return nil, e
 	}
-	o := &winObservation{file: held, info: info, meta: meta, outsideRoot: outsideRoot}
+	o := &winObservation{file: held, info: info, meta: meta, traversalOnly: traversalOnly}
 	s.records[meta] = o
 	winInfos.Lock()
 	winInfos.m[info] = o
@@ -287,6 +305,9 @@ func (s *source) remember(f *os.File, outside ...bool) (*pinned, error) {
 }
 func openSource(name string) (_ *source, err error) { return openSourceWithMetadataStage(name, nil) }
 func openSourceWithMetadataStage(name string, stage func(*os.File, string)) (_ *source, err error) {
+	return openWindowsRoot(name, winCapturedSource, stage)
+}
+func openWindowsRoot(name string, purpose winAcquisitionPurpose, stage func(*os.File, string)) (_ *source, err error) {
 	name = strings.ReplaceAll(name, "/", `\`)
 	// Bootstrap ONLY a literal fixed drive root. The remainder never goes through
 	// Win32 path cleaning. In particular junction/../x is evaluated in order.
@@ -306,7 +327,7 @@ func openSourceWithMetadataStage(name string, stage func(*os.File, string)) (_ *
 		return nil, fail("root_unreadable")
 	}
 	rest := strings.TrimRight(name[3:], `\`)
-	s := &source{records: make(map[winSnapshot]*winObservation), selectionDepth: winSelectionDepth(rest), metadataStage: stage}
+	s := &source{records: make(map[winSnapshot]*winObservation), selectionDepth: winSelectionDepth(rest), purpose: purpose, metadataStage: stage}
 	defer func() {
 		if err != nil {
 			_ = s.close()
@@ -369,7 +390,12 @@ func (s *source) close() error {
 	}
 	return errors.Join(es...)
 }
-func (s *source) pin(rel string, nofollow bool) (*pinned, error) { return s.walk(rel, nofollow, false) }
+func (s *source) pin(rel string, nofollow bool) (*pinned, error) {
+	if s.purpose == winTrustedScratch {
+		return nil, fail("source_changed")
+	}
+	return s.walk(rel, nofollow, false)
+}
 func winParts(p string) ([]string, error) {
 	if p == "" || len(p) > 4096 || !utf8.ValidString(p) || strings.ContainsAny(p, ":\x00*?\"") || p[0] == '/' || p[0] == '\\' {
 		return nil, syscall.EXDEV
@@ -458,7 +484,7 @@ func (s *source) walk(rel string, nofollow, rootSelection bool) (*pinned, error)
 		if e != nil {
 			return nil, e
 		}
-		if outsideRoot {
+		if outsideRoot || s.purpose == winTrustedScratch {
 			// ChangeTime also detects rename before delete protection. Excluding
 			// its epoch therefore requires a fresh metadata-only name check from
 			// the held parent AFTER the child is protected, never a data fallback.
@@ -569,12 +595,12 @@ func (p *pinned) reopen(directory bool) (*os.File, error) {
 	if (directory && !p.info.IsDir()) || (!directory && !p.info.Mode().IsRegular()) {
 		return nil, fail("wrong_kind")
 	}
-	// Outside-root identity pins authorize traversal only, never captured data.
+	// Traversal identity pins, including scratch leaves, never authorize data.
 	winInfos.RLock()
 	o := winInfos.m[p.info]
-	outsideRoot := o != nil && o.outsideRoot
+	traversalOnly := o != nil && o.traversalOnly
 	winInfos.RUnlock()
-	if outsideRoot {
+	if traversalOnly {
 		return nil, fail("source_changed")
 	}
 	// Refuse any attribute/type/reparse/link-count change before upgrading access.
@@ -608,7 +634,7 @@ func same(a, b os.FileInfo) bool {
 		if o := winInfos.m[i]; o != nil {
 			found = true
 			m, e := winMeta(o.file)
-			if e != nil || !winUnchanged(o.meta, m, o.outsideRoot) {
+			if e != nil || !winUnchanged(o.meta, m, o.traversalOnly) {
 				return false
 			}
 		}

--- a/install/integrationctl/agentplugins/adapters/packageview/source_windows.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_windows.go
@@ -28,10 +28,13 @@ import (
 // Device-map changes, hostile filesystem filters and privileged volume changes
 // are outside this local-kernel profile. No UNC, ADS or DOS device path fallback.
 type source struct {
-	anchor     *os.File
-	legacyInfo os.FileInfo
-	volume     uint32
-	records    map[winSnapshot]*winObservation
+	anchor         *os.File
+	legacyInfo     os.FileInfo
+	volume         uint32
+	records        map[winSnapshot]*winObservation
+	selectionDepth int
+	// Operation-local native test seam; nil in production. No pathname is passed.
+	metadataStage func(*os.File, string)
 }
 type pinned struct {
 	file *os.File
@@ -59,9 +62,10 @@ type winSnapshot struct {
 	Creation, Write, Change              int64
 }
 type winObservation struct {
-	file *os.File
-	info os.FileInfo
-	meta winSnapshot
+	file        *os.File
+	info        os.FileInfo
+	meta        winSnapshot
+	outsideRoot bool
 }
 
 const winShare = windows.FILE_SHARE_READ | windows.FILE_SHARE_WRITE | windows.FILE_SHARE_DELETE
@@ -178,9 +182,21 @@ func winDup(f *os.File) (*os.File, error) {
 	}
 	return os.NewFile(uintptr(h), "source-pin"), nil
 }
-func (s *source) remember(f *os.File) (*pinned, error) {
+
+// winUnchanged excludes only the write/change epoch of a proven outside-root
+// directory. Its identity, creation, size, attributes and link count stay pinned.
+// Captured root/descendant observations always require the complete snapshot.
+func winUnchanged(a, b winSnapshot, outsideRoot bool) bool {
+	if outsideRoot && a.Attributes&windows.FILE_ATTRIBUTE_DIRECTORY != 0 && a.Attributes&windows.FILE_ATTRIBUTE_REPARSE_POINT == 0 {
+		a.Write, a.Change = b.Write, b.Change
+	}
+	return a == b
+}
+
+func (s *source) remember(f *os.File, outside ...bool) (*pinned, error) {
 	// Takes ownership on all paths; hard bounds include root-selection ancestors.
 	defer f.Close()
+	outsideRoot := len(outside) == 1 && outside[0]
 	meta, e := winMeta(f)
 	if e != nil {
 		return nil, e
@@ -192,12 +208,15 @@ func (s *source) remember(f *os.File) (*pinned, error) {
 	if e != nil || kind != windows.FILE_TYPE_DISK {
 		return nil, syscall.EXDEV
 	}
+	if s.metadataStage != nil {
+		s.metadataStage(f, "stat")
+	}
 	info, e := f.Stat()
 	if e != nil {
 		return nil, e
 	}
 	after, e := winMeta(f)
-	if e != nil || meta != after {
+	if e != nil || !winUnchanged(meta, after, outsideRoot) {
 		return nil, fail("source_changed")
 	}
 	if meta.Attributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
@@ -209,6 +228,17 @@ func (s *source) remember(f *os.File) (*pinned, error) {
 		}
 	}
 	if o := s.records[meta]; o != nil {
+		// A strict observation of this exact epoch may promote an identity pin;
+		// never downgrade a captured observation on a root-selection revisit.
+		winInfos.Lock()
+		if o.outsideRoot && !outsideRoot {
+			// The ancestor's Stat may have observed a newer permitted epoch.
+			// Bind promotion to this fresh, fully checked Stat instead.
+			delete(winInfos.m, o.info)
+			o.info, o.outsideRoot = info, false
+			winInfos.m[info] = o
+		}
+		winInfos.Unlock()
 		dup, e := winDup(o.file)
 		if e != nil {
 			return nil, e
@@ -231,12 +261,15 @@ func (s *source) remember(f *os.File) (*pinned, error) {
 	// it participates in share accounting. Denying WRITE prevents new data
 	// writers/reparse setters; denying DELETE on directories holds ancestry.
 	// Existing incompatible handles cause an availability failure, no fallback.
+	if s.metadataStage != nil {
+		s.metadataStage(f, "protect")
+	}
 	held, e := winReopen(f, access, share)
 	if e != nil {
 		return nil, e
 	}
 	locked, e := winMeta(held)
-	if e != nil || locked != meta {
+	if e != nil || !winUnchanged(meta, locked, outsideRoot) {
 		held.Close()
 		return nil, fail("source_changed")
 	}
@@ -245,14 +278,15 @@ func (s *source) remember(f *os.File) (*pinned, error) {
 		held.Close()
 		return nil, e
 	}
-	o := &winObservation{held, info, meta}
+	o := &winObservation{file: held, info: info, meta: meta, outsideRoot: outsideRoot}
 	s.records[meta] = o
 	winInfos.Lock()
 	winInfos.m[info] = o
 	winInfos.Unlock()
 	return &pinned{dup, info}, nil
 }
-func openSource(name string) (_ *source, err error) {
+func openSource(name string) (_ *source, err error) { return openSourceWithMetadataStage(name, nil) }
+func openSourceWithMetadataStage(name string, stage func(*os.File, string)) (_ *source, err error) {
 	name = strings.ReplaceAll(name, "/", `\`)
 	// Bootstrap ONLY a literal fixed drive root. The remainder never goes through
 	// Win32 path cleaning. In particular junction/../x is evaluated in order.
@@ -271,7 +305,8 @@ func openSource(name string) (_ *source, err error) {
 	if e != nil {
 		return nil, fail("root_unreadable")
 	}
-	s := &source{records: make(map[winSnapshot]*winObservation)}
+	rest := strings.TrimRight(name[3:], `\`)
+	s := &source{records: make(map[winSnapshot]*winObservation), selectionDepth: winSelectionDepth(rest), metadataStage: stage}
 	defer func() {
 		if err != nil {
 			_ = s.close()
@@ -283,7 +318,7 @@ func openSource(name string) (_ *source, err error) {
 	if windows.GetVolumeInformationByHandle(windows.Handle(f.Fd()), nil, 0, &s.volume, nil, nil, &fs[0], uint32(len(fs))) != nil || windows.UTF16ToString(fs[:]) != "NTFS" {
 		return nil, fail("filesystem_unavailable")
 	}
-	p, e := s.rememberMustDuplicate(f)
+	p, e := s.rememberMustDuplicate(f, s.selectionDepth > 0)
 	if e != nil {
 		return nil, fail("platform_unavailable")
 	}
@@ -294,7 +329,6 @@ func openSource(name string) (_ *source, err error) {
 	}
 	s.anchor.Close()
 	s.anchor = p.file
-	rest := strings.TrimRight(name[3:], `\`)
 	if rest != "" {
 		p, e = s.walk(rest, true, true)
 		if e != nil {
@@ -312,12 +346,12 @@ func openSource(name string) (_ *source, err error) {
 	}
 	return s, nil
 }
-func (s *source) rememberMustDuplicate(f *os.File) (*pinned, error) {
+func (s *source) rememberMustDuplicate(f *os.File, outside ...bool) (*pinned, error) {
 	dup, e := winDup(f)
 	if e != nil {
 		return nil, e
 	}
-	return s.remember(dup)
+	return s.remember(dup, outside...)
 }
 func (s *source) close() error {
 	var es []error
@@ -341,6 +375,32 @@ func winParts(p string) ([]string, error) {
 		return nil, syscall.EXDEV
 	}
 	return strings.Split(strings.ReplaceAll(p, `\`, "/"), "/"), nil
+}
+
+// Compute only a depth, never a cleaned acquisition path. Root selection still
+// opens EVERY component in order and rejects reparses before processing '..'.
+// With fixed-volume, no-reparse, delete-protected directory ancestry, an object
+// shallower than the final depth cannot be the captured root or its descendant.
+// Excursions at/under that depth remain strict; malformed paths gain no exception.
+func winSelectionDepth(rest string) int {
+	parts, e := winParts(rest)
+	if e != nil {
+		return 0
+	}
+	depth := 0
+	for _, n := range parts {
+		switch n {
+		case "", ".":
+		case "..":
+			depth--
+			if depth < 0 {
+				return 0
+			}
+		default:
+			depth++
+		}
+	}
+	return depth
 }
 func (s *source) walk(rel string, nofollow, rootSelection bool) (*pinned, error) {
 	todo, e := winParts(rel)
@@ -393,9 +453,27 @@ func (s *source) walk(rel string, nofollow, rootSelection bool) (*pinned, error)
 		if e != nil {
 			return nil, e
 		}
-		p, e := s.remember(f)
+		outsideRoot := rootSelection && len(stack) < s.selectionDepth
+		p, e := s.remember(f, outsideRoot)
 		if e != nil {
 			return nil, e
+		}
+		if outsideRoot {
+			// ChangeTime also detects rename before delete protection. Excluding
+			// its epoch therefore requires a fresh metadata-only name check from
+			// the held parent AFTER the child is protected, never a data fallback.
+			check, e := winOpen(parent, n, true)
+			if e != nil {
+				p.file.Close()
+				return nil, fail("source_changed")
+			}
+			named, ne := winMeta(check)
+			held, he := winMeta(p.file)
+			ce := check.Close()
+			if ne != nil || he != nil || ce != nil || !winUnchanged(held, named, true) {
+				p.file.Close()
+				return nil, fail("source_changed")
+			}
 		}
 		if p.info.Mode()&os.ModeSymlink != 0 {
 			if rootSelection {
@@ -491,6 +569,14 @@ func (p *pinned) reopen(directory bool) (*os.File, error) {
 	if (directory && !p.info.IsDir()) || (!directory && !p.info.Mode().IsRegular()) {
 		return nil, fail("wrong_kind")
 	}
+	// Outside-root identity pins authorize traversal only, never captured data.
+	winInfos.RLock()
+	o := winInfos.m[p.info]
+	outsideRoot := o != nil && o.outsideRoot
+	winInfos.RUnlock()
+	if outsideRoot {
+		return nil, fail("source_changed")
+	}
 	// Refuse any attribute/type/reparse/link-count change before upgrading access.
 	if !same(p.info, p.info) {
 		return nil, fail("source_changed")
@@ -522,7 +608,7 @@ func same(a, b os.FileInfo) bool {
 		if o := winInfos.m[i]; o != nil {
 			found = true
 			m, e := winMeta(o.file)
-			if e != nil || m != o.meta {
+			if e != nil || !winUnchanged(o.meta, m, o.outsideRoot) {
 				return false
 			}
 		}

--- a/install/integrationctl/agentplugins/adapters/packageview/source_windows.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_windows.go
@@ -1,4 +1,4 @@
-//go:build windows && amd64
+//go:build windows && (amd64 || arm64)
 
 package packageview
 

--- a/install/integrationctl/agentplugins/adapters/packageview/source_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_windows_test.go
@@ -1,4 +1,4 @@
-//go:build windows && amd64
+//go:build windows && (amd64 || arm64)
 
 package packageview
 
@@ -52,7 +52,7 @@ func nativeSharedRename(old, next string) error {
 	if err != nil {
 		return err
 	}
-	// FILE_RENAME_INFORMATION, amd64: BOOLEAN at 0, HANDLE at 8,
+	// FILE_RENAME_INFORMATION, amd64/arm64: BOOLEAN at 0, HANDLE at 8,
 	// ULONG at 16, WCHAR[] at 20. RootDirectory=NULL + a basename renames
 	// within the existing parent. No replace/POSIX flags or access bypasses.
 	buf := make([]byte, 20+2*(len(name)-1))
@@ -440,11 +440,42 @@ func TestWindowsInventoryMutationRejected(t *testing.T) {
 	}
 }
 
-// Ensure the hand-declared FILE_BASIC_INFO ABI remains 40 bytes on amd64.
+// Both Windows targets use the same LLP64 NT ABI. These assignments are
+// compile-time equalities, so cross-compiling the tests checks real selected
+// Go/x/sys layouts too. Native syscall/identity tests are still mandatory.
+var (
+	_ [8]byte  = [unsafe.Sizeof(windows.Handle(0))]byte{}
+	_ [40]byte = [unsafe.Sizeof(winBasic{})]byte{}
+	_ [8]byte  = [unsafe.Alignof(winBasic{})]byte{}
+	_ [24]byte = [unsafe.Offsetof(winBasic{}.Change)]byte{}
+	_ [32]byte = [unsafe.Offsetof(winBasic{}.Attributes)]byte{}
+	_ [48]byte = [unsafe.Sizeof(windows.OBJECT_ATTRIBUTES{})]byte{}
+	_ [8]byte  = [unsafe.Offsetof(windows.OBJECT_ATTRIBUTES{}.RootDirectory)]byte{}
+	_ [16]byte = [unsafe.Offsetof(windows.OBJECT_ATTRIBUTES{}.ObjectName)]byte{}
+	_ [24]byte = [unsafe.Offsetof(windows.OBJECT_ATTRIBUTES{}.Attributes)]byte{}
+	_ [32]byte = [unsafe.Offsetof(windows.OBJECT_ATTRIBUTES{}.SecurityDescriptor)]byte{}
+	_ [40]byte = [unsafe.Offsetof(windows.OBJECT_ATTRIBUTES{}.SecurityQoS)]byte{}
+	_ [16]byte = [unsafe.Sizeof(windows.NTUnicodeString{})]byte{}
+	_ [8]byte  = [unsafe.Offsetof(windows.NTUnicodeString{}.Buffer)]byte{}
+	_ [16]byte = [unsafe.Sizeof(windows.IO_STATUS_BLOCK{})]byte{}
+	_ [8]byte  = [unsafe.Offsetof(windows.IO_STATUS_BLOCK{}.Information)]byte{}
+	_ [52]byte = [unsafe.Sizeof(windows.ByHandleFileInformation{})]byte{}
+)
+
+// Check the manual rename fixture against the native declaration. The scaffold
+// rename uses this same field order with Sizeof/Offsetof rather than constants.
 func TestWindowsBasicInfoABI(t *testing.T) {
-	if unsafe.Sizeof(winBasic{}) != 40 {
-		t.Fatal("FILE_BASIC_INFO ABI mismatch")
+	type renameInfo struct {
+		ReplaceIfExists byte
+		RootDirectory   windows.Handle
+		FileNameLength  uint32
+		FileName        [1]uint16
 	}
+	var _ [24]byte = [unsafe.Sizeof(renameInfo{})]byte{}
+	var _ [8]byte = [unsafe.Offsetof(renameInfo{}.RootDirectory)]byte{}
+	var _ [16]byte = [unsafe.Offsetof(renameInfo{}.FileNameLength)]byte{}
+	var _ [20]byte = [unsafe.Offsetof(renameInfo{}.FileName)]byte{}
+	t.Log("64-bit NT layouts: BASIC=40 OBJECT_ATTRIBUTES=48 UNICODE_STRING=16 IO_STATUS_BLOCK=16 RENAME name offset=20")
 }
 
 func TestWindowsExistingWriterAndReparseSetterDenied(t *testing.T) {

--- a/scripts/check-authoring-native-results.py
+++ b/scripts/check-authoring-native-results.py
@@ -232,6 +232,18 @@ def check(root):
                                 "TestWindowsScratchAliasResolutionStages", "TestWindowsReopenProtectedParameters",
                                 "TestWindowsModeAndChangeMetadata", "TestWindowsRootAndIntermediateReparseRejected",
                                 "TestWindowsScratchAliasFailuresStayBeforeData"]
+        critical["windows"] += [
+            'TestWindowsSharedScratchEpochBoundary/scratch/stat',
+            'TestWindowsSharedScratchEpochBoundary/scratch/protect',
+            'TestWindowsSharedScratchEpochBoundary/source/stat',
+            'TestWindowsSharedScratchEpochBoundary/source/protect',
+            'TestWindowsSharedScratchReplacementRejected/directory/stat',
+            'TestWindowsSharedScratchReplacementRejected/directory/protect',
+            'TestWindowsSharedScratchReplacementRejected/junction/stat',
+            'TestWindowsSharedScratchReplacementRejected/junction/protect',
+            'TestWindowsSharedScratchReplacementRejected/reparse/stat',
+            'TestWindowsSharedScratchReplacementRejected/reparse/protect',
+        ]
         for test in critical.get(native_os, []):
             require((native_package, test) in passed, "missing mandatory native contract: " + test)
         scaffold_package = "github.com/777genius/plugin-kit-ai/cli/internal/authoring/scaffold"

--- a/scripts/check-authoring-native-results.py
+++ b/scripts/check-authoring-native-results.py
@@ -16,6 +16,42 @@ import re
 import sys
 
 
+def host_identity():
+    system = {"Linux": "linux", "Darwin": "darwin", "Windows": "windows"}.get(platform.system())
+    arch = {"x86_64": "amd64", "amd64": "amd64", "arm64": "arm64", "aarch64": "arm64"}.get(platform.machine().lower())
+    if system == "windows":
+        # Python/bash may be x64 tools on Windows ARM. Query the native kernel,
+        # then inspect Go and product PE machines separately; never trust an
+        # emulated process's platform.machine() as hardware evidence.
+        import ctypes
+        kernel = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel.GetCurrentProcess.restype = ctypes.c_void_p
+        query = kernel.IsWow64Process2
+        query.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_ushort), ctypes.POINTER(ctypes.c_ushort)]
+        query.restype = ctypes.c_int
+        process, native = ctypes.c_ushort(), ctypes.c_ushort()
+        if not query(kernel.GetCurrentProcess(), ctypes.byref(process), ctypes.byref(native)):
+            raise OSError("cannot establish native Windows machine")
+        arch = {0x8664: "amd64", 0xAA64: "arm64"}.get(native.value)
+    return system, arch
+
+
+def executable_identity(path):
+    """Read native 64-bit ELF/PE machine IDs, rejecting x86 and ARM64EC/X."""
+    with path.open("rb") as stream:
+        header = stream.read(64)
+        if len(header) != 64:
+            raise ValueError("truncated executable: " + str(path))
+        if header[:4] == b"\x7fELF" and header[4:7] == b"\x02\x01\x01":
+            return "linux", {62: "amd64", 183: "arm64"}.get(int.from_bytes(header[18:20], "little"))
+        if header[:2] == b"MZ":
+            stream.seek(int.from_bytes(header[60:64], "little"))
+            pe = stream.read(26)
+            if len(pe) == 26 and pe[:4] == b"PE\0\0" and pe[24:26] == b"\x0b\x02":
+                return "windows", {0x8664: "amd64", 0xAA64: "arm64"}.get(int.from_bytes(pe[4:6], "little"))
+    raise ValueError("unsupported executable header: " + str(path))
+
+
 def unavailable_diagnostic(text, test):
     """Ignore only complete Go status lines naming this event's exact test."""
     name = re.escape(test)
@@ -24,7 +60,7 @@ def unavailable_diagnostic(text, test):
     for line in text.splitlines():
         if test and re.fullmatch(structural, line):
             continue
-        if re.search(r"platform_unavailable|not[ _-]?available|gate.*(?:incomplete|unproven)", line, re.I):
+        if re.search(r"platform_unavailable|scratch_unavailable|not[ _-]?available|gate.*(?:incomplete|unproven)", line, re.I):
             return True
     return False
 
@@ -54,17 +90,33 @@ def check(root):
         require(bool(re.fullmatch(r"[0-9a-f]{40}", head)) and head == os.environ["EXPECTED_HEAD"], "head mismatch")
         env = json.loads((evidence / "go-env.json").read_text(encoding="utf-8"))
         summary["go"] = env
-        native_os = {"Linux": "linux", "Darwin": "darwin", "Windows": "windows"}.get(platform.system())
-        native_arch = {"x86_64": "amd64", "amd64": "amd64", "arm64": "arm64", "aarch64": "arm64"}.get(platform.machine().lower())
-        summary["host"] = {"os": native_os, "arch": native_arch, "release": platform.release()}
+        native_os, native_arch = host_identity()
+        summary["host"] = {"os": native_os, "arch": native_arch, "release": platform.release(),
+                           "runner_arch": os.environ.get("RUNNER_ARCH")}
         require(native_os in ("linux", "windows"), "checkpoint supports Linux and Windows only; macOS writable release gate UNPROVEN")
         require(native_os == env["GOHOSTOS"] == env["GOOS"] == os.environ["EXPECTED_OS"], "native OS mismatch")
         require(native_arch == env["GOHOSTARCH"] == env["GOARCH"] == os.environ["EXPECTED_ARCH"], "native architecture mismatch")
+        require(native_arch in ("amd64", "arm64"), "unsupported native architecture")
+        require(os.environ.get("RUNNER_ARCH", "").lower() == {"amd64": "x64", "arm64": "arm64"}.get(native_arch), "runner architecture mismatch")
         require(env["GOVERSION"] == "go1.25.13", "Go pin mismatch")
         suffix = ".exe" if native_os == "windows" else ""
         summary["go_sha256"] = digest(Path(env["GOROOT"]) / "bin" / ("go" + suffix))
         binaries = {name: digest(root / "bin" / (name + suffix)) for name in ("agentplugins", "plugin-kit-ai")}
         summary["binary_sha256"] = binaries
+        executables = {name: root / "bin" / (name + suffix) for name in binaries}
+        executables["go"] = Path(env["GOROOT"]) / "bin" / ("go" + suffix)
+        summary["executable_machines"] = {name: executable_identity(path) for name, path in executables.items()}
+        for name, identity in summary["executable_machines"].items():
+            require(identity == (native_os, native_arch), "native executable architecture mismatch: " + name)
+        summary["builds"] = {}
+        for name in binaries:
+            build = json.loads((evidence / (name + "-build.json")).read_text(encoding="utf-8"))
+            summary["builds"][name] = build
+            settings = {item["Key"]: item["Value"] for item in build["Settings"]}
+            require(build["GoVersion"] == env["GOVERSION"], "binary Go pin mismatch: " + name)
+            require(build["Path"] == "github.com/777genius/plugin-kit-ai/cli/cmd/" + name, "binary entrypoint mismatch: " + name)
+            require((settings.get("GOOS"), settings.get("GOARCH")) == (native_os, native_arch), "binary build architecture mismatch: " + name)
+            require(settings.get("vcs.revision") == head and settings.get("vcs.modified") == "false", "binary source revision/cleanliness mismatch: " + name)
         if native_os == "windows":
             import ctypes
             volume = Path(root).anchor
@@ -169,6 +221,12 @@ def check(root):
                         "TestWindowsReplacementBeforeAndAfterNameCheck", "TestWindowsReplacementWithPipeNamespaceLink", "TestWindowsSameObjectReopenAfterNameReplacement", "TestWindowsMetadataProbeReplacement", "TestWindowsExistingWriterAndReparseSetterDenied", "TestWindowsAttributesOnlyHandleCannotSetReparse", "TestWindowsDirectoryAncestryHeld", "TestWindowsInventoryMutationRejected", "TestWindowsJunctionsAndNamespaceRoots", "TestWindowsInertFIFOReparseRejected", "TestWindowsHandleLifetimeAndFailureCleanup", "TestWindowsOfflineFileHasNoDataOpen",
                         "TestWindowsScratchPhysicalAliases", "TestWindowsScratchIdentityUnavailableFailsClosed", "TestWindowsScratchAncestryHeld", "TestWindowsScratchDistinctNTFSVolumes"],
         }
+        # These diagnostics and negative controls must not disappear from ARM
+        # discovery via an amd64-only build guard either.
+        critical["windows"] += ["TestWindowsBasicInfoABI", "TestWindowsBootstrapStages",
+                                "TestWindowsScratchAliasResolutionStages", "TestWindowsReopenProtectedParameters",
+                                "TestWindowsModeAndChangeMetadata", "TestWindowsRootAndIntermediateReparseRejected",
+                                "TestWindowsScratchAliasFailuresStayBeforeData"]
         for test in critical.get(native_os, []):
             require((native_package, test) in passed, "missing mandatory native contract: " + test)
         scaffold_package = "github.com/777genius/plugin-kit-ai/cli/internal/authoring/scaffold"

--- a/scripts/check-authoring-native-results.py
+++ b/scripts/check-authoring-native-results.py
@@ -223,7 +223,12 @@ def check(root):
         }
         # These diagnostics and negative controls must not disappear from ARM
         # discovery via an amd64-only build guard either.
-        critical["windows"] += ["TestWindowsBasicInfoABI", "TestWindowsBootstrapStages",
+        critical["windows"] += ["TestWindowsAncestorEpochBoundary/outside/stat", "TestWindowsAncestorEpochBoundary/outside/protect",
+                                "TestWindowsAncestorEpochBoundary/root/stat", "TestWindowsAncestorEpochBoundary/root/protect",
+                                "TestWindowsAncestorEpochBoundary/descendant/stat", "TestWindowsAncestorEpochBoundary/descendant/protect",
+                                "TestWindowsAncestorEpochOrderedRoot", "TestWindowsAncestorEpochMetadataGuards",
+                                "TestWindowsAncestorEpochReplacementRejected",
+                                "TestWindowsBasicInfoABI", "TestWindowsBootstrapStages",
                                 "TestWindowsScratchAliasResolutionStages", "TestWindowsReopenProtectedParameters",
                                 "TestWindowsModeAndChangeMetadata", "TestWindowsRootAndIntermediateReparseRejected",
                                 "TestWindowsScratchAliasFailuresStayBeforeData"]

--- a/scripts/test_check_authoring_native_results.py
+++ b/scripts/test_check_authoring_native_results.py
@@ -1,7 +1,15 @@
-"""Offline regression for Linux run34015662605/job101438843915 output."""
+"""Native evidence controls plus Linux run34015662605/job101438843915 regression."""
 import importlib.util
 from pathlib import Path
 import unittest
+from unittest import mock
+import contextlib
+import ctypes
+import hashlib
+import io
+import json
+import os
+import tempfile
 
 SPEC = importlib.util.spec_from_file_location(
     "checker", Path(__file__).with_name("check-authoring-native-results.py"))
@@ -29,7 +37,7 @@ class UnavailableDiagnosticTests(unittest.TestCase):
 
     def test_go_status_names(self):
         for name in (ACTUAL[0]["Test"], "TestCapability/platform_unavailable",
-                     "TestCapability/not-available", "TestGate/unproven"):
+                     "TestCapability/not-available", "TestGate/unproven", "TestCapability/scratch_unavailable"):
             for line in (f"=== RUN   {name}", f"=== PAUSE {name}",
                          f"=== CONT  {name}", f"--- PASS: {name} (0.00s)",
                          f"--- FAIL: {name} (1.23s)", f"--- SKIP: {name} (0.00s)"):
@@ -40,7 +48,7 @@ class UnavailableDiagnosticTests(unittest.TestCase):
         name = ACTUAL[0]["Test"]
         for warning in ("platform_unavailable", "not available", "not_available",
                         "not-available", "NOT AVAILABLE", "gate incomplete",
-                        "gate unproven", name):
+                        "gate unproven", "scratch_unavailable", name):
             for text in (warning, "    native_test.go:42: " + warning + "\n",
                          ACTUAL[0]["Output"] + warning + "\n" + ACTUAL[1]["Output"],
                          ACTUAL[1]["Output"].rstrip() + " " + warning):
@@ -60,6 +68,287 @@ class UnavailableDiagnosticTests(unittest.TestCase):
         name = "TestGate/incomplete[1]"
         self.assertFalse(checker.unavailable_diagnostic(f"=== RUN   {name}\n", name))
         self.assertTrue(checker.unavailable_diagnostic("=== RUN   TestGate/incomplete1\n", name))
+
+
+# Synthetic passing transcripts, never claims of native execution.
+CONTRACTS = {
+    'linux': [
+        'TestDeviceMetadataOnly',
+        'TestReplacementRacesNeverFollowSpecialOrOutside/before-name-check/device',
+        'TestReplacementRacesNeverFollowSpecialOrOutside/after-name-check/device',
+    ],
+    'windows': [
+        'TestWindowsPureNamespaceReplacement/before_name_check',
+        'TestWindowsPureNamespaceReplacement/after_name_check',
+        'TestWindowsFinalCleanupAcquisitionStages',
+        'TestWindowsSharedRenameCalibration/regular',
+        'TestWindowsSharedRenameCalibration/directory',
+        'TestWindowsNTSelfOpenAccessAndRead',
+        'TestWindowsNTSelfOpenDirectoryAfterNameReplacement',
+        'TestWindowsNTSelfOpenExistingConflictsAndCleanup',
+        'TestWindowsNTSelfOpenInvalidHandles',
+        'TestWindowsBootstrapDirectoryGuard',
+        'TestWindowsBootstrapDirectoryGuardWrongKind',
+        'TestWindowsBootstrapDirectoryGuardUnsafe',
+        'TestNativeCaptureAndCleanup',
+        'TestNativeTraversalOrderAndBoundedLinks',
+        'TestNativeLegacyMetadataAndHardlinks',
+        'TestNativeLegacySymlinkAlias',
+        'TestNativeRootLinkRejected',
+        'TestWindowsReplacementBeforeAndAfterNameCheck',
+        'TestWindowsReplacementWithPipeNamespaceLink',
+        'TestWindowsSameObjectReopenAfterNameReplacement',
+        'TestWindowsMetadataProbeReplacement',
+        'TestWindowsExistingWriterAndReparseSetterDenied',
+        'TestWindowsAttributesOnlyHandleCannotSetReparse',
+        'TestWindowsDirectoryAncestryHeld',
+        'TestWindowsInventoryMutationRejected',
+        'TestWindowsJunctionsAndNamespaceRoots',
+        'TestWindowsInertFIFOReparseRejected',
+        'TestWindowsHandleLifetimeAndFailureCleanup',
+        'TestWindowsOfflineFileHasNoDataOpen',
+        'TestWindowsScratchPhysicalAliases',
+        'TestWindowsScratchIdentityUnavailableFailsClosed',
+        'TestWindowsScratchAncestryHeld',
+        'TestWindowsScratchDistinctNTFSVolumes',
+        'TestWindowsBasicInfoABI',
+        'TestWindowsBootstrapStages',
+        'TestWindowsScratchAliasResolutionStages',
+        'TestWindowsReopenProtectedParameters',
+        'TestWindowsModeAndChangeMetadata',
+        'TestWindowsRootAndIntermediateReparseRejected',
+        'TestWindowsScratchAliasFailuresStayBeforeData',
+    ],
+}
+
+
+def executable(system, arch):
+    header = bytearray(64)
+    if system == "linux":
+        header[:7] = b"\x7fELF\x02\x01\x01"
+        header[18:20] = {"amd64": 62, "arm64": 183}[arch].to_bytes(2, "little")
+    else:
+        header[:2] = b"MZ"
+        header[60:64] = (64).to_bytes(4, "little")
+        pe = bytearray(26)
+        pe[:4] = b"PE\0\0"
+        pe[4:6] = {"amd64": 0x8664, "arm64": 0xAA64}[arch].to_bytes(2, "little")
+        pe[24:26] = b"\x0b\x02"
+        header += pe
+    return header
+
+
+class NativeEvidenceTests(unittest.TestCase):
+    def fixture(self, system, arch):
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        root = Path(temp.name)
+        evidence = root / "evidence"
+        evidence.mkdir()
+        (root / "bin").mkdir()
+        (root / "go" / "bin").mkdir(parents=True)
+        head = "a" * 40
+        (evidence / "head.txt").write_text(head)
+        self.system, self.arch, self.root = system, arch, root
+        self.env = dict(GOOS=system, GOHOSTOS=system, GOARCH=arch, GOHOSTARCH=arch,
+                        GOVERSION="go1.25.13", GOROOT=str(root / "go"))
+        self.expected = dict(EXPECTED_OS=system, EXPECTED_ARCH=arch, EXPECTED_HEAD=head,
+                             RUNNER_ARCH="X64" if arch == "amd64" else "ARM64")
+        self.suffix = ".exe" if system == "windows" else ""
+        (root / "go" / "bin" / ("go" + self.suffix)).write_bytes(executable(system, arch))
+        self.builds = {}
+        for name in ("agentplugins", "plugin-kit-ai"):
+            (root / "bin" / (name + self.suffix)).write_bytes(executable(system, arch))
+            settings = dict(GOOS=system, GOARCH=arch, **{"vcs.revision": head, "vcs.modified": "false"})
+            self.builds[name] = dict(GoVersion="go1.25.13",
+                Path="github.com/777genius/plugin-kit-ai/cli/cmd/" + name,
+                Settings=[dict(Key=k, Value=v) for k, v in settings.items()])
+        prefix = "github.com/777genius/plugin-kit-ai/"
+        self.native = prefix + "install/integrationctl/agentplugins/adapters/packageview"
+        self.commands = prefix + "cli/internal/authoring/commands"
+        scaffold = prefix + "cli/internal/authoring/scaffold"
+        packages = [self.native, self.commands, scaffold,
+            prefix + "install/integrationctl/agentplugins/adapters/packagedigest",
+            prefix + "install/integrationctl/agentplugins/conformance",
+            prefix + "install/integrationctl/agentplugins/adapters/loader",
+            prefix + "cli/internal/authoringcli", prefix + "cli/internal/authoring/project"]
+        (evidence / "packages.txt").write_text("\n".join(packages))
+        tests = {(p, "TestFixture") for p in packages}
+        tests.update((self.native, name) for name in CONTRACTS[system])
+        tests.add((scaffold, "TestDeniedParent"))
+        templates = ["skill", "mcp-remote", "mcp-stdio", "hybrid", "hybrid-remote"]
+        tests.update((self.commands, "TestNativeBinaryVerticalSlice/" + t) for t in templates)
+        tests.add((self.commands, "TestNativeBinaryVerticalSlice"))
+        tests.update((self.commands, "TestNativeBinaryLifecycle/" + t) for t in
+            ("generated-skill", "skills-init", "static-validation", "duplicate-unchanged",
+             "readiness", "strict-flags", "malformed-skill", "sdk-static-only"))
+        paths = ["ordinary-relative-roots", "traversal-order", "reparse-before-dot-dot"]
+        if system == "windows":
+            paths += ["namespace-rejection", "same-volume-overlapping-alias", "two-physical-ntfs-volumes"]
+        tests.update((self.commands, "TestNativePathFixBothBinaries/" + t) for t in paths)
+        self.events = [dict(Action="pass", Package=p, Test=t) for p, t in sorted(tests)]
+        self.events += [dict(Action="pass", Package=p) for p in packages]
+        self.discovery = [dict(Action="output", Package=p, Output=t + "\n")
+                          for p, t in sorted(tests) if "/" not in t]
+        self.discovery += [dict(Action="pass", Package=p) for p in packages]
+        self.markers = [dict(entrypoint=name, sha256=hashlib.sha256(executable(system, arch)).hexdigest(),
+            revision=head, read_profile=f"packageview-local-{system}-v1", templates=templates,
+            sdk={"@modelcontextprotocol/sdk": "locked", "package-lock-sha256": "b" * 64})
+            for name in self.builds]
+        (evidence / "test-exit.txt").write_text("0")
+
+    def check(self):
+        evidence = self.root / "evidence"
+        (evidence / "go-env.json").write_text(json.dumps(self.env))
+        for name, build in self.builds.items():
+            (evidence / (name + "-build.json")).write_text(json.dumps(build))
+        events = self.events + [dict(Action="output", Package=self.commands,
+            Test="TestNativeBinaryVerticalSlice", Output="AUTHORING_NATIVE_E2E " + json.dumps(m))
+            for m in self.markers]
+        for file, data in (("go-test.json", events), ("test-discovery.json", self.discovery)):
+            (evidence / file).write_text("\n".join(json.dumps(e) for e in data))
+        def volume(*args):
+            args[6].value = "NTFS"
+            return 1
+        kernel = mock.Mock()
+        kernel.GetDriveTypeW.return_value = 3
+        kernel.GetVolumeInformationW.side_effect = volume
+        with mock.patch.dict(os.environ, self.expected), \
+             mock.patch.object(checker, "host_identity", return_value=(self.system, self.arch)), \
+             mock.patch.object(ctypes, "windll", mock.Mock(kernel32=kernel), create=True), \
+             contextlib.redirect_stdout(io.StringIO()):
+            result = checker.check(self.root)
+        summary = json.loads((evidence / "summary.json").read_text())
+        self.assertEqual(result, bool(summary["errors"]))
+        return summary
+
+    def rejected(self, message):
+        summary = self.check()
+        self.assertEqual(summary["status"], "unproven", summary)
+        self.assertTrue(any(message in e for e in summary["errors"]), summary["errors"])
+
+    def test_four_lane_controls(self):
+        for system in ("linux", "windows"):
+            for arch in ("amd64", "arm64"):
+                with self.subTest(system=system, arch=arch):
+                    self.fixture(system, arch)
+                    self.assertEqual(self.check()["errors"], [])
+
+    def test_architecture_mismatch(self):
+        for system in ("linux", "windows"):
+            for field in ("GOARCH", "GOHOSTARCH"):
+                with self.subTest(system=system, field=field):
+                    self.fixture(system, "arm64")
+                    self.env[field] = "amd64"
+                    self.rejected("native architecture mismatch")
+            self.fixture(system, "arm64")
+            self.expected["EXPECTED_ARCH"] = "amd64"
+            self.rejected("native architecture mismatch")
+            self.fixture(system, "arm64")
+            self.expected["RUNNER_ARCH"] = "X64"
+            self.rejected("runner architecture mismatch")
+            self.fixture(system, "arm64")
+            self.expected["RUNNER_ARCH"] = ""
+            self.rejected("runner architecture mismatch")
+            self.fixture(system, "arm64")
+            self.arch = "amd64"  # all Go evidence says ARM, native kernel does not
+            self.rejected("native architecture mismatch")
+
+    def test_emulated_executables_rejected(self):
+        for system in ("linux", "windows"):
+            for name in ("go", "agentplugins", "plugin-kit-ai"):
+                with self.subTest(system=system, executable=name):
+                    self.fixture(system, "arm64")
+                    directory = self.root / ("go/bin" if name == "go" else "bin")
+                    (directory / (name + self.suffix)).write_bytes(executable(system, "amd64"))
+                    self.rejected("native executable architecture mismatch: " + name)
+
+    def test_build_revision_arch_and_pin_controls(self):
+        for field, value, error in (("GOARCH", "amd64", "build architecture"),
+                                   ("vcs.revision", "b" * 40, "source revision"),
+                                   ("vcs.modified", "true", "source revision")):
+            self.fixture("windows", "arm64")
+            for item in self.builds["agentplugins"]["Settings"]:
+                if item["Key"] == field:
+                    item["Value"] = value
+            self.rejected(error)
+        self.fixture("linux", "arm64")
+        self.builds["plugin-kit-ai"]["GoVersion"] = "go1.25.12"
+        self.rejected("binary Go pin mismatch")
+
+    def test_both_binary_journey_identity_controls(self):
+        for field, value, error in (("revision", "b" * 40, "E2E revision"),
+                                   ("sha256", "0" * 64, "binary hash"),
+                                   ("read_profile", "platform_unavailable", "read profile"),
+                                   ("templates", ["skill"], "template journeys")):
+            for name in ("agentplugins", "plugin-kit-ai"):
+                self.fixture("windows", "arm64")
+                next(m for m in self.markers if m["entrypoint"] == name)[field] = value
+                self.rejected(error)
+
+    def test_missing_contract_is_not_architecture_unavailable_as_pass(self):
+        for system in ("linux", "windows"):
+            for arch in ("amd64", "arm64"):
+                names = (["TestDeviceMetadataOnly"] if system == "linux" else
+                    ["TestWindowsScratchDistinctNTFSVolumes", "TestWindowsBasicInfoABI",
+                     "TestWindowsNTSelfOpenAccessAndRead", "TestWindowsScratchAliasResolutionStages"])
+                for name in names:
+                    with self.subTest(system=system, arch=arch, test=name):
+                        self.fixture(system, arch)
+                        self.events = [e for e in self.events if e.get("Test") != name]
+                        self.discovery = [e for e in self.discovery if e.get("Output") != name + "\n"]
+                        self.rejected("missing mandatory native contract: " + name)
+
+    def test_required_fixture_skips_and_missing_journeys(self):
+        for arch in ("amd64", "arm64"):
+            for name in ("TestWindowsScratchDistinctNTFSVolumes", "TestDeniedParent",
+                         "TestNativePathFixBothBinaries/two-physical-ntfs-volumes",
+                         "TestNativeBinaryLifecycle/sdk-static-only", "TestNativeBinaryVerticalSlice/skill"):
+                for action in ("skip", "omit"):
+                    with self.subTest(arch=arch, test=name, action=action):
+                        self.fixture("windows", arch)
+                        if action == "omit":
+                            self.events = [e for e in self.events if e.get("Test") != name]
+                        else:
+                            next(e for e in self.events if e.get("Test") == name)["Action"] = "skip"
+                        self.assertEqual(self.check()["status"], "unproven")
+
+    def test_unattributed_scratch_unavailable_recurrence_fails(self):
+        self.fixture("windows", "arm64")
+        self.events.append(dict(Action="output", Package=self.native,
+                                Output="scratch_unavailable\n"))
+        self.rejected("unavailable native evidence")
+
+
+class ExecutableIdentityTests(unittest.TestCase):
+    def test_malformed_and_hybrid_headers(self):
+        with tempfile.TemporaryDirectory() as temp:
+            path = Path(temp) / "binary"
+            for data in (b"", b"MZ", bytes(90)):
+                path.write_bytes(data)
+                with self.assertRaises(ValueError):
+                    checker.executable_identity(path)
+            for machine in (0xA641, 0xA64E, 0x14C):  # ARM64EC, ARM64X, x86
+                data = executable("windows", "arm64")
+                data[68:70] = machine.to_bytes(2, "little")
+                path.write_bytes(data)
+                self.assertEqual(checker.executable_identity(path), ("windows", None))
+
+    def test_windows_kernel_identity_ignores_emulated_python_architecture(self):
+        kernel = mock.Mock()
+        def query(process, process_machine, native_machine):
+            process_machine._obj.value = 0x8664
+            native_machine._obj.value = 0xAA64
+            return 1
+        kernel.IsWow64Process2.side_effect = query
+        with mock.patch.object(checker.platform, "system", return_value="Windows"), \
+             mock.patch.object(checker.platform, "machine", return_value="AMD64"), \
+             mock.patch.object(ctypes, "WinDLL", return_value=kernel, create=True):
+            self.assertEqual(checker.host_identity(), ("windows", "arm64"))
+            kernel.IsWow64Process2.side_effect = None
+            kernel.IsWow64Process2.return_value = 0
+            with self.assertRaises(OSError):
+                checker.host_identity()
 
 
 if __name__ == "__main__":

--- a/scripts/test_check_authoring_native_results.py
+++ b/scripts/test_check_authoring_native_results.py
@@ -78,6 +78,17 @@ CONTRACTS = {
         'TestReplacementRacesNeverFollowSpecialOrOutside/after-name-check/device',
     ],
     'windows': [
+        'TestWindowsSharedScratchReplacementRejected/reparse/stat',
+        'TestWindowsSharedScratchReplacementRejected/reparse/protect',
+        'TestWindowsSharedScratchEpochBoundary/scratch/stat',
+        'TestWindowsSharedScratchEpochBoundary/scratch/protect',
+        'TestWindowsSharedScratchEpochBoundary/source/stat',
+        'TestWindowsSharedScratchEpochBoundary/source/protect',
+        'TestWindowsSharedScratchReplacementRejected/directory/stat',
+        'TestWindowsSharedScratchReplacementRejected/directory/protect',
+        'TestWindowsSharedScratchReplacementRejected/junction/stat',
+        'TestWindowsSharedScratchReplacementRejected/junction/protect',
+
         'TestWindowsAncestorEpochBoundary/outside/stat',
         'TestWindowsAncestorEpochBoundary/outside/protect',
         'TestWindowsAncestorEpochBoundary/root/stat',
@@ -301,7 +312,7 @@ class NativeEvidenceTests(unittest.TestCase):
                 names = (["TestDeviceMetadataOnly"] if system == "linux" else
                     ["TestWindowsScratchDistinctNTFSVolumes", "TestWindowsBasicInfoABI",
                      "TestWindowsNTSelfOpenAccessAndRead", "TestWindowsScratchAliasResolutionStages"] +
-                    [n for n in CONTRACTS["windows"] if n.startswith("TestWindowsAncestorEpoch")])
+                    [n for n in CONTRACTS["windows"] if n.startswith(("TestWindowsAncestorEpoch", "TestWindowsSharedScratch"))])
                 for name in names:
                     with self.subTest(system=system, arch=arch, test=name):
                         self.fixture(system, arch)
@@ -313,7 +324,8 @@ class NativeEvidenceTests(unittest.TestCase):
         for arch in ("amd64", "arm64"):
             for name in ("TestWindowsScratchDistinctNTFSVolumes", "TestDeniedParent",
                          "TestNativePathFixBothBinaries/two-physical-ntfs-volumes",
-                         "TestNativeBinaryLifecycle/sdk-static-only", "TestNativeBinaryVerticalSlice/skill"):
+                         "TestNativeBinaryLifecycle/sdk-static-only", "TestNativeBinaryVerticalSlice/skill",
+                         *[n for n in CONTRACTS["windows"] if n.startswith("TestWindowsSharedScratch")]):
                 for action in ("skip", "omit"):
                     with self.subTest(arch=arch, test=name, action=action):
                         self.fixture("windows", arch)

--- a/scripts/test_check_authoring_native_results.py
+++ b/scripts/test_check_authoring_native_results.py
@@ -78,6 +78,15 @@ CONTRACTS = {
         'TestReplacementRacesNeverFollowSpecialOrOutside/after-name-check/device',
     ],
     'windows': [
+        'TestWindowsAncestorEpochBoundary/outside/stat',
+        'TestWindowsAncestorEpochBoundary/outside/protect',
+        'TestWindowsAncestorEpochBoundary/root/stat',
+        'TestWindowsAncestorEpochBoundary/root/protect',
+        'TestWindowsAncestorEpochBoundary/descendant/stat',
+        'TestWindowsAncestorEpochBoundary/descendant/protect',
+        'TestWindowsAncestorEpochOrderedRoot',
+        'TestWindowsAncestorEpochMetadataGuards',
+        'TestWindowsAncestorEpochReplacementRejected',
         'TestWindowsPureNamespaceReplacement/before_name_check',
         'TestWindowsPureNamespaceReplacement/after_name_check',
         'TestWindowsFinalCleanupAcquisitionStages',
@@ -291,7 +300,8 @@ class NativeEvidenceTests(unittest.TestCase):
             for arch in ("amd64", "arm64"):
                 names = (["TestDeviceMetadataOnly"] if system == "linux" else
                     ["TestWindowsScratchDistinctNTFSVolumes", "TestWindowsBasicInfoABI",
-                     "TestWindowsNTSelfOpenAccessAndRead", "TestWindowsScratchAliasResolutionStages"])
+                     "TestWindowsNTSelfOpenAccessAndRead", "TestWindowsScratchAliasResolutionStages"] +
+                    [n for n in CONTRACTS["windows"] if n.startswith("TestWindowsAncestorEpoch")])
                 for name in names:
                     with self.subTest(system=system, arch=arch, test=name):
                         self.fixture(system, arch)


### PR DESCRIPTION
Linux and Windows ARM64 assets now run the same native authoring contract as amd64. Windows ARM64 selects the existing 64-bit NTFS backend with compile-time NT ABI checks. The four-lane workflow verifies native host/toolchain/product architecture, exact clean source revision, both actual binaries and mandatory security, template, Skills, scratch and cleanup coverage.

Native execution exposed two Windows defects. NT rename collision errors lacked Go's standard existence classification, so concurrent initialization reported init_failed; the OS boundary now preserves NTSTATUS and exposes its Win32 errno. Directory changes above the selected package root could invalidate acquisition; those traversal-only observations now retain identity, creation, attributes, size, links and protected ancestry while excluding unrelated write/change epochs. A fresh held-parent name check after protection still rejects replacement. Selected root and descendants retain strict epoch checks, and outside-root pins cannot authorize data access.

Windows ARM64 creates a fresh disposable NTFS VHDX under RUNNER_TEMP for mandatory two-filesystem tests, with exact disk identity checks and owned-image cleanup. Native diagnostics are opt-in workflow_dispatch only and explicitly cannot qualify as clean release proof.

Validation:
- Exact baseline c622c0fa regression reproduced on both native Windows architectures in run 34035783111: outside-root mutations fail old acquisition, while root/descendant rejection assertions pass. This diagnostic is separate from release proof.
- At 3d0dc065, Linux amd64/arm64 pass. Windows exposed test calibration defects: same-tick timestamps, collision precedence in the sharing fixture, and a stale copied diagnostic resolver. These are corrected at 905387c5 with observed clock advancement before one mutation, an absent destination and a sharing-participating handle, and calls to the actual resolver.
- Windows amd64/arm64 packageview diagnostic overlays and scaffold cross-compile/vet pass; 15 checker regression tests pass. Clean native run 34036085937 at 905387c5 passes all four lanes: each Windows architecture has 844 passes and zero skips; each Linux architecture has 801 passes plus one explicitly optional Unix-socket fixture skip. Calibrated old-code regression run 34036107783 confirms expected old failures on both Windows architectures.
- Earlier xhigh hosted review accepted the ARM64 ABI/backend selection. Final independent review of the Windows fixes is pending hosted account capacity. No merge until current native gates and review are proven.

1,476 changed LOC (1,310 additions, 166 deletions). Bounded continuation after #160. No public authoring activation, writable macOS acceptance or full MVP release is claimed; those plan gates remain open. Earlier native failures and their logs remain preserved rather than waived by reruns.

Integration hold: stacked #165 at ade20cef passes fresh real Linux-pair staging and 57/57 tests, but native run 34036251158 reproduces concurrent init_failed on Windows amd64. This new recurrence prevents accepting the foundation solely from its earlier green run. Same-invocation diagnostic run 34036452229 is pending; no causal closure or merge is claimed.

Current checkpoint 37cc9063 adds an explicit trusted scratch traversal purpose and a metadata-only existence observation after native rename sharing failure. Native run 34038656157 proves all new scratch boundary/replacement cases on both Windows architectures with zero skips, but rejects rename fixtures whose expected sharing precedence was not observed. The held destination returns name collision, and rooted File.Name is not a fixture path. These tests are being corrected. Bounded concurrent diagnostic 34038705676 still records sharing failures with absent destinations (2/32 amd64, 1/32 arm64), so concurrency acceptance remains open; no green-run waiver. A deterministic live-reader/common-parent diagnostic and independent current-source review are in progress. Current diff: 1,906 changed LOC.

At a5f7eb1a, native run 34039478874 passes all four lanes: Windows 870 tests and zero skips per architecture; Linux 801 passes plus one optional Unix-socket skip per architecture. Structured exact-head evidence was verified. Independent review accepts 37cc9063 source without P1/P2; a5f7eb1a changes tests only. Earlier absent-destination concurrent sharing failures remain open despite this green run. Paired live-reader lease diagnosis is pending.
