### PR TITLE
docs(authoring): prepare English use and build journeys

### DIFF
--- a/docs/PHASE6_ENGLISH_JOURNEYS_PREPARATION.md
+++ b/docs/PHASE6_ENGLISH_JOURNEYS_PREPARATION.md
@@ -1,0 +1,160 @@
+# Phase 6 D1 English journeys preparation
+
+Task: uap-authoring-phase6-english-journeys-20260906.
+Status: bounded English content preparation; public activation is not accepted.
+Date: 2026-09-06 UTC.
+
+## Scope and immutable inputs
+
+Initial HEAD was exactly `ec0883bf0bfb7f4044321bba9dfd4fd8d6467721` and
+`git status --short` was empty. One exclusive Git index-lock creation was
+attempted and failed with `EROFS` on `.git/index.lock`. No lock was created,
+no existing lock was removed, and no repeat lock or commit attempt was made.
+Root reviews and commits mechanically after this terminal handoff.
+
+Future command facts were read with `git show 070663ef:<path>` in
+`/var/data/uap-authoring-test-20260906/private-npm-pair-integration`.
+The full source pin is `070663efb27f69ecae8609e6b839f86f843efbb0`.
+No private source was edited or executed. This is command-source evidence,
+not proof that a v2 package is available or a release accepted.
+
+Historical tag `v1.2.4^{}` resolves to
+`9beca10448ac50fbe526a52101d1433a12471980`. The annotated tag object is not
+substituted for that commit. Historical command context comes from that commit,
+not current main. Current installer examples come from the frozen README,
+`npm/agentplugins/README.md`, `docs/NATIVE_INSTALL.md`, and the existing
+`docs/AGENTPLUGINS_CLIENT_E2E.md` list-command evidence.
+
+Read controls: AGENTS.md, owner preservation contract, implementation-plan owner
+clarification, full intake main sections and relevant inventories/appendices,
+and `/var/data/uap-authoring-test-20260906/inputs/WORKER_SCOPE_CONTRACT.md`.
+Requested hosting policy: gpt-6-astra LOW/default, no fast. No model overrides,
+subagents, or fast-mode actions were requested by this worker; this note does
+not attest hidden runtime telemetry.
+
+## Route inventory and rationale
+
+These are source route contracts for later integration, not activated URLs.
+All 13 pages visibly identify prepared, unreleased authoring content.
+Paths below are relative to `website/source`; index routes use trailing slashes.
+VitePress frontmatter retains title, description, canonicalId, section, locale,
+generated=false, and translationRequired=true conventions.
+
+| Source | Proposed route | Lines | Purpose |
+| --- | --- | ---: | --- |
+| en/use/index.md | /en/use/ | 81 | One-screen Use/Build/legacy choice and command boundaries. |
+| en/use/install.md | /en/use/install | 106 | Existing discovery, explicit target dry run, install and activation. |
+| en/use/manage.md | /en/use/manage | 103 | Managed state, update, repair and removal. |
+| en/build/index.md | /en/build/ | 82 | Template choice and equivalent future entrypoints. |
+| en/build/skill.md | /en/build/skill | 105 | Standalone standard Skill package, useful instruction body. |
+| en/build/mcp-remote.md | /en/build/mcp-remote | 99 | Endpoint inputs and remote runtime/authentication boundary. |
+| en/build/mcp-stdio.md | /en/build/mcp-stdio | 107 | Node stdio files, prerequisites and static-only evidence. |
+| en/build/hybrid.md | /en/build/hybrid | 105 | Skill plus explicit remote or stdio MCP choice. |
+| en/build/skills.md | /en/build/skills | 95 | Extra Skill creation, exact root and committed-result recovery. |
+| en/build/layout.md | /en/build/layout | 103 | Manifest authority, component roles and optional metadata. |
+| en/build/checks.md | /en/build/checks | 118 | Conformance, readiness, compatibility and doctor interpretation. |
+| en/build/handoff.md | /en/build/handoff | 102 | Local installer validation and dry-run boundary, no install execution. |
+| en/legacy/v1/index.md | /en/legacy/v1/ | 100 | Exact 1.2.4 context and retained YAML/runtime/SDK/design pointers. |
+
+Total website content: 1,306 lines. This note's count and total added line count
+are recorded in external HANDOFF.md. The split keeps each tutorial complete
+while centralizing report semantics and avoiding copies of historical pages.
+No existing public route, page, navigation, generated registry, locale, landing,
+metadata, code, test, or workflow file is changed. There is no redirect change.
+
+## Command review evidence
+
+The exact future factories in `internal/authoring/commands/commands.go` and
+`skills.go` define supported jobs, flags, explicit roots, and Skill arguments.
+`public_contract.go` and `internal/authoringcli/{command,release}.go` distinguish
+public parsing from inherited installer flags. Scaffold `plan.go` and
+`templates.go` establish actual files, required URL/runtime inputs, Node >=22,
+Skill names, optional license inputs, and the absence of install/execution.
+`cmd/plugin-kit-ai/release_compat.go` supplies retirement and migration context.
+Paths in this paragraph are beneath `cli/plugin-kit-ai/` at the future pin.
+
+Tutorials use explicit names, descriptions, destinations and required template
+inputs. `--mcp-template` is the public hybrid flag. All authoring command families
+have equivalent `agentplugins author` and `plugin-kit-ai` guidance. Installer
+validate/doctor remain separate. Remote example URLs are visibly placeholders.
+No future npm acquisition snippet, implicit YAML fallback, deferred runnable v2
+job, bulk example migration, or claim of a maintained second engine is added.
+
+## Lightweight verification and limits
+
+Checks ran in an external disposable directory using existing Python, Bash,
+and Node only. No dependencies were installed or provisioned.
+
+- Copied existing frontmatter helper and its tests: 3 tests passed with Node.
+- Draft frontmatter: JSON-compatible scalar parsing, required keys, English
+  locale, unique canonical IDs, and preparation markers passed for 13 pages.
+- Markdown: balanced code fences, one prose H1, and trailing-whitespace checks
+  passed. Shell blocks passed `bash -n`; no command in those blocks was executed.
+- 59 internal draft/historical links resolved to current source pages.
+- 10 pinned repository blob/tree links resolved through local Git objects.
+  Review caught a nonexistent tagged authoring-doc path; it was corrected to
+  the existing tagged CLI README before final verification.
+- Static command-block checks reject deferred v2 jobs and legacy/installer flags
+  in future authoring examples. Source review, not a candidate binary run,
+  establishes the remaining argument semantics.
+- Tracked-file diff against HEAD remained empty: all task changes are additions.
+
+These are bounded source checks, not a Markdown renderer or comprehensive linter.
+External HTTP links, built routes, anchors, .html aliases, redirects, site base
+paths, locale parity and navigation were not exercised. No docs generation,
+full build, browser, candidate binary, product runtime, live service, real user
+project/profile, provider action, dependency install, push, PR or publication ran.
+Owning lanes must perform full docs/locale/landing activation checks later.
+
+## Preservation inventory
+
+| Inventory item | Disposition and unchanged location | Support interpretation |
+| --- | --- | --- |
+| Existing English guides/reference/releases/API | Preserve in website/source/en and website/generated/en. | Historical/support links are contextual; same-named v1/v2 jobs differ. |
+| YAML specification and authoring design | Preserve docs/PLUGIN_YAML_V1_SPEC.md and existing docs. | No standard-root fallback or conversion. |
+| Launcher/runtime/SDK source and docs | Preserve cli, sdk, npm and python trees. | Retention does not register deferred v2 commands. |
+| Native generation/import, bundle/publication services | Preserve implementation, dependencies and tests in place. | No removal decision or execution claim. |
+| External Skills and integration lifecycle services | Preserve existing implementation and tests. | Future authoring exposes only local Skills init/validate. |
+| Legacy examples and starters | Preserve all examples without conversion or moves. | D4 may classify descriptions; no new standard-MVP claim. |
+| Existing locales, public navigation and deployment | Preserve all existing files. | D2–D5 own integration and activation. |
+
+Deletions: zero. Moves: zero. Owner-accepted removal items: none. No unresolved
+capability is retired; retention outside the standard graph remains the rule.
+
+## Handoff dependencies and release boundary
+
+D2 consumes the route table and canonical IDs. Generate future CLI reference
+from shared factories at the accepted final SHA; do not invoke/register the v1
+export shim. Own navigation, generated groups, old-route/fragment inventory,
+static aliases and source/rendered link checks. Preserve old CLI route meaning.
+
+D3 consumes the same English routes. Update RU/ES/FR/ZH or supply explicit
+canonical-English fallback with localized context; remove stale runnable current
+journey snippets rather than relying on a banner. Verify all five locales,
+locale switching, canonical IDs and navigation together with D2.
+
+D4 owns root README, landing, shared strings/SEO and example classification.
+Connect Use and Build consistently, preserve create-plugin visibility/noindex
+constraints, and retain useful legacy text. Coordinate all five landing locales.
+Do not change runtime examples or infer Build publication from installer copy.
+
+D5 must obtain final accepted engine SHA, native/wrapper same-engine provenance,
+actual published channel/version evidence, and accepted Milestone A/platform,
+upgrade, checksum/cache and launcher evidence from their owners. Regenerate and
+recheck commands, full docs, link/alias, locale and landing behavior before
+activation. Package metadata copy remains with the package owner.
+
+**Do not merge or activate this standalone preparation branch before locale,
+navigation and release gates are satisfied.** Pages auto-deploys main/master;
+a visible draft notice is not a deployment gate. No gating framework is added.
+Root may review and mechanically commit this bounded patch to a non-deploying
+preparation branch after terminal handoff; that is not permission to merge.
+
+Release acceptance=false; platform acceptance=false; public activation=false;
+Phase 6 complete=false; global program acceptance=false. D1 content preparation
+and bounded source checks do not satisfy these later gates.
+
+External terminal artifacts:
+`/tmp/uap-authoring-phase6-english-journeys-20260906-artifacts/`
+contains HANDOFF.md, terminal.patch, SOURCE_PINS.json, CHECKS.json, line counts,
+and disposable check inputs. Git metadata was read-only, so no commit was tried.

