### PR TITLE
feat(release): stage a frozen dual-authoring candidate

### DIFF
--- a/npm/agentplugins/scripts/dual-authoring-candidate.js
+++ b/npm/agentplugins/scripts/dual-authoring-candidate.js
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+"use strict";
+
+// PRIVATE PREPARATION contract, deliberately unrelated to assets.json schema v2.
+// Checksums and Go build info are consistency checks, NOT attestation or platform
+// acceptance. Trust starts at the controlled builder and an independently saved
+// manifest digest. Never execute a supplied asset to discover its identity.
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+const zlib = require("node:zlib");
+
+const REPOSITORY = "777genius/universal-agent-plugins";
+const SCHEMA = "dual-authoring-candidate/v1";
+const PRODUCTS = Object.freeze(["agentplugins", "plugin-kit-ai"]);
+const TARGETS = Object.freeze([
+  "darwin-amd64", "darwin-arm64", "linux-amd64", "linux-arm64", "windows-amd64", "windows-arm64"
+]);
+const COMMANDS = "github.com/777genius/plugin-kit-ai/cli/internal/authoring/commands";
+const MAX_BINARY = 128 * 1024 * 1024;
+const digest = (body) => crypto.createHash("sha256").update(body).digest("hex");
+const encode = (value) => Buffer.from(JSON.stringify(value, null, 2) + "\n");
+
+function keys(value, expected, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value) ||
+      Object.keys(value).sort().join(",") !== [...expected].sort().join(",")) {
+    throw new Error(`${label}: unexpected or missing fields`);
+  }
+}
+
+function identity(value) {
+  keys(value, ["repository", "commit", "engine_revision", "versions"], "identity");
+  keys(value.versions, PRODUCTS, "product versions");
+  if (value.repository !== REPOSITORY || typeof value.commit !== "string" ||
+      !/^[0-9a-f]{40}$/.test(value.commit) || value.engine_revision !== value.commit) {
+    throw new Error("candidate repository or exact source/engine revision is invalid");
+  }
+  for (const version of Object.values(value.versions)) {
+    if (typeof version !== "string" || !/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(version)) {
+      throw new Error("candidate requires exact product versions");
+    }
+  }
+  if (value.versions.agentplugins === value.versions["plugin-kit-ai"]) {
+    throw new Error("candidate product versions must be distinct; engine identity is separate");
+  }
+  return value;
+}
+
+function assetName(product, version, target) {
+  if (!PRODUCTS.includes(product) || !TARGETS.includes(target)) throw new Error("unknown product or target");
+  const suffix = product === "plugin-kit-ai" ? ".tar.gz" : target.startsWith("windows-") ? ".exe" : "";
+  return `${product}_${version}_${target.replace("-", "_")}${suffix}`;
+}
+
+function executableName(product, target) {
+  return product + (target.startsWith("windows-") ? ".exe" : "");
+}
+
+function linkerFlags(product, id) {
+  return `-X main.version=${id.versions[product]} -X ${COMMANDS}.Enabled=vertical-slice-v1 -X ${COMMANDS}.Revision=${id.commit}`;
+}
+
+// Walk every component, including ancestors, before resolving paths. This is a
+// private, quiescent local namespace contract, not protection from a hostile
+// same-UID process or privileged mount replacement. Never normalize '..' away.
+function safeDirectory(value) {
+  if (typeof value !== "string" || !path.isAbsolute(value) || value.includes("\0") ||
+      value.split(/[\\/]/).includes("..") || path.resolve(value) !== value) {
+    throw new Error("directory must be an absolute normalized safe path");
+  }
+  let current = path.parse(value).root;
+  for (const component of value.slice(current.length).split(path.sep).filter(Boolean)) {
+    current = path.join(current, component);
+    const stat = fs.lstatSync(current);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error("directory contains a symlink or non-directory");
+  }
+  return value;
+}
+
+function inside(a, b) { return a === b || a.startsWith(b + path.sep); }
+
+function outputPlacement(output, protectedRoots) {
+  if (typeof output !== "string" || !path.isAbsolute(output) || path.resolve(output) !== output ||
+      output.split(/[\\/]/).includes("..") || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(path.basename(output))) {
+    throw new Error("unsafe candidate output path");
+  }
+  safeDirectory(path.dirname(output));
+  for (const root of protectedRoots) {
+    safeDirectory(root);
+    if (inside(output, root) || inside(root, output)) throw new Error("candidate output overlaps protected input");
+  }
+  try {
+    fs.lstatSync(output);
+  } catch (error) {
+    if (error.code === "ENOENT") return;
+    throw error;
+  }
+  throw new Error("candidate output already exists");
+}
+
+// O_NOFOLLOW plus descriptor identity/link-count checks freeze the read bytes.
+// Ancestor checks rely on the private/quiescent namespace boundary above.
+function readFile(file, maximum = MAX_BINARY) {
+  safeDirectory(path.dirname(file));
+  const before = fs.lstatSync(file);
+  if (!before.isFile() || before.nlink !== 1 || before.size <= 0 || before.size > maximum) {
+    throw new Error("candidate file must be regular, nonempty, bounded and unaliased");
+  }
+  const fd = fs.openSync(file, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0));
+  try {
+    const opened = fs.fstatSync(fd);
+    if (opened.dev !== before.dev || opened.ino !== before.ino || opened.nlink !== 1) throw new Error("candidate file changed");
+    const body = fs.readFileSync(fd);
+    const after = fs.fstatSync(fd);
+    const named = fs.lstatSync(file);
+    if (body.length !== before.size || after.size !== before.size || after.mtimeMs !== before.mtimeMs ||
+        after.ctimeMs !== before.ctimeMs || after.nlink !== 1 || named.dev !== before.dev || named.ino !== before.ino) {
+      throw new Error("candidate file changed while freezing bytes");
+    }
+    return body;
+  } finally { fs.closeSync(fd); }
+}
+
+// A deliberately tiny deterministic ustar subset: exactly one ordinary product
+// executable, no paths, extension records, links, trailing files or extraction.
+// Public plugin-kit archive filenames remain the existing six tar.gz names.
+function archive(binary, name) {
+  if (!/^(agentplugins|plugin-kit-ai)(\.exe)?$/.test(name) || !binary.length || binary.length > MAX_BINARY) {
+    throw new Error("invalid candidate archive input");
+  }
+  const header = Buffer.alloc(512);
+  const field = (offset, length, value) => header.write(value, offset, length, "ascii");
+  field(0, 100, name);
+  field(100, 8, "0000755\0");
+  field(108, 8, "0000000\0");
+  field(116, 8, "0000000\0");
+  field(124, 12, binary.length.toString(8).padStart(11, "0") + "\0");
+  field(136, 12, "00000000000\0");
+  header.fill(32, 148, 156);
+  field(156, 1, "0");
+  field(257, 6, "ustar\0");
+  field(263, 2, "00");
+  const sum = header.reduce((a, b) => a + b, 0);
+  field(148, 8, sum.toString(8).padStart(6, "0") + "\0 ");
+  return zlib.gzipSync(Buffer.concat([header, binary, Buffer.alloc((512 - binary.length % 512) % 512 + 1024)]), { level: 9 });
+}
+
+function unpack(body, name) {
+  const tar = zlib.gunzipSync(body, { maxOutputLength: MAX_BINARY + 2048 });
+  if (tar.length < 1536) throw new Error("invalid candidate archive");
+  const sizeText = tar.subarray(124, 136).toString("ascii");
+  if (!/^[0-7]{11}\0$/.test(sizeText)) throw new Error("invalid archive size");
+  const size = parseInt(sizeText, 8);
+  if (size <= 0 || size > MAX_BINARY || 512 + size > tar.length) throw new Error("invalid archive binary size");
+  const binary = tar.subarray(512, 512 + size);
+  // Compare the uncompressed canonical record too, rejecting alternate headers,
+  // extra members, unsafe names and padding. No archive is ever extracted to disk.
+  if (!tar.equals(zlib.gunzipSync(archive(binary, name)))) throw new Error("noncanonical or unsafe candidate archive");
+  return binary;
+}
+
+function metadata(body) { return { sha256: digest(body), size: body.length }; }
+
+// Two bounded preparation scopes. A Linux pair supports this checkpoint's real
+// offline journey without pretending missing target assets passed a release gate.
+// The six-platform scope is closed; neither scope changes published v2 assets.
+function scopeTargets(scope) {
+  if (scope === "linux-amd64-pair") return ["linux-amd64"];
+  if (scope === "six-platform-pair") return TARGETS;
+  throw new Error("unknown candidate asset scope");
+}
+
+function checkMetadata(value, body, label) {
+  keys(value, ["sha256", "size"], label);
+  if (typeof value.sha256 !== "string" || !/^[0-9a-f]{64}$/.test(value.sha256) ||
+      !Number.isSafeInteger(value.size) || value.size <= 0 ||
+      value.sha256 !== digest(body) || value.size !== body.length) throw new Error(`${label}: digest or size mismatch`);
+}
+
+function manifestShape(manifest, expected, expectedScope) {
+  identity(expected);
+  const targets = scopeTargets(expectedScope);
+  keys(manifest, ["schema", "status", "identity", "asset_scope", "build", "products", "release_eligible"], "candidate");
+  identity(manifest.identity);
+  if (manifest.schema !== SCHEMA || manifest.asset_scope !== expectedScope || manifest.status !== "CANDIDATE" || manifest.release_eligible !== false ||
+      manifest.identity.commit !== expected.commit || manifest.identity.repository !== expected.repository ||
+      PRODUCTS.some((p) => manifest.identity.versions[p] !== expected.versions[p])) throw new Error("candidate identity/schema mismatch");
+  keys(manifest.build, ["method", "go_version", "go_sha256", "source_archive_sha256", "authoring_mode"], "build");
+  if (manifest.build.method !== "controlled-git-archive-go-build/v1" || manifest.build.go_version !== "go1.25.13" ||
+      manifest.build.authoring_mode !== "vertical-slice-v1" ||
+      typeof manifest.build.go_sha256 !== "string" || typeof manifest.build.source_archive_sha256 !== "string" ||
+      !/^[0-9a-f]{64}$/.test(manifest.build.go_sha256) || !/^[0-9a-f]{64}$/.test(manifest.build.source_archive_sha256)) {
+    throw new Error("candidate controlled build description is invalid");
+  }
+  keys(manifest.products, PRODUCTS, "products");
+  for (const product of PRODUCTS) {
+    const value = manifest.products[product];
+    keys(value, ["version", "assets"], product);
+    if (value.version !== expected.versions[product]) throw new Error("wrong product version");
+    keys(value.assets, targets, `${product} assets`);
+    for (const target of targets) {
+      const asset = value.assets[target];
+      keys(asset, ["file", "sha256", "size", "binary"], "asset");
+      keys(asset.binary, ["file", "sha256", "size"], "binary");
+      if (asset.file !== assetName(product, value.version, target) || asset.binary.file !== executableName(product, target)) {
+        throw new Error("wrong product asset or binary name");
+      }
+    }
+  }
+}
+
+// This function validates STRUCTURE/BYTES ONLY. The public verifier additionally
+// checks embedded product/build settings with the trusted Go tool. Neither is a
+// platform gate, and neither establishes provenance from untrusted metadata.
+function frozenCandidate(root, expected, manifestDigest, expectedScope) {
+  safeDirectory(root);
+  if (typeof manifestDigest !== "string" || !/^[0-9a-f]{64}$/.test(manifestDigest)) throw new Error("independent manifest digest is required");
+  const body = readFile(path.join(root, "candidate.json"), 1024 * 1024);
+  if (digest(body) !== manifestDigest) throw new Error("candidate manifest digest mismatch");
+  const manifest = JSON.parse(body);
+  // Require canonical encoding: duplicate JSON keys and ambiguous encodings fail.
+  if (!body.equals(encode(manifest))) throw new Error("noncanonical candidate JSON");
+  manifestShape(manifest, expected, expectedScope);
+  const expectedFiles = ["candidate.json"];
+  const binaries = [];
+  const seen = new Set();
+  for (const product of PRODUCTS) {
+    for (const target of scopeTargets(expectedScope)) {
+      const asset = manifest.products[product].assets[target];
+      expectedFiles.push(asset.file);
+      const bytes = readFile(path.join(root, asset.file));
+      checkMetadata({ sha256: asset.sha256, size: asset.size }, bytes, "asset");
+      const binary = product === "plugin-kit-ai" ? unpack(bytes, asset.binary.file) : bytes;
+      checkMetadata({ sha256: asset.binary.sha256, size: asset.binary.size }, binary, "binary");
+      if (seen.has(asset.binary.sha256)) throw new Error("duplicate executable bytes across products/targets");
+      seen.add(asset.binary.sha256);
+      binaries.push({ product, target, binary });
+    }
+  }
+  if (fs.readdirSync(root).sort().join("\n") !== expectedFiles.sort().join("\n")) throw new Error("candidate contains extra or missing files");
+  return { manifest, binaries, manifest_sha256: manifestDigest };
+}
+
+module.exports = {
+  REPOSITORY, SCHEMA, PRODUCTS, TARGETS, COMMANDS, digest, encode, keys, identity,
+  assetName, executableName, linkerFlags, safeDirectory, outputPlacement, readFile,
+  archive, unpack, metadata, scopeTargets, manifestShape, frozenCandidate
+};

