### PR TITLE
feat(authoring): add shared public command contract

### DIFF
--- a/cli/plugin-kit-ai/internal/agentpluginscli/output.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/output.go
@@ -1,9 +1,10 @@
 package agentpluginscli
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/777genius/plugin-kit-ai/cli/internal/outputjson"
 )
 
 const outputSchemaVersion = 1
@@ -17,12 +18,7 @@ type outputResultProvider interface {
 	outputResult() string
 }
 
-type outputEnvelope struct {
-	SchemaVersion int    `json:"schema_version"`
-	Command       string `json:"command"`
-	Result        string `json:"result"`
-	Data          any    `json:"data"`
-}
+type outputEnvelope = outputjson.Envelope
 
 func writeJSONOutput(writer io.Writer, command string, data any) error {
 	result := outputResultSuccess
@@ -35,9 +31,7 @@ func writeJSONOutput(writer io.Writer, command string, data any) error {
 }
 
 func writeJSONResult(writer io.Writer, command, result string, data any) error {
-	encoder := json.NewEncoder(writer)
-	encoder.SetEscapeHTML(false)
-	return encoder.Encode(outputEnvelope{SchemaVersion: outputSchemaVersion, Command: command, Result: result, Data: data})
+	return outputjson.Write(writer, command, result, data)
 }
 
 func writeProgress(app App, _ string, message string) {

--- a/cli/plugin-kit-ai/internal/authoring/commands/commands.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/commands.go
@@ -16,6 +16,7 @@ import (
 	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/readiness"
 	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/report"
 	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/scaffold"
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/skills"
 	"github.com/777genius/plugin-kit-ai/cli/internal/authoringcli"
 	"github.com/777genius/plugin-kit-ai/cli/internal/exitx"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/packageview"
@@ -34,6 +35,8 @@ type RootBuilder func(...authoringcli.Factory) (*cobra.Command, error)
 type App struct {
 	Projects project.Service
 	Revision string
+	// PublicContract opts into the private Phase 6 contract; mains retain their existing mode.
+	PublicContract bool
 }
 
 func commandNames() []string {
@@ -41,6 +44,7 @@ func commandNames() []string {
 }
 
 type request struct {
+	inventory         []string
 	targets           []domain.ClientID
 	root              string
 	disclose, release bool
@@ -51,6 +55,9 @@ type request struct {
 // All state, including the enclosing root/options, is invocation-owned. Raw Cobra
 // errors and buffered help/parser output never enter machine-readable reports.
 func (a App) Execute(ctx context.Context, args []string, streams authoringcli.Streams, build RootBuilder) error {
+	if a.PublicContract {
+		return a.executePublic(ctx, args, streams, build)
+	}
 	var captured *report.Report
 	var human bytes.Buffer
 	factory := authoringcli.Factory(func() (*cobra.Command, error) {
@@ -173,6 +180,9 @@ func (a App) command(name string, capture func(report.Report)) (*cobra.Command, 
 		return a.skillsCommand(capture)
 	}
 	use, args := name+" <path>", cobra.ExactArgs(1)
+	if a.PublicContract && name != "init" {
+		use, args = name+" [package-path]", cobra.MaximumNArgs(1)
+	}
 	if name == "capabilities" {
 		use, args = name, cobra.NoArgs
 	}
@@ -191,6 +201,9 @@ func (a App) command(name string, capture func(report.Report)) (*cobra.Command, 
 					{"url", "explicit remote MCP URL"}, {"author-name", "optional explicit author"}, {"license", "optional MIT or ISC license"},
 					{"copyright-holder", "explicit license holder"}, {"copyright-year", "explicit four-digit license year"},
 				} {
+					if a.PublicContract && v.name == "mcp" {
+						v.name = "mcp-template"
+					}
 					f.String(v.name, "", v.help)
 				}
 			} else {
@@ -199,11 +212,22 @@ func (a App) command(name string, capture func(report.Report)) (*cobra.Command, 
 		},
 		Decode: func(c *cobra.Command, opts authoringcli.Options, args []string) (request, error) {
 			if name == "capabilities" {
-				return request{}, nil
+				return request{inventory: implementedLeaves(c.Root())}, nil
 			}
 			get := func(n string) string { v, _ := c.Flags().GetString(n); return v }
 			disclose, _ := c.Flags().GetBool("include-root")
-			req := request{root: args[0], disclose: disclose}
+			root := ""
+			if len(args) > 0 {
+				root = args[0]
+			}
+			req := request{root: root, disclose: disclose}
+			if a.PublicContract {
+				var err error
+				req.root, err = skills.ExactRoot(filepath.FromSlash(root))
+				if err != nil {
+					return request{}, err
+				}
+			}
 			if name == "compat" || name == "inspect" && (opts.Target != "" || c.Flags().Changed("target")) {
 				ids, err := readiness.Targets(opts.Target)
 				if err != nil {
@@ -212,7 +236,22 @@ func (a App) command(name string, capture func(report.Report)) (*cobra.Command, 
 				req.targets = ids
 			}
 			if name == "init" {
-				req.template = scaffold.Options{Template: scaffold.Template(get("template")), Name: get("name"), Description: get("description"), SkillName: get("skill-name"), MCPChoice: scaffold.Template(get("mcp")), Runtime: get("runtime"), RemoteURL: get("url"), AuthorName: get("author-name"), License: get("license"), CopyrightHolder: get("copyright-holder"), CopyrightYear: get("copyright-year")}
+				mcpFlag := "mcp"
+				if a.PublicContract {
+					mcpFlag = "mcp-template"
+				}
+				req.template = scaffold.Options{Template: scaffold.Template(get("template")), Name: get("name"), Description: get("description"), SkillName: get("skill-name"), MCPChoice: scaffold.Template(get(mcpFlag)), Runtime: get("runtime"), RemoteURL: get("url"), AuthorName: get("author-name"), License: get("license"), CopyrightHolder: get("copyright-holder"), CopyrightYear: get("copyright-year")}
+				if a.PublicContract {
+					if !c.Flags().Changed("name") && !strings.ContainsAny(root, `/\`) && root != "." && root != ".." {
+						req.template.Name = root
+					}
+					if !c.Flags().Changed("description") {
+						req.template.Description = scaffold.DefaultDescription(req.template.Template)
+					}
+					if _, err := scaffold.BuildPlan(req.template); err != nil {
+						return request{}, publicInputError(err)
+					}
+				}
 			} else {
 				req.release, _ = c.Flags().GetBool("release-policy")
 			}
@@ -221,7 +260,11 @@ func (a App) command(name string, capture func(report.Report)) (*cobra.Command, 
 		Runner: authoringcli.RunnerFunc[request, report.Report](func(ctx context.Context, req request) (report.Report, error) {
 			if name == "capabilities" {
 				r := report.New(name, a.Revision)
-				c, err := readiness.Engine(commandNames())
+				names := commandNames()
+				if a.PublicContract {
+					names = req.inventory
+				}
+				c, err := readiness.Engine(names)
 				r.Capabilities = c
 				if err != nil {
 					r.AddError("capabilities_unavailable", "Check the embedded engine metadata.")

--- a/cli/plugin-kit-ai/internal/authoring/commands/public_contract.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/public_contract.go
@@ -385,9 +385,12 @@ func writePublicHuman(w io.Writer, p report.Public, result string) error {
 // Help lists definitions rather than flag values; never serialize mutable pflag
 // values, which can contain credentials even when help bypasses a runner.
 func publicHelp(s selection) *report.CommandHelp {
-	h := &report.CommandHelp{Use: s.command.Use, Flags: []string{}, Guidance: publicArguments}
+	// Only trusted tree definitions supply the route and argument placeholders;
+	// argv and mutable flag values never contribute to usage text.
+	use := s.command.CommandPath() + strings.TrimPrefix(s.command.Use, s.command.Name())
+	h := &report.CommandHelp{Use: use, Flags: []string{}, Guidance: publicArguments}
 	if s.operation == "author" {
-		h.Use = "author <command>"
+		h.Use += " <command>"
 	}
 	seen := map[string]bool{}
 	for c := s.command; c != nil; c = c.Parent() {

--- a/cli/plugin-kit-ai/internal/authoring/commands/public_contract.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/public_contract.go
@@ -1,0 +1,414 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/report"
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/scaffold"
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoringcli"
+	"github.com/777genius/plugin-kit-ai/cli/internal/exitx"
+	"github.com/777genius/plugin-kit-ai/cli/internal/outputjson"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const operationKey = "authoring.public-operation"
+
+// Tag only factories supplied by this engine. Enclosing installer commands and
+// Cobra utilities cannot become author capabilities by having a matching name.
+func tagOperations(c *cobra.Command, prefix string) {
+	if c.Annotations == nil {
+		c.Annotations = map[string]string{}
+	}
+	c.Annotations[operationKey] = prefix
+	for _, child := range c.Commands() {
+		tagOperations(child, prefix+"."+child.Name())
+	}
+}
+func implementedLeaves(root *cobra.Command) []string {
+	var out []string
+	var walk func(*cobra.Command)
+	walk = func(c *cobra.Command) {
+		if c == nil {
+			return
+		}
+		if !c.Hidden && !c.HasSubCommands() && c.Runnable() && c.Annotations[operationKey] != "" {
+			out = append(out, c.Annotations[operationKey])
+		}
+		for _, child := range c.Commands() {
+			walk(child)
+		}
+	}
+	walk(root)
+	sort.Strings(out)
+	return out
+}
+
+type selection struct {
+	command                 *cobra.Command
+	operation, mode, format string
+	help, invalid           bool
+	flags                   []string
+}
+
+// selectPublic observes definitions on the fresh tree without executing a
+// parser, decoding a request, or accessing a project. Known flag values consume
+// their actual arity. An unknown token freezes routing at the nearest known
+// command; its unknown arity can never promote a credential value into a verb.
+// Format selection continues after errors, with pflag's final-value semantics.
+func selectPublic(root *cobra.Command, args []string) selection {
+	s := selection{command: root, operation: "author", mode: "read", format: "human"}
+	positional, helpCommand := false, false
+	lookup := func(name string, short bool) *pflag.Flag {
+		for c := s.command; c != nil; c = c.Parent() {
+			for _, fs := range []*pflag.FlagSet{c.Flags(), c.PersistentFlags()} {
+				var f *pflag.Flag
+				if short {
+					f = fs.ShorthandLookup(name)
+				} else {
+					f = fs.Lookup(name)
+				}
+				if f != nil {
+					return f
+				}
+			}
+		}
+		return nil
+	}
+	flag := func(f *pflag.Flag, value string) {
+		if f.Name == "format" {
+			s.format = value
+		}
+		if f.Name == "help" {
+			v, err := strconv.ParseBool(value)
+			s.help = v
+			if err != nil {
+				s.invalid = true
+			}
+		}
+		switch f.Name {
+		case "scope", "accept-security-risk", "security-details", "dry-run":
+			s.invalid = true
+		}
+	}
+	for i := 0; i < len(args); i++ {
+		start := i
+		token := args[i]
+		if token == "--" {
+			if i+1 < len(args) && s.command.HasSubCommands() {
+				s.invalid = true
+			}
+			break
+		}
+		if strings.HasPrefix(token, "--") {
+			name, value, equal := strings.Cut(token[2:], "=")
+			f := lookup(name, false)
+			if f == nil {
+				s.invalid = true
+				positional = true
+				continue
+			}
+			if !equal {
+				if f.NoOptDefVal != "" {
+					value = f.NoOptDefVal
+				} else if i+1 < len(args) {
+					i++
+					value = args[i]
+				} else {
+					s.invalid = true
+					continue
+				}
+			}
+			flag(f, value)
+			s.flags = append(s.flags, args[start:i+1]...)
+			continue
+		}
+		if strings.HasPrefix(token, "-") && token != "-" {
+			cluster := token[1:]
+			for len(cluster) > 0 {
+				f := lookup(cluster[:1], true)
+				cluster = cluster[1:]
+				if f == nil {
+					s.invalid = true
+					positional = true
+					break
+				}
+				value := f.NoOptDefVal
+				if strings.HasPrefix(cluster, "=") {
+					value = cluster[1:]
+					cluster = ""
+				} else if f.NoOptDefVal == "" {
+					if cluster != "" {
+						value = cluster
+						cluster = ""
+					} else if i+1 < len(args) {
+						i++
+						value = args[i]
+					} else {
+						s.invalid = true
+						break
+					}
+				}
+				flag(f, value)
+			}
+			s.flags = append(s.flags, args[start:i+1]...)
+			continue
+		}
+		if positional {
+			continue
+		}
+		if token == "help" && s.command.HasSubCommands() {
+			helpCommand = true
+			continue
+		}
+		var next *cobra.Command
+		for _, c := range s.command.Commands() {
+			if c.Name() == token && (!c.Hidden || c.Name() == "author") {
+				next = c
+				break
+			}
+		}
+		if next == nil {
+			positional = true
+			if s.command.HasSubCommands() || helpCommand {
+				s.invalid = true
+			}
+			continue
+		}
+		s.command = next
+	}
+	s.help = s.help || helpCommand
+	if id := s.command.Annotations[operationKey]; id != "" {
+		s.operation = id
+	} else {
+		s.invalid = true
+	}
+	if s.operation == "author.init" || s.operation == "author.skills.init" {
+		s.mode = "local_mutation"
+	}
+	if s.format != "human" && s.format != "json" {
+		s.invalid = true
+	}
+	return s
+}
+
+type inputError struct{ code, action string }
+
+func (e *inputError) Error() string { return e.action }
+func publicInputError(err error) error {
+	code, action := failure(err, "template")
+	if code == "template_options_invalid" {
+		action = "Choose --template skill, mcp-remote, mcp-stdio or hybrid. Remote requires --url; stdio requires --runtime node; hybrid requires --mcp-template. Use --name for a path destination. Licenses require explicit holder and year."
+	}
+	var identity *scaffold.IdentityError
+	if errors.As(err, &identity) {
+		if suggestion := report.DisplayIdentity(identity.Suggestion); suggestion != "" && report.DisplayIdentity(identity.Value) != "" {
+			action += " Suggested identity: " + suggestion + "; supply it explicitly."
+		}
+	}
+	return &inputError{code, action}
+}
+
+func (a App) executePublic(ctx context.Context, args []string, streams authoringcli.Streams, build RootBuilder) error {
+	var captured *report.Report
+	var selected = selection{operation: "author", mode: "read", format: "human"}
+	var surface []string
+	factory := authoringcli.Factory(func() (*cobra.Command, error) {
+		factories := make([]authoringcli.Factory, 0, len(commandNames()))
+		for _, name := range commandNames() {
+			factories = append(factories, func() (*cobra.Command, error) {
+				c, err := a.command(name, func(r report.Report) { captured = &r })
+				if err == nil {
+					tagOperations(c, "author."+name)
+				}
+				return c, err
+			})
+		}
+		root, err := build(factories...)
+		if err != nil {
+			return nil, err
+		}
+		if root == nil {
+			return nil, errors.New("missing authoring root")
+		}
+		root.CompletionOptions.DisableDefaultCmd = true
+		if root.Name() == "plugin-kit-ai" {
+			root.Annotations = map[string]string{operationKey: "author"}
+		}
+		var prepare func(*cobra.Command)
+		prepare = func(c *cobra.Command) {
+			if c.Name() == "author" {
+				c.Annotations = map[string]string{operationKey: "author"}
+			}
+			c.InitDefaultHelpFlag()
+			if c.Annotations[operationKey] != "" && c.HasSubCommands() {
+				c.Args = cobra.NoArgs
+				c.RunE = func(c *cobra.Command, _ []string) error {
+					_, err := authoringcli.AdaptFlags(c, authoringcli.Support{Format: true, NoColor: true})
+					return err
+				}
+			}
+			for _, child := range c.Commands() {
+				prepare(child)
+			}
+		}
+		prepare(root)
+		surface = implementedLeaves(root)
+		selected = selectPublic(root, args)
+		if selected.invalid {
+			return nil, &inputError{"arguments_invalid", publicArguments}
+		}
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		// Help verbs and --help share a pre-run closure. Validate values with the
+		// actual selected pflag set, then stop before Cobra's group help routing.
+		if selected.help {
+			if err := selected.command.ParseFlags(selected.flags); err != nil {
+				return nil, &inputError{"arguments_invalid", publicArguments}
+			}
+			if _, err := authoringcli.AdaptFlags(selected.command, authoringcli.Support{Format: true, NoColor: true, Target: selected.operation == "author.inspect" || selected.operation == "author.compat"}); err != nil {
+				return nil, &inputError{"arguments_invalid", publicArguments}
+			}
+			return nil, errPublicHelp
+		}
+
+		return root, nil
+	})
+	err := factory.Execute(ctx, args, authoringcli.Streams{In: streams.In, Out: io.Discard, Err: io.Discard})
+	if errors.Is(err, errPublicHelp) {
+		err = nil
+	}
+	attempted := captured != nil
+	code := 0
+	if err != nil {
+		code = exitx.Code(err)
+	}
+	if captured == nil {
+		r := report.New(selected.operation, a.Revision)
+		if err != nil {
+			var input *inputError
+			errorCode, action := failure(err, "arguments")
+			if errors.As(err, &input) {
+				errorCode, action = input.code, input.action
+			}
+			if errorCode == "arguments_invalid" {
+				action = publicArguments
+			}
+			var pathError *os.PathError
+			if errorCode != "canceled" && !errors.As(err, &pathError) {
+				// An existing exitx annotation wins over the syntax fallback.
+				code = exitx.Code(errors.Join(err, exitx.Wrap(err, 2)))
+			}
+			r.AddOperationError(errorCode, action)
+		}
+		captured = &r
+	}
+	// Cleanup is authoritative even after a commit or an annotated/canceled error.
+	if captured.Error != nil && captured.Error.Code == "private_cleanup_failed" {
+		code = 1
+	}
+	var commands []string
+	if !attempted && err == nil || selected.operation == "author.capabilities" {
+		commands = surface
+	}
+	p := captured.PublicResult(selected.operation, selected.mode, attempted, commands)
+	if !attempted && err == nil {
+		p.Help = publicHelp(selected)
+	}
+	result := outputjson.Success
+	if err != nil {
+		result = outputjson.Failure
+	}
+	var outputErr error
+	if selected.format == "json" {
+		outputErr = outputjson.Write(streams.Out, selected.operation, result, p)
+	} else {
+		outputErr = writePublicHuman(streams.Out, p, result)
+	}
+	if outputErr != nil {
+		return exitx.Wrap(errors.New("authoring output failed"), 1)
+	}
+	if err != nil {
+		return exitx.Wrap(errors.New("authoring operation failed; see report"), code)
+	}
+	return nil
+}
+
+var errPublicHelp = errors.New("authoring command surface requested")
+
+const publicArguments = "Use an implemented authoring command; read paths default to the exact current directory. Use --format human or json. Compat requires explicit comma-separated --target clients. Inherited --scope, --accept-security-risk and --security-details are installer-only; use agentplugins add for installation policy. Unsupported --dry-run and runtime flags are rejected."
+
+func writePublicHuman(w io.Writer, p report.Public, result string) error {
+	// Buffer only trusted projected data and write once, preserving output failure
+	// precedence without a second result attempt or raw Cobra/parser text.
+	var b strings.Builder
+	if p.Help != nil {
+		fmt.Fprintf(&b, "Usage: %s\nFlags: %s\n%s\n", p.Help.Use, strings.Join(p.Help.Flags, ", "), p.Help.Guidance)
+	}
+	fmt.Fprintf(&b, "%s: %s; readiness %s; conformance %s; runtime %s\n", p.Command, result, p.Readiness.Status, p.Conformance.Status, p.Runtime.Status)
+	if p.Inspection != nil {
+		fmt.Fprintf(&b, "package: %s; version: %s; schema: %s\n", p.Inspection.Name, p.Inspection.Version, p.Inspection.Schema)
+		for _, c := range p.Inspection.Components {
+			fmt.Fprintf(&b, "%s %s%s; executable: %s (%s)\n", c.Type, c.Name, c.Namespace, c.Executable, c.ExecutableKind)
+		}
+	}
+	for _, f := range p.Findings {
+		fmt.Fprintf(&b, "%s: %s (%s)\n", f.Severity, f.Code, f.Layer)
+	}
+	for _, client := range p.Clients {
+		fmt.Fprintf(&b, "target %s: static support only; %s\n", client.ClientID, strings.Join(client.Limitations, ", "))
+		for _, c := range client.Components {
+			fmt.Fprintf(&b, "  %s %d: %s\n", c.Kind, c.Index, c.Support)
+		}
+	}
+	for _, c := range p.DoctorChecks {
+		fmt.Fprintf(&b, "%s: %s; %s\n", c.ID, c.Status, c.Action)
+	}
+	if len(p.Surface) > 0 {
+		fmt.Fprintf(&b, "commands: %s\n", strings.Join(p.Surface, ", "))
+	}
+	for _, action := range p.NextActions {
+		fmt.Fprintln(&b, action.Message)
+	}
+	_, err := io.WriteString(w, b.String())
+	return err
+}
+
+// Help lists definitions rather than flag values; never serialize mutable pflag
+// values, which can contain credentials even when help bypasses a runner.
+func publicHelp(s selection) *report.CommandHelp {
+	h := &report.CommandHelp{Use: s.command.Use, Flags: []string{}, Guidance: publicArguments}
+	if s.operation == "author" {
+		h.Use = "author <command>"
+	}
+	seen := map[string]bool{}
+	for c := s.command; c != nil; c = c.Parent() {
+		for _, fs := range []*pflag.FlagSet{c.Flags(), c.PersistentFlags()} {
+			fs.VisitAll(func(f *pflag.Flag) {
+				if f.Hidden || seen[f.Name] {
+					return
+				}
+				seen[f.Name] = true
+				switch f.Name {
+				case "scope", "accept-security-risk", "security-details":
+					return
+				}
+				label := "--" + f.Name
+				if f.NoOptDefVal == "" {
+					label += " <value>"
+				}
+				h.Flags = append(h.Flags, label)
+			})
+		}
+	}
+	sort.Strings(h.Flags)
+	return h
+}

--- a/cli/plugin-kit-ai/internal/authoring/commands/public_contract_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/public_contract_test.go
@@ -3,8 +3,10 @@ package commands_test
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -158,6 +160,12 @@ func TestPublicParserAndHelpParity(t *testing.T) {
 				if bytes.Contains(b, []byte("unknown-secret")) || bytes.Contains(b, []byte("invalid-secret")) {
 					t.Fatalf("token echo: %s", b)
 				}
+				if e.Data.Help != nil {
+					// Assert the actual route before normalizing only its allowed
+					// invocation prefix; all remaining payload bytes still match.
+					prefix := assertPublicHelpRoute(t, e, mount)
+					b = bytes.Replace(b, []byte(`"use":"`+prefix), []byte(`"use":"author`), 1)
+				}
 				if first != nil && !bytes.Equal(first, b) {
 					t.Fatalf("entrypoint drift:\n%s\n%s", first, b)
 				}
@@ -167,6 +175,115 @@ func TestPublicParserAndHelpParity(t *testing.T) {
 	}
 	if files, _ := os.ReadDir(a.Projects.Scratch); len(files) != 0 {
 		t.Fatalf("scratch leaked: %v", files)
+	}
+}
+
+func assertPublicHelpRoute(t *testing.T, e publicEnvelope, mount bool) string {
+	t.Helper()
+	prefix := "plugin-kit-ai"
+	if mount {
+		prefix = "agentplugins author"
+	}
+	route := strings.ReplaceAll(strings.TrimPrefix(e.Command, "author"), ".", " ")
+	suffix := " [package-path]"
+	switch e.Command {
+	case "author":
+		suffix = " <command>"
+	case "author.skills", "author.capabilities":
+		suffix = ""
+	case "author.init":
+		suffix = " <path>"
+	case "author.skills.init":
+		suffix = " <name> [package-path]"
+	}
+	if e.Data.Help == nil || e.Data.Help.Use != prefix+route+suffix {
+		t.Fatalf("incorrect help route for %s", e.Command)
+	}
+	return prefix
+}
+
+func TestPublicHelpExecutableAndAncestry(t *testing.T) {
+	for _, route := range []string{"", "skills", "init", "inspect", "validate", "test", "compat", "doctor", "capabilities", "skills init", "skills validate"} {
+		for _, mount := range []bool{false, true} {
+			for _, helpVerb := range []bool{false, true} {
+				args := append(strings.Fields(route), "--help")
+				if helpVerb {
+					args = append([]string{"help"}, strings.Fields(route)...)
+				}
+				a := publicApp(t)
+				e, code, _ := publicRun(t, a, append(args, "--format=json"), mount)
+				if code != 0 {
+					t.Fatal("help failed")
+				}
+				assertPublicHelpRoute(t, e, mount)
+				noPolicy(t, e)
+				human := executeRaw(a, args, mount)
+				if human.err != nil || len(human.errout) != 0 || !bytes.HasPrefix(human.out, []byte("Usage: "+e.Data.Help.Use+"\n")) {
+					t.Fatal("human usage disagrees with the verified JSON route")
+				}
+			}
+		}
+	}
+}
+
+func TestPublicCredentialFamilySinks(t *testing.T) {
+	// Non-live synthetic values are assembled only in memory. Failure logs never
+	// include shaped inputs or raw output, even when exercising a disclosure bug.
+	for family, value := range map[string]string{
+		"gitlab": "glpat-" + strings.Repeat("b", 20),
+		"slack":  "xoxb-" + strings.Repeat("1", 12) + "-" + strings.Repeat("2", 12) + "-" + strings.Repeat("a", 24),
+	} {
+		for _, field := range []string{"name", "version", "server", "namespace", "executable", "skill"} {
+			for _, mount := range []bool{false, true} {
+				for _, format := range []string{"json", "human"} {
+					t.Run(fmt.Sprintf("%s/%s/mount=%t/%s", family, field, mount, format), func(t *testing.T) {
+						a, root := publicApp(t), t.TempDir()
+						manifest := map[string]any{"$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json", "name": "visible-demo", "version": "preview-1"}
+						serverName := "visible-server"
+						server := map[string]any{"type": "stdio", "command": "node", "args": []string{"server.mjs"}}
+						switch field {
+						case "name", "version":
+							manifest[field] = value
+						case "server":
+							serverName = value
+						case "namespace":
+							manifest["extensions"] = map[string]any{value: map[string]any{}}
+						case "executable":
+							server["command"] = value
+						}
+						body, _ := json.Marshal(manifest)
+						write(t, root, "plugin.json", string(body))
+						body, _ = json.Marshal(map[string]any{"$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json", "mcpServers": map[string]any{serverName: server}})
+						write(t, root, "mcp.json", string(body))
+						check := func(args []string, mutation bool) {
+							raw := executeRaw(a, append(args, "--format="+format), mount)
+							disclosed := bytes.Contains(raw.out, []byte(value)) || bytes.Contains(raw.errout, []byte(value))
+							t.Logf("disclosed=%t output_sha256=%x", disclosed, sha256.Sum256(raw.out))
+							if disclosed || raw.err != nil || len(raw.errout) != 0 {
+								t.Fatal("credential projection disclosed input or operation failed")
+							}
+							if format == "json" {
+								e, _ := publicDecode(t, raw) // Safe only after the disclosure assertion.
+								if e.Data.Committed != mutation || mutation && (len(e.Data.Paths) != 0 || len(e.Data.WithheldPathIDs) != 1 || !e.Data.Effects.Attempted) {
+									t.Fatal("incorrect mutation projection")
+								}
+							}
+						}
+						if field == "skill" {
+							check([]string{"skills", "init", value, root, "--description=Example"}, true)
+							if _, err := os.Stat(filepath.Join(root, "skills", value, "SKILL.md")); err != nil {
+								t.Fatal("display policy prevented the requested Skill commit")
+							}
+						}
+						before := tree(t, root)
+						check([]string{"inspect", root}, false)
+						if !reflect.DeepEqual(before, tree(t, root)) {
+							t.Fatal("inspection changed source")
+						}
+					})
+				}
+			}
+		}
 	}
 }
 
@@ -511,16 +628,20 @@ func TestPublicFreshInventoryCancellationAndOutput(t *testing.T) {
 		t.Fatalf("output precedence: %v calls %d", err, w.calls)
 	}
 	var wg sync.WaitGroup
-	results := make(chan rawExecution, 8)
+	results := make([]rawExecution, 8)
 	for i := 0; i < 8; i++ {
 		wg.Add(1)
-		go func(i int) { defer wg.Done(); results <- executeRaw(a, []string{"skills", "--format=json"}, i%2 == 0) }(i)
+		go func(i int) {
+			defer wg.Done()
+			results[i] = executeRaw(a, []string{"skills", "--format=json"}, i%2 == 0)
+		}(i)
 	}
 	wg.Wait()
-	close(results)
 	var first []byte
-	for raw := range results {
-		publicDecode(t, raw)
+	for i, raw := range results {
+		e, _ := publicDecode(t, raw)
+		prefix := assertPublicHelpRoute(t, e, i%2 == 0)
+		raw.out = bytes.Replace(raw.out, []byte(`"use":"`+prefix), []byte(`"use":"author`), 1)
 		if first != nil && !bytes.Equal(first, raw.out) {
 			t.Fatal("concurrent factory drift")
 		}

--- a/cli/plugin-kit-ai/internal/authoring/commands/public_contract_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/public_contract_test.go
@@ -1,0 +1,606 @@
+package commands_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/commands"
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/project"
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/report"
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoringcli"
+	"github.com/777genius/plugin-kit-ai/cli/internal/exitx"
+	"github.com/spf13/cobra"
+)
+
+const publicRevision = "ade20cefd90f85e6bec80754c83d1f2865701c9d"
+
+type publicEnvelope struct {
+	SchemaVersion int           `json:"schema_version"`
+	Command       string        `json:"command"`
+	Result        string        `json:"result"`
+	Data          report.Public `json:"data"`
+}
+
+func publicApp(t *testing.T) commands.App {
+	t.Helper()
+	return commands.App{Projects: project.Service{Scratch: t.TempDir()}, Revision: publicRevision, PublicContract: true}
+}
+func publicDecode(t *testing.T, raw rawExecution) (publicEnvelope, int) {
+	t.Helper()
+	if len(raw.errout) != 0 {
+		t.Fatalf("unexpected stderr: %s", raw.errout)
+	}
+	var e publicEnvelope
+	d := json.NewDecoder(bytes.NewReader(raw.out))
+	d.DisallowUnknownFields()
+	if err := d.Decode(&e); err != nil {
+		t.Fatalf("decode: %v\n%s", err, raw.out)
+	}
+	var extra any
+	if err := d.Decode(&extra); err != io.EOF {
+		t.Fatalf("more than one document: %v", err)
+	}
+	code := 0
+	if raw.err != nil {
+		code = exitx.Code(raw.err)
+	}
+	expected := "success"
+	if code != 0 {
+		expected = "failure"
+	}
+	if e.SchemaVersion != 1 || e.Result != expected || e.Data.AuthoringSchemaVersion != 1 || e.Data.EngineVersion != "standard-first-slice/1" || e.Data.Revision != publicRevision {
+		t.Fatalf("identity/result: %+v", e)
+	}
+	if e.Command != e.Data.Command || e.Command != e.Data.Requested.Operation || e.Data.Requested.Mode != e.Data.Mode || e.Data.Committed != e.Data.Effects.Committed {
+		t.Fatalf("operation/effects disagree: %+v", e)
+	}
+	ids := map[string]bool{}
+	for _, f := range e.Data.Findings {
+		if ids[f.ID] {
+			t.Fatal("duplicate finding")
+		}
+		ids[f.ID] = true
+	}
+	assessments := []report.Assessment{e.Data.Conformance, e.Data.Readiness, e.Data.HostSafety, e.Data.Release, e.Data.Loadability, e.Data.Compatibility, e.Data.Runtime, e.Data.Toolchain}
+	for _, c := range e.Data.Checks {
+		assessments = append(assessments, c.Assessment)
+	}
+	for _, a := range assessments {
+		seen := map[string]bool{}
+		for _, id := range a.FindingIDs {
+			if !ids[id] || seen[id] {
+				t.Fatalf("invalid reference %s", id)
+			}
+			seen[id] = true
+		}
+	}
+	return e, code
+}
+func publicRun(t *testing.T, a commands.App, args []string, mount bool) (publicEnvelope, int, []byte) {
+	t.Helper()
+	raw := executeRaw(a, args, mount)
+	e, c := publicDecode(t, raw)
+	return e, c, raw.out
+}
+func noPolicy(t *testing.T, e publicEnvelope) {
+	t.Helper()
+	for _, a := range []report.Assessment{e.Data.Conformance, e.Data.Readiness, e.Data.HostSafety, e.Data.Release, e.Data.Loadability, e.Data.Compatibility, e.Data.Runtime, e.Data.Toolchain} {
+		if a.Status != report.NotEvaluated {
+			t.Fatalf("unevaluated policy changed: %+v", e)
+		}
+	}
+	if e.Data.Effects.Attempted || e.Data.Committed || len(e.Data.Paths) != 0 {
+		t.Fatalf("syntax/help claimed effects: %+v", e)
+	}
+}
+
+func TestPublicParserAndHelpParity(t *testing.T) {
+	a := publicApp(t)
+	cases := []struct {
+		args      []string
+		operation string
+		code      int
+	}{
+		{nil, "author", 0},
+		{[]string{"--help"}, "author", 0},
+		{[]string{"skills"}, "author.skills", 0},
+		{[]string{"skills", "--help"}, "author.skills", 0},
+		{[]string{"help", "skills", "init"}, "author.skills.init", 0},
+		{[]string{"skills", "init", "-h"}, "author.skills.init", 0},
+		{[]string{"init", "--help"}, "author.init", 0},
+		{[]string{"init", "--include-root=invalid-secret", "--help"}, "author.init", 2},
+		{[]string{"help", "skills", "init", "unknown-secret"}, "author.skills.init", 2},
+		{[]string{"init"}, "author.init", 2},
+		{[]string{"skills", "init"}, "author.skills.init", 2},
+		{[]string{"skills", "unknown-secret"}, "author.skills", 2},
+		{[]string{"unknown-secret"}, "author", 2},
+		{[]string{"help", "unknown-secret"}, "author", 2},
+		{[]string{"init", "--description", "test"}, "author.init", 2},
+		{[]string{"init", "--description=author", "--name", "inspect"}, "author.init", 2},
+		{[]string{"--target", "init", "skills", "init"}, "author.skills.init", 2},
+		{[]string{"--unknown-secret", "init"}, "author", 2},
+		{[]string{"validate", "--unknown-secret=inspect"}, "author.validate", 2},
+		{[]string{"skills", "validate", "--unknown-secret"}, "author.skills.validate", 2},
+		{[]string{"init", "--description"}, "author.init", 2},
+		{[]string{"init", "-hx"}, "author.init", 2},
+		{[]string{"validate", "one", "two"}, "author.validate", 2},
+		{[]string{"init", "--help=false"}, "author.init", 2},
+		{[]string{"init", "--include-root=invalid-secret"}, "author.init", 2},
+		{[]string{"init", "--dry-run=false", "--help"}, "author.init", 2},
+		{[]string{"init", "--target=claude", "--help"}, "author.init", 2},
+		{[]string{"skills", "--target=claude", "--help"}, "author.skills", 2},
+		{[]string{"compat"}, "author.compat", 2},
+		{[]string{"init", "demo", "--template", "hybrid"}, "author.init", 2},
+		{[]string{"init", "demo", "--template", "mcp-remote"}, "author.init", 2},
+		{[]string{"init", "demo", "--template", "mcp-stdio"}, "author.init", 2},
+		{[]string{"init", "demo", "--template", "skill", "--description="}, "author.init", 2},
+		{[]string{"skills", "init", "demo"}, "author.skills.init", 2},
+	}
+	for _, tc := range cases {
+		t.Run(strings.Join(tc.args, "_"), func(t *testing.T) {
+			var first []byte
+			for _, mount := range []bool{false, true} {
+				args := append([]string{"--format=json"}, tc.args...)
+				e, c, b := publicRun(t, a, args, mount)
+				if c != tc.code || e.Command != tc.operation {
+					t.Fatalf("code %d operation %s: %s", c, e.Command, b)
+				}
+				noPolicy(t, e)
+				if bytes.Contains(b, []byte("unknown-secret")) || bytes.Contains(b, []byte("invalid-secret")) {
+					t.Fatalf("token echo: %s", b)
+				}
+				if first != nil && !bytes.Equal(first, b) {
+					t.Fatalf("entrypoint drift:\n%s\n%s", first, b)
+				}
+				first = b
+			}
+		})
+	}
+	if files, _ := os.ReadDir(a.Projects.Scratch); len(files) != 0 {
+		t.Fatalf("scratch leaked: %v", files)
+	}
+}
+
+func TestPublicFormatArityAndDelimiter(t *testing.T) {
+	a := publicApp(t)
+	for _, tc := range []struct {
+		args []string
+		json bool
+	}{
+		{[]string{"--format=json", "--format", "human", "init"}, false},
+		{[]string{"--format=human", "--format", "json", "init"}, true},
+		{[]string{"init", "--description", "--format=json"}, false},
+		{[]string{"--format=json", "init", "--description", "--format=human"}, true},
+		{[]string{"init", "--", "--format=json"}, false},
+		{[]string{"--format=json", "init", "--", "--format=human"}, true},
+		{[]string{"--format=json", "init", "--format"}, true},
+	} {
+		for _, mount := range []bool{false, true} {
+			raw := executeRaw(a, tc.args, mount)
+			if bytes.HasPrefix(raw.out, []byte("{")) != tc.json {
+				t.Fatalf("format selection %v: %s", tc.args, raw.out)
+			}
+			if tc.json {
+				e, c := publicDecode(t, raw)
+				if c != 2 || e.Command != "author.init" {
+					t.Fatalf("unexpected result %+v code %d", e, c)
+				}
+			}
+		}
+	}
+	// A path named like a command is still an argument after a leaf or --.
+	for _, args := range [][]string{{"validate", "test", "init"}, {"--format=json", "--", "init"}} {
+		if !strings.HasPrefix(args[0], "--format") {
+			args = append([]string{"--format=json"}, args...)
+		}
+		e, c, _ := publicRun(t, a, args, false)
+		if c != 2 || e.Data.Effects.Attempted {
+			t.Fatalf("delimiter/position selection: %+v", e)
+		}
+	}
+}
+
+func TestPublicLiteralExamplesAndEveryLeaf(t *testing.T) {
+	lanes := []struct {
+		name  string
+		flags []string
+	}{
+		{"docs-skill", []string{"--template", "skill"}},
+		{"docs-helper", []string{"--template", "mcp-remote", "--url", "https://docs.example.com/mcp"}},
+		{"local-helper", []string{"--template", "mcp-stdio", "--runtime", "node"}},
+		{"hybrid-helper", []string{"--template", "hybrid", "--mcp-template", "mcp-remote", "--url", "https://docs.example.com/mcp"}},
+		{"hybrid-local", []string{"--template", "hybrid", "--mcp-template", "mcp-stdio", "--runtime", "node"}},
+	}
+	for _, lane := range lanes {
+		t.Run(lane.name, func(t *testing.T) {
+			var first [][]byte
+			var firstTree map[string]string
+			for _, mount := range []bool{false, true} {
+				parent := t.TempDir()
+				t.Chdir(parent)
+				a := publicApp(t)
+				args := append([]string{"init", lane.name, "--format=json"}, lane.flags...)
+				e, c, b := publicRun(t, a, args, mount)
+				if c != 0 || !e.Data.Committed || !e.Data.Effects.Attempted || e.Data.Mode != "local_mutation" || e.Data.Inspection.Name != lane.name {
+					t.Fatalf("literal example: %s", b)
+				}
+				root := filepath.Join(parent, lane.name)
+				body, err := os.ReadFile(filepath.Join(root, "plugin.json"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				var manifest map[string]any
+				json.Unmarshal(body, &manifest)
+				if manifest["version"] != "0.1.0" || manifest["description"] == "" || manifest["author"] != nil || manifest["license"] != nil {
+					t.Fatalf("defaults: %s", body)
+				}
+				for _, path := range []string{"LICENSE", "plugin/plugin.yaml", ".codex-plugin/plugin.json", "hooks"} {
+					if _, err := os.Stat(filepath.Join(root, path)); !os.IsNotExist(err) {
+						t.Fatalf("unexpected generated %s", path)
+					}
+				}
+				gotTree := tree(t, root)
+				if firstTree == nil {
+					firstTree = gotTree
+				} else if !reflect.DeepEqual(firstTree, gotTree) {
+					t.Fatal("template tree parity")
+				}
+				results := [][]byte{b}
+				for _, verb := range []string{"validate", "inspect", "test", "compat", "doctor", "skills validate"} {
+					args := append(strings.Fields(verb), root, "--format=json")
+					if verb == "compat" {
+						args = append(args, "--target", "claude,codex")
+					}
+					r, code, out := publicRun(t, a, args, mount)
+					if verb != "doctor" && code != 0 {
+						t.Fatalf("%s: %s", verb, out)
+					}
+					if r.Data.Conformance.Status != report.Pass || r.Data.Runtime.Status != report.NotEvaluated || r.Data.Identity.TreeDigest == "" || r.Data.Root != "" {
+						t.Fatalf("policy/identity: %s", out)
+					}
+					if bytes.Contains(out, []byte(parent)) || bytes.Contains(out, []byte(a.Projects.Scratch)) {
+						t.Fatalf("local path leaked: %s", out)
+					}
+					results = append(results, out)
+				}
+				r, code, out := publicRun(t, a, []string{"skills", "init", "extra-skill", root, "--description", "Use for extra documentation requests", "--format=json"}, mount)
+				if code != 0 || !r.Data.Committed || !reflect.DeepEqual(r.Data.Paths, []string{"skills/extra-skill/SKILL.md"}) {
+					t.Fatalf("Skills mutation: %s", out)
+				}
+				results = append(results, out)
+				if first == nil {
+					first = results
+				} else if !reflect.DeepEqual(first, results) {
+					t.Fatal("full policy/digest/identity parity")
+				}
+				if entries, _ := os.ReadDir(a.Projects.Scratch); len(entries) != 0 {
+					t.Fatalf("scratch leaked: %v", entries)
+				}
+			}
+		})
+	}
+}
+
+func TestPublicCWDAndExplicitInputs(t *testing.T) {
+	parent := t.TempDir()
+	t.Chdir(parent)
+	a := publicApp(t)
+	root := filepath.Join(parent, "explicit-destination")
+	_, c, b := publicRun(t, a, []string{"init", root, "--name", "explicit-name", "--description", "Explicit description", "--template", "skill", "--format=json"}, false)
+	if c != 0 {
+		t.Fatalf("explicit caller: %s", b)
+	}
+	before := tree(t, root)
+	_, c, b = publicRun(t, a, []string{"init", root, "--name", "other-name", "--template", "skill", "--format=json"}, true)
+	if c != 1 || !reflect.DeepEqual(before, tree(t, root)) {
+		t.Fatalf("collision changed destination: %s", b)
+	}
+	t.Chdir(root)
+	for _, mount := range []bool{false, true} {
+		for _, verb := range []string{"validate", "inspect", "test", "doctor", "compat", "skills validate"} {
+			args := append(strings.Fields(verb), "--include-root", "--format=json")
+			if verb == "compat" {
+				args = append(args, "--target=claude,codex")
+			}
+			e, c, b := publicRun(t, a, args, mount)
+			if c != 0 || e.Data.Root != root {
+				t.Fatalf("omitted exact CWD: %s", b)
+			}
+		}
+	}
+	child := filepath.Join(root, "child")
+	os.Mkdir(child, 0700)
+	t.Chdir(child)
+	e, c, b := publicRun(t, a, []string{"validate", "--format=json"}, false)
+	if c != 1 || !bytes.Contains(b, []byte("missing_standard_manifest")) || e.Data.Inspection != nil {
+		t.Fatalf("ancestor search: %s", b)
+	}
+	for _, args := range [][]string{
+		{"init", filepath.Join(parent, "ambiguous"), "--template", "skill"},
+		{"init", "UPPER", "--template", "skill"},
+		{"init", "demo", "--name=", "--template", "skill"},
+		{"init", "demo", "--template", "hybrid", "--mcp", "mcp-remote"},
+	} {
+		_, c, b := publicRun(t, a, append(args, "--format=json"), false)
+		if c != 2 {
+			t.Fatalf("unsafe implicit input: %s", b)
+		}
+	}
+	_, _, b = publicRun(t, a, []string{"init", "UPPER", "--template", "skill", "--format=json"}, false)
+	if !bytes.Contains(b, []byte("Suggested identity: upper")) {
+		t.Fatalf("safe suggestion missing: %s", b)
+	}
+}
+
+func TestPublicFailureBoundariesAndCredentialProjection(t *testing.T) {
+	a := publicApp(t)
+	for _, tc := range []struct {
+		name, plugin, mcp string
+		legacy            bool
+		code              int
+	}{
+		{"missing", "", "", false, 1},
+		{"legacy-only", "", "", true, 1},
+		{"both", `{"$schema":"https://agent-plugins.org/schemas/1.0.0/plugin.schema.json","name":"demo"}`, "", true, 1},
+		{"malformed", `{"SECRET-PARSER-VALUE":`, "", false, 1},
+		{"unknown-schema", `{"$schema":"https://secret.invalid/SECRET-SCHEMA","name":"demo"}`, "", false, 1},
+		{"bad-core", `{"$schema":"https://agent-plugins.org/schemas/1.0.0/plugin.schema.json","name":123}`, "", false, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			if tc.plugin != "" {
+				write(t, root, "plugin.json", tc.plugin)
+			}
+			if tc.legacy {
+				write(t, root, "plugin/plugin.yaml", "SECRET-LEGACY-BYTES")
+			}
+			var first []byte
+			for _, mount := range []bool{false, true} {
+				e, c, b := publicRun(t, a, []string{"validate", root, "--release-policy", "--format=json"}, mount)
+				if c != tc.code || bytes.Contains(b, []byte("SECRET")) {
+					t.Fatalf("failure projection: %s", b)
+				}
+				if tc.name == "missing" || tc.name == "legacy-only" {
+					if !bytes.Contains(b, []byte("missing_standard_manifest")) || bytes.Contains(b, []byte("plugin_manifest_missing")) {
+						t.Fatalf("missing projection: %s", b)
+					}
+				}
+				if tc.legacy && (!bytes.Contains(b, []byte("1.2.4")) || !bytes.Contains(b, []byte("migration is unavailable")) || bytes.Contains(b, []byte("migrate project"))) {
+					t.Fatalf("legacy guidance: %s", b)
+				}
+				if tc.name == "both" && (e.Data.Conformance.Status != report.Pass || e.Data.Release.Status != report.Fail) {
+					t.Fatalf("policy conflation: %s", b)
+				}
+				if first != nil && !bytes.Equal(first, b) {
+					t.Fatal("failure parity")
+				}
+				first = b
+			}
+		})
+	}
+	// Independently vary identity fields and private payload fields. Ordinary
+	// display names remain useful; credential-like identities are withheld whole.
+	for _, field := range []string{"ordinary", "name", "version", "server", "headers", "env", "args", "extension", "malformed-mcp"} {
+		t.Run(field, func(t *testing.T) {
+			root := t.TempDir()
+			secret := "test-token"
+			manifest := map[string]any{"$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json", "name": "public-demo", "version": "preview-1", "extensions": map[string]any{"com.example.docs": map[string]any{"private": secret}}}
+			serverName := "docs-server"
+			server := map[string]any{"type": "stdio", "command": "node", "args": []string{"server.mjs"}}
+			switch field {
+			case "name":
+				manifest["name"] = secret
+			case "version":
+				manifest["version"] = secret
+			case "server":
+				serverName = secret
+			case "headers":
+				server = map[string]any{"type": "streamable-http", "url": "https://docs.example.com/mcp", "headers": map[string]any{"Authorization": secret}}
+			case "env":
+				server["env"] = map[string]any{"PASSWORD": secret}
+			case "args":
+				server["args"] = []string{secret}
+			case "extension":
+				manifest["extensions"] = map[string]any{secret: map[string]any{"value": secret}}
+			}
+			mb, _ := json.Marshal(manifest)
+			write(t, root, "plugin.json", string(mb))
+			mc, _ := json.Marshal(map[string]any{"$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json", "mcpServers": map[string]any{serverName: server}})
+			if field == "malformed-mcp" {
+				mc = []byte(`{"` + secret + `":`)
+			}
+			write(t, root, "mcp.json", string(mc))
+			for _, mount := range []bool{false, true} {
+				e, _, b := publicRun(t, a, []string{"inspect", root, "--format=json"}, mount)
+				if bytes.Contains(b, []byte(secret)) || bytes.Contains(b, []byte(root)) {
+					t.Fatalf("credential/path echo: %s", b)
+				}
+				if field == "ordinary" && (e.Data.Inspection == nil || e.Data.Inspection.Name != "public-demo" || e.Data.Inspection.Version != "preview-1" || !bytes.Contains(b, []byte(`"namespace":"com.example.docs"`)) || !bytes.Contains(b, []byte(`"executable":"node"`))) {
+					t.Fatalf("unusable inspection: %s", b)
+				}
+				human := executeRaw(a, []string{"inspect", root}, mount)
+				if bytes.Contains(human.out, []byte(secret)) || bytes.Contains(human.out, []byte(root)) {
+					t.Fatal("human inspection disclosed private data")
+				}
+			}
+		})
+	}
+}
+
+func TestPublicFreshInventoryCancellationAndOutput(t *testing.T) {
+	a := publicApp(t)
+	expected := []string{"author.capabilities", "author.compat", "author.doctor", "author.init", "author.inspect", "author.skills.init", "author.skills.validate", "author.test", "author.validate"}
+	for _, mount := range []bool{false, true} {
+		e, c, b := publicRun(t, a, []string{"capabilities", "--format=json"}, mount)
+		if c != 0 || !reflect.DeepEqual(e.Data.Capabilities.Commands, expected) || !reflect.DeepEqual(e.Data.Surface, expected) {
+			t.Fatalf("actual leaves: %s", b)
+		}
+		for _, name := range []string{"migrate", "bootstrap", "version", "install", "__docs"} {
+			if bytes.Contains(b, []byte("author."+name)) {
+				t.Fatalf("deferred name: %s", b)
+			}
+		}
+	}
+	// Remove a real factory leaf in the composition; no separate capability table
+	// may keep advertising it. Add a real leaf with flag arity before error routing.
+	builder := func(fs ...authoringcli.Factory) (*cobra.Command, error) {
+		r, err := authoringcli.NewPluginKitRoot(fs...)
+		if err != nil {
+			return nil, err
+		}
+		for _, c := range r.Commands() {
+			if c.Name() == "doctor" {
+				r.RemoveCommand(c)
+			}
+		}
+		r.PersistentFlags().StringP("fixture-option", "q", "", "test-only string arity")
+		return r, nil
+	}
+	var out bytes.Buffer
+	err := a.Execute(context.Background(), []string{"-qinit", "capabilities", "--format=json"}, authoringcli.Streams{Out: &out, Err: io.Discard}, builder)
+	e, _ := publicDecode(t, rawExecution{out: out.Bytes(), err: err})
+	if e.Command != "author.capabilities" || len(e.Data.Capabilities.Commands) != 8 {
+		t.Fatalf("factory inventory/arity: %s", out.Bytes())
+	}
+	for _, args := range [][]string{{"--scope=user", "author", "init", "--help"}, {"--accept-security-risk=false", "author", "inspect", "--help"}, {"author", "skills", "--security-details=false", "--help"}} {
+		out.Reset()
+		err = a.Execute(context.Background(), append(args, "--format=json"), authoringcli.Streams{Out: &out, Err: io.Discard}, mounted)
+		e, c := publicDecode(t, rawExecution{out: out.Bytes(), err: err})
+		if c != 2 {
+			t.Fatalf("installer flag accepted: %s", out.Bytes())
+		}
+		noPolicy(t, e)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	out.Reset()
+	err = a.Execute(ctx, []string{"inspect", "--format=json"}, authoringcli.Streams{Out: &out, Err: io.Discard}, authoringcli.NewPluginKitRoot)
+	e, c := publicDecode(t, rawExecution{out: out.Bytes(), err: err})
+	if c != 1 || e.Data.Error.Code != "canceled" {
+		t.Fatalf("cancel: %s", out.Bytes())
+	}
+	noPolicy(t, e)
+	ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+	checks := 0
+	duringDecode := faultContext{Context: ctx, check: func() {
+		checks++
+		if checks == 3 {
+			cancel()
+		}
+	}}
+	out.Reset()
+	err = a.Execute(duringDecode, []string{"skills", "init", "demo", "--description=Example", "--format=json"}, authoringcli.Streams{Out: &out, Err: io.Discard}, authoringcli.NewPluginKitRoot)
+	e, c = publicDecode(t, rawExecution{out: out.Bytes(), err: err})
+	if c != 1 || e.Data.Error.Code != "canceled" {
+		t.Fatal("decode cancellation became syntax failure")
+	}
+	noPolicy(t, e)
+	w := &publicBrokenWriter{}
+	err = a.Execute(context.Background(), []string{"init", "--format=json"}, authoringcli.Streams{Out: w, Err: io.Discard}, authoringcli.NewPluginKitRoot)
+	if exitx.Code(err) != 1 || w.calls != 1 {
+		t.Fatalf("output precedence: %v calls %d", err, w.calls)
+	}
+	var wg sync.WaitGroup
+	results := make(chan rawExecution, 8)
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) { defer wg.Done(); results <- executeRaw(a, []string{"skills", "--format=json"}, i%2 == 0) }(i)
+	}
+	wg.Wait()
+	close(results)
+	var first []byte
+	for raw := range results {
+		publicDecode(t, raw)
+		if first != nil && !bytes.Equal(first, raw.out) {
+			t.Fatal("concurrent factory drift")
+		}
+		first = raw.out
+	}
+}
+
+type publicBrokenWriter struct{ calls int }
+
+func (w *publicBrokenWriter) Write([]byte) (int, error) {
+	w.calls++
+	return 0, errors.New("SECRET-output-error")
+}
+
+func TestPublicHelpUsesActualFlagsWithoutValues(t *testing.T) {
+	a := publicApp(t)
+	for _, mount := range []bool{false, true} {
+		e, c, b := publicRun(t, a, []string{"init", "--description", "test-token", "--help", "--format=json"}, mount)
+		if c != 0 || e.Data.Help == nil || !strings.Contains(strings.Join(e.Data.Help.Flags, ","), "--mcp-template <value>") || bytes.Contains(b, []byte("test-token")) || !strings.Contains(e.Data.Help.Guidance, "--scope") {
+			t.Fatalf("help contract: %s", b)
+		}
+	}
+}
+
+func TestPublicAnnotatedErrorAndRealCleanup(t *testing.T) {
+	a := publicApp(t)
+	var out bytes.Buffer
+	err := a.Execute(context.Background(), []string{"inspect", "--format=json"}, authoringcli.Streams{Out: &out, Err: io.Discard}, func(fs ...authoringcli.Factory) (*cobra.Command, error) {
+		r, err := authoringcli.NewPluginKitRoot(fs...)
+		r.PersistentPreRunE = func(*cobra.Command, []string) error { return exitx.Wrap(errors.New("test-token"), 1) }
+		return r, err
+	})
+	e, code := publicDecode(t, rawExecution{out: out.Bytes(), err: err})
+	if code != 1 || bytes.Contains(out.Bytes(), []byte("test-token")) {
+		t.Fatal("annotated error lost or disclosed")
+	}
+	noPolicy(t, e)
+	for _, canceled := range []bool{false, true} {
+		for _, mount := range []bool{false, true} {
+			parent := t.TempDir()
+			ctx, cancel := context.WithCancel(context.Background())
+			stage := ""
+			fault := faultContext{Context: ctx, check: func() {
+				if stage != "" {
+					return
+				}
+				entries, err := os.ReadDir(parent)
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, entry := range entries {
+					if strings.HasPrefix(entry.Name(), ".authoring-") {
+						stage = filepath.Join(parent, entry.Name())
+						write(t, stage, "preserve", "retained fixture")
+						if canceled {
+							cancel()
+						}
+						return
+					}
+				}
+			}}
+			out.Reset()
+			args := []string{"init", filepath.Join(parent, "demo"), "--name=demo", "--template=skill", "--format=json"}
+			builder := authoringcli.NewPluginKitRoot
+			if mount {
+				args = append([]string{"author"}, args...)
+				builder = mounted
+			}
+			err := a.Execute(fault, args, authoringcli.Streams{Out: &out, Err: io.Discard}, builder)
+			cancel()
+			e, code := publicDecode(t, rawExecution{out: out.Bytes(), err: err})
+			if stage == "" || code != 1 || e.Data.Error == nil || e.Data.Error.Code != "private_cleanup_failed" || e.Data.Committed == canceled || !e.Data.Effects.Attempted || (len(e.Data.Paths) == 0) != canceled {
+				t.Fatalf("real cleanup precedence: %s", out.Bytes())
+			}
+			if body, err := os.ReadFile(filepath.Join(stage, "preserve")); err != nil || string(body) != "retained fixture" {
+				t.Fatal("unowned entry removed")
+			}
+			if bytes.Contains(out.Bytes(), []byte(parent)) || bytes.Contains(out.Bytes(), []byte(a.Projects.Scratch)) {
+				t.Fatal("cleanup path disclosed")
+			}
+		}
+	}
+}

--- a/cli/plugin-kit-ai/internal/authoring/commands/skills.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/skills.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/report"
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/scaffold"
 	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/skills"
 	"github.com/777genius/plugin-kit-ai/cli/internal/authoringcli"
 	"github.com/spf13/cobra"
@@ -47,6 +48,14 @@ func (a App) skillsCommand(capture func(report.Report)) (*cobra.Command, error) 
 				root := ""
 				if len(args) > 0 {
 					root = args[0]
+				}
+				if a.PublicContract && verb == "init" {
+					if _, err := scaffold.BuildSkillPlan(c.Context(), req.Name, req.Description); err != nil {
+						if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+							return req, err
+						}
+						return req, &inputError{"skill_options_invalid", "Supply an exact portable Skill name and --description (1–1024 characters); names are never normalized."}
+					}
 				}
 				var err error
 				// Accept the documented ./package spelling on Windows too. Only

--- a/cli/plugin-kit-ai/internal/authoring/report/public.go
+++ b/cli/plugin-kit-ai/internal/authoring/report/public.go
@@ -1,0 +1,238 @@
+package report
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/project"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+const AuthoringSchemaVersion = 1
+
+// Public embeds the existing policy report, with independently versioned command
+// semantics. Inspection contains display values, never retained parser objects.
+type CommandHelp struct {
+	Use      string   `json:"use"`
+	Flags    []string `json:"flags"`
+	Guidance string   `json:"guidance"`
+}
+
+type Public struct {
+	Help *CommandHelp `json:"help,omitempty"`
+	Report
+	AuthoringSchemaVersion int         `json:"authoring_schema_version"`
+	EngineVersion          string      `json:"engine_version"`
+	Requested              Requested   `json:"requested"`
+	Effects                Effects     `json:"effects"`
+	NextActions            []Action    `json:"next_actions"`
+	Inspection             *Inspection `json:"inspection,omitempty"`
+	Surface                []string    `json:"commands,omitempty"`
+	WithheldPathIDs        []string    `json:"withheld_path_ids,omitempty"`
+}
+type Requested struct {
+	Operation string `json:"operation"`
+	Mode      string `json:"mode"`
+}
+type Effects struct {
+	// Attempted means the selected service was entered, not that a write occurred.
+	Attempted bool `json:"attempted"`
+	Committed bool `json:"committed"`
+}
+type Action struct {
+	Code      string `json:"code"`
+	Operation string `json:"operation,omitempty"`
+	Message   string `json:"message"`
+}
+type Inspection struct {
+	Name       string             `json:"name,omitempty"`
+	Version    string             `json:"version,omitempty"`
+	Schema     string             `json:"schema"`
+	Components []DisplayComponent `json:"components"`
+	Truncated  bool               `json:"truncated,omitempty"`
+}
+type DisplayComponent struct {
+	ID             string `json:"id"`
+	Type           string `json:"type"`
+	Name           string `json:"name,omitempty"`
+	Namespace      string `json:"namespace,omitempty"`
+	Executable     string `json:"executable,omitempty"`
+	ExecutableKind string `json:"executable_kind,omitempty"`
+}
+
+// DisplayIdentity is a conservative display policy, never a conformance rule.
+// It withholds whole values rather than leaking prefixes of unsafe input. Short
+// ordinary names and non-SemVer versions remain useful; paths, controls, URL and
+// credential-like tokens do not become public identity or suggestion text.
+func DisplayIdentity(s string) string {
+	if len(s) == 0 || len(s) > 64 {
+		return ""
+	}
+	lower := strings.ToLower(s)
+	for _, token := range []string{"secret", "token", "password", "passwd", "credential", "authorization", "bearer", "ghp_", "gho_", "github_pat", "sk-", "akia"} {
+		if strings.Contains(lower, token) {
+			return ""
+		}
+	}
+	run := 0
+	for _, c := range s {
+		if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' {
+			run++
+			if run > 24 {
+				return ""
+			}
+			continue
+		}
+		if !strings.ContainsRune("._-+", c) {
+			return ""
+		}
+		run = 0
+	}
+	if s == "." || s == ".." || strings.Contains(s, "..") {
+		return ""
+	}
+	return s
+}
+
+func inspection(p project.Result) *Inspection {
+	pkg := p.Facts.Package
+	if pkg == nil {
+		return nil
+	}
+	d := &Inspection{Name: DisplayIdentity(pkg.Manifest.Name), Version: DisplayIdentity(pkg.Manifest.Version), Schema: pkg.SchemaURI, Components: []DisplayComponent{}}
+	// Iterate sorted identities, so the bounded display is deterministic even for
+	// a package larger than the display budget. The policy report retains coverage.
+	items := map[string]DisplayComponent{}
+	add := func(kind, name, typ string) DisplayComponent {
+		return DisplayComponent{ID: opaque(kind + ":" + name), Type: typ, Name: DisplayIdentity(name)}
+	}
+	for name, s := range pkg.MCP.Servers {
+		c := add("mcp", name, "mcp_"+s.Type)
+		if req := s.StdioRequirement; req != nil {
+			c.ExecutableKind = string(req.Kind)
+			// Bare executable names are requirements, not argv. Bundled paths remain
+			// opaque; no source/scratch path or arbitrary launcher argument is exposed.
+			if req.Kind == domain.ExecutableBare {
+				c.Executable = DisplayIdentity(req.Command)
+			}
+		}
+		items[c.ID] = c
+	}
+	for name := range pkg.MCP.InvalidServer {
+		c := add("mcp", name, "mcp_server")
+		items[c.ID] = c
+	}
+	for name := range pkg.Skills {
+		c := add("skill", name, "skill")
+		items[c.ID] = c
+	}
+	for _, name := range pkg.Inventory.InvalidSkills {
+		c := add("skill", name, "skill")
+		items[c.ID] = c
+	}
+	for name := range pkg.Manifest.Extensions {
+		c := add("extension", name, "opaque_extension")
+		c.Namespace = c.Name
+		c.Name = ""
+		items[c.ID] = c
+	}
+	ids := make([]string, 0, len(items))
+	for id := range items {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for i, id := range ids {
+		if i == 128 {
+			d.Truncated = true
+			break
+		}
+		d.Components = append(d.Components, items[id])
+	}
+	return d
+}
+
+// AddOperationError does not evaluate package policies. Syntax, help and
+// cancellation before decoding supply no facts about package validity or safety.
+func (r *Report) AddOperationError(code, action string) {
+	r.Error = &Error{Code: code, Action: action}
+	r.add(Finding{Code: code, Layer: "operation", Rule: "authoring/command", Severity: "error"})
+	r.finish()
+}
+
+// PublicResult is a value projection: it does not rewrite installer facts or the
+// private vertical-slice report, including its diagnostic IDs and policy states.
+func (r Report) PublicResult(operation, mode string, attempted bool, surface []string) Public {
+	r.Command, r.Mode = operation, mode
+	r.Findings = append([]Finding{}, r.Findings...)
+	replacements := map[string]string{}
+	for i, f := range r.Findings {
+		if f.Code != "plugin_manifest_missing" {
+			continue
+		}
+		old := f.ID
+		f.Code = "missing_standard_manifest"
+		f.ID = ""
+		// Use the same stable finding constructor, then remap every reference.
+		tmp := New("", "")
+		f.ID = tmp.add(f)
+		r.Findings[i] = f
+		replacements[old] = f.ID
+	}
+	remap := func(a Assessment) Assessment {
+		a.FindingIDs = append([]string{}, a.FindingIDs...)
+		for i, id := range a.FindingIDs {
+			if replacement, ok := replacements[id]; ok {
+				a.FindingIDs[i] = replacement
+			}
+		}
+		return a
+	}
+	r.Loadability = remap(r.Loadability)
+	r.Conformance = remap(r.Conformance)
+	r.HostSafety = remap(r.HostSafety)
+	r.Readiness = remap(r.Readiness)
+	r.Release = remap(r.Release)
+	r.Runtime = remap(r.Runtime)
+	r.Compatibility = remap(r.Compatibility)
+	r.Toolchain = remap(r.Toolchain)
+	r.Checks = append([]Check{}, r.Checks...)
+	for i := range r.Checks {
+		r.Checks[i].Assessment = remap(r.Checks[i].Assessment)
+	}
+	r.finish()
+	p := Public{Report: r, AuthoringSchemaVersion: AuthoringSchemaVersion, EngineVersion: r.Engine,
+		Requested: Requested{operation, mode}, Effects: Effects{attempted, r.Committed}, NextActions: []Action{}, Inspection: r.Display, Surface: surface}
+	p.Paths = []string{}
+	for _, path := range r.Paths {
+		safe := true
+		for _, part := range strings.Split(path, "/") {
+			if DisplayIdentity(part) == "" {
+				safe = false
+			}
+		}
+		if safe {
+			p.Paths = append(p.Paths, path)
+		} else {
+			p.WithheldPathIDs = append(p.WithheldPathIDs, opaque(path))
+		}
+	}
+	if r.Error != nil {
+		p.NextActions = append(p.NextActions, Action{Code: r.Error.Code, Message: r.Error.Action})
+	}
+	if len(replacements) > 0 {
+		p.NextActions = append(p.NextActions, Action{Code: "missing_standard_manifest", Message: "Select the exact package root containing plugin.json; no ancestor search or format fallback is performed."})
+	}
+	if r.Error == nil && len(replacements) == 0 && r.Readiness.Status == Fail {
+		p.NextActions = append(p.NextActions, Action{"review_findings", "author.validate", "Review the typed findings by policy layer, correct the selected package, then validate it again."})
+	}
+	if r.Legacy != "" && r.Legacy != "absent" {
+		p.NextActions = append(p.NextActions, Action{Code: "legacy_workflow_unavailable", Message: "This v1 workflow is unavailable in v2. Use plugin-kit-ai 1.2.4 for the legacy workflow. Project migration is unavailable in v2."})
+	}
+	if r.Error == nil && r.Readiness.Status == Pass {
+		if operation == "author.init" || operation == "author.skills.init" {
+			p.NextActions = append(p.NextActions, Action{"inspect_package", "author.inspect", "Inspect the created package using its explicit package path."})
+		}
+		p.NextActions = append(p.NextActions, Action{"static_test", "author.test", "Run the offline static test with the package path; runtime behavior remains unevaluated."})
+	}
+	return p
+}

--- a/cli/plugin-kit-ai/internal/authoring/report/public.go
+++ b/cli/plugin-kit-ai/internal/authoring/report/public.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"regexp"
 	"sort"
 	"strings"
 
@@ -60,12 +61,20 @@ type DisplayComponent struct {
 	ExecutableKind string `json:"executable_kind,omitempty"`
 }
 
+// Recognize bounded GitLab PAT and Slack token families, including shapes
+// embedded in a larger identity. Short ordinary names sharing a prefix remain
+// useful. This supplements, rather than replaces, the existing display rules.
+var publicCredentialFamily = regexp.MustCompile(`(?i)(glpat-[a-z0-9_-]{20}|xox[baprs]-[0-9]{10,13}-[0-9]{10,13}-[a-z0-9]{24})`)
+
 // DisplayIdentity is a conservative display policy, never a conformance rule.
 // It withholds whole values rather than leaking prefixes of unsafe input. Short
 // ordinary names and non-SemVer versions remain useful; paths, controls, URL and
 // credential-like tokens do not become public identity or suggestion text.
 func DisplayIdentity(s string) string {
 	if len(s) == 0 || len(s) > 64 {
+		return ""
+	}
+	if publicCredentialFamily.MatchString(s) {
 		return ""
 	}
 	lower := strings.ToLower(s)

--- a/cli/plugin-kit-ai/internal/authoring/report/public_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/report/public_test.go
@@ -101,6 +101,33 @@ func TestPublicAffectedPathsWithholdCredentialNames(t *testing.T) {
 	}
 }
 
+func TestPublicCredentialFamilies(t *testing.T) {
+	gitlab := "glpat-" + strings.Repeat("b", 20)
+	slack := "xoxb-" + strings.Repeat("1", 12) + "-" + strings.Repeat("2", 12) + "-" + strings.Repeat("a", 24)
+	for i, value := range []string{gitlab, slack, strings.ToUpper(gitlab), strings.ToUpper(slack), "docs." + gitlab, slack + ".v1", "glpat-" + strings.Repeat("a_", 10)} {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			if got := DisplayIdentity(value); got != "" {
+				t.Fatalf("disclosed=true output_sha256=%x", sha256.Sum256([]byte(got)))
+			}
+			r := New("skills init", "revision")
+			r.Committed = true
+			r.Paths = []string{"skills/" + value + "/SKILL.md", "plugin.json"}
+			p := r.PublicResult("author.skills.init", "local_mutation", true, nil)
+			if !p.Committed || !p.Effects.Attempted || !reflect.DeepEqual(p.Paths, []string{"plugin.json"}) || !reflect.DeepEqual(p.WithheldPathIDs, []string{opaque(r.Paths[0])}) {
+				t.Fatal("withholding lost path identity or committed effects")
+			}
+			if r.Paths[0] != "skills/"+value+"/SKILL.md" {
+				t.Fatal("display policy rewrote private path")
+			}
+		})
+	}
+	for _, value := range []string{"glpat-helper", "xoxb-helper", "xoxb-docs-preview-build", "com.example.docs", "preview-1", "2026.09+build", "UPPER"} {
+		if DisplayIdentity(value) != value {
+			t.Errorf("ordinary identity withheld: %s", value)
+		}
+	}
+}
+
 // Freeze complete payload bytes in addition to the independently asserted
 // semantics above. Full documents are logged for review in immutable test logs.
 func TestPublicGoldenResults(t *testing.T) {

--- a/cli/plugin-kit-ai/internal/authoring/report/public_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/report/public_test.go
@@ -1,0 +1,151 @@
+package report
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/project"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/conformance"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+func TestPublicProjectionReferencesAndCleanup(t *testing.T) {
+	r := New("validate", "revision")
+	id := r.add(Finding{Code: "plugin_manifest_missing", Layer: "normative", Rule: "core", Location: "plugin.json", Severity: "error"})
+	r.Conformance = Assessment{Fail, []string{id}}
+	r.Loadability = r.Conformance
+	r.Readiness = r.Conformance
+	r.Release = r.Conformance
+	r.Checks = []Check{{"portable_configuration", r.Conformance}}
+	before, _ := json.Marshal(r)
+	p := r.PublicResult("author.validate", "read", true, nil)
+	if len(p.Findings) != 1 || p.Findings[0].Code != "missing_standard_manifest" || p.Findings[0].ID == id {
+		t.Fatalf("projection: %+v", p)
+	}
+	for _, a := range []Assessment{p.Conformance, p.Loadability, p.Readiness, p.Release, p.Checks[0].Assessment} {
+		if !reflect.DeepEqual(a.FindingIDs, []string{p.Findings[0].ID}) || a.Status != Fail {
+			t.Fatalf("reference or policy: %+v", a)
+		}
+	}
+	after, _ := json.Marshal(r)
+	if string(before) != string(after) {
+		t.Fatal("public projection mutated private report")
+	}
+	r = New("init", "revision")
+	r.Committed = true
+	r.Paths = []string{"plugin.json", "skills/demo/SKILL.md"}
+	r.AddError("private_cleanup_failed", "Inspect the committed package and owned staging before retrying.")
+	p = r.PublicResult("author.init", "local_mutation", true, nil)
+	if !p.Committed || !p.Effects.Committed || !p.Effects.Attempted || !reflect.DeepEqual(p.Paths, r.Paths) || p.Error.Code != "private_cleanup_failed" || p.Conformance.Status != NotEvaluated {
+		t.Fatalf("postcommit evidence lost: %+v", p)
+	}
+}
+
+func TestPublicDisplayBoundsAndWithholding(t *testing.T) {
+	for _, s := range []string{"demo", "docs-helper", "com.example.docs", "preview-1", "1.2+build", "node", "UPPER"} {
+		if DisplayIdentity(s) != s {
+			t.Errorf("ordinary identity withheld: %s", s)
+		}
+	}
+	for _, s := range []string{"ghp_aabbcc", "github_pat_aabbcc", "sk-private", "my-secret", "AKIA123456789", "Bearer-abcd", "hello\nworld", "../private", "/tmp/private", "C:\\private", "https://private.example", strings.Repeat("x", 65), strings.Repeat("z", 25)} {
+		if DisplayIdentity(s) != "" {
+			t.Errorf("unsafe display: %q", s)
+		}
+	}
+	pkg := &domain.PackageEnvelope{SchemaURI: domain.PluginSchemaV1, Manifest: domain.PluginManifest{Name: "demo", Version: "preview-1"}}
+	pkg.MCP.Servers = map[string]domain.MCPServer{
+		"local":   {Type: "stdio", StdioRequirement: &domain.StdioRequirement{Command: "node", Kind: domain.ExecutableBare}, Decoded: map[string]any{"args": []string{"SECRET"}, "env": map[string]any{"PASSWORD": "SECRET"}}},
+		"bundled": {Type: "stdio", StdioRequirement: &domain.StdioRequirement{Command: "/SECRET/private", Kind: domain.ExecutableBundled, BundledRelativePath: "SECRET/private"}},
+	}
+	pkg.Manifest.Extensions = map[string]json.RawMessage{"com.example.docs": json.RawMessage(`{"SECRET":"SECRET"}`)}
+	p := project.Result{Facts: conformance.Facts{Package: pkg}}
+	d := inspection(p)
+	body, _ := json.Marshal(d)
+	if strings.Contains(string(body), "SECRET") || !strings.Contains(string(body), `"executable":"node"`) || !strings.Contains(string(body), `"namespace":"com.example.docs"`) {
+		t.Fatalf("display: %s", body)
+	}
+	pkg.Inventory.InvalidSkills = make([]string, 200)
+	for i := range pkg.Inventory.InvalidSkills {
+		pkg.Inventory.InvalidSkills[i] = strings.Repeat("x", i+1)
+	}
+	first := inspection(p)
+	second := inspection(p)
+	if !first.Truncated || len(first.Components) != 128 || !reflect.DeepEqual(first, second) {
+		t.Fatal("unbounded or unstable display")
+	}
+}
+
+func TestPublicOperationErrorsNeverEvaluatePolicies(t *testing.T) {
+	for _, code := range []string{"arguments_invalid", "canceled", "plugin_identity_invalid"} {
+		r := New("init", "revision")
+		r.AddOperationError(code, "Choose explicit safe inputs.")
+		p := r.PublicResult("author.init", "local_mutation", false, nil)
+		if p.HostSafety.Status != NotEvaluated || p.Readiness.Status != NotEvaluated || p.Conformance.Status != NotEvaluated || p.Findings[0].Layer != "operation" || p.Effects.Attempted {
+			t.Fatalf("operation changed policies: %+v", p)
+		}
+	}
+}
+
+func TestPublicAffectedPathsWithholdCredentialNames(t *testing.T) {
+	r := New("skills init", "revision")
+	r.Committed = true
+	r.Paths = []string{"skills/token-private/SKILL.md", "plugin.json"}
+	p := r.PublicResult("author.skills.init", "local_mutation", true, nil)
+	b, _ := json.Marshal(p)
+	if strings.Contains(string(b), "token-private") || len(p.WithheldPathIDs) != 1 || !reflect.DeepEqual(p.Paths, []string{"plugin.json"}) || !p.Committed {
+		t.Fatalf("affected paths: %s", b)
+	}
+}
+
+// Freeze complete payload bytes in addition to the independently asserted
+// semantics above. Full documents are logged for review in immutable test logs.
+func TestPublicGoldenResults(t *testing.T) {
+	for _, tc := range []struct{ name, hash string }{
+		{"success", "402d8caeae2e5e56fc276391f635ab1c5da157a743f3ed73c5d11ce1d90ac42c"}, {"policy_failure", "6f7549eae5eab9fe44c75e95cc2b7cf284694f996a57140be13abd7d8c7032a2"}, {"syntax", "1bd9fb42dc70764d46f0f7a7181634a3bea43546d52b4ba48337d398c48e8740"}, {"missing_standard", "1c5385081a5180efc89c67c3d0cac3df44fb043dd34c9d237d22ecc81900d0b9"}, {"help", "ad5d089f528e1613cf34bc82edc0bb99fc7700bc476951087550cfc737ed91d8"}, {"postcommit_cleanup", "4d9572e97a8ef633f48c58143c9b7e6d61fb0e6e03e8bbc5524505b81ecce527"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := New("inspect", "exact-revision")
+			operation, mode, attempted := "author.inspect", "read", true
+			switch tc.name {
+			case "success":
+				r.Loadability = assessment(Pass)
+				r.Conformance = assessment(Pass)
+				r.HostSafety = assessment(Pass)
+				r.Readiness = assessment(Pass)
+			case "policy_failure":
+				id := r.add(Finding{Code: "mcp_server_invalid", Layer: "normative", Rule: "mcp/server", Severity: "error"})
+				r.Conformance = Assessment{Fail, []string{id}}
+				r.Readiness = r.Conformance
+				r.Loadability = assessment(Pass)
+			case "syntax":
+				operation, mode, attempted = "author.init", "local_mutation", false
+				r.AddOperationError("arguments_invalid", "Choose an implemented template.")
+			case "missing_standard":
+				id := r.add(Finding{Code: "plugin_manifest_missing", Layer: "normative", Rule: "core", Location: "plugin.json", Severity: "error"})
+				r.Conformance = Assessment{Fail, []string{id}}
+				r.Loadability = r.Conformance
+				r.Legacy = "present"
+			case "help":
+				operation, attempted = "author.skills", false
+			case "postcommit_cleanup":
+				operation, mode = "author.init", "local_mutation"
+				r.Committed = true
+				r.Paths = []string{"plugin.json"}
+				r.AddError("private_cleanup_failed", "Inspect owned staging before retrying.")
+			}
+			body, err := json.Marshal(r.PublicResult(operation, mode, attempted, nil))
+			if err != nil {
+				t.Fatal(err)
+			}
+			sum := fmt.Sprintf("%x", sha256.Sum256(body))
+			t.Logf("PUBLIC_GOLDEN %s %s %s", tc.name, sum, body)
+			if sum != tc.hash {
+				t.Fatalf("public schema changed: %s", sum)
+			}
+		})
+	}
+}

--- a/cli/plugin-kit-ai/internal/authoring/report/report.go
+++ b/cli/plugin-kit-ai/internal/authoring/report/report.go
@@ -78,6 +78,9 @@ type Error struct {
 	Action string `json:"action"`
 }
 type Report struct {
+	// Display is a sanitized projection retained only for explicit public rendering.
+	Display       *Inspection                   `json:"-"`
+	Legacy        string                        `json:"-"`
 	Compatibility Assessment                    `json:"compatibility"`
 	Clients       []planner.ClientCompatibility `json:"clients,omitempty"`
 	Capabilities  *readiness.Capabilities       `json:"capabilities,omitempty"`
@@ -151,6 +154,7 @@ func (r *Report) AddError(code, action string) {
 func Build(command, revision string, p project.Result, release bool) Report {
 	r := New(command, revision)
 	v, f := p.Input, p.Facts
+	r.Display, r.Legacy = inspection(p), string(v.Legacy)
 	r.Identity = Identity{ScopeAlgorithm: v.Identity.ScopeID, ScopeDigest: v.Identity.Digest, TreeAlgorithm: v.Identity.TreeAlgorithm, TreeDigest: v.Identity.TreeDigest, ReadProfile: packageview.ReadProfile, TreeExclusions: []string{"root .git", "root non-directory .plugin-kit-ai.lock"}}
 	c := f.Coverage
 	r.Coverage = Coverage{v.Coverage.ComponentsRequested, v.Coverage.SkillsEnumerated, v.Coverage.InventoryComplete, v.Coverage.TreeComplete, state(c.Plugin), state(c.MCP), state(c.Skills), state(c.Filesystem), c.Complete}

--- a/cli/plugin-kit-ai/internal/authoring/scaffold/plan.go
+++ b/cli/plugin-kit-ai/internal/authoring/scaffold/plan.go
@@ -273,3 +273,20 @@ func validateURL(raw string) error {
 	}
 	return nil
 }
+
+// DefaultDescription is neutral deterministic template text for the explicit
+// public command option. BuildPlan retains its explicit-input contract.
+func DefaultDescription(t Template) string {
+	switch t {
+	case Skill:
+		return "A Skill for documentation and task guidance."
+	case MCPRemote:
+		return "An Agent Plugins package with a remote MCP server."
+	case MCPStdio:
+		return "An Agent Plugins package with a local Node MCP server."
+	case Hybrid:
+		return "An Agent Plugins package with a Skill and an MCP server."
+	default:
+		return ""
+	}
+}

--- a/cli/plugin-kit-ai/internal/outputjson/envelope.go
+++ b/cli/plugin-kit-ai/internal/outputjson/envelope.go
@@ -1,0 +1,24 @@
+// Package outputjson writes the shared one-document CLI envelope.
+package outputjson
+
+import (
+	"encoding/json"
+	"io"
+)
+
+const SchemaVersion = 1
+const Success = "success"
+const Failure = "failure"
+
+type Envelope struct {
+	SchemaVersion int    `json:"schema_version"`
+	Command       string `json:"command"`
+	Result        string `json:"result"`
+	Data          any    `json:"data"`
+}
+
+func Write(w io.Writer, command, result string, data any) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+	return encoder.Encode(Envelope{SchemaVersion, command, result, data})
+}

--- a/cli/plugin-kit-ai/internal/outputjson/envelope_test.go
+++ b/cli/plugin-kit-ai/internal/outputjson/envelope_test.go
@@ -1,0 +1,34 @@
+package outputjson
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestEnvelopeFrozenBytes(t *testing.T) {
+	for _, result := range []string{Success, Failure} {
+		var b bytes.Buffer
+		err := Write(&b, "author.inspect", result, map[string]any{"value": "<example>&"})
+		expected := "{\"schema_version\":1,\"command\":\"author.inspect\",\"result\":\"" + result + "\",\"data\":{\"value\":\"<example>&\"}}\n"
+		if err != nil || b.String() != expected {
+			t.Fatalf("bytes %q, error %v", b.String(), err)
+		}
+	}
+}
+
+type brokenWriter struct{ calls int }
+
+var writeFailure = errors.New("output unavailable")
+
+func (w *brokenWriter) Write([]byte) (int, error) { w.calls++; return 0, writeFailure }
+func TestEnvelopeWritesOnceAndPropagatesFailure(t *testing.T) {
+	w := &brokenWriter{}
+	if err := Write(w, "author", Failure, struct{}{}); !errors.Is(err, writeFailure) || w.calls != 1 {
+		t.Fatalf("error %v calls %d", err, w.calls)
+	}
+	var b bytes.Buffer
+	if err := Write(&b, "author", Success, make(chan int)); err == nil || b.Len() != 0 {
+		t.Fatalf("encoding failure wrote %q: %v", b.String(), err)
+	}
+}

--- a/docs/AUTHORING_PUBLIC_CONTRACT.md
+++ b/docs/AUTHORING_PUBLIC_CONTRACT.md
@@ -1,0 +1,42 @@
+# Private authoring contract v1 (Phase 6 PR A)
+
+Opt in only through `commands.App{PublicContract: true}` and `App.Execute` with
+fresh `authoringcli.NewPluginKitRoot` or a fresh mounted `NewAuthorCommand` tree.
+There is no new build/environment/public flag switch. Default v1 and the private
+`vertical-slice-v1` mode keep their existing input and output contracts.
+
+The required outer document is `{schema_version:1, command, result, data}`.
+`result` is `success` or `failure`; the serializer retains literal HTML characters
+and a terminal newline. JSON selection follows the final actual `--format` value,
+consumes flag values according to the fresh tree, and stops at `--`.
+Unknown input never supplies operation text. Leaves use `author.<leaf>`;
+Skills use `author.skills.init` / `author.skills.validate`; groups use `author`
+and `author.skills`. Capabilities enumerate implemented factory leaves only.
+
+Required data includes numeric `authoring_schema_version:1`, `engine_version`
+(`standard-first-slice/1`), injected `revision`, `requested:{operation,mode}`,
+`effects:{attempted,committed}`, `next_actions`, and the existing report policies,
+coverage, identities and deduplicated finding references. Attempted means the
+service ran; it does not imply filesystem mutation. Syntax/help leave all package
+policies `not_evaluated`. Exit codes are 0 success/help, 2 syntax, 1 policy/I/O/
+cancellation/cleanup/output failure; existing exitx annotations retain precedence.
+Cleanup retains committed state and affected paths. Output failure returns 1
+without attempting another document. Human output uses the same safe projection.
+
+Optional data: `error`, `inspection`, `help`, `commands`, explicit `root`, client/
+doctor/capability details, and withheld affected-path hashes. Inspection joins
+canonical components by stable IDs, with at most 128 display entries. Names and
+versions have conservative 64-byte display limits; unsafe values are withheld
+whole. Bare executable requirements are bounded labels; bundled paths, argv,
+headers, env, manifest/MCP bodies, extensions and parser messages are never dumped.
+Only `--include-root` exposes the selected absolute root; scratch is always private.
+
+Reads default to exact CWD with no ancestor search. Minimal init derives identity
+only from a simple positional name, uses deterministic neutral descriptions and
+requires explicit remote URL, Node runtime or hybrid `--mcp-template` selection.
+Explicit name/destination/description callers and all transaction checks remain.
+Public missing-manifest findings become `missing_standard_manifest`, with remapped
+references. Legacy guidance names v1 1.2.4 and says migration is unavailable.
+Optional additions are compatible; removals or semantic changes bump the numeric
+authoring version independently of the outer envelope. Version factories, release
+roots, v1 shims, distribution and public activation belong to dependent PR B.


### PR DESCRIPTION
The private authoring slice requires extra arguments for the documented minimal init command and returns internal reports without the shared CLI envelope. This change adds an explicitly selected command contract with exact-current-directory reads, deterministic template defaults, stable operation IDs, safe inspection fields and structured next actions.

Both products reuse the same command factories and serializer. Ordinary builds retain their current routing; connecting the contract to actual release binaries is the next dependent checkpoint.

Stacked on #165. Source checkpoint: `3ede8e45cd8e7947dd06fff0963541fc36bf47c0`.

Validation: the integrated command, report, factory, JSON and installer CLI suites passed with 612 passing test events and no failures or skips. Independent review identified credential-shape disclosure and incomplete help routes. Both were corrected; the original independent fixtures now pass, including all 44 disclosure probes, and added regression matrices cover identity sinks and exact human/JSON help ancestry. The integrator reviewed the repair and tested the final integration. This does not establish native Windows/Mac acceptance or public release readiness; the known Windows concurrency issue and Mac contract decision remain open.