--- a/website/source/en/build/checks.md
+++ b/website/source/en/build/checks.md
@@ -17,7 +17,9 @@ translationRequired: true
 
 Use these future commands against the same exact package root after editing.
 The example assumes `./review-helper` exists and contains root `plugin.json`.
-An explicit path keeps the check independent of your current directory.
+Run these relative-path examples from the package's parent directory.
+An explicit root avoids relying on the current-directory default; use an absolute
+path if the working directory may change.
 
 ## Run the offline authoring loop
 

--- a/website/source/en/build/checks.md
+++ b/website/source/en/build/checks.md
@@ -1,0 +1,118 @@
+---
+title: "Check a package without running it"
+description: "Interpret conformance, static readiness, compatibility, and toolchain evidence separately."
+canonicalId: "page:build:checks"
+section: "build"
+locale: "en"
+generated: false
+translationRequired: true
+---
+
+# Check a package without running it
+
+> **Prepared, unreleased authoring contract.** This page is a review draft on a
+> non-deploying preparation branch. Future authoring examples require the accepted
+> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> examples are identified separately. Public activation remains pending.
+
+Use these future commands against the same exact package root after editing.
+The example assumes `./review-helper` exists and contains root `plugin.json`.
+An explicit path keeps the check independent of your current directory.
+
+## Run the offline authoring loop
+
+```bash
+agentplugins author validate ./review-helper
+agentplugins author inspect ./review-helper
+agentplugins author test ./review-helper
+```
+
+Equivalent future authoring executable commands:
+
+```bash
+plugin-kit-ai validate ./review-helper
+plugin-kit-ai inspect ./review-helper
+plugin-kit-ai test ./review-helper
+```
+
+Choose one entrypoint. Validate evaluates exact-root standard configuration and
+authoring readiness. Inspect shows captured components and unresolved runtime
+requirements. Test checks configuration, hygiene, Skills, and MCP statically.
+It does not launch scripts, perform a handshake, or execute a tool fixture.
+
+## Read the evidence layers
+
+| Layer | What it can establish | What it cannot establish |
+| --- | --- | --- |
+| Conformance | Captured standard data satisfies the embedded schemas/profile. | A useful or working plugin in every agent. |
+| Host safety | Selected input meets bounded filesystem/host checks. | Authorization to install or execute it. |
+| Readiness | Available static package evidence is sufficiently complete for the checked policy. | Publication or platform acceptance. |
+| Compatibility | Static adapter support for selected clients and components. | Those clients are installed, activated, or signed in. |
+| Toolchain | Bounded project/native-file and executable-metadata evidence. | Successful dependency resolution or server startup. |
+| Runtime | The report identifies runtime evaluation status. | Static jobs do not supply execution evidence. |
+
+Do not collapse these into a single “works everywhere” badge. A conforming
+manifest may coexist with incomplete component or host evidence, so conformance
+alone need not mean a successful overall readiness result.
+
+## Select clients explicitly
+
+```bash
+agentplugins author compat ./review-helper --target codex,claude
+agentplugins author inspect ./review-helper --target codex,claude
+```
+
+The equivalent forms begin `plugin-kit-ai compat` and `plugin-kit-ai inspect`.
+Compat requires distinct comma-separated client IDs. Use explicit IDs rather
+than `all` or historical target names such as `codex-runtime`. These are static
+adapter checks; installed clients are not required. Inspect accepts an optional
+target selection when you want client-specific component findings.
+
+## Inspect project and engine evidence
+
+```bash
+agentplugins author doctor ./review-helper
+agentplugins author capabilities
+```
+
+```bash
+plugin-kit-ai doctor ./review-helper
+plugin-kit-ai capabilities
+```
+
+Doctor reads captured native files and executable metadata without processes or
+network. Capabilities takes no package path and reports embedded schemas,
+profiles, client metadata, and implemented commands. It describes this engine;
+it does not certify a package or prove the engine has been publicly released.
+
+## Capture a reviewable report
+
+```bash
+agentplugins author validate ./review-helper --format json
+plugin-kit-ai inspect ./review-helper --format json
+```
+
+Human output is `--format human`; `--no-color` is supported. Package commands can
+use `--include-root` to disclose the explicitly selected root in their report.
+Avoid disclosing private paths when sharing diagnostics. Capabilities has no
+root to include.
+
+Read commands validate, inspect, test, compat, and doctor accept
+`--release-policy` for bounded release hygiene. This is not publication approval.
+Skills subcommands have their own smaller flag surface; do not infer that every
+package flag also applies to `skills validate`.
+
+## Keep flags and responsibilities separate
+
+Installer `--dry-run` and security/scope policy are not authoring flags. Authoring
+init is a real local file creation job, even when another root's help lists
+installer flags. Legacy `--strict`, runtime fixture flags, and overwrite flags
+are not shortcuts to stronger v2 checks.
+
+`agentplugins validate ./review-helper` is the separate installer validation
+job. `agentplugins doctor` diagnoses managed installation state. Neither is an
+alias for the authoring commands above.
+
+If a report fails or is incomplete, fix the named input or preserve the limit in
+the handoff. Do not relabel “not evaluated” as a passing runtime test.
+Continue with the [local installer planner handoff](./handoff).