--- a/npm/agentplugins/scripts/stage-dual-authoring-candidate.js
+++ b/npm/agentplugins/scripts/stage-dual-authoring-candidate.js
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+"use strict";
+
+// Opt-in offline producer. No published wrapper, workflow, or default build calls
+// this module. Compile only the two known mains; never run package scripts,
+// generators, downloaded executables, or binaries supplied by a caller.
+const fs = require("node:fs");
+const path = require("node:path");
+const cp = require("node:child_process");
+const c = require("./dual-authoring-candidate");
+
+const SOURCE_PATHS = ["go.mod", "go.work", "go.work.sum", "cli", "install", "sdk"];
+const GO_VERSION = "go1.25.13";
+
+function run(command, args, options = {}) {
+  return cp.execFileSync(command, args, { timeout: 10 * 60 * 1000, maxBuffer: 64 * 1024 * 1024, ...options });
+}
+
+function optIn(options, fields) {
+  c.keys(options, ["candidate", ...fields], "options");
+  if (options.candidate !== true) throw new Error("explicit candidate opt-in required");
+  c.identity(options.identity);
+}
+
+function privateContext(workParent) {
+  c.safeDirectory(workParent);
+  const root = fs.mkdtempSync(path.join(workParent, "dual-authoring-"));
+  fs.chmodSync(root, 0o700);
+  for (const name of ["home", "tmp", "cache", "config", "data", "state", "bin", "source"]) {
+    fs.mkdirSync(path.join(root, name), { mode: 0o700 });
+  }
+  // Start from an allowlist; inherited GOFLAGS, toolchain, profiles, credentials,
+  // proxy settings, NODE_OPTIONS and Git config cannot change this build.
+  const env = {
+    PATH: "/usr/bin:/bin", HOME: path.join(root, "home"), USERPROFILE: path.join(root, "home"),
+    TMPDIR: path.join(root, "tmp"), TMP: path.join(root, "tmp"), TEMP: path.join(root, "tmp"),
+    XDG_CONFIG_HOME: path.join(root, "config"), XDG_CACHE_HOME: path.join(root, "cache"),
+    XDG_DATA_HOME: path.join(root, "data"), XDG_STATE_HOME: path.join(root, "state"),
+    APPDATA: path.join(root, "config"), LOCALAPPDATA: path.join(root, "data"),
+    GIT_CONFIG_NOSYSTEM: "1", GIT_CONFIG_GLOBAL: "/dev/null", GIT_TERMINAL_PROMPT: "0",
+    GIT_NO_REPLACE_OBJECTS: "1", GIT_NO_LAZY_FETCH: "1",
+    GIT_CONFIG_COUNT: "1", GIT_CONFIG_KEY_0: "protocol.allow", GIT_CONFIG_VALUE_0: "never",
+    GOENV: "off", GOTOOLCHAIN: "local", GOPROXY: "off", GOSUMDB: "off", GOVCS: "*:off",
+    GOMAXPROCS: "2", GOCACHE: path.join(root, "cache"), CGO_ENABLED: "0", LC_ALL: "C", TZ: "UTC"
+  };
+  return { root, env };
+}
+
+function toolchain(go, context) {
+  if (typeof go !== "string" || !path.isAbsolute(go)) throw new Error("trusted Go tool path must be absolute");
+  const hash = c.digest(c.readFile(go));
+  const info = JSON.parse(run(go, ["env", "-json", "GOVERSION", "GOHOSTOS", "GOHOSTARCH"], { env: context.env }));
+  if (info.GOVERSION !== GO_VERSION || info.GOHOSTOS !== "linux" || info.GOHOSTARCH !== "amd64") {
+    throw new Error("this bounded candidate producer/verifier requires trusted Go 1.25.13 on Linux amd64");
+  }
+  return hash;
+}
+
+function buildInfo(info, product, target, id) {
+  if (!info || info.GoVersion !== GO_VERSION || info.Path !== `github.com/777genius/plugin-kit-ai/cli/cmd/${product}` ||
+      !Array.isArray(info.Settings)) throw new Error("embedded Go product/toolchain identity mismatch");
+  const settings = new Map();
+  for (const setting of info.Settings) {
+    if (settings.has(setting.Key)) throw new Error("duplicate Go build setting");
+    settings.set(setting.Key, setting.Value);
+  }
+  const [os, arch] = target.split("-");
+  const required = {
+    GOOS: os, GOARCH: arch, CGO_ENABLED: "0", "-buildmode": "exe", "-compiler": "gc",
+    "-ldflags": c.linkerFlags(product, id)
+  };
+  for (const [key, value] of Object.entries(required)) {
+    if (settings.get(key) !== value) throw new Error(`embedded Go build setting mismatch: ${product}/${target}/${key}`);
+  }
+}
+
+function inspectBinary(go, file, product, target, id, env) {
+  // `go version` reads build info; it never starts the subject executable.
+  buildInfo(JSON.parse(run(go, ["version", "-m", "-json", file], { env })), product, target, id);
+}
+
+function sourceSnapshot(repo, commit, context) {
+  c.safeDirectory(repo);
+  const options = { cwd: repo, env: context.env };
+  const head = run("/usr/bin/git", ["rev-parse", "HEAD"], options).toString().trim();
+  if (head !== commit) throw new Error("declared source commit must equal checkout HEAD");
+  const tree = run("/usr/bin/git", ["ls-tree", "-r", "-z", commit, "--", ...SOURCE_PATHS], options).toString();
+  for (const entry of tree.split("\0").filter(Boolean)) {
+    const match = /^(100644|100755) blob [0-9a-f]{40}\t(.+)$/.exec(entry);
+    if (!match || /[\x00-\x1f\x7f]/.test(match[2]) || match[2].split("/").some((part) => !part || part === "." || part === "..") ||
+        match[2].startsWith("/") || match[2].includes("\\")) throw new Error("unsafe frozen source tree entry");
+  }
+  const snapshot = path.join(context.root, "source.tar");
+  run("/usr/bin/git", ["-c", "core.attributesFile=/dev/null", "archive", "--format=tar", "--output", snapshot, commit, "--", ...SOURCE_PATHS], options);
+  const body = c.readFile(snapshot);
+  run("/usr/bin/tar", ["-xf", snapshot, "-C", path.join(context.root, "source"), "--no-same-owner"], { env: context.env });
+  // Git archive applies export attributes. Check each extracted tracked blob
+  // against the exact Git object, so local attributes/export-subst cannot alter
+  // compiled source. Missing/export-ignored inputs fail instead of weakening proof.
+  for (const entry of tree.split("\0").filter(Boolean)) {
+    const [description, name] = entry.split("\t");
+    const object = description.split(" ")[2];
+    const file = path.join(context.root, "source", name);
+    const bytes = fs.readFileSync(file); // tree above forbids all links
+    const actual = require("node:crypto").createHash("sha1")
+      .update(`blob ${bytes.length}\0`).update(bytes).digest("hex");
+    if (actual !== object) throw new Error("source snapshot does not match exact Git blob");
+  }
+  return c.digest(body);
+}
+
+function writeExclusive(file, body, mode = 0o444) {
+  fs.writeFileSync(file, body, { flag: "wx", mode });
+  fs.chmodSync(file, mode);
+}
+
+function stageCandidate(options) {
+  optIn(options, ["repo", "output", "workParent", "go", "modCache", "identity", "assetScope"]);
+  const targets = c.scopeTargets(options.assetScope);
+  const id = structuredClone(options.identity);
+  c.safeDirectory(options.modCache);
+  c.safeDirectory(options.workParent);
+  c.outputPlacement(options.output, [options.repo, options.modCache, options.workParent, path.dirname(options.go)]);
+  const context = privateContext(options.workParent);
+  const goHash = toolchain(options.go, context);
+  const sourceHash = sourceSnapshot(options.repo, id.commit, context);
+  const env = { ...context.env, GOMODCACHE: options.modCache, GOWORK: path.join(context.root, "source", "go.work") };
+  const manifest = {
+    schema: c.SCHEMA, status: "CANDIDATE", identity: id, asset_scope: options.assetScope,
+    build: { method: "controlled-git-archive-go-build/v1", go_version: GO_VERSION, go_sha256: goHash,
+      source_archive_sha256: sourceHash, authoring_mode: "vertical-slice-v1" },
+    products: {}, release_eligible: false
+  };
+  // Reserve an absent destination exclusively. Partial output has no candidate
+  // marker. Existing output is never reused, replaced, or recursively removed.
+  c.outputPlacement(options.output, [options.repo, options.modCache, options.workParent, path.dirname(options.go)]);
+  fs.mkdirSync(options.output, { mode: 0o700 });
+  const log = [];
+  let markerOwned = false;
+  try {
+    for (const product of c.PRODUCTS) {
+      const assets = {};
+      manifest.products[product] = { version: id.versions[product], assets };
+      for (const target of targets) {
+        const [os, arch] = target.split("-");
+        const binaryPath = path.join(context.root, "bin", `${product}-${target}`);
+        // No trimpath: Go intentionally omits -ldflags from build info with
+        // trimpath. Preserve the exact embedded version/engine linker settings
+        // for byte inspection. Reproducibility is a later, separate gate.
+        const args = ["build", "-p", "2", "-buildvcs=false", "-mod=readonly", "-ldflags", c.linkerFlags(product, id),
+          "-o", binaryPath, `./cli/plugin-kit-ai/cmd/${product}`];
+        run(options.go, args, { cwd: path.join(context.root, "source"), env: { ...env, GOOS: os, GOARCH: arch } });
+        inspectBinary(options.go, binaryPath, product, target, id, env);
+        const binary = c.readFile(binaryPath);
+        const file = c.assetName(product, id.versions[product], target);
+        const binaryName = c.executableName(product, target);
+        const bytes = product === "plugin-kit-ai" ? c.archive(binary, binaryName) : binary;
+        assets[target] = { file, ...c.metadata(bytes), binary: { file: binaryName, ...c.metadata(binary) } };
+        writeExclusive(path.join(options.output, file), bytes);
+        log.push({ product, target, argv: [options.go, ...args], binary_sha256: c.digest(binary) });
+        // A private transcript is evidence of this local invocation, not a
+        // portable attestation. It is outside the closed candidate file set.
+        fs.writeFileSync(path.join(context.root, "build-log.json"), c.encode(log));
+      }
+    }
+    c.manifestShape(manifest, id, options.assetScope);
+    const body = c.encode(manifest);
+    const manifestHash = c.digest(body);
+    // Validate the complete set in a separate private root before publishing the
+    // final marker. Copies are independent bytes, never hardlinks.
+    const checkRoot = path.join(context.root, "check");
+    fs.mkdirSync(checkRoot, { mode: 0o700 });
+    for (const file of fs.readdirSync(options.output)) writeExclusive(path.join(checkRoot, file), c.readFile(path.join(options.output, file)));
+    writeExclusive(path.join(checkRoot, "candidate.json"), body);
+    verifyCandidate({ candidate: true, root: checkRoot, identity: id, manifestDigest: manifestHash,
+      go: options.go, workParent: options.workParent, assetScope: options.assetScope });
+    // Recheck final output bytes immediately before committing the marker.
+    for (const product of c.PRODUCTS) for (const asset of Object.values(manifest.products[product].assets)) {
+      if (c.digest(c.readFile(path.join(options.output, asset.file))) !== asset.sha256) throw new Error("staged bytes changed");
+    }
+    if (fs.readdirSync(options.output).length !== targets.length * 2) throw new Error("unexpected partial output entry");
+    writeExclusive(path.join(options.output, "candidate.json"), body);
+    markerOwned = true;
+    fs.chmodSync(options.output, 0o555);
+    return { status: "CANDIDATE", manifest_sha256: manifestHash, output: options.output,
+      local_build_evidence: context.root, release_eligible: false, platform_acceptance: false, attested: false };
+  } catch (error) {
+    // Leave inspectable partial bytes but no success marker, even if final chmod
+    // failed. Do not delete caller files or erase the failed build's evidence.
+    const marker = path.join(options.output, "candidate.json");
+    if (markerOwned) fs.unlinkSync(marker);
+    throw error;
+  }
+}
+
+function verifyCandidate(options) {
+  optIn(options, ["root", "identity", "manifestDigest", "go", "workParent", "assetScope"]);
+  c.safeDirectory(options.workParent);
+  if (options.workParent === options.root || options.workParent.startsWith(options.root + path.sep)) {
+    throw new Error("verification scratch must be outside candidate output");
+  }
+  const frozen = c.frozenCandidate(options.root, options.identity, options.manifestDigest, options.assetScope);
+  const context = privateContext(options.workParent);
+  const goHash = toolchain(options.go, context);
+  if (goHash !== frozen.manifest.build.go_sha256) throw new Error("trusted Go tool digest mismatch");
+  for (const { product, target, binary } of frozen.binaries) {
+    const file = path.join(context.root, "bin", `${product}-${target}`);
+    writeExclusive(file, binary); // no executable bit; no execution during verify
+    inspectBinary(options.go, file, product, target, options.identity, context.env);
+  }
+  return { status: "CANDIDATE", manifest_sha256: frozen.manifest_sha256,
+    consistency_verified: true, release_eligible: false, platform_acceptance: false, attested: false };
+}
+
+function main(argv) {
+  const [command, opt, config] = argv;
+  if (argv.length !== 3 || opt !== "--candidate" || !["stage", "verify"].includes(command)) {
+    throw new Error("usage: stage-dual-authoring-candidate.js <stage|verify> --candidate <absolute-config.json>");
+  }
+  if (!path.isAbsolute(config)) throw new Error("config path must be absolute");
+  const options = JSON.parse(c.readFile(config, 1024 * 1024));
+  return command === "stage" ? stageCandidate(options) : verifyCandidate(options);
+}
+
+if (require.main === module) {
+  try { process.stdout.write(JSON.stringify(main(process.argv.slice(2)), null, 2) + "\n"); }
+  catch (error) { process.stderr.write(`dual authoring candidate: ${error.message}\n`); process.exitCode = 1; }
+}
+
+module.exports = { stageCandidate, verifyCandidate, buildInfo, sourceSnapshot, privateContext, main };