--- a/website/source/en/build/handoff.md
+++ b/website/source/en/build/handoff.md
@@ -1,0 +1,102 @@
+---
+title: "Hand a package to the installer planner"
+description: "Pass source and static evidence across an explicit installation boundary."
+canonicalId: "page:build:handoff"
+section: "build"
+locale: "en"
+generated: false
+translationRequired: true
+---
+
+# Hand a package to the installer planner
+
+> **Prepared, unreleased authoring contract.** This page is a review draft on a
+> non-deploying preparation branch. Future authoring examples require the accepted
+> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> examples are identified separately. Public activation remains pending.
+
+The author's output is a standard package directory plus evidence. The installer
+makes a separate plan for selected agents. This page deliberately ends at a dry
+run; no install invocation is part of the authoring handoff.
+
+## Prepare the package and evidence
+
+Use the same exact directory for authoring checks and installation planning.
+For example, `./review-helper` should contain root `plugin.json` and its Skills
+and/or MCP configuration, not a parent repository with an ambiguous nested root.
+
+Before handing it off, record:
+
+- The package identity, version, and exact source revision or reviewed snapshot.
+- The relative package root within that snapshot.
+- Which components are present and their purpose.
+- Static validate, inspect, and test findings from the accepted authoring engine.
+- Compatibility findings for the intended client IDs.
+- Runtime prerequisites, authentication needs, and work not evaluated.
+
+Keep package version and CLI version separate. Include the authoring engine
+revision with reports so the receiver can tell which contract produced them.
+Avoid secrets and unnecessary absolute paths in shared evidence.
+
+## Finish the authoring side
+
+Future authoring commands for the selected root:
+
+```bash
+agentplugins author validate ./review-helper
+agentplugins author inspect ./review-helper
+agentplugins author test ./review-helper
+agentplugins author compat ./review-helper --target codex
+agentplugins author doctor ./review-helper
+```
+
+The equivalent future prefix is `plugin-kit-ai`. These commands do not inspect
+or modify a real user's client profile. Runtime execution and activation remain
+separate from this static package review.
+
+## Ask the existing installer to plan
+
+The following are **existing installer commands**, not authoring aliases:
+
+```bash
+agentplugins validate ./review-helper
+agentplugins add ./review-helper --target codex --dry-run
+```
+
+Installer validation supplies its own package-reading evidence. The dry run
+selects Codex and prints the proposed installation without writing managed
+installation changes. It does not execute the package or finish client setup.
+For another agent, use a supported client ID reviewed in compatibility findings.
+
+Read the package identity, selected source, target destinations, security
+findings, and remaining activation requirements in the plan. If these differ
+from the author's intended handoff, resolve the discrepancy before applying.
+Do not treat the plan as proof that installation has already occurred.
+
+## Describe the remaining boundary
+
+| Evidence provided | Work still separate |
+| --- | --- |
+| Standard conformance | Useful behavior and runtime correctness. |
+| Static authoring readiness | Release approval, channel publication, and platform acceptance. |
+| Static client support | Actual client availability and native activation. |
+| Installer dry run | Intentional application of managed changes. |
+| MCP configuration | Connectivity, authentication, and tool execution. |
+
+The receiving user can continue through [Use plugins](/en/use/install) when they
+intend to install. Keep that decision explicit. A dry run in this documentation
+is not permission to run against a real user's profile during preparation.
+
+## Keep unavailable jobs out of the handoff
+
+Do not ask the receiver to run v2 import, migrate, export, bundle, publish,
+bootstrap, or dev commands. Do not label a YAML example as a migrated standard
+package. Historical workflows remain linked from [v1 context](/en/legacy/v1/).
+
+For remote source sharing, the existing installer requires a full 40-character
+commit SHA and an explicit package subpath when discovery is ambiguous. That is
+source selection, not a v2 publication operation. Registry submission and public
+release evidence belong to their own owners.
+
+At release time, recheck examples against the final accepted engine and published
+channels. This prepared source contract alone cannot make that acceptance true.

--- a/website/source/en/build/hybrid.md
+++ b/website/source/en/build/hybrid.md
@@ -1,0 +1,105 @@
+---
+title: "Build a hybrid package"
+description: "Combine one Skill and one MCP configuration under a single package identity."
+canonicalId: "page:build:hybrid"
+section: "build"
+locale: "en"
+generated: false
+translationRequired: true
+---
+
+# Build a hybrid package
+
+> **Prepared, unreleased authoring contract.** This page is a review draft on a
+> non-deploying preparation branch. Future authoring examples require the accepted
+> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> examples are identified separately. Public activation remains pending.
+
+A hybrid is useful when instructions explain how and when to use tools. Both
+components live under one root manifest. A client may support them differently,
+so keep per-component compatibility findings visible in the handoff.
+
+## Choose the MCP side explicitly
+
+The hybrid flag is `--mcp-template`. Choose `mcp-remote` or `mcp-stdio`, then supply
+that template's required inputs. A hybrid does not infer a transport from the
+URL, local files, or installed runtimes.
+
+Future remote hybrid example:
+
+```bash
+agentplugins author init ./research-helper \
+  --template hybrid \
+  --name research-helper \
+  --description 'Guide research using the team MCP service' \
+  --skill-name research-guide \
+  --mcp-template mcp-remote \
+  --url https://mcp.example.com/mcp
+```
+
+Equivalent future authoring executable example; choose one:
+
+```bash
+plugin-kit-ai init ./research-helper \
+  --template hybrid \
+  --name research-helper \
+  --description 'Guide research using the team MCP service' \
+  --skill-name research-guide \
+  --mcp-template mcp-remote \
+  --url https://mcp.example.com/mcp
+```
+
+The URL is an example placeholder, not a promised service. Replace it with your
+actual endpoint. Read the [remote MCP requirements](./mcp-remote).
+
+## Or choose a local process
+
+For a different, absent destination, the future stdio variant is:
+
+```bash
+agentplugins author init ./local-research \
+  --template hybrid \
+  --name local-research \
+  --description 'Guide research using local Node tools' \
+  --skill-name research-guide \
+  --mcp-template mcp-stdio \
+  --runtime node
+```
+
+The equivalent prefix is `plugin-kit-ai init`; every argument stays the same.
+Do not add `--url` to the stdio variant. Review the
+[stdio prerequisite and runtime limits](./mcp-stdio).
+
+## Connect instructions to tools
+
+A remote hybrid has this core layout:
+
+```text
+research-helper/
+  plugin.json
+  mcp.json
+  skills/
+    research-guide/
+      SKILL.md
+```
+
+README and `.gitignore` are also created. A stdio hybrid adds the Node source and
+package files described in the stdio journey. Review `SKILL.md` so that it names
+when to use the tools, what input is needed, and how to report missing access.
+Do not tell the agent to treat Skill text as an authorization grant.
+
+## Check both components
+
+```bash
+agentplugins author skills validate ./research-helper
+agentplugins author validate ./research-helper
+agentplugins author inspect ./research-helper --target codex,claude
+agentplugins author test ./research-helper
+agentplugins author compat ./research-helper --target codex,claude
+```
+
+For the local variant, select `./local-research` instead. Preserve component-level
+findings: a client supporting the Skill does not automatically support the MCP
+transport or activate the service. A combined package does not erase that limit.
+
+Continue with [extra Skills](./skills) or [handoff](./handoff).

--- a/website/source/en/build/index.md
+++ b/website/source/en/build/index.md
@@ -1,0 +1,82 @@
+---
+title: "Build plugins"
+description: "Prepare a Skill, MCP package, or hybrid through the shared future authoring contract."
+canonicalId: "page:build:index"
+section: "build"
+locale: "en"
+generated: false
+translationRequired: true
+---
+
+# Build plugins
+
+> **Prepared, unreleased authoring contract.** This page is a review draft on a
+> non-deploying preparation branch. Future authoring examples require the accepted
+> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> examples are identified separately. Public activation remains pending.
+
+| Your job | Journey | Result |
+| --- | --- | --- |
+| Install someone else's package | [Use plugins](/en/use/) | Managed client installation and activation instructions. |
+| Write a new portable package | Continue below | Root `plugin.json`, Skills and/or MCP configuration. |
+| Keep an existing YAML/runtime project working | [Historical v1](/en/legacy/v1/) | Version-pinned 1.2.4 context; no v2 migration. |
+
+This journey describes the prepared future authoring contract at source revision
+`070663efb27f69ecae8609e6b839f86f843efbb0`. It is not installation advice for a
+published v2 package. Use the accepted release supplied by the release owner
+before running these examples; an older executable may have different semantics.
+
+## Choose the smallest useful package
+
+| Need | Template | Inputs beyond destination and identity |
+| --- | --- | --- |
+| Instructions an agent can follow | [Standalone Skill](./skill) | `--template skill`; optional explicit Skill name. |
+| Connect to an existing service | [Remote MCP](./mcp-remote) | `--template mcp-remote --url` with an explicit endpoint. |
+| Provide a local MCP process | [Stdio MCP](./mcp-stdio) | `--template mcp-stdio --runtime node`. |
+| Instructions plus tools | [Hybrid](./hybrid) | `--template hybrid --mcp-template` plus the selected MCP inputs. |
+
+A standalone Skill here means a standard package whose portable component is a
+Skill. It still has root `plugin.json`; it is not an external Skills installer.
+Add more instructions later with [extra Skills](./skills).
+
+## Two equivalent authoring entrypoints
+
+Choose one spelling and use it consistently:
+
+| Shared authoring job | Installer executable | Authoring executable |
+| --- | --- | --- |
+| Create a package | `agentplugins author init` | `plugin-kit-ai init` |
+| Validate | `agentplugins author validate` | `plugin-kit-ai validate` |
+| Inspect | `agentplugins author inspect` | `plugin-kit-ai inspect` |
+| Static test | `agentplugins author test` | `plugin-kit-ai test` |
+| Static client compatibility | `agentplugins author compat` | `plugin-kit-ai compat` |
+| Project doctor | `agentplugins author doctor` | `plugin-kit-ai doctor` |
+| Engine capabilities | `agentplugins author capabilities` | `plugin-kit-ai capabilities` |
+| Add or validate Skills | `agentplugins author skills` | `plugin-kit-ai skills` |
+
+The table names jobs, not complete invocations. The tutorials supply explicit
+paths and template inputs. Both entrypoints use the same prepared authoring
+engine; neither is a second YAML implementation.
+
+## Follow the authoring loop
+
+1. Choose a template and an absent destination under an existing parent.
+2. Review and edit the resulting [package files](./layout).
+3. Run [validate, inspect, and static test](./checks) against the exact root.
+4. Evaluate explicit target compatibility and inspect project doctor evidence.
+5. Send the package and its limits to the [installer planner](./handoff).
+
+Creating files is local mutation. Validation, inspection, static test, and
+compatibility do not install into clients or launch package code. A passing
+static report is useful evidence, but it does not establish runtime success.
+
+## What this journey does not expose
+
+Runtime execution, dev loops, dependency bootstrap, import, normalization,
+project migration, client generation, export/bundle, and publication are deferred
+from the v2 journey. Their retained v1 source and documentation remain useful;
+they are not runnable v2 features. Hooks remain client-specific extensions.
+
+Do not add legacy `--platform`, `--strict`, `--typescript`, `--output`, or
+`--force` flags to these examples. Select destinations positionally and read
+[command boundaries](./checks) before adapting automation.

--- a/website/source/en/build/layout.md
+++ b/website/source/en/build/layout.md
@@ -1,0 +1,103 @@
+---
+title: "Understand the package root"
+description: "Keep portable identity and components in an explicit standard package root."
+canonicalId: "page:build:layout"
+section: "build"
+locale: "en"
+generated: false
+translationRequired: true
+---
+
+# Understand the package root
+
+> **Prepared, unreleased authoring contract.** This page is a review draft on a
+> non-deploying preparation branch. Future authoring examples require the accepted
+> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> examples are identified separately. Public activation remains pending.
+
+The selected directory is the package root. Future authoring reads root
+`plugin.json` and its standard components. It does not search parents for a
+project, convert YAML, or fall back to a native client's hidden manifest.
+
+## Minimal and combined layouts
+
+A Skill-only package:
+
+```text
+review-helper/
+  plugin.json
+  skills/
+    review-docs/
+      SKILL.md
+```
+
+A remote hybrid package:
+
+```text
+research-helper/
+  plugin.json
+  mcp.json
+  skills/
+    research-guide/
+      SKILL.md
+```
+
+A stdio package also carries its runtime source and dependency manifests. Those
+files are needed for later execution, but their presence does not cause the
+authoring reader to execute anything.
+
+## Give each file a clear responsibility
+
+| File or directory | Responsibility |
+| --- | --- |
+| `plugin.json` | Standard package identity and metadata. |
+| `mcp.json` | MCP server configuration when the package supplies tools. |
+| `skills/<name>/SKILL.md` | One immediate Skill's identity, description, and instructions. |
+| `README.md` | Intended use, prerequisites, validation, and remaining limits. |
+| `package.json`, `package-lock.json`, `src/server.mjs` | Node stdio scaffold inputs for separate runtime work. |
+| `LICENSE` | Explicit selected license, when supplied during init. |
+
+The scaffold starts the manifest version at `0.1.0`. That is your new package's
+metadata, not the authoring executable's release version. Keep the distinction
+when reporting versions to users.
+
+## Identity and optional metadata
+
+Use explicit `--name` and `--description` in repeatable init instructions.
+The public contract can derive a name from a bare destination name and supplies
+a deterministic default description, but paths such as `./review-helper` should
+carry an explicit name. These tutorials supply both to avoid accidental identity.
+
+For templates containing a Skill, `--skill-name` defaults to the package name
+when omitted. Choose it explicitly if the Skill needs a different identity.
+Skill names are never silently normalized.
+
+Optional `--author-name` supplies an explicit author. No author is inferred from
+Git or the environment. License generation supports explicit MIT or ISC choices
+and requires both `--copyright-holder` and a four-digit `--copyright-year`.
+There is no default license selection.
+
+## Select the root consistently
+
+```bash
+agentplugins author validate ./research-helper
+agentplugins author inspect ./research-helper
+plugin-kit-ai test ./research-helper
+```
+
+All three select the same root despite the different command prefixes. Passing
+`./research-helper/skills` would select the wrong directory. The optional path
+on read commands defaults only to the current directory, not a discovered parent.
+
+Standard conformance and filesystem safety are separate concerns. A schema-valid
+identity can still be unsuitable for a host path, and a readable manifest alone
+can leave required component evidence incomplete. Use the full report.
+
+## Keep legacy material separate
+
+Existing `plugin/plugin.yaml`, launcher source, generated client files, SDK docs,
+and runtime examples remain preserved in their existing locations. They are
+[historical or supporting material](/en/legacy/v1/), not implicit inputs to this
+standard root. Do not copy them wholesale into a new package to satisfy a check.
+
+Continue with [static checks](./checks), then [handoff](./handoff).