--- a/npm/agentplugins/scripts/stage-dual-authoring-candidate.js
+++ b/npm/agentplugins/scripts/stage-dual-authoring-candidate.js
@@ -136,6 +136,7 @@ function stageCandidate(options) {
   c.outputPlacement(options.output, [options.repo, options.modCache, options.workParent, path.dirname(options.go)]);
   fs.mkdirSync(options.output, { mode: 0o700 });
   const log = [];
+  const marker = path.join(options.output, "candidate.json");
   let markerOwned = false;
   try {
     for (const product of c.PRODUCTS) {
@@ -179,16 +180,41 @@ function stageCandidate(options) {
       if (c.digest(c.readFile(path.join(options.output, asset.file))) !== asset.sha256) throw new Error("staged bytes changed");
     }
     if (fs.readdirSync(options.output).length !== targets.length * 2) throw new Error("unexpected partial output entry");
-    writeExclusive(path.join(options.output, "candidate.json"), body);
+    // Own the marker as soon as exclusive creation succeeds, before any write
+    // or finalization can throw. A failed open never authorizes its removal.
+    const markerFd = fs.openSync(marker, "wx", 0o444);
     markerOwned = true;
+    try {
+      fs.writeFileSync(markerFd, body);
+    } catch (error) {
+      // Preserve the write failure even if closing also fails; retain that
+      // secondary diagnostic without retrying a possibly closed descriptor.
+      try { fs.closeSync(markerFd); } catch (closeError) { error.closeError = closeError; }
+      throw error;
+    }
+    fs.closeSync(markerFd);
+    fs.chmodSync(marker, 0o444);
     fs.chmodSync(options.output, 0o555);
     return { status: "CANDIDATE", manifest_sha256: manifestHash, output: options.output,
       local_build_evidence: context.root, release_eligible: false, platform_acceptance: false, attested: false };
   } catch (error) {
     // Leave inspectable partial bytes but no success marker, even if final chmod
     // failed. Do not delete caller files or erase the failed build's evidence.
-    const marker = path.join(options.output, "candidate.json");
-    if (markerOwned) fs.unlinkSync(marker);
+    if (markerOwned) {
+      try {
+        try { fs.unlinkSync(marker); }
+        catch (cleanupError) {
+          if (!["EACCES", "EPERM"].includes(cleanupError.code)) throw cleanupError;
+          // Directory finalization may have changed permissions before throwing.
+          // Only this invocation's reserved output is made writable for cleanup.
+          fs.chmodSync(options.output, 0o700);
+          fs.unlinkSync(marker);
+        }
+      } catch (cleanupError) {
+        throw new AggregateError([error, cleanupError],
+          `${error.message}; candidate marker cleanup failed: ${cleanupError.message}`, { cause: error });
+      }
+    }
     throw error;
   }
 }

--- a/npm/agentplugins/test/dual-authoring-candidate-marker.test.js
+++ b/npm/agentplugins/test/dual-authoring-candidate-marker.test.js
@@ -1,0 +1,157 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const cp = require("node:child_process");
+const test = require("node:test");
+const c = require("../scripts/dual-authoring-candidate");
+const producer = require("../scripts/stage-dual-authoring-candidate");
+
+// Structural controlled-builder fixtures only: Go env/build/inspection are
+// stubbed. Git snapshot, exclusive creation, writes and cleanup are real.
+// Actual Linux bytes and native journeys are separate opt-in evidence.
+function fixture(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "candidate-marker-"));
+  const repo = path.resolve(__dirname, "../../..");
+  const workParent = path.join(root, "work");
+  const modCache = path.join(root, "modules");
+  fs.mkdirSync(workParent); fs.mkdirSync(modCache);
+  const context = producer.privateContext(workParent);
+  const commit = cp.execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: repo, env: context.env, encoding: "utf8" }).trim();
+  const identity = { repository: c.REPOSITORY, commit, engine_revision: commit,
+    versions: { agentplugins: "0.1.23", "plugin-kit-ai": "2.0.0" } };
+  const go = path.join(root, "structural-go");
+  fs.writeFileSync(go, "structural tool fixture, never executed");
+  const output = path.join(root, "candidate");
+  const marker = path.join(output, "candidate.json");
+  const options = { candidate: true, repo, workParent, modCache, go, output, identity, assetScope: "linux-amd64-pair" };
+  // Keep the trusted tool directory disjoint from candidate output.
+  const tools = path.join(root, "tools"); fs.mkdirSync(tools);
+  fs.renameSync(go, path.join(tools, "go")); options.go = path.join(tools, "go");
+  const exec = cp.execFileSync;
+  t.mock.method(cp, "execFileSync", function (command, args, opts) {
+    if (command !== options.go) return exec.apply(this, arguments);
+    if (args[0] === "env") return JSON.stringify({ GOVERSION: "go1.25.13", GOHOSTOS: "linux", GOHOSTARCH: "amd64" });
+    if (args[0] === "build") {
+      const product = args.at(-1).split("/").at(-1);
+      fs.writeFileSync(args[args.indexOf("-o") + 1], `STRUCTURAL ONLY: ${product}`);
+      return Buffer.alloc(0);
+    }
+    assert.equal(args[0], "version");
+    const product = fs.readFileSync(args.at(-1), "utf8").replace("STRUCTURAL ONLY: ", "");
+    assert.ok(c.PRODUCTS.includes(product));
+    return JSON.stringify({ GoVersion: "go1.25.13", Path: `github.com/777genius/plugin-kit-ai/cli/cmd/${product}`,
+      Settings: Object.entries({ GOOS: "linux", GOARCH: "amd64", CGO_ENABLED: "0", "-buildmode": "exe", "-compiler": "gc",
+        "-ldflags": c.linkerFlags(product, identity) }).map(([Key, Value]) => ({ Key, Value })) });
+  });
+  return { options, marker, output };
+}
+
+const faults = ["marker-chmod", "partial-write", "complete-write", "close", "write-and-close",
+  "directory-chmod", "directory-chmod-after-change", "exclusive-collision", "cleanup-unlink", "cleanup-after-partial-write", "cleanup-permission-retry", "cleanup-permission-failure"];
+for (const fault of faults) test(`owned candidate marker failure: ${fault}`, {
+  skip: process.env.AGENTPLUGINS_STAGED_TEST_CHILD === "1"
+}, (t) => {
+  const { options, marker, output } = fixture(t);
+  const original = Object.fromEntries(["openSync", "writeFileSync", "closeSync", "chmodSync", "unlinkSync"].map(name => [name, fs[name]]));
+  const primary = Object.assign(new Error(`injected ${fault}`), { code: "EIO" });
+  const cleanup = Object.assign(new Error("injected marker cleanup failure"), { code: "EACCES" });
+  const closeError = Object.assign(new Error("injected secondary close failure"), { code: "EIO" });
+  let markerFd, injected = false, written = false, closeInjected = false, unlinkCalls = 0, restored = false;
+  const unrelated = Buffer.from("unrelated marker must survive");
+  const collide = () => {
+    const fd = original.openSync(marker, "wx", 0o640);
+    try { original.writeFileSync(fd, unrelated); } finally { original.closeSync(fd); }
+    injected = true;
+  };
+  t.mock.method(fs, "openSync", function (file, flags) {
+    if (file === marker && flags === "wx" && fault === "exclusive-collision" && !injected) collide();
+    const fd = original.openSync.apply(this, arguments);
+    if (file === marker && flags === "wx") markerFd = fd;
+    return fd;
+  });
+  t.mock.method(fs, "writeFileSync", function (file, body, opts) {
+    if (file === marker || (markerFd !== undefined && file === markerFd)) {
+      // The path branch also reproduces the pre-fix writeFileSync(..., 'wx').
+      if (fault === "exclusive-collision" && !injected) collide();
+      if (["partial-write", "write-and-close", "cleanup-after-partial-write"].includes(fault)) {
+        original.writeFileSync(file, body.subarray(0, 31), opts);
+        assert.equal(fs.statSync(marker).size, 31);
+        injected = true; throw primary;
+      }
+      const result = original.writeFileSync.apply(this, arguments);
+      c.manifestShape(JSON.parse(fs.readFileSync(marker)), options.identity, options.assetScope);
+      written = true;
+      if (fault === "complete-write") { injected = true; throw primary; }
+      return result;
+    }
+    return original.writeFileSync.apply(this, arguments);
+  });
+  t.mock.method(fs, "closeSync", function (fd) {
+    const result = original.closeSync.apply(this, arguments);
+    if (fd === markerFd && !closeInjected && ["close", "write-and-close"].includes(fault)) {
+      // Close for real before throwing; do not leak the fixture descriptor.
+      closeInjected = true; injected = true;
+      throw fault === "close" ? primary : closeError;
+    }
+    return result;
+  });
+  t.mock.method(fs, "chmodSync", function (file, mode) {
+    if (file === marker && ["marker-chmod", "cleanup-unlink", "cleanup-permission-failure"].includes(fault)) {
+      assert.equal(written, true); injected = true; throw primary;
+    }
+    if (file === output && mode === 0o555 && fault.startsWith("directory-chmod")) {
+      assert.equal(written, true);
+      if (fault === "directory-chmod-after-change") original.chmodSync(file, mode);
+      injected = true; throw primary;
+    }
+    if (file === output && mode === 0o555 && fault === "cleanup-permission-retry") {
+      original.chmodSync(file, mode); injected = true; throw primary;
+    }
+    if (file === output && mode === 0o700) restored = true;
+    return original.chmodSync.apply(this, arguments);
+  });
+  t.mock.method(fs, "unlinkSync", function (file) {
+    if (file === marker) {
+      unlinkCalls++;
+      if (["cleanup-unlink", "cleanup-after-partial-write"].includes(fault)) throw Object.assign(cleanup, { code: "EIO" });
+      if (fault === "cleanup-permission-failure" || (fault === "cleanup-permission-retry" && unlinkCalls === 1)) throw cleanup;
+    }
+    return original.unlinkSync.apply(this, arguments);
+  });
+  let failure;
+  try { producer.stageCandidate(options); } catch (error) { failure = error; }
+  assert.equal(injected, true, "must reach the requested finalization fault");
+  if (fault === "exclusive-collision") {
+    assert.equal(failure.code, "EEXIST");
+    assert.deepEqual(fs.readFileSync(marker), unrelated);
+    assert.equal(fs.statSync(marker).mode & 0o777, 0o640);
+    assert.equal(unlinkCalls, 0);
+  } else if (["cleanup-unlink", "cleanup-after-partial-write", "cleanup-permission-failure"].includes(fault)) {
+    assert.ok(failure instanceof AggregateError);
+    assert.equal(failure.cause, primary);
+    assert.deepEqual(failure.errors, [primary, cleanup]);
+    assert.match(failure.message, /marker cleanup failed/);
+    assert.equal(fs.existsSync(marker), true, "failed cleanup is reported, not hidden");
+  } else {
+    assert.equal(failure, primary, "successful cleanup preserves the original error object/code/message");
+    assert.equal(fs.existsSync(marker), false);
+    assert.equal(fs.readdirSync(output).length, 2, "retain partial assets for inspection");
+    if (fault === "write-and-close") assert.equal(failure.closeError, closeError);
+    if (fault === "cleanup-permission-retry") { assert.equal(unlinkCalls, 2); assert.equal(restored, true); }
+  }
+});
+
+test("successful structural candidate still finalizes and verifies", {
+  skip: process.env.AGENTPLUGINS_STAGED_TEST_CHILD === "1"
+}, (t) => {
+  const { options, marker, output } = fixture(t);
+  const result = producer.stageCandidate(options);
+  assert.equal(fs.statSync(marker).mode & 0o777, 0o444);
+  assert.equal(fs.statSync(output).mode & 0o777, 0o555);
+  assert.equal(producer.verifyCandidate({ candidate: true, root: output, identity: options.identity,
+    manifestDigest: result.manifest_sha256, go: options.go, workParent: options.workParent,
+    assetScope: options.assetScope }).consistency_verified, true);
+});