--- a/website/source/en/build/mcp-remote.md
+++ b/website/source/en/build/mcp-remote.md
@@ -1,0 +1,99 @@
+---
+title: "Build a remote MCP package"
+description: "Describe an existing MCP endpoint without confusing configuration with connectivity."
+canonicalId: "page:build:mcp-remote"
+section: "build"
+locale: "en"
+generated: false
+translationRequired: true
+---
+
+# Build a remote MCP package
+
+> **Prepared, unreleased authoring contract.** This page is a review draft on a
+> non-deploying preparation branch. Future authoring examples require the accepted
+> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> examples are identified separately. Public activation remains pending.
+
+Choose remote MCP when the server already exists and the package should describe
+how an agent connects to it. Authoring records the URL without contacting it.
+You remain responsible for knowing the service's transport and authentication
+requirements before handing the package to users.
+
+## Supply the endpoint explicitly
+
+The examples use `https://mcp.example.com/mcp` as a documentation placeholder.
+Replace it with your service's real MCP endpoint when preparing your own package.
+The authoring command accepts the URL as configuration; it does not verify that
+the address serves MCP or that your account can use it.
+
+Future installer-hosted authoring spelling:
+
+```bash
+agentplugins author init ./docs-service \
+  --template mcp-remote \
+  --name docs-service \
+  --description 'Connect to the team documentation MCP service' \
+  --url https://mcp.example.com/mcp
+```
+
+Equivalent future authoring executable spelling; run only one:
+
+```bash
+plugin-kit-ai init ./docs-service \
+  --template mcp-remote \
+  --name docs-service \
+  --description 'Connect to the team documentation MCP service' \
+  --url https://mcp.example.com/mcp
+```
+
+Use an absent destination under an existing parent. The template requires an
+absolute HTTPS URL, or HTTP on loopback. Credentials, fragments, and unresolved
+URL tokens are not accepted template inputs. Do not put a password in the URL.
+
+## Understand the files
+
+```text
+docs-service/
+  plugin.json
+  mcp.json
+  README.md
+  .gitignore
+```
+
+The root manifest owns package identity. `mcp.json` describes the server under
+`mcpServers`; this template uses `type: streamable-http` and the supplied URL.
+It does not generate a server or add a Skill. Use [hybrid](./hybrid) if the
+package also needs instructions that explain when to call its tools.
+
+Review the README and document the endpoint's purpose, account prerequisites,
+and where users obtain authentication guidance. Keep secrets outside the package.
+A URL in a conforming file is not evidence of a live service.
+
+## Check configuration and target support
+
+```bash
+agentplugins author validate ./docs-service
+agentplugins author inspect ./docs-service --target codex,claude
+agentplugins author test ./docs-service
+agentplugins author compat ./docs-service --target codex,claude
+agentplugins author doctor ./docs-service
+```
+
+The same arguments work with the future `plugin-kit-ai` prefix. `inspect` can
+show components and unresolved requirements. `compat` evaluates the selected
+clients' static adapter support; neither command needs those clients installed.
+Doctor does not contact the endpoint.
+
+## Keep the remaining work visible
+
+The author's static evidence should identify the transport and intended clients.
+The receiving installer still needs to evaluate installation policy and show
+activation instructions. The user may need to sign in, approve access, or start
+a new client session. Runtime tool discovery and calls need separate evidence.
+
+If static checks fail, correct the captured configuration first. If the endpoint
+is unreachable later, investigate the service or client connection instead of
+interpreting another successful static test as a connectivity check.
+
+Continue with [report interpretation](./checks) and the [planner handoff](./handoff).

--- a/website/source/en/build/mcp-stdio.md
+++ b/website/source/en/build/mcp-stdio.md
@@ -1,0 +1,107 @@
+---
+title: "Build a stdio MCP package"
+description: "Prepare a local Node MCP server while keeping runtime setup and execution separate."
+canonicalId: "page:build:mcp-stdio"
+section: "build"
+locale: "en"
+generated: false
+translationRequired: true
+---
+
+# Build a stdio MCP package
+
+> **Prepared, unreleased authoring contract.** This page is a review draft on a
+> non-deploying preparation branch. Future authoring examples require the accepted
+> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> examples are identified separately. Public activation remains pending.
+
+Choose stdio MCP when the package should supply a local process that communicates
+with the agent over standard input and output. The prepared template supports
+Node.js 22 or newer. This is a package scaffold; it does not establish that the
+host can start the server or that the tools behave correctly.
+
+## Create the scaffold
+
+Use an existing disposable parent directory with no `./local-tools` child.
+The runtime is an explicit template input.
+
+Future installer-hosted authoring spelling:
+
+```bash
+agentplugins author init ./local-tools \
+  --template mcp-stdio \
+  --name local-tools \
+  --description 'Provide local tools through a Node MCP server' \
+  --runtime node
+```
+
+Equivalent future standalone authoring spelling; choose one:
+
+```bash
+plugin-kit-ai init ./local-tools \
+  --template mcp-stdio \
+  --name local-tools \
+  --description 'Provide local tools through a Node MCP server' \
+  --runtime node
+```
+
+Do not substitute a legacy Go, Python, shell, or TypeScript runtime flag. Those
+historical authoring lanes are described in [v1 context](/en/legacy/v1/), not
+implemented by this future template.
+
+## Review the runtime boundary
+
+```text
+local-tools/
+  plugin.json
+  mcp.json
+  package.json
+  package-lock.json
+  src/
+    server.mjs
+  README.md
+  .gitignore
+```
+
+`mcp.json` records a stdio server with command `node` and argument
+`${PLUGIN_ROOT}/src/server.mjs`. The package root token lets the consumer resolve
+the server file within the selected package; it is not your shell's current
+working directory.
+
+The template includes the official MCP SDK dependency and its lockfile.
+`src/server.mjs` starts from a small `hello` tool. Review and adapt that source
+for your intended behavior, keeping application logs away from protocol output.
+No dependency install occurs during init, and no server process starts.
+
+## Gather static evidence
+
+```bash
+agentplugins author validate ./local-tools
+agentplugins author inspect ./local-tools
+agentplugins author test ./local-tools
+agentplugins author compat ./local-tools --target codex,claude
+agentplugins author doctor ./local-tools
+```
+
+Use `plugin-kit-ai` in place of `agentplugins author` for the equivalent future
+entrypoint. Static test inspects configuration, hygiene, Skills, and MCP; it is
+not an MCP handshake or a test invocation of `hello`.
+
+Doctor inspects captured native files and executable metadata without processes
+or network. Its evidence is bounded. A toolchain finding cannot prove dependencies
+are installed, that imports resolve, or that the server starts successfully.
+
+## Prepare an honest README
+
+Record Node.js 22 or newer as a runtime prerequisite and explain what tools the
+server provides. Identify the pinned dependency files and describe the remaining
+runtime verification work as separate work. Do not present bootstrap, dev, or
+runtime test commands as available v2 authoring operations.
+
+A receiver needs both a conforming package and an explicit understanding of its
+execution requirements. Installation planning can evaluate target support, but
+it cannot stand in for independent runtime testing or user authorization to
+execute the server.
+
+Continue with [checks and evidence](./checks). Add instructions through
+[extra Skills](./skills), or prepare the [installer handoff](./handoff).

--- a/website/source/en/build/skill.md
+++ b/website/source/en/build/skill.md
@@ -1,0 +1,105 @@
+---
+title: "Build a standalone Skill"
+description: "Create a standard package containing one useful instruction Skill."
+canonicalId: "page:build:skill"
+section: "build"
+locale: "en"
+generated: false
+translationRequired: true
+---
+
+# Build a standalone Skill
+
+> **Prepared, unreleased authoring contract.** This page is a review draft on a
+> non-deploying preparation branch. Future authoring examples require the accepted
+> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> examples are identified separately. Public activation remains pending.
+
+Use this path when the agent needs a repeatable method, checklist, or writing
+instruction and does not need an MCP tool connection. The package contains one
+Skill and a root manifest. No server, runtime installation, or client profile is
+needed for the authoring steps.
+
+## Choose an explicit destination
+
+The examples assume your working directory is a disposable parent directory and
+`./review-helper` does not exist. Choose a lowercase portable package identity.
+The path names the destination; `--name` names the package inside its manifest.
+
+Future `agentplugins author` invocation:
+
+```bash
+agentplugins author init ./review-helper \
+  --template skill \
+  --name review-helper \
+  --description 'Review documentation changes for clarity and evidence' \
+  --skill-name review-docs
+```
+
+Equivalent future `plugin-kit-ai` invocation; choose one, not both:
+
+```bash
+plugin-kit-ai init ./review-helper \
+  --template skill \
+  --name review-helper \
+  --description 'Review documentation changes for clarity and evidence' \
+  --skill-name review-docs
+```
+
+Init requires an absent destination and does not overwrite an existing directory.
+If creation reports a committed result with a later failure, inspect the result
+before retrying. There is no overwrite flag in this workflow.
+
+## Review the created files
+
+```text
+review-helper/
+  plugin.json
+  README.md
+  .gitignore
+  skills/
+    review-docs/
+      SKILL.md
+```
+
+The generated Skill is a starting instruction. Replace its body with a concrete
+method useful to your users. Keep the Skill name and directory aligned.
+For example, the body of `skills/review-docs/SKILL.md` could be:
+
+```markdown
+# Review documentation changes
+
+Use this Skill when reviewing a documentation change before handoff.
+
+1. Identify the intended reader and the task the page helps them finish.
+2. Check that every command names its input and describes its effect.
+3. Separate verified behavior from prerequisites and untested claims.
+4. Report unclear instructions with a suggested replacement sentence.
+
+Return a short list of findings with file locations. If no issue is found,
+state which pages you reviewed and which checks remain outside the review.
+```
+
+Keep the generated frontmatter above that body. Its `name` and `description`
+identify the Skill and help the agent decide when to use it. Instructions in a
+Skill do not grant permission to run scripts or access private resources.
+
+## Check the exact package root
+
+```bash
+agentplugins author validate ./review-helper
+agentplugins author skills validate ./review-helper
+agentplugins author inspect ./review-helper
+agentplugins author test ./review-helper
+```
+
+For the other entrypoint, replace `agentplugins author` with `plugin-kit-ai` and
+keep every path and argument unchanged. These checks are static. They do not
+ask an agent to follow the instructions or score the quality of its response.
+
+Review the report's conformance and readiness separately. A well-formed Skill
+still needs human review for usefulness, accuracy, and appropriate scope.
+
+Continue with [extra Skills](./skills), [target checks](./checks), or the
+[local installer handoff](./handoff). To add tools as well as instructions,
+choose the [hybrid journey](./hybrid) for a new package.

--- a/website/source/en/build/skills.md
+++ b/website/source/en/build/skills.md
@@ -1,0 +1,95 @@
+---
+title: "Add extra Skills"
+description: "Extend an existing standard package with another immediate Skill."
+canonicalId: "page:build:skills"
+section: "build"
+locale: "en"
+generated: false
+translationRequired: true
+---
+
+# Add extra Skills
+
+> **Prepared, unreleased authoring contract.** This page is a review draft on a
+> non-deploying preparation branch. Future authoring examples require the accepted
+> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> examples are identified separately. Public activation remains pending.
+
+Use the future `skills init` job to add one Skill to an existing standard package.
+It works for Skill, MCP, or hybrid packages. Select the package root containing
+`plugin.json`, not the `skills/` directory or an individual `SKILL.md` file.
+
+## Name the new Skill and package
+
+Assume `./review-helper` is the package from the [standalone Skill journey](./skill)
+and `skills/release-notes/` does not exist.
+
+Future installer-hosted spelling:
+
+```bash
+agentplugins author skills init release-notes ./review-helper \
+  --description 'Use when drafting release notes from reviewed changes'
+```
+
+Equivalent future authoring executable spelling; choose one:
+
+```bash
+plugin-kit-ai skills init release-notes ./review-helper \
+  --description 'Use when drafting release notes from reviewed changes'
+```
+
+The positional Skill name is required, as is an explicit description of 1–1024
+characters. Names are not normalized. Use an exact lowercase portable name with
+hyphens, and choose a new destination instead of expecting an overwrite.
+
+## Review the additional component
+
+```text
+review-helper/
+  plugin.json
+  skills/
+    review-docs/
+      SKILL.md
+    release-notes/
+      SKILL.md
+```
+
+Edit `skills/release-notes/SKILL.md` to explain its trigger, method, and expected
+output. Keep its name and description accurate. For example, instruct it to
+separate user-visible changes from maintenance changes and to cite the reviewed
+source for each release claim.
+
+Scripts, references, and assets can support instructions, but their presence is
+not proof of execution or permission to run them. The `allowed-tools` field is
+not independent authorization evidence. Review supporting material with the
+same care as the instruction text.
+
+## Validate the package and immediate Skills
+
+```bash
+agentplugins author skills validate ./review-helper
+plugin-kit-ai skills validate ./review-helper
+```
+
+These are equivalent checks; one entrypoint is sufficient. The command reports
+package-wide readiness and isolated immediate Skills. An error elsewhere in the
+package can therefore affect the overall result even when the new Skill's own
+findings are clean.
+
+Omitting the package path uses only the current directory, with no ancestor
+search. Explicit roots make scripts and troubleshooting clearer. Running from
+inside `skills/release-notes/` is not a substitute for selecting the package root.
+
+## Handle a failure without overwriting work
+
+Read `committed` and the accompanying error guidance if creation fails. A Skill
+can be committed before resulting package checks fail or remain incomplete.
+Inspect the actual files and the report before retrying; a second init against
+an existing destination will not overwrite it.
+
+Correct the reported input or package issue and repeat validation. If the name
+is wrong, review the intended source change explicitly rather than adding a
+force flag. No external Skills install, update, remove, or generate lifecycle is
+part of this v2 authoring journey.
+
+Continue with [static package checks](./checks) and the [handoff](./handoff).