--- a/npm/agentplugins/test/dual-authoring-candidate-native.test.js
+++ b/npm/agentplugins/test/dual-authoring-candidate-native.test.js
@@ -20,7 +20,15 @@ test("actual controlled Linux pair: offline verification, engine reports, frozen
 }, () => {
   const options = JSON.parse(c.readFile(config, 1024 * 1024));
   assert.equal(options.assetScope, "linux-amd64-pair");
-  assert.equal(options.identity.commit, "55c5b5bc9bec353560f66f86008a4090b5634e12");
+  // Bind the candidate to the intended source checkout, independently of its
+  // manifest. An explicit source also permits replay from a detached test copy.
+  const sourceRepo = process.env.UAP_CANDIDATE_NATIVE_SOURCE_REPO || path.resolve(__dirname, "../../..");
+  c.safeDirectory(sourceRepo);
+  const sourceContext = producer.privateContext(options.workParent);
+  const sourceHead = cp.execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], {
+    cwd: sourceRepo, env: sourceContext.env, encoding: "utf8"
+  }).trim();
+  assert.equal(options.identity.commit, sourceHead, "candidate revision must equal intended source HEAD");
   assert.deepEqual(producer.verifyCandidate(options), {
     status: "CANDIDATE", manifest_sha256: options.manifestDigest,
     consistency_verified: true, release_eligible: false, platform_acceptance: false, attested: false
@@ -106,8 +114,13 @@ test("actual controlled Linux pair: offline verification, engine reports, frozen
   const emptyModules = path.join(contexts[0].root, "empty-modules"); fs.mkdirSync(emptyModules);
   const failureRoot = fs.mkdtempSync(path.join(path.dirname(options.workParent), "candidate-failure-"));
   const failedOutput = path.join(failureRoot, "failed-build");
-  const stageOptions = { candidate: true, repo: path.resolve(__dirname, "../../.."), output: failedOutput,
+  const stageOptions = { candidate: true, repo: sourceRepo, output: failedOutput,
     modCache: emptyModules, workParent: options.workParent, go: options.go, identity: options.identity, assetScope: options.assetScope };
+  const wrongCommit = (sourceHead[0] === "0" ? "1" : "0") + sourceHead.slice(1);
+  assert.throws(() => producer.stageCandidate({ ...stageOptions,
+    identity: { ...options.identity, commit: wrongCommit, engine_revision: wrongCommit }
+  }), /declared source commit must equal checkout HEAD/);
+  assert.equal(fs.existsSync(failedOutput), false);
   assert.throws(() => producer.stageCandidate(stageOptions), /Command failed/);
   assert.equal(fs.statSync(failedOutput).isDirectory(), true);
   assert.equal(fs.existsSync(path.join(failedOutput, "candidate.json")), false);

--- a/npm/agentplugins/test/dual-authoring-candidate-native.test.js
+++ b/npm/agentplugins/test/dual-authoring-candidate-native.test.js
@@ -1,0 +1,124 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const cp = require("node:child_process");
+const test = require("node:test");
+const c = require("../scripts/dual-authoring-candidate");
+const producer = require("../scripts/stage-dual-authoring-candidate");
+
+// Explicit opt-in ONLY for the output of a locally trusted controlled build.
+// Never point this at downloaded candidates. Unlike verifyCandidate, this test
+// executes the two already built Linux entrypoints in disposable fixture roots.
+// Structural fixtures in the sibling test never enter this execution path.
+const config = process.env.UAP_CANDIDATE_NATIVE_CONFIG;
+const enabled = !!config && process.env.AGENTPLUGINS_STAGED_TEST_CHILD !== "1";
+
+test("actual controlled Linux pair: offline verification, engine reports, frozen journeys and negative proof", {
+  skip: !enabled
+}, () => {
+  const options = JSON.parse(c.readFile(config, 1024 * 1024));
+  assert.equal(options.assetScope, "linux-amd64-pair");
+  assert.equal(options.identity.commit, "55c5b5bc9bec353560f66f86008a4090b5634e12");
+  assert.deepEqual(producer.verifyCandidate(options), {
+    status: "CANDIDATE", manifest_sha256: options.manifestDigest,
+    consistency_verified: true, release_eligible: false, platform_acceptance: false, attested: false
+  });
+  const frozen = c.frozenCandidate(options.root, options.identity, options.manifestDigest, options.assetScope);
+  const before = new Map(fs.readdirSync(options.root).map((name) => [name, c.digest(c.readFile(path.join(options.root, name)))]));
+  assert.equal(fs.statSync(options.root).mode & 0o222, 0);
+  const contexts = c.PRODUCTS.map(() => producer.privateContext(options.workParent));
+  const reports = [];
+  const trees = [];
+  for (let i = 0; i < frozen.binaries.length; i++) {
+    const { product, binary } = frozen.binaries[i];
+    const context = contexts[i];
+    const executable = path.join(context.root, "bin", product);
+    fs.writeFileSync(executable, binary, { flag: "wx", mode: 0o700 });
+    assert.equal(c.digest(c.readFile(executable)), frozen.manifest.products[product].assets["linux-amd64"].binary.sha256);
+    const productReports = [];
+    const productTrees = [];
+    const invoke = (...args) => {
+      const argv = [...(product === "agentplugins" ? ["author"] : []), ...args, "--format=json"];
+      const result = cp.spawnSync(executable, argv, {
+        cwd: context.root, env: { ...context.env, PATH: path.join(context.root, "bin") },
+        timeout: 30000, encoding: "utf8"
+      });
+      assert.equal(result.status, 0, `${product}: ${result.stdout}\n${result.stderr}`);
+      assert.equal(result.stderr, "");
+      const report = JSON.parse(result.stdout);
+      assert.equal(report.revision, options.identity.commit);
+      assert.equal(report.engine, "standard-first-slice/1");
+      assert.equal(result.stdout.includes(context.root), false);
+      productReports.push({ argv, report });
+      return report;
+    };
+    invoke("capabilities");
+    for (const template of ["skill", "mcp-remote"]) {
+      const project = path.join(context.root, template);
+      const extra = template === "mcp-remote" ? ["--url=https://example.invalid/mcp"] : [];
+      const initialized = invoke("init", project, `--template=${template}`, "--name=demo", "--description=Disposable candidate fixture.", ...extra);
+      assert.equal(initialized.committed, true);
+      for (const command of ["validate", "inspect", "test"]) {
+        const report = invoke(command, project);
+        assert.equal(report.runtime_evidence.status, "not_evaluated");
+        assert.ok(report.identity.tree_digest);
+      }
+      const tree = [];
+      const walk = (relative) => {
+        for (const name of fs.readdirSync(path.join(project, relative)).sort()) {
+          const child = path.join(relative, name);
+          const file = path.join(project, child);
+          const stat = fs.lstatSync(file);
+          assert.equal(stat.isSymbolicLink(), false);
+          if (stat.isDirectory()) walk(child);
+          else tree.push({ path: child, mode: stat.mode & 0o777, sha256: c.digest(c.readFile(file)) });
+        }
+      };
+      walk(""); productTrees.push(tree);
+    }
+    reports.push(productReports); trees.push(productTrees);
+  }
+  assert.deepEqual(reports[0].map((r) => r.report), reports[1].map((r) => r.report));
+  assert.deepEqual(trees[0], trees[1]);
+  for (const [name, hash] of before) {
+    assert.equal(c.digest(c.readFile(path.join(options.root, name))), hash);
+    assert.equal(fs.statSync(path.join(options.root, name)).mode & 0o222, 0);
+  }
+  // Swap the two *real* mains and repin all hashes. Structure still looks valid;
+  // embedded Go main identity must fail. Verification never executes either file.
+  const badRoot = path.join(contexts[0].root, "swapped"); fs.mkdirSync(badRoot);
+  const bad = structuredClone(frozen.manifest);
+  for (let i = 0; i < c.PRODUCTS.length; i++) {
+    const product = c.PRODUCTS[i];
+    const asset = bad.products[product].assets["linux-amd64"];
+    const wrongBinary = frozen.binaries[1 - i].binary;
+    const body = product === "plugin-kit-ai" ? c.archive(wrongBinary, asset.binary.file) : wrongBinary;
+    Object.assign(asset, c.metadata(body)); Object.assign(asset.binary, c.metadata(wrongBinary));
+    fs.writeFileSync(path.join(badRoot, asset.file), body);
+  }
+  const badBody = c.encode(bad); fs.writeFileSync(path.join(badRoot, "candidate.json"), badBody);
+  const badOptions = { ...options, root: badRoot, manifestDigest: c.digest(badBody) };
+  assert.equal(c.frozenCandidate(badRoot, options.identity, badOptions.manifestDigest, options.assetScope).binaries.length, 2);
+  assert.throws(() => producer.verifyCandidate(badOptions), /embedded Go product/);
+  // A build failure cannot produce a success marker or overwrite existing output.
+  const emptyModules = path.join(contexts[0].root, "empty-modules"); fs.mkdirSync(emptyModules);
+  const failureRoot = fs.mkdtempSync(path.join(path.dirname(options.workParent), "candidate-failure-"));
+  const failedOutput = path.join(failureRoot, "failed-build");
+  const stageOptions = { candidate: true, repo: path.resolve(__dirname, "../../.."), output: failedOutput,
+    modCache: emptyModules, workParent: options.workParent, go: options.go, identity: options.identity, assetScope: options.assetScope };
+  assert.throws(() => producer.stageCandidate(stageOptions), /Command failed/);
+  assert.equal(fs.statSync(failedOutput).isDirectory(), true);
+  assert.equal(fs.existsSync(path.join(failedOutput, "candidate.json")), false);
+  // Existing unrelated bytes survive rejection before any compiler invocation.
+  const unrelated = path.join(failureRoot, "unrelated"); fs.mkdirSync(unrelated);
+  fs.writeFileSync(path.join(unrelated, "sentinel"), "preserve");
+  assert.throws(() => producer.stageCandidate({ ...stageOptions, output: unrelated }), /already exists|overlaps/);
+  assert.equal(fs.readFileSync(path.join(unrelated, "sentinel"), "utf8"), "preserve");
+  fs.writeFileSync(path.join(contexts[0].root, "native-journey.json"), c.encode({
+    kind: "local-linux-candidate-journey", identity: options.identity, manifest_sha256: options.manifestDigest,
+    reports, trees, platform_acceptance: false, attested: false
+  }), { flag: "wx", mode: 0o444 });
+  process.stdout.write(`native journey evidence: ${path.join(contexts[0].root, "native-journey.json")}\n`);
+});

--- a/npm/agentplugins/test/dual-authoring-candidate.test.js
+++ b/npm/agentplugins/test/dual-authoring-candidate.test.js
@@ -1,0 +1,287 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const cp = require("node:child_process");
+const zlib = require("node:zlib");
+const test = require("node:test");
+const c = require("../scripts/dual-authoring-candidate");
+const producer = require("../scripts/stage-dual-authoring-candidate");
+const legacy = require("../scripts/release-assets");
+
+const SCOPE = "six-platform-pair";
+const freeze = (root, id, hash) => c.frozenCandidate(root, id, hash, SCOPE);
+const ID = {
+  repository: c.REPOSITORY, commit: "a".repeat(40), engine_revision: "a".repeat(40),
+  versions: { agentplugins: "0.1.23", "plugin-kit-ai": "2.0.0" }
+};
+const temp = () => fs.mkdtempSync(path.join(os.tmpdir(), "dual-candidate-test-"));
+// Disposable roots are retained for inspection. No recursive deletion of roots
+// (which can contain Git fixtures) is needed by this suite.
+
+function structuralFixture() {
+  const root = temp();
+  const manifest = {
+    schema: c.SCHEMA, status: "CANDIDATE", asset_scope: SCOPE, identity: structuredClone(ID),
+    build: { method: "controlled-git-archive-go-build/v1", go_version: "go1.25.13",
+      go_sha256: "b".repeat(64), source_archive_sha256: "c".repeat(64), authoring_mode: "vertical-slice-v1" },
+    products: {}, release_eligible: false
+  };
+  for (const product of c.PRODUCTS) {
+    const assets = {};
+    manifest.products[product] = { version: ID.versions[product], assets };
+    for (const target of c.TARGETS) {
+      // These are byte-shape fixtures ONLY. No native or revision proof claimed.
+      const binary = Buffer.from(`STRUCTURAL ONLY: ${product}/${target}\n`);
+      const name = c.executableName(product, target);
+      const body = product === "plugin-kit-ai" ? c.archive(binary, name) : binary;
+      const file = c.assetName(product, ID.versions[product], target);
+      fs.writeFileSync(path.join(root, file), body, { flag: "wx" });
+      assets[target] = { file, ...c.metadata(body), binary: { file: name, ...c.metadata(binary) } };
+    }
+  }
+  const save = () => {
+    const body = c.encode(manifest);
+    fs.writeFileSync(path.join(root, "candidate.json"), body);
+    return c.digest(body);
+  };
+  return { root, manifest, save, hash: save() };
+}
+
+test("candidate explicitly separates current producer from unchanged historic identity and six-asset v2", () => {
+  assert.equal(c.REPOSITORY, "777genius/universal-agent-plugins");
+  assert.equal(legacy.PRODUCER_REPOSITORY, "777genius/plugin-kit-ai");
+  assert.deepEqual(Object.keys(legacy.expectedAssets(ID.versions.agentplugins)), c.TARGETS);
+  for (const target of c.TARGETS) {
+    assert.equal(c.assetName("agentplugins", ID.versions.agentplugins, target), legacy.expectedAssets(ID.versions.agentplugins)[target]);
+    assert.equal(c.assetName("plugin-kit-ai", "2.0.0", target), `plugin-kit-ai_2.0.0_${target.replace("-", "_")}.tar.gz`);
+  }
+  const historical = path.join(__dirname, "fixtures", "historical-evidence");
+  assert.equal(c.digest(fs.readFileSync(path.join(historical, "AGENTPLUGINS_CLIENT_E2E.md"))),
+    "df6769bf430a337f116cd9df75bcc3ea26df166a016eacf9bc9fbc6cfbf9b100");
+  assert.equal(c.digest(fs.readFileSync(path.join(historical, "evidence", "agentplugins-client-e2e-2026-08-30.json"))),
+    "437da1bc7423a85b231be139ff9bfbd7e89c942ef216a61ebde668c08a9c2ee3");
+});
+
+test("exact two-product identity rejects aliases, ambiguous versions and engine/source drift", () => {
+  assert.deepEqual(c.identity(ID), ID);
+  const mutations = [
+    (v) => { v.repository = "777genius/plugin-kit-ai"; },
+    (v) => { v.repository = "other/universal-agent-plugins"; },
+    (v) => { v.commit = "a".repeat(39); },
+    (v) => { v.commit = "A".repeat(40); },
+    (v) => { v.engine_revision = "b".repeat(40); },
+    (v) => { v.engine_revision = "unversioned"; },
+    (v) => { v.versions.agentplugins = "2.0.0"; },
+    (v) => { v.versions.agentplugins = "01.2.3"; },
+    (v) => { v.versions.agentplugins = "latest"; },
+    (v) => { v.versions.agentplugins = "1.2.3+metadata"; },
+    (v) => { v.versions.agentplugins = "1.2.3-rc.1"; },
+    (v) => { v.versions.agentplugins = 123; },
+    (v) => { v.versions["universal-agent-plugins"] = "0.1.23"; },
+    (v) => { delete v.versions["plugin-kit-ai"]; },
+    (v) => { v.tag = "v2.0.0"; }
+  ];
+  for (const mutation of mutations) {
+    const invalid = structuredClone(ID);
+    mutation(invalid);
+    assert.throws(() => c.identity(invalid));
+  }
+  assert.throws(() => c.assetName("plugin-kit-ai-runtime", "2.0.0", "linux-amd64"));
+  assert.throws(() => c.assetName("agentplugins", "2.0.0", "linux-386"));
+});
+
+test("STRUCTURAL ONLY: closed candidate schema, every nested field and both exact product sets", () => {
+  const fixture = structuralFixture();
+  const frozen = freeze(fixture.root, ID, fixture.hash);
+  assert.equal(frozen.binaries.length, 12);
+  assert.equal(frozen.manifest.release_eligible, false);
+  const cases = [
+    (v) => { v.schema = 2; }, (v) => { v.asset_scope = "linux-amd64-pair"; }, (v) => { v.status = "RELEASE"; },
+    (v) => { v.release_eligible = true; }, (v) => { delete v.release_eligible; },
+    (v) => { v.attestation = true; }, (v) => { v.identity.commit = "b".repeat(40); v.identity.engine_revision = v.identity.commit; },
+    (v) => { v.identity.engine_revision = "b".repeat(40); },
+    (v) => { v.identity.repository = "777genius/plugin-kit-ai"; },
+    (v) => { v.identity.versions.agentplugins = "0.1.24"; },
+    (v) => { v.build.extra = false; }, (v) => { delete v.build.go_sha256; },
+    (v) => { v.build.method = "metadata-only"; }, (v) => { v.build.go_version = "go1.24.0"; },
+    (v) => { v.build.go_sha256 = "z".repeat(64); }, (v) => { v.build.authoring_mode = "enabled"; },
+    (v) => { v.build.go_sha256 = ["b".repeat(64)]; },
+    (v) => { v.build.source_archive_sha256 = ["c".repeat(64)]; },
+    (v) => { delete v.products["plugin-kit-ai"]; }, (v) => { v.products.other = v.products.agentplugins; },
+    (v) => { v.products.agentplugins.version = "0.1.24"; },
+    (v) => { v.products.agentplugins.extra = 1; },
+    (v) => { delete v.products.agentplugins.assets["linux-amd64"]; },
+    (v) => { v.products.agentplugins.assets["linux-386"] = v.products.agentplugins.assets["linux-amd64"]; },
+    (v) => { v.products.agentplugins.assets["linux-amd64"].file = "../payload"; },
+    (v) => { v.products.agentplugins.assets["linux-amd64"].extra = true; },
+    (v) => { v.products.agentplugins.assets["linux-amd64"].binary.file = "plugin-kit-ai"; },
+    (v) => { v.products.agentplugins.assets["linux-amd64"].binary.extra = 0; }
+  ];
+  for (const change of cases) {
+    const value = structuredClone(fixture.manifest);
+    change(value);
+    assert.throws(() => c.manifestShape(value, ID, SCOPE));
+  }
+  const pin = fixture.hash;
+  fixture.manifest.build.source_archive_sha256 = "d".repeat(64);
+  fixture.save();
+  assert.throws(() => freeze(fixture.root, ID, pin), /manifest digest/);
+  assert.throws(() => freeze(fixture.root, ID), /independent manifest digest/);
+});
+
+test("STRUCTURAL ONLY: rejects duplicate JSON keys even when repinned", () => {
+  const fixture = structuralFixture();
+  const body = Buffer.from(c.encode(fixture.manifest).toString().replace('"status": "CANDIDATE",', '"status": "CANDIDATE", "status": "CANDIDATE",'));
+  fs.writeFileSync(path.join(fixture.root, "candidate.json"), body);
+  assert.throws(() => freeze(fixture.root, ID, c.digest(body)), /noncanonical/);
+});
+
+test("STRUCTURAL ONLY: hash/size fields, missing bytes, extra files, and substituted executable bytes fail", () => {
+  for (const field of ["sha256", "size"]) for (const binary of [false, true]) {
+    const fixture = structuralFixture();
+    const asset = fixture.manifest.products.agentplugins.assets["linux-amd64"];
+    (binary ? asset.binary : asset)[field] = field === "size" ? 999 : "0".repeat(64);
+    assert.throws(() => freeze(fixture.root, ID, fixture.save()), /digest or size/);
+  }
+  for (const size of ["4", 0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
+    const fixture = structuralFixture();
+    fixture.manifest.products.agentplugins.assets["linux-amd64"].size = size;
+    assert.throws(() => freeze(fixture.root, ID, fixture.save()), /digest or size/);
+  }
+  const missing = structuralFixture();
+  fs.unlinkSync(path.join(missing.root, missing.manifest.products.agentplugins.assets["linux-amd64"].file));
+  assert.throws(() => freeze(missing.root, ID, missing.hash), /ENOENT/);
+  const extra = structuralFixture();
+  fs.writeFileSync(path.join(extra.root, "unrelated"), "preserve");
+  assert.throws(() => freeze(extra.root, ID, extra.hash), /extra or missing/);
+  assert.equal(fs.readFileSync(path.join(extra.root, "unrelated"), "utf8"), "preserve");
+  const duplicate = structuralFixture();
+  const raw = duplicate.manifest.products.agentplugins.assets["linux-amd64"];
+  const kit = duplicate.manifest.products["plugin-kit-ai"].assets["linux-amd64"];
+  const rawBytes = fs.readFileSync(path.join(duplicate.root, raw.file));
+  const substitute = c.archive(rawBytes, kit.binary.file);
+  Object.assign(kit, c.metadata(substitute));
+  Object.assign(kit.binary, c.metadata(rawBytes));
+  fs.writeFileSync(path.join(duplicate.root, kit.file), substitute);
+  assert.throws(() => freeze(duplicate.root, ID, duplicate.save()), /duplicate executable/);
+});
+
+test("STRUCTURAL ONLY: verifies frozen bytes independent of later source mutation", () => {
+  const fixture = structuralFixture();
+  const frozen = freeze(fixture.root, ID, fixture.hash);
+  const first = frozen.binaries[0];
+  const before = Buffer.from(first.binary);
+  const asset = fixture.manifest.products[first.product].assets[first.target];
+  fs.writeFileSync(path.join(fixture.root, asset.file), "changed");
+  assert.deepEqual(first.binary, before);
+  assert.throws(() => freeze(fixture.root, ID, fixture.hash), /digest or size/);
+});
+
+test("STRUCTURAL ONLY: symlinks, hardlinks, empty files and directory assets rejected", () => {
+  for (const kind of ["symlink", "hardlink", "empty", "directory"]) for (const name of ["candidate.json", "agentplugins_0.1.23_linux_amd64"]) {
+    const fixture = structuralFixture();
+    const file = path.join(fixture.root, name);
+    const held = path.join(temp(), "held");
+    fs.renameSync(file, held);
+    if (kind === "symlink") fs.symlinkSync(held, file);
+    if (kind === "hardlink") fs.linkSync(held, file);
+    if (kind === "empty") fs.writeFileSync(file, "");
+    if (kind === "directory") fs.mkdirSync(file);
+    assert.throws(() => freeze(fixture.root, ID, fixture.hash), /regular.*unaliased/);
+  }
+  const fixture = structuralFixture();
+  const link = path.join(temp(), "link");
+  fs.symlinkSync(fixture.root, link, "dir");
+  assert.throws(() => freeze(link, ID, fixture.hash), /symlink/);
+});
+
+test("safe placement rejects normalization, overlaps, existing outputs and symlink ancestors", () => {
+  const root = temp();
+  const repo = path.join(root, "repo");
+  const scratch = path.join(root, "scratch");
+  fs.mkdirSync(repo); fs.mkdirSync(scratch);
+  c.outputPlacement(path.join(root, "candidate"), [repo, scratch]);
+  for (const output of [repo, root, path.join(repo, "new"), path.join(scratch, "new"), "relative", root + "/../escape", root + "/bad name"]) {
+    assert.throws(() => c.outputPlacement(output, [repo, scratch]));
+  }
+  const link = path.join(root, "link");
+  fs.symlinkSync(scratch, link, "dir");
+  assert.throws(() => c.outputPlacement(path.join(link, "new"), [repo]), /symlink/);
+  const dangling = path.join(root, "dangling");
+  fs.symlinkSync(path.join(root, "absent"), dangling);
+  assert.throws(() => c.outputPlacement(dangling, [repo]), /already exists/);
+});
+
+test("canonical archive rejects path traversal, links, headers, extra records and corrupt gzip", () => {
+  const binary = Buffer.from("structural archive fixture");
+  const good = c.archive(binary, "plugin-kit-ai");
+  assert.deepEqual(c.unpack(good, "plugin-kit-ai"), binary);
+  assert.deepEqual(c.archive(binary, "plugin-kit-ai"), good);
+  assert.throws(() => c.unpack(good, "plugin-kit-ai.exe"), /noncanonical/);
+  for (const [offset, value] of [[0, "../outside"], [156, "1"], [156, "2"], [156, "x"], [345, "prefix"], [148, "000000"], [100, "0004755"]]) {
+    const tar = zlib.gunzipSync(good);
+    tar.write(value, offset, "ascii");
+    assert.throws(() => c.unpack(zlib.gzipSync(tar), "plugin-kit-ai"), /noncanonical/);
+  }
+  const extra = zlib.gzipSync(Buffer.concat([zlib.gunzipSync(good), Buffer.alloc(512)]));
+  assert.throws(() => c.unpack(extra, "plugin-kit-ai"), /noncanonical/);
+  assert.throws(() => c.unpack(Buffer.from("not gzip"), "plugin-kit-ai"));
+});
+
+test("Go build-info parser binds actual main path, flags, product version, engine, target and compiler", () => {
+  const valid = {
+    GoVersion: "go1.25.13", Path: "github.com/777genius/plugin-kit-ai/cli/cmd/agentplugins",
+    Settings: Object.entries({ GOOS: "linux", GOARCH: "amd64", CGO_ENABLED: "0", "-buildmode": "exe", "-compiler": "gc",
+      "-ldflags": c.linkerFlags("agentplugins", ID) }).map(([Key, Value]) => ({ Key, Value }))
+  };
+  producer.buildInfo(valid, "agentplugins", "linux-amd64", ID);
+  const mutations = [
+    (v) => { v.Path = v.Path.replace("agentplugins", "plugin-kit-ai"); },
+    (v) => { v.GoVersion = "go1.25.12"; },
+    (v) => { v.Settings[0].Value = "darwin"; },
+    (v) => { v.Settings[1].Value = "arm64"; },
+    (v) => { v.Settings[2].Value = "1"; },
+    (v) => { v.Settings.pop(); },
+    (v) => { v.Settings.at(-1).Value = c.linkerFlags("plugin-kit-ai", ID); },
+    (v) => { v.Settings.at(-1).Value = c.linkerFlags("agentplugins", { ...ID, commit: "b".repeat(40) }); },
+    (v) => { v.Settings.push(v.Settings[0]); }
+  ];
+  for (const change of mutations) {
+    const invalid = structuredClone(valid); change(invalid);
+    assert.throws(() => producer.buildInfo(invalid, "agentplugins", "linux-amd64", ID));
+  }
+});
+
+test("CLI requires explicit opt-in, exact options and no trailing arguments before any build", () => {
+  const root = temp();
+  const config = path.join(root, "config.json");
+  fs.writeFileSync(config, JSON.stringify({ candidate: false }));
+  for (const argv of [[], ["stage", config], ["stage", "--candidate", config, "extra"], ["publish", "--candidate", config]]) {
+    assert.throws(() => producer.main(argv), /usage/);
+  }
+  assert.throws(() => producer.main(["stage", "--candidate", config]), /fields/);
+  const options = { candidate: false, repo: root, output: path.join(root, "out"), workParent: root, go: "/missing",
+    modCache: root, identity: ID, assetScope: SCOPE };
+  assert.throws(() => producer.stageCandidate(options), /opt-in/);
+  assert.throws(() => producer.stageCandidate({ ...options, candidate: true, execute: true }), /fields/);
+  assert.equal(fs.existsSync(options.output), false);
+});
+
+test("offline controlled snapshot matches exact HEAD blobs and rejects a different HEAD", {
+  skip: process.env.AGENTPLUGINS_STAGED_TEST_CHILD === "1"
+}, () => {
+  const repo = path.resolve(__dirname, "../../..");
+  const context = producer.privateContext(temp());
+  const git = (...args) => cp.execFileSync("/usr/bin/git", args, { cwd: repo, env: context.env, encoding: "utf8" }).trim();
+  const commit = git("rev-parse", "HEAD");
+  assert.match(producer.sourceSnapshot(repo, commit, context), /^[0-9a-f]{64}$/);
+  for (const file of ["go.work", "cli/plugin-kit-ai/cmd/agentplugins/main.go", "cli/plugin-kit-ai/cmd/plugin-kit-ai/main.go"]) {
+    const expected = cp.execFileSync("/usr/bin/git", ["show", `${commit}:${file}`], { cwd: repo, env: context.env });
+    assert.deepEqual(fs.readFileSync(path.join(context.root, "source", file)), expected);
+  }
+  assert.equal(fs.existsSync(path.join(context.root, "source", "npm")), false);
+  assert.throws(() => producer.sourceSnapshot(repo, "b".repeat(40), producer.privateContext(temp())), /HEAD/);
+});


### PR DESCRIPTION
Prepare both authoring products from one frozen source revision without changing current publishers or consumers. The opt-in offline builder produces a closed candidate manifest, product-specific assets and embedded Go identity checks; the verifier rejects mismatched identities, bytes, archives and unsafe output aliases.

Existing schema-v1 audit evidence, schema-v2 assets, historical producer identity and default staging remain unchanged. Candidate consistency is explicitly not attestation, platform acceptance or publication. Both Linux-pair preparation and the complete six-platform pair have explicit, noninterchangeable scopes.

Validation at 2553093e89df61affadb0f87a991a52fd1ddf3d5: independent hosted gpt-6-astra xhigh final review accepted the bounded change and closed both P2 findings. One fresh controlled Linux pair, separate verifier and all 57 focused checks passed with zero skips. Manifest pin: 8ce2772c168648989da655308c3d48a8e9eac1a0ce4c54cbd50455c23617c69d. All twelve actual assets had separately passed staging and byte/build-identity verification at cb64e4d9; unchanged build logic permits reuse of that consistency evidence, without claiming twelve new-head native executions.


Stacked on #164. Current integration: e707ca59501812f8ef6f259e699305c8aead9d32, including reviewed foundation a5f7eb1a4d861eabfe5cd24ea22476bec01f6035. The staging implementation is unchanged. Native CI for this integrated commit is pending; the unresolved Windows concurrency gate in #164 remains a merge hold. No retries or weaker assertions are used as acceptance.

Prior actual Linux-pair evidence at ade20cefd90f85e6bec80754c83d1f2865701c9d passed separate verification and 57 tests; manifest SHA256 6913c61dcb8c43634a499973560691aac6754804805e0d8c8b59560cf2cca375. This is evidence for that source revision, not a newly built candidate for the current merge commit.

This private checkpoint leaves public activation, writable macOS, consumer adoption and stable release gates open. No version, release, tag or channel is published.