--- a/website/source/en/legacy/v1/index.md
+++ b/website/source/en/legacy/v1/index.md
@@ -1,0 +1,100 @@
+---
+title: "Historical plugin-kit-ai v1, baseline 1.2.4"
+description: "Version-pinned context for preserved YAML, runtime, SDK, and publication references."
+canonicalId: "page:legacy:v1:index"
+section: "legacy"
+locale: "en"
+generated: false
+translationRequired: true
+---
+
+# Historical plugin-kit-ai v1, baseline 1.2.4
+
+> **Prepared, unreleased authoring contract.** This page is a review draft on a
+> non-deploying preparation branch. Future authoring examples require the accepted
+> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> examples are identified separately. Public activation remains pending.
+
+This index preserves a way to understand existing projects. Its command baseline
+is tag **v1.2.4**, resolving to commit
+`9beca10448ac50fbe526a52101d1433a12471980`, rather than the broader command tree
+on the current documentation branch.
+
+**Project migration is not available in v2 yet. Maintain legacy projects using
+the v1 1.2.4 command set.** A version pin records historical behavior; it does not
+promise a second maintained YAML engine or a new support commitment.
+
+## Choose the right context
+
+| What you have | Where to go |
+| --- | --- |
+| A new root `plugin.json` package | [Prepared Build journey](/en/build/). |
+| A package to install into an agent | [Use plugins](/en/use/). |
+| `plugin/plugin.yaml`, generated targets, or launcher source | Use the historical baseline and retained references below. |
+| A plan to convert a legacy project automatically | Migration is unavailable in v2; preserve the project. |
+
+Do not run new Build commands against a legacy directory expecting conversion.
+Standard authoring has no YAML fallback, temporary conversion, or native hidden
+manifest fallback.
+
+## Exact historical command context
+
+The tagged [root command source](https://github.com/777genius/universal-agent-plugins/blob/9beca10448ac50fbe526a52101d1433a12471980/cli/plugin-kit-ai/cmd/plugin-kit-ai/root.go)
+registers init, bootstrap, doctor, dev, test, export, bundle, generate, import,
+inspect, compat, publish, publication, normalize, validate, capabilities,
+install, integrations, and version. Skills registration is visible separately in
+the tagged [Skills source](https://github.com/777genius/universal-agent-plugins/blob/9beca10448ac50fbe526a52101d1433a12471980/cli/plugin-kit-ai/cmd/plugin-kit-ai/skills.go).
+These are historical names, not the v2 command navigation.
+
+The tagged [init source](https://github.com/777genius/universal-agent-plugins/blob/9beca10448ac50fbe526a52101d1433a12471980/cli/plugin-kit-ai/cmd/plugin-kit-ai/init.go)
+describes `online-service`, `local-tool`, and `custom-logic`, with authored source
+under `plugin/`. Runtime and platform switches there have historical meanings.
+For example, v1 test exercises launcher fixtures, while prepared v2 test is a
+static package check. The same command name does not imply the same behavior.
+
+Use version 1.2.4 deliberately when maintaining those projects; avoid unversioned
+or latest-channel historical installation snippets. This index does not install
+or replace any executable. Package-wrapper development version placeholders in
+the tagged source are not the historical release version.
+
+## Retained explanations
+
+These existing site pages remain intact. They are linked as legacy/support
+explanations; their current-branch wording is not a byte-for-byte v1.2.4 snapshot.
+Use the exact tagged sources above when a command detail depends on the version.
+
+| Topic | Retained reading |
+| --- | --- |
+| YAML project and generated outputs | [Managed project model](/en/concepts/managed-project-model), [historical authoring workflow](/en/reference/authoring-workflow). |
+| Runtime and target selection | [Choosing runtime](/en/concepts/choosing-runtime), [target model](/en/concepts/target-model). |
+| Node and Python launcher projects | [Node/TypeScript runtime](/en/guide/node-typescript-runtime), [Python runtime](/en/guide/python-runtime). |
+| SDK and runtime API context | [Existing API index](/en/api/); these generated references are not the new authoring CLI contract. |
+| Bundle and publication explanations | [Bundle handoff](/en/guide/bundle-handoff), [publishing guide](/en/guide/how-to-publish-plugins). |
+| Historical changes | [Existing release records](/en/releases/). |
+
+## Pinned design and support sources
+
+- [1.2.4 YAML specification](https://github.com/777genius/universal-agent-plugins/blob/9beca10448ac50fbe526a52101d1433a12471980/docs/PLUGIN_YAML_V1_SPEC.md).
+- [1.2.4 authoring documentation](https://github.com/777genius/universal-agent-plugins/blob/9beca10448ac50fbe526a52101d1433a12471980/cli/plugin-kit-ai/README.md).
+- [1.2.4 SDK README](https://github.com/777genius/universal-agent-plugins/blob/9beca10448ac50fbe526a52101d1433a12471980/sdk/README.md).
+- [1.2.4 Node runtime README](https://github.com/777genius/universal-agent-plugins/blob/9beca10448ac50fbe526a52101d1433a12471980/npm/plugin-kit-ai-runtime/README.md).
+- [1.2.4 Python runtime README](https://github.com/777genius/universal-agent-plugins/blob/9beca10448ac50fbe526a52101d1433a12471980/python/plugin-kit-ai-runtime/README.md).
+- [1.2.4 publication design](https://github.com/777genius/universal-agent-plugins/blob/9beca10448ac50fbe526a52101d1433a12471980/docs/PUBLISH_LAYER_SPEC.md).
+- [1.2.4 repository tree](https://github.com/777genius/universal-agent-plugins/tree/9beca10448ac50fbe526a52101d1433a12471980).
+
+The repository's 1.2.4 release note is dated 2026-05-24. Historical release
+records may describe planned downstream publication; they alone do not prove a
+channel is currently available. SDK and runtime helper packages also have their
+own versions, independent of any later authoring CLI major version.
+
+## Preservation is deliberate
+
+Useful YAML implementation, dependencies, tests, examples, and design docs stay
+in their existing locations. Removing a command from the standard authoring
+surface does not authorize deleting its service or documentation. Unresolved
+capabilities remain preserved outside the standard dependency graph.
+
+This index does not copy all historical pages, bulk-migrate examples, or advertise
+a maintained parallel engine. Future source removal requires an inventory and
+explicit owner acceptance. Public navigation and redirects need separate review
+before this preparation can be activated.

--- a/website/source/en/use/index.md
+++ b/website/source/en/use/index.md
@@ -1,0 +1,81 @@
+---
+title: "Use plugins"
+description: "Choose installation or authoring, then follow the appropriate journey."
+canonicalId: "page:use:index"
+section: "use"
+locale: "en"
+generated: false
+translationRequired: true
+---
+
+# Use plugins
+
+> **Prepared, unreleased authoring contract.** This page is a review draft on a
+> non-deploying preparation branch. Future authoring examples require the accepted
+> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> examples are identified separately. Public activation remains pending.
+
+Choose by the result you need:
+
+| Your job | Start here | Tool boundary |
+| --- | --- | --- |
+| Use an existing plugin in an agent | [Find and install](./install) | `agentplugins` manages installation and activation instructions. |
+| Write instructions or connect tools in a new package | [Build plugins](/en/build/) | Future `agentplugins author` and `plugin-kit-ai` share the authoring engine. |
+| Maintain a YAML or launcher project | [Historical v1](/en/legacy/v1/) | Use the historical 1.2.4 context; migration is unavailable in v2. |
+
+You do not need to create a project to use someone else's plugin. The installer
+accepts standard packages from the registry, local directories, or exact GitHub
+commits. Compatibility depends on both the package and the selected agent.
+
+## The installer journey
+
+1. [Find and inspect a package](./install) before selecting agents.
+2. Review its source, tools, permissions, and any sign-in requirements.
+3. Preview an explicit target selection with the installer's dry run.
+4. Install only after reviewing the plan, then follow the printed activation steps.
+5. [Check and maintain installed state](./manage) when updating or repairing.
+
+A successful installation can still require a client restart, a fresh session,
+manual activation, or OAuth. Read the result for your selected client instead of
+assuming that every agent activates the same way.
+
+## Existing installer entrypoints
+
+The current installer documentation uses the native `agentplugins` executable
+or the npm package `universal-agent-plugins`. The npm wrapper requires Node.js 22
+or newer. These two examples express the same discovery job; choose one:
+
+```bash
+agentplugins search docs
+```
+
+```bash
+npx universal-agent-plugins search docs
+```
+
+For installer acquisition, use the repository's
+[native installation guide](https://github.com/777genius/universal-agent-plugins/blob/ec0883bf0bfb7f4044321bba9dfd4fd8d6467721/docs/NATIVE_INSTALL.md).
+The examples here assume the chosen installer is already available. No future
+Build package installation command is implied by this installer guidance.
+
+## Similar command names, different jobs
+
+| Command | Question it answers |
+| --- | --- |
+| `agentplugins validate ./my-plugin` | Can the installer read this local standard package? |
+| `agentplugins doctor` | What needs attention in installer-managed state? |
+| Future `agentplugins author validate ./my-plugin` | Does this authored package conform, and is its static readiness complete? |
+| Future `agentplugins author doctor ./my-plugin` | What project and toolchain evidence can be inspected without execution? |
+
+Installer doctor does not author a package. Authoring doctor does not repair an
+installation. Keep reports from these jobs separate when asking for help.
+
+## What travels between the journeys
+
+The handoff is a directory with root `plugin.json` and the package's components.
+It is not a generated YAML project or a promise that a server has been tested.
+Authors can prepare [a local planner handoff](/en/build/handoff); installers then
+make their own target, security, and activation decisions.
+
+Portable components are Skills and MCP configuration. Client-specific hooks or
+extensions are separate compatibility concerns, not a third portable component.

--- a/website/source/en/use/install.md
+++ b/website/source/en/use/install.md
@@ -1,0 +1,106 @@
+---
+title: "Find and install a plugin"
+description: "Inspect an existing package, preview target changes, and understand activation."
+canonicalId: "page:use:install"
+section: "use"
+locale: "en"
+generated: false
+translationRequired: true
+---
+
+# Find and install a plugin
+
+> **Prepared, unreleased authoring contract.** This page is a review draft on a
+> non-deploying preparation branch. Future authoring examples require the accepted
+> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> examples are identified separately. Public activation remains pending.
+
+These are **existing installer commands**, sourced from the frozen installer
+README and contract. They are separate from the future Build examples.
+Choose a package because it solves your task and its source is acceptable to you.
+
+## Discover the package
+
+```bash
+agentplugins search docs
+agentplugins info context7
+```
+
+Search finds candidates; info lets you inspect a candidate before installation.
+A registry short name such as `context7` comes from the signed Universal Agent
+Plugins Registry. Discovery is not execution of the package or proof that its
+remote service is available.
+
+Read what the package exposes and which agents can consume its components.
+Do not substitute a similarly named package when the source is ambiguous.
+
+## Preview one explicit selection
+
+```bash
+agentplugins add context7 --target codex,cursor --dry-run
+```
+
+This asks the installer for a plan for Codex and Cursor. `--dry-run` belongs to
+installation policy; it does not add an authoring mode or test an MCP server.
+Review the selected package, destinations, compatibility findings, and remaining
+activation work. A plan is not an installed-state receipt.
+
+## Install after reviewing the plan
+
+For an intentional installation, the existing installer command is:
+
+```bash
+agentplugins add context7 --target codex,cursor
+```
+
+For interactive use, omit `--target` and choose among detected agents. One
+detected agent is selected automatically; several produce a multi-select prompt.
+Use explicit targets when you need a reproducible selection.
+
+The installer preflights selected agents before changing managed files. If a
+multi-agent operation cannot finish, follow its rollback or repair instruction.
+Do not manually delete unrelated client configuration to clear an error.
+
+## Finish activation
+
+Read the per-client result. Complete any sign-in or manual activation it names,
+then start the session requested by that client. Installation and activation
+are distinct: writing native configuration does not prove OAuth succeeded or
+that a client loaded every component.
+
+If the plugin is missing in the client, use [managed-state diagnostics](./manage)
+and retain the activation instructions. Re-running authoring validation cannot
+finish a client login.
+
+## Use a local package
+
+For a directory supplied by an author, select the actual package root:
+
+```bash
+agentplugins validate ./my-plugin
+agentplugins add ./my-plugin --target codex --dry-run
+```
+
+The first command is installer validation. The second previews installation;
+it deliberately stops short of applying it. See the author's
+[handoff checklist](/en/build/handoff) for the static evidence to request.
+`plugin.json` is the installation authority; legacy `plugin.yaml` cannot
+replace it or override its identity.
+
+## Use an exact remote source
+
+The installer accepts a full commit SHA, with an explicit package path when
+needed. This is a **syntax example**: replace the owner, repository, full SHA,
+and path with a real source you reviewed before invoking it.
+
+```text
+agentplugins add owner/repository@0123456789abcdef0123456789abcdef01234567//path/to/plugin --target codex --dry-run
+```
+
+Branches, tags, and abbreviated SHAs are rejected. Without a package path, the
+installer uses a valid root package or the only valid nested candidate. Multiple
+candidates require an explicit path; more than 16 possible packages require it
+before candidate fetching. An exact source is immutable: repair replays recorded
+source, while moving to another exact source is a separate switch decision.
+
+Continue with [maintaining installed plugins](./manage).

--- a/website/source/en/use/manage.md
+++ b/website/source/en/use/manage.md
@@ -1,0 +1,103 @@
+---
+title: "Maintain installed plugins"
+description: "Separate installed-state diagnostics, updates, repair, and authoring checks."
+canonicalId: "page:use:manage"
+section: "use"
+locale: "en"
+generated: false
+translationRequired: true
+---
+
+# Maintain installed plugins
+
+> **Prepared, unreleased authoring contract.** This page is a review draft on a
+> non-deploying preparation branch. Future authoring examples require the accepted
+> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> examples are identified separately. Public activation remains pending.
+
+These are **existing installer commands**. They operate on managed installation
+state, not on future authoring scaffolds. Keep the package name, selected agents,
+and any reported installation identity available when diagnosing a problem.
+
+## Inspect the situation first
+
+```bash
+agentplugins list
+agentplugins doctor
+agentplugins outdated --all
+```
+
+`list` reports installations. Installer `doctor` diagnoses managed state.
+`outdated --all` identifies update candidates; it does not perform the update.
+These jobs cannot prove a remote MCP endpoint is healthy or that the client has
+completed authentication.
+
+Before changing anything, identify the symptom:
+
+| Symptom | Next step |
+| --- | --- |
+| Package was never installed | Return to [find and install](./install). |
+| Managed files drifted | Review a repair plan for the affected package and clients. |
+| A registry package has a newer version | Review an update plan. |
+| Client still needs activation or sign-in | Follow that client's printed instructions. |
+| Local authored package fails validation | Give the report to the author; use [Build checks](/en/build/checks). |
+
+## Update deliberately
+
+```bash
+agentplugins update context7 --target codex,cursor --dry-run
+```
+
+Review the planned source and destinations before applying the update:
+
+```bash
+agentplugins update context7 --target codex,cursor
+```
+
+The existing installer also supports `agentplugins update --all`. Use it only
+when the intended scope really is all managed update candidates. A direct
+full-SHA source stays immutable; do not expect an update to follow a branch.
+
+## Repair recorded state
+
+```bash
+agentplugins repair context7 --target codex,cursor --dry-run
+```
+
+Repair reapplies the recorded source. It is useful for managed-file drift,
+not for changing the authored package or selecting a different remote revision.
+After reviewing the plan, the corresponding apply command is:
+
+```bash
+agentplugins repair context7 --target codex,cursor
+```
+
+If an operation reports a partial rollback or recovery instruction, retain that
+report and follow it. Avoid deleting user-owned files or treating every client
+configuration file as installer-owned.
+
+## Remove the selected installation
+
+```bash
+agentplugins remove context7 --target codex,cursor --dry-run
+```
+
+Review what the installer owns before applying removal:
+
+```bash
+agentplugins remove context7 --target codex,cursor
+```
+
+Removal changes files owned by the CLI. It does not revoke a service account,
+uninstall an unrelated runtime, or delete an author's source directory.
+
+## Report a problem clearly
+
+Record the operation, package source, selected clients, result, and remaining
+activation instruction. Share diagnostics with credentials removed. State
+whether the problem occurred during planning, managed-file application, client
+activation, authentication, or runtime use; these are different failure stages.
+
+Future authoring `doctor ./my-plugin` supplies project evidence only. It cannot
+replace installer doctor, repair managed state, or complete OAuth. Authors and
+installers can compare evidence through the [handoff boundary](/en/build/handoff).


### PR DESCRIPTION
Prepare separate Use plugins and Build plugins journeys, with a version-pinned historical v1 reference. The 13 new English pages explain current installer operations, the prepared standard-first authoring contract, and the boundaries between static checks, installation, runtime and activation. Existing documentation, YAML implementation, examples and dependencies are preserved unchanged.

Depends on #166. This is D1 content preparation only. Do not merge or activate before navigation/reference integration, maintained locale updates and release gates are satisfied: Pages auto-deploys main, and draft notices do not prevent publication. No public navigation or existing route is changed here.

Validation: independent medium review inspected all 14 added files and verified command facts against exact installer, prepared authoring and historical source revisions. All 38 Bash blocks passed syntax parsing, 59 internal source links and 11 pinned Git links resolved, and frontmatter checks passed. The review's single low-severity relative-path wording finding was corrected in 914737b5. Commands were not executed; full site generation, rendering, route aliases, locale parity and browser checks remain later integration gates.

The preparation adds 1,468 lines including the maintainer handoff note. No release, platform or public activation acceptance is claimed. Related implementation checkpoint: #170.
