### PR TITLE
fix(agentplugins): align v1 admission and client lifecycle semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,7 @@ The installed package is standard-first:
 ```text
 plugin.json
 ├── skills/       optional reusable instructions
-├── mcp.json      optional MCP servers
-└── hooks/        optional client-supported hooks
+└── mcp.json      optional MCP servers
 ```
 
 You can also install a local package or a pinned GitHub package without adding

--- a/cli/plugin-kit-ai/cmd/agentplugins/main.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/statemigration"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/statev2"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/managedstdio"
 	clientplanner "github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/planner"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/transaction"
@@ -60,6 +61,9 @@ var (
 )
 
 func main() {
+	if handled, code := managedstdio.Dispatch(os.Args[1:], os.Stderr); handled {
+		os.Exit(code)
+	}
 	if commands.IsEnabled() && commands.IsAuthorInvocation(os.Args[1:], agentpluginscli.NewRoot(agentpluginscli.App{})) {
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
@@ -117,6 +121,9 @@ func run() error {
 	directoryManager := dirswap.Manager{JournalDir: filepath.Join(dataRoot, "operations-v2")}
 	mutationLock := processlock.Lock{Path: filepath.Join(dataRoot, "mutation.lock")}
 	stager := providers.Stager{}
+	if executable, err := os.Executable(); err == nil {
+		stager.LauncherSource, _ = managedstdio.NewSource(executable, version)
+	}
 	activator := providers.Activator{Runner: runner}
 	planner := clientplanner.Planner{ManagedRoot: filepath.Join(dataRoot, "managed"), Detected: map[domain.ClientID]domain.DetectedClient{}}
 	lifecycle := usecase.Service{

--- a/cli/plugin-kit-ai/cmd/agentplugins/managed_stdio_test.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins/managed_stdio_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestManagedStdioMainSubprocess(t *testing.T) {
+	if os.Getenv("UAP_EARLY_MAIN_FIXTURE") != "1" {
+		return
+	}
+	os.Args = []string{"agentplugins", "--internal-stdio-v1"}
+	main()
+}
+
+func TestManagedStdioDispatchPrecedesAllUserState(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	state := filepath.Join(root, "must-not-exist")
+	cmd := exec.Command(exe, "-test.run=^TestManagedStdioMainSubprocess$")
+	cmd.Env = append(os.Environ(), "UAP_EARLY_MAIN_FIXTURE=1", "HOME="+state, "AGENTPLUGINS_HOME="+state, "AGENTPLUGINS_DIRECTORY_ORIGIN=not-a-url")
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	if ee, ok := err.(*exec.ExitError); !ok || ee.ExitCode() != 126 {
+		t.Fatalf("wrong private mode error: %v %s", err, stderr.String())
+	}
+	if out.Len() != 0 || !bytes.Contains(stderr.Bytes(), []byte("managed stdio:")) {
+		t.Fatalf("private stdout/stderr = %q / %q", out.String(), stderr.String())
+	}
+	if _, err := os.Stat(state); !os.IsNotExist(err) {
+		t.Fatalf("private mode touched user state: %v", err)
+	}
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/gemini_lifecycle_e2e_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/gemini_lifecycle_e2e_test.go
@@ -17,8 +17,13 @@ func TestGeminiDisposableHomeAddUpdateRemoveE2E(t *testing.T) {
 	client := fixtureClient(t, domain.ClientGemini)
 	fixture := newCLIFixture(t, []domain.DetectedClient{client})
 	plugin := writeCLIPlugin(t)
-	mcpFixture := `{"$schema":"https://agent-plugins.org/schemas/1.0.0/mcp.schema.json","mcpServers":{"demo":{"type":"streamable-http","url":"https://example.test/mcp"},"local-fixture":{"type":"stdio","command":"node","args":["${PLUGIN_ROOT}/server.js"],"env":{"DATA":"${PLUGIN_DATA}"},"cwd":"./workspace"}}}`
+	// The Go toolchain is already required to run this test. This fixture only
+	// exercises configuration delivery; it never starts the configured command.
+	mcpFixture := `{"$schema":"https://agent-plugins.org/schemas/1.0.0/mcp.schema.json","mcpServers":{"demo":{"type":"streamable-http","url":"https://example.test/mcp"},"local-fixture":{"type":"stdio","command":"go","args":["version"],"env":{"DATA":"${PLUGIN_DATA}"},"cwd":"./workspace"}}}`
 	if err := os.WriteFile(filepath.Join(plugin, "mcp.json"), []byte(mcpFixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(plugin, "workspace"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	skill := filepath.Join(plugin, "skills", "docs", "SKILL.md")
@@ -106,7 +111,7 @@ func assertGeminiCLIProjection(t *testing.T, root, url, marker string, present b
 		t.Fatalf("Gemini local MCP presence = %v, want %v", localExists, present)
 	}
 	if present {
-		if local["command"] != "node" || !strings.HasSuffix(local["cwd"].(string), "/workspace") {
+		if local["command"] != "go" || !strings.HasSuffix(local["cwd"].(string), "/workspace") {
 			t.Fatalf("Gemini local MCP projection = %+v", local)
 		}
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/portable_identity_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/portable_identity_test.go
@@ -1,0 +1,109 @@
+package agentpluginscli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPortableReservedInfoReconciliation(t *testing.T) {
+	fixture := newCLIFixture(t, nil)
+	client := domain.DetectedClient{ClientID: domain.ClientCopilot, DisplayName: "GitHub Copilot CLI", Status: domain.DetectionDetected,
+		Version: "1.0.80", ExecutablePath: "/test/bin/copilot", ConfigRoot: filepath.Join(fixture.root, "home", ".copilot")}
+	detector := &observedProbingDetector{clients: []domain.DetectedClient{client}}
+	fixture.app.Detector = detector
+	observer := &capturingNativeObserver{observation: domain.NativeIdentityObservation{State: domain.NativeIdentityManaged, ReceiptReconciled: true,
+		NativeDiscoveryReconciled: true, NativeDiscoveryState: domain.NativeIdentityManaged, NativeDiscoveryAttempted: true}}
+	fixture.app.Lifecycle.NativeObserver = observer
+
+	installationID := "00000000-0000-4000-8000-000000000001"
+	physical := domain.ComputePhysicalArtifactID("con.foo", installationID)
+	target, err := fixture.app.Lifecycle.Targets.ResolveTarget(context.Background(), client, domain.ScopeUser, physical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bindingID := domain.ComputeClientBindingID(installationID, string(domain.ClientCopilot), string(domain.ScopeUser), target.ActivePath)
+	digest := "sha256:owned"
+	binding := domain.ClientBinding{
+		ClientBindingID: bindingID, ClientID: string(domain.ClientCopilot), Scope: string(domain.ScopeUser), TargetLocator: target.ActivePath,
+		PhysicalArtifact: physical, Materialization: domain.MaterializationMaterialized, Activation: domain.ActivationActive,
+		Authentication: domain.AuthenticationNotRequired, Policy: domain.PolicyAllowed, Verification: domain.VerificationInstalled,
+		PackageRevision: &domain.ClientPackageRevision{Version: "1.7.0-uap.1", TreeDigest: "sha256:tree", ManifestDigest: "sha256:manifest"},
+		NativeObjects:   []domain.NativeObjectOwnership{{ObjectID: "package:copilot:" + physical, Kind: "managed_package_directory", LogicalName: "con.foo", ManagedDigest: digest}},
+		Receipts:        []domain.MutationReceipt{{OperationID: "op-0000000000000001", Sequence: 1, ClientBindingID: bindingID, AfterDigest: digest, Phase: "committed"}},
+	}
+	state := domain.StateFileV2{SchemaVersion: domain.StateSchemaVersion, Installations: []domain.Installation{{
+		InstallationID: installationID, DeclaredName: "con.foo",
+		Source:  domain.SourceBinding{SourceBindingID: "src_con.foo", RequestedSource: "con.foo", CanonicalSource: "https://example.test/con.foo", ResolvedRevision: strings.Repeat("a", 40), TreeDigest: "sha256:tree"},
+		Package: domain.PackageBinding{LoaderKind: domain.LoaderKindAgentPlugins, FormatID: domain.FormatIDAgentPluginsV1, SchemaURI: domain.PluginSchemaV1, DeclaredName: "con.foo", Version: "9.9.9", ManifestDigest: "sha256:manifest"},
+		Clients: map[string]domain.ClientBinding{bindingID: binding},
+	}}}
+	if err := fixture.store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(fixture.store.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, err := fixture.execute(false, "info", "con.foo", "--target", "copilot", "--format", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(fixture.store.Path)
+	if err != nil || !bytes.Equal(before, after) {
+		t.Fatalf("info mutated state: %v", err)
+	}
+	if strings.Contains(stdout, fixture.root) || strings.Contains(stdout, client.ExecutablePath) || strings.Contains(stdout, client.ConfigRoot) {
+		t.Fatalf("info leaked a local path: %s", stdout)
+	}
+	var output struct {
+		SchemaVersion int `json:"schema_version"`
+		Data          struct {
+			Clients []struct {
+				ReceiptReconciled         bool   `json:"receipt_reconciled"`
+				NativeDiscoveryReconciled bool   `json:"native_discovery_reconciled"`
+				NativeIdentityState       string `json:"native_identity_state"`
+				ClientVersion             string `json:"client_version"`
+				NativeDiscoveryEvidence   struct {
+					Basis            string `json:"basis"`
+					VersionOperation struct {
+						Argv                  []string `json:"argv"`
+						ObservedClientVersion string   `json:"observed_client_version"`
+					} `json:"version_operation"`
+					DiscoveryOperation struct {
+						Argv       []string `json:"argv"`
+						Discovered bool     `json:"discovered"`
+						ProductID  string   `json:"product_id"`
+					} `json:"discovery_operation"`
+				} `json:"native_discovery_evidence"`
+			} `json:"clients"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatal(err)
+	}
+	if output.SchemaVersion != 1 || len(output.Data.Clients) != 1 {
+		t.Fatalf("output = %s", stdout)
+	}
+	got := output.Data.Clients[0]
+	if !got.ReceiptReconciled || !got.NativeDiscoveryReconciled || got.NativeIdentityState != "managed" || got.ClientVersion != "1.0.80" {
+		t.Fatalf("reconciliation = %+v", got)
+	}
+	evidence := got.NativeDiscoveryEvidence
+	if evidence.Basis != "native_client_command" || evidence.VersionOperation.ObservedClientVersion != "1.0.80" ||
+		!evidence.DiscoveryOperation.Discovered || !strings.HasPrefix(evidence.DiscoveryOperation.ProductID, "con.foo@agentplugins-") ||
+		strings.Join(evidence.VersionOperation.Argv, " ") != "copilot --version" || strings.Join(evidence.DiscoveryOperation.Argv, " ") != "copilot plugin list" {
+		t.Fatalf("native discovery evidence = %+v", evidence)
+	}
+	if detector.targetedCalls != 1 || detector.probeCalls != 0 || detector.readOnlyCalls != 0 || len(detector.targets) != 1 || detector.targets[0] != domain.ClientCopilot {
+		t.Fatalf("detector calls = read-only:%d probe:%d targeted:%d targets:%v", detector.readOnlyCalls, detector.probeCalls, detector.targetedCalls, detector.targets)
+	}
+	if len(observer.plans) != 1 || observer.plans[0].DeclaredVersion != "1.7.0-uap.1" {
+		t.Fatalf("observer plan did not use binding revision: %+v", observer.plans)
+	}
+}

--- a/cli/plugin-kit-ai/internal/authoring/commands/slice_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/slice_test.go
@@ -231,7 +231,10 @@ func TestReportsAndFreshFactory(t *testing.T) {
 		{"non-semver", plugin(`,"version":"banana"`), "", "", report.Pass, report.Pass, report.Pass},
 		{"unknown", plugin(`,"ordinary-fixture-marker":{"value":"ordinary-fixture-marker"}`), "", "", report.Pass, report.Fail, report.Pass},
 		{"extensions", plugin(`,"extensions":17`), "", "", report.Pass, report.Fail, report.Pass},
-		{"unsafe-name", strings.Replace(plugin(""), `"demo"`, `"con"`, 1), "", "", report.Pass, report.Pass, report.Fail},
+		{"reserved-con", strings.Replace(plugin(""), `"demo"`, `"con"`, 1), "", "", report.Pass, report.Pass, report.Pass},
+		{"reserved-con-dot", strings.Replace(plugin(""), `"demo"`, `"con.foo"`, 1), "", "", report.Pass, report.Pass, report.Pass},
+		{"reserved-aux-dot", strings.Replace(plugin(""), `"demo"`, `"aux.tools"`, 1), "", "", report.Pass, report.Pass, report.Pass},
+		{"invalid-name", strings.Replace(plugin(""), `"demo"`, `"demo..invalid"`, 1), "", "", report.Fail, report.Fail, report.NotEvaluated},
 		{"bad-core", `{"name":`, mcp(`{"good":{"type":"stdio","command":"missing-fixture-command"}}`), "", report.Fail, report.Fail, report.NotEvaluated},
 		{"wrong-type", plugin(`,"version":17`), "", "", report.Fail, report.Fail, report.NotEvaluated},
 		{"duplicate", plugin(`,"name":"ordinary-fixture-marker"`), "", "", report.Fail, report.NotEvaluated, report.Fail},
@@ -725,6 +728,34 @@ func TestNativeBinaryVerticalSlice(t *testing.T) {
 			}
 		})
 	}
+	// Portable names remain valid when their generated physical IDs are safe.
+	for _, name := range []string{"con", "con.foo", "aux.tools"} {
+		t.Run("portable-name-"+name, func(t *testing.T) {
+			first := map[string][]byte{}
+			for i := range binaries {
+				root := filepath.Join(roots[i], "portable-name-"+name)
+				write(t, root, "plugin.json", strings.Replace(plugin(""), `"demo"`, `"`+name+`"`, 1))
+				before := tree(t, root)
+				for _, command := range []string{"validate", "inspect", "test"} {
+					r, c, b := run(i, command, root)
+					if c != 0 || r.Loadability.Status != report.Pass || r.Conformance.Status != report.Pass || r.HostSafety.Status != report.Pass {
+						t.Fatalf("native portable name %s %s failed (%d): %s", name, command, c, b)
+					}
+					if r.Runtime.Status != report.NotEvaluated {
+						t.Fatal("static runtime evidence fabricated")
+					}
+					if i == 0 {
+						first[command] = append([]byte{}, b...)
+					} else if !bytes.Equal(first[command], b) {
+						t.Fatalf("native portable name parity: %s / %s", first[command], b)
+					}
+				}
+				if !reflect.DeepEqual(before, tree(t, root)) {
+					t.Fatal("native portable name read changed source")
+				}
+			}
+		})
+	}
 	// Native failure parity, including raw flag values and an unresolvable binary.
 	for _, tc := range []struct{ name, body, mc string }{
 		{"unknown", plugin(`,"ordinary-fixture-marker":true`), ""},
@@ -734,7 +765,7 @@ func TestNativeBinaryVerticalSlice(t *testing.T) {
 		{"duplicate", plugin(`,"name":"ordinary-fixture-marker"`), ""},
 		{"bad-schema", strings.Replace(plugin(""), "1.0.0", "7.0.0", 1), ""},
 		{"bad-sibling", plugin(""), mcp(`{"good":{"type":"stdio","command":"missing-fixture-command"},"bad":{"type":"stdio","command":4}}`)},
-		{"unsafe", strings.Replace(plugin(""), `"demo"`, `"con"`, 1), ""},
+		{"invalid-name", strings.Replace(plugin(""), `"demo"`, `"demo..invalid"`, 1), ""},
 		{"missing-executable", plugin(""), mcp(`{"good":{"type":"stdio","command":"absent-fixture-executable"}}`)},
 		{"legacy-only", "", ""},
 		{"native-only", "", ""},
@@ -769,6 +800,9 @@ func TestNativeBinaryVerticalSlice(t *testing.T) {
 			}
 			if tc.name != "missing-executable" && c == 0 {
 				t.Fatalf("native negative accepted: %s", b)
+			}
+			if tc.name == "invalid-name" && (r.Loadability.Status != report.Fail || r.Conformance.Status != report.Fail || r.HostSafety.Status != report.NotEvaluated || r.Coverage.ComponentsRequested) {
+				t.Fatalf("invalid portable name assessment: %s", b)
 			}
 			if tc.name == "coexisting" {
 				if r.Conformance.Status != report.Pass || r.Readiness.Status == report.Pass || r.Identity.TreeDigest != "" {

--- a/cli/plugin-kit-ai/internal/authoring/report/report.go
+++ b/cli/plugin-kit-ai/internal/authoring/report/report.go
@@ -215,7 +215,7 @@ func Build(command, revision string, p project.Result, release bool) Report {
 	if f.Package != nil {
 		r.Loadability.Status = Pass
 		r.Identity.ManifestDigest = f.Package.ManifestDigest
-		if pathpolicy.ValidateLeafID(f.Package.Manifest.Name) != nil {
+		if pathpolicy.ValidateLeafID(domain.ComputePhysicalArtifactID(f.Package.Manifest.Name, "authoring-preview")) != nil {
 			id := r.add(Finding{Code: "physical_name_unsafe", Layer: "host_safety", Rule: "host/portable-leaf", Location: "plugin.json", Severity: "error"})
 			r.HostSafety.Status = Fail
 			r.HostSafety.FindingIDs = append(r.HostSafety.FindingIDs, id)

--- a/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows.go
+++ b/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows.go
@@ -19,6 +19,11 @@ func renameExclusive(from *os.File, old string, to *os.File, new string) error {
 	runtime.KeepAlive(from)
 	runtime.KeepAlive(to)
 	if err != nil {
+		// Native NTSTATUS errors do not implement errors.Is. Convert to the
+		// Win32 errno so callers can classify collisions with os.ErrExist.
+		if status, ok := err.(windows.NTStatus); ok {
+			err = status.Errno()
+		}
 		return &os.LinkError{Op: "rename-exclusive", Old: old, New: new, Err: err}
 	}
 	return nil

--- a/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows_test.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package scaffold
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWindowsRenameExclusiveExistingDestination(t *testing.T) {
+	parent := t.TempDir()
+	for _, name := range []string{"source", "destination"} {
+		path := filepath.Join(parent, name)
+		if err := os.Mkdir(path, 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(path, "marker"), []byte(name), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir, err := os.Open(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dir.Close()
+	err = renameExclusive(dir, "source", dir, "destination")
+	if !errors.Is(err, os.ErrExist) {
+		t.Fatalf("expected os.ErrExist, got %T: %v", err, err)
+	}
+	for _, name := range []string{"source", "destination"} {
+		contents, err := os.ReadFile(filepath.Join(parent, name, "marker"))
+		if err != nil || string(contents) != name {
+			t.Errorf("%s changed: contents=%q err=%v", name, contents, err)
+		}
+	}
+}

--- a/docs/AGENTPLUGINS_CLIENT_E2E.md
+++ b/docs/AGENTPLUGINS_CLIENT_E2E.md
@@ -80,3 +80,7 @@ checks proved:
 Plugin data was retained by default, matching the CLI's documented safe-remove
 contract. No browser, model, tool call, consent screen, or OAuth session was
 used in this evidence run.
+
+Compatibility work dated 2026-09-06 is tracked separately in
+[release preparation](AGENTPLUGINS_RELEASE_PREPARATION.md). This historical
+transcript does not prove the unreleased candidate's cwd or transport behavior.

--- a/docs/AGENTPLUGINS_RELEASE_PREPARATION.md
+++ b/docs/AGENTPLUGINS_RELEASE_PREPARATION.md
@@ -1,0 +1,81 @@
+# Agent Plugins 1.0 compatibility release preparation
+
+Status: unreleased work, 2026-09-06. This is a preparation record, not a release
+receipt or native runtime claim. Existing version-bound lifecycle evidence is in
+[the August 30 record](AGENTPLUGINS_CLIENT_E2E.md); its artifact identity and
+limitations must not be reassigned to this candidate.
+
+## Source evidence and limits
+
+| Target surface | Version-bound source fact | Candidate limitation |
+| --- | --- | --- |
+| Cline extension v4.1.17 | [Schema](https://github.com/cline/cline/blob/v4.1.17/apps/vscode/src/services/mcp/schemas.ts) accepts flat and nested cwd; [McpHub](https://github.com/cline/cline/blob/v4.1.17/apps/vscode/src/services/mcp/McpHub.ts) passes cwd to stdio transport | Source support permits direct projection; native launch with candidate not proven |
+| Cline CLI cli-v3.0.61 | [Client](https://github.com/cline/cline/blob/cli-v3.0.61/sdk/packages/core/src/extensions/mcp/client.ts) forwards transport.cwd to spawn | Separate surface; source support does not prove candidate CLI integration |
+| OpenCode v1.18.29 | [Connection code](https://github.com/anomalyco/opencode/blob/v1.18.29/packages/opencode/src/mcp/index.ts) starts remote with Streamable HTTP and may fall back to SSE | HTTP-first supports HTTP mapping; explicit SSE selection cannot be preserved by the native config |
+| Windsurf / Devin on macOS and Linux | Candidate uses a Unix launcher for cwd, environment and process lifecycle | macOS launcher tests and Linux compilation are not native client handshake evidence |
+| Windsurf / Devin on Windows | No Windows launcher backend in this candidate | Stdio explicitly unsupported; native process lifecycle support remains unimplemented |
+
+These are reviewed versions, not inferred minimum versions or guarantees for all
+client releases. Projection/unit tests only prove the behavior they exercise.
+
+## Release evidence to collect
+
+Reuse the existing structured E2E transcript convention and release workflow
+artifacts. Each completed row must bind exact CLI version, commit SHA, binary
+SHA-256, OS/architecture, target product/version/surface, component/transport and
+package tree/manifest digests. Use explicit `not evaluated` for missing proof.
+
+| Candidate scope | Schema/loader | Prepared | Installed | Activated | Handshake/tool call | OAuth |
+| --- | --- | --- | --- | --- | --- | --- |
+| Cline extension stdio with cwd | Pending final candidate report | Pending candidate evidence | Not evaluated | Not evaluated | Not evaluated | Not evaluated |
+| Cline CLI stdio with cwd | Pending final candidate report | Pending candidate evidence | Not evaluated | Not evaluated | Not evaluated | Not evaluated |
+| OpenCode Streamable HTTP | Pending final candidate report | Pending candidate evidence | Not evaluated | Not evaluated | Not evaluated | Not evaluated |
+| OpenCode declared SSE | Valid input may be unsupported for this target | Must report unsupported | Not claimed | Not claimed | Not claimed | Not evaluated |
+| Windsurf macOS/Linux stdio with cwd | Pending final candidate report | Pending candidate evidence | Not evaluated | Not evaluated | Not evaluated | Not evaluated |
+
+Windows Windsurf stdio is explicitly unsupported in this candidate. It is not a
+pending supported path: a native Windows launcher and lifecycle proof are needed
+before that capability can be advertised.
+
+This table intentionally contains no new successful runtime or release records.
+Record focused check results against the final commit, then attach reproducible
+exact-head CI and release artifact provenance using the existing mechanisms.
+
+Use only new disposable profiles/projects and test identities. A benign fixture
+may report cwd/argv/env and speak minimal MCP. Keep HTTP endpoints loopback and
+headers secret-free. Demonstrate local and immutable Git installation without
+Directory membership, update preserving PLUGIN_DATA, owned-only removal, and
+healthy skill/HTTP siblings surviving unsupported transport selection. Separately
+prove safe global abort for ownership conflicts. Preserve the exact conformance
+corpus pin and strict reporting; it tests loading, not client execution.
+
+Do not fabricate adoption evidence: independent reproducible user cases remain
+to be collected. Two or three cases are a practical aim, not an upstream rule.
+Release only via the existing verified workflow. Preserve failed release bytes
+and evidence; rollback distribution to a known artifact instead of replacing
+bytes under an existing version or automatically modifying user installations.
+
+## Updating historical projections
+
+Installing a newer CLI does not itself refresh an existing renderer or launcher.
+An update with the same source and revision normally returns `NoChange`. The
+unreleased candidate has one narrow exception: explicit update may remove a
+proven previously delivered MCP component that is now statically unsupported,
+such as a historical OpenCode SSE projection. Add and repair must not reactivate
+that component; they direct the user to controlled update. This exception does
+not refresh a helper or renderer merely because the CLI changed. An intact old
+artifact plus an accepted new package revision can deliver the newer projection
+and helper; update still verifies the old artifact before mutation.
+
+Do not use plain `update` as a promised recovery for a damaged historical artifact.
+If the current CLI cannot reproduce the recorded bytes for exact repair, recovery
+requires a verified compatible older CLI for repair, or an explicitly verified
+owned remove/reinstall path that preserves existing data under lifecycle rules.
+Removal can itself be blocked by integrity or ownership checks. No cache lookup,
+forced integrity bypass or automatic migration is implied by this candidate.
+
+The unsupported-component withdrawal exception is local candidate behavior under
+implementation and verification, not shipped compatibility or a reported test
+pass. It introduces no state-version migration and bypasses no ownership or
+integrity checks. It does not turn damaged historical artifacts into repairable
+ones or justify dropping unrelated healthy components.

--- a/docs/AGENTPLUGINS_UPSTREAM_DRAFT.md
+++ b/docs/AGENTPLUGINS_UPSTREAM_DRAFT.md
@@ -1,0 +1,66 @@
+# Local upstream proposal drafts
+
+Status: not submitted, not reviewed, not listed, not endorsed. Prepared on
+2026-09-06. Publication and maintainer contact require explicit owner approval.
+No release or native runtime proof for the compatibility candidate is claimed.
+
+## Informational tooling proposal
+
+Universal Agent Plugins (UAP) is an independent cross-client installer and
+lifecycle manager for Agent Plugins packages. Selected clients provide the
+runtime. Local and immutable Git installation work independently of the optional
+Directory. Published Agent Plugins text and schemas remain the portable contract.
+
+Would an informational installation-tooling entry be useful, or does the current
+compatible-client category require a runtime? We propose one product-family
+entry, with per-target limitations in a linked version-bound matrix. We would
+not combine unrelated adapter capabilities into a universal supports claim.
+An installation-tooling section is a proposal, not an existing acceptance path.
+
+Source: [UAP](https://github.com/777genius/universal-agent-plugins).
+[Release preparation and evidence limits](AGENTPLUGINS_RELEASE_PREPARATION.md)
+and [existing lifecycle record](AGENTPLUGINS_CLIENT_E2E.md) distinguish source,
+projection, discovery, activation, tool execution and OAuth evidence.
+
+Before submission, attach the actual compatibility release/version, setup guide,
+artifact provenance, completed matrix, reproducible demo and logo provenance.
+These attachments are pending, not implied by this draft. Align the eventual
+entry with [the pinned submission guidance](https://github.com/agentplugins/agent-plugins-site/blob/c4a3a8dc683838f14d178392aaeaabeba4533377/CONTRIBUTING.md).
+Informational inclusion would not mean endorsement or certification. Any reference
+implementation discussion would need a separate bounded scope and governance
+decision, reproducible release ownership and demonstrated implementer usefulness.
+
+## Published 1.0 extension clarification
+
+For the same otherwise valid package containing a healthy skill, compare:
+
+```json
+{"$schema":"https://agent-plugins.org/schemas/1.0.0/plugin.schema.json","name":"example","extensions":null}
+```
+
+```json
+{"$schema":"https://agent-plugins.org/schemas/1.0.0/plugin.schema.json","name":"example","extensions":{"com.example.future":"opaque"}}
+```
+
+Both fail the original author schema. For the first, our installer reports
+`plugin_extensions_ignored` and loads the healthy skill under the published 1.0
+container exception. For the second, it currently rejects the manifest. One
+reading applies the object-member requirement before namespace interpretation;
+the other ignores an unimplemented namespace before checking its contents.
+Please clarify the published 1.0 loader disposition and reporting obligation for
+the second input independently of author-schema validity and draft 1.1 changes.
+
+The [local profile decision](../install/integrationctl/agentplugins/conformance/profiles/README.md)
+records the pinned corpus fixture, disputed status and unchanged policy. No
+canonical schema change or assertion of official certification is proposed.
+
+Candidate lifecycle limitation: same-source, same-revision update normally returns
+`NoChange` and does not refresh renderer/helper bytes. The local unreleased
+candidate is implementing a narrow explicit-update exception to withdraw proven
+previously delivered MCP components now statically unsupported, such as historical
+OpenCode SSE. Add/repair must not reactivate those components and instead explain
+controlled update. This is not a shipped claim or a completed verification claim. New-revision update requires the old
+artifact to pass integrity checks. Damaged historical artifacts require verified
+exact repair or an explicitly verified recovery path; this proposal does not
+promise that upgrading the CLI and running update repairs them. See the
+[historical projection limits](AGENTPLUGINS_RELEASE_PREPARATION.md#updating-historical-projections).

--- a/docs/CLINE_OPENCODE_TRANSPORT_EVIDENCE.md
+++ b/docs/CLINE_OPENCODE_TRANSPORT_EVIDENCE.md
@@ -1,0 +1,39 @@
+# Cline cwd and OpenCode declared transport
+
+This records adapter behavior and source evidence, separately from native runtime
+verification. Client discovery checks presence, not version; no minimum version
+is inferred from these release snapshots.
+
+- Cline VS Code extension v4.1.17 accepts nested `transport.cwd` in
+  `apps/vscode/src/services/mcp/schemas.ts` and passes it to the stdio transport in
+  `McpHub.ts`. Cline CLI cli-v3.0.61 passes cwd to spawn in
+  `sdk/packages/core/src/extensions/mcp/client.ts`. UAP retains its nested shape,
+  including normalized default `${PLUGIN_ROOT}` cwd and explicit cwd. These are
+  source-inspected surfaces, not claims that native execution was tested here.
+- OpenCode v1.18.29 has no native remote transport selector in
+  `packages/core/src/v1/config/mcp.ts`. Its `connectRemote` in
+  `packages/opencode/src/mcp/index.ts` starts with Streamable HTTP. Consequently
+  portable Streamable HTTP remains supported and declared SSE is unsupported for
+  this adapter. A fallback to SSE does not preserve an SSE-first declaration.
+  Other clients retain their independent transport capabilities. URLs and headers
+  are copied literally; UAP adds no invented native selector.
+
+Portable SSE is still valid Agent Plugins 1.0.0 input. A client capability refusal
+is not a package validation error. Component selection must omit unsupported SSE
+from OpenCode native configuration and receipts while preserving usable siblings.
+
+Local tests cover projection, native receipt updates from historical no-cwd Cline
+entries, cwd ownership drift, and receipt-based removal. They use temporary paths
+and do not start Cline or OpenCode. No native runtime, activation, OAuth, or release
+verification is claimed by these tests.
+
+Historical Cline artifacts use their recorded digest. Adding cwd changes the
+projection digest: exact repair must refuse a historical rebuild mismatch without
+changing state or native configuration. A controlled update is the migration
+path. Historical intact receipts remain usable for removal. Reverting the renderer
+must not discard receipts or erase cwd fields through unowned cleanup.
+
+Sources: [Cline extension](https://github.com/cline/cline/tree/v4.1.17),
+[Cline CLI](https://github.com/cline/cline/tree/cli-v3.0.61),
+[OpenCode](https://github.com/anomalyco/opencode/tree/v1.18.29),
+[Agent Plugins 1.0.0 section 7.2.1](https://github.com/agentplugins/agent-plugins-spec/blob/ff8ab5e392cc87bd88d87c060815a87490e51003/spec/1.0.0.md#721-remote-transport).

--- a/install/integrationctl/agentplugins/adapters/loader/mcp.go
+++ b/install/integrationctl/agentplugins/adapters/loader/mcp.go
@@ -4,14 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/conformance"
-	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
 
-	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/pathpolicy"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/pathcontract"
 )
 
 func (loader Loader) loadMCP(filename, pluginSchema string) (domain.MCPComponent, []domain.Diagnostic) {
@@ -33,79 +31,28 @@ func validateStdioServer(root string, config map[string]any) (*domain.StdioRequi
 		if err != nil {
 			return "", err
 		}
-		candidate := filepath.Join(root, filepath.FromSlash(relative))
-		if err := validateExistingCommandAncestor(root, candidate, command); err != nil {
-			return "", err
+		observed := pathcontract.Resolve(root, relative)
+		if observed.State == pathcontract.Invalid {
+			return "", observed.Err
 		}
 		return relative, nil
-	}, validateCWD)
-}
-
-func validateExistingCommandAncestor(root, candidate, command string) error {
-	current := candidate
-	for {
-		if _, err := os.Lstat(current); err == nil {
-			resolved, resolveErr := filepath.EvalSymlinks(current)
-			if resolveErr != nil {
-				return fmt.Errorf("resolve bundled stdio command %q: %w", command, resolveErr)
-			}
-			contained, relativeErr := filepath.Rel(root, resolved)
-			if relativeErr != nil || contained == ".." || filepath.IsAbs(contained) || strings.HasPrefix(contained, ".."+string(filepath.Separator)) {
-				return fmt.Errorf("bundled stdio command %q resolves outside the plugin root", command)
-			}
+	}, func(value string) error {
+		parsed, err := pathcontract.ParseCWD(value)
+		if err != nil {
+			return err
+		}
+		if parsed.Anchor == pathcontract.Data {
 			return nil
-		} else if !os.IsNotExist(err) {
-			return fmt.Errorf("inspect bundled stdio command %q: %w", command, err)
 		}
-
-		parent := filepath.Dir(current)
-		if parent == current {
-			return fmt.Errorf("bundled stdio command %q has no resolvable plugin-root ancestor", command)
+		observed := pathcontract.Resolve(root, parsed.Relative)
+		if observed.State == pathcontract.Invalid {
+			return observed.Err
 		}
-		current = parent
-	}
-}
-
-func bundledCommandPath(command string) (string, error) {
-	if !strings.HasPrefix(command, "./") || strings.Contains(command, `\\`) {
-		return "", fmt.Errorf("bundled stdio command %q must be a ./-prefixed plugin-relative path", command)
-	}
-	relative := strings.TrimPrefix(command, "./")
-	if relative == "" || path.Clean(relative) != relative || strings.HasPrefix(relative, "../") {
-		return "", fmt.Errorf("bundled stdio command %q escapes the plugin root", command)
-	}
-	for _, segment := range strings.Split(relative, "/") {
-		if err := pathpolicy.ValidatePortablePathSegment(segment); err != nil {
-			return "", fmt.Errorf("bundled stdio command %q contains a non-portable path segment: %w", command, err)
-		}
-	}
-	return relative, nil
-}
-
-func validateCWD(value string) error {
-	var suffix string
-	switch {
-	case strings.HasPrefix(value, "./"):
-		suffix = strings.TrimPrefix(value, "./")
-	case value == "${PLUGIN_ROOT}" || value == "${PLUGIN_DATA}":
 		return nil
-	case strings.HasPrefix(value, "${PLUGIN_ROOT}/"):
-		suffix = strings.TrimPrefix(value, "${PLUGIN_ROOT}/")
-	case strings.HasPrefix(value, "${PLUGIN_DATA}/"):
-		suffix = strings.TrimPrefix(value, "${PLUGIN_DATA}/")
-	default:
-		return fmt.Errorf("stdio cwd must be ./-, PLUGIN_ROOT-, or PLUGIN_DATA-rooted")
-	}
-	if suffix == "" || path.IsAbs(suffix) || strings.Contains(suffix, `\\`) || path.Clean(suffix) != suffix || strings.HasPrefix(suffix, "../") {
-		return fmt.Errorf("stdio cwd escapes its declared root")
-	}
-	for _, segment := range strings.Split(suffix, "/") {
-		if err := pathpolicy.ValidatePortablePathSegment(segment); err != nil {
-			return fmt.Errorf("stdio cwd contains a non-portable path segment: %w", err)
-		}
-	}
-	return nil
+	})
 }
+func bundledCommandPath(command string) (string, error) { return pathcontract.ParseCommand(command) }
+func validateCWD(value string) error                    { _, err := pathcontract.ParseCWD(value); return err }
 
 func (loader Loader) loadOpenAIMCP(path string, declared bool) (domain.MCPComponent, []domain.Diagnostic) {
 	body, exists, err := readRegularFile(path)

--- a/install/integrationctl/agentplugins/adapters/loader/path_semantics_test.go
+++ b/install/integrationctl/agentplugins/adapters/loader/path_semantics_test.go
@@ -1,0 +1,37 @@
+package loader
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStdioPermittedDotSegments(t *testing.T) {
+	root := t.TempDir()
+	for _, d := range []string{"bin", "data"} {
+		if e := os.Mkdir(filepath.Join(root, d), 0700); e != nil {
+			t.Fatal(e)
+		}
+	}
+	if e := os.WriteFile(filepath.Join(root, "bin/server"), []byte("inert"), 0600); e != nil {
+		t.Fatal(e)
+	}
+	for _, cwd := range []string{"./", "./data/..", "${PLUGIN_ROOT}"} {
+		config := map[string]any{"command": "./bin/../bin/server", "cwd": cwd}
+		r, e := validateStdioServer(root, config)
+		if e != nil {
+			t.Fatal(e)
+		}
+		if r.BundledRelativePath != "bin/../bin/server" || config["cwd"] != cwd {
+			t.Fatal("raw path changed")
+		}
+	}
+	for _, cwd := range []string{"./../outside", "${PLUGIN_ROOT}/../data"} {
+		if _, e := validateStdioServer(root, map[string]any{"command": "node", "cwd": cwd}); e == nil {
+			t.Fatalf("accepted %s", cwd)
+		}
+	}
+	if _, e := validateStdioServer(root, map[string]any{"command": "./missing/../bin/server"}); e != nil {
+		t.Fatalf("missing is readiness: %v", e)
+	}
+}

--- a/install/integrationctl/agentplugins/adapters/loader/plugin.go
+++ b/install/integrationctl/agentplugins/adapters/loader/plugin.go
@@ -2,7 +2,6 @@ package loader
 
 import (
 	"encoding/json"
-	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/pathpolicy"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/conformance"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 )
@@ -18,10 +17,6 @@ func (loader Loader) loadPluginManifest(path string) (domain.PluginManifest, []d
 	manifest, diagnostics, digest, err := (conformance.InstallerDecoder{Registry: loader.Registry}).Plugin(body)
 	if err != nil {
 		return manifest, diagnostics, digest, err
-	}
-	// Installer physical policy remains before any component reads.
-	if err := pathpolicy.ValidateLeafID(manifest.Name); err != nil {
-		return domain.PluginManifest{}, diagnostics, "", domain.FatalLoad("plugin_name_unsafe", "plugin.json", "plugin name cannot be used as a portable physical identifier", err)
 	}
 	return manifest, diagnostics, digest, nil
 }

--- a/install/integrationctl/agentplugins/adapters/loader/policy_compat_test.go
+++ b/install/integrationctl/agentplugins/adapters/loader/policy_compat_test.go
@@ -93,16 +93,15 @@ func (r *recordingRegistry) Validate(uri string, value any) error {
 	r.uris = append(r.uris, uri)
 	return r.interfaceRegistry.Validate(uri, value)
 }
-func TestPhysicalNamePolicyBeforeComponentDecode(t *testing.T) {
+func TestPortableNameDoesNotPreventComponentDecode(t *testing.T) {
 	root := t.TempDir()
 	writeMinimalPlugin(t, root, "con")
 	writeLoaderFile(t, filepath.Join(root, "mcp.json"), "not JSON")
 	writeLoaderFile(t, filepath.Join(root, "skills", "bad", "SKILL.md"), "not YAML")
 	original := testLoader(t)
 	registry := &recordingRegistry{interfaceRegistry: original.Registry}
-	_, e := (Loader{Registry: registry}).Load(context.Background(), domain.LoadInput{SnapshotRoot: root})
-	var load *domain.LoadError
-	if !errors.As(e, &load) || load.Diagnostic.Code != "plugin_name_unsafe" || len(registry.uris) != 1 || registry.uris[0] != domain.PluginSchemaV1 {
+	pkg, e := (Loader{Registry: registry}).Load(context.Background(), domain.LoadInput{SnapshotRoot: root})
+	if e != nil || pkg.Manifest.Name != "con" || len(pkg.Diagnostics) == 0 || len(registry.uris) == 0 || registry.uris[0] != domain.PluginSchemaV1 {
 		t.Fatalf("precedence: %v %v", e, registry.uris)
 	}
 	f, e := (conformance.Decoder{Registry: original.Registry}).DecodePlugin(context.Background(), conformance.NewDocument("plugin.json", conformance.Present, []byte(`{"$schema":"`+domain.PluginSchemaV1+`","name":"con"}`)))

--- a/install/integrationctl/agentplugins/adapters/loader/portable_identity_test.go
+++ b/install/integrationctl/agentplugins/adapters/loader/portable_identity_test.go
@@ -1,0 +1,20 @@
+package loader
+
+import (
+	"context"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"testing"
+)
+
+func TestPortableReservedDeclaredNames(t *testing.T) {
+	for _, name := range []string{"con", "con.foo", "aux.tools", "nul.x", "com1.plugin", "lpt9.plugin"} {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			writeMinimalPlugin(t, root, name)
+			pkg, err := testLoader(t).Load(context.Background(), domain.LoadInput{SnapshotRoot: root})
+			if err != nil || pkg.Manifest.Name != name {
+				t.Fatalf("declared name changed/rejected: %+v %v", pkg.Manifest, err)
+			}
+		})
+	}
+}

--- a/install/integrationctl/agentplugins/adapters/statemigration/portable_identity_test.go
+++ b/install/integrationctl/agentplugins/adapters/statemigration/portable_identity_test.go
@@ -1,0 +1,29 @@
+package statemigration
+
+import (
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/pathpolicy"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"testing"
+	"time"
+)
+
+func TestLegacyPhysicalIdentitySeedAndInvalidNames(t *testing.T) {
+	for _, name := range []string{"ordinary", "con.foo", "CON.foo", "con.bad_name", "con..bad"} {
+		record := legacyInstallation{IntegrationID: name}
+		// Exercise the real migration decoder to avoid inventing target fields.
+		record.Targets = map[string]legacyTarget{"cursor": {TargetID: "cursor"}}
+		installation, err := migrateInstallation(record, time.Now(), func() (string, error) { return "installation", nil })
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, binding := range installation.Clients {
+			want := domain.ComputePhysicalArtifactID(name, "installation\x00cursor")
+			if binding.PhysicalArtifact != want {
+				t.Fatalf("migration seed changed: %q != %q", binding.PhysicalArtifact, want)
+			}
+			if name != "ordinary" && name != "con.foo" && pathpolicy.ValidateLeafID(binding.PhysicalArtifact) == nil {
+				t.Fatalf("invalid legacy name sanitized: %s", name)
+			}
+		}
+	}
+}

--- a/install/integrationctl/agentplugins/adapters/statev2/portable_identity_test.go
+++ b/install/integrationctl/agentplugins/adapters/statev2/portable_identity_test.go
@@ -1,0 +1,47 @@
+package statev2
+
+import (
+	"encoding/json"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUnsafePersistedPhysicalIdentityStillFailsClosed(t *testing.T) {
+	store := Store{Path: filepath.Join(t.TempDir(), "state-v2.json")}
+	installation := validInstallation("00000000-0000-4000-8000-000000000001", "src_one", "con.foo-000000000001")
+	installation.DeclaredName = "con.foo"
+	installation.Package.DeclaredName = "con.foo"
+	for key, binding := range installation.Clients {
+		binding.PhysicalArtifact = domain.ComputePhysicalArtifactID("con.foo", installation.InstallationID)
+		installation.Clients[key] = binding
+	}
+	safe := domain.StateFileV2{SchemaVersion: domain.StateSchemaVersion, Installations: []domain.Installation{installation}}
+	if err := store.Save(safe); err != nil {
+		t.Fatal("safe control failed", err)
+	}
+	for key, binding := range installation.Clients {
+		binding.PhysicalArtifact = "con.foo-000000000001"
+		installation.Clients[key] = binding
+	}
+	state := domain.StateFileV2{SchemaVersion: domain.StateSchemaVersion, Installations: []domain.Installation{installation}}
+	if err := store.Save(state); err == nil || !strings.Contains(err.Error(), "physical artifact") {
+		t.Fatal("unsafe physical identity saved")
+	}
+	raw, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.Path, raw, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Load(); err == nil || !strings.Contains(err.Error(), "physical artifact") {
+		t.Fatal("unsafe imported identity bypassed validation")
+	}
+	after, err := os.ReadFile(store.Path)
+	if err != nil || string(after) != string(raw) {
+		t.Fatal("unsafe state automatically mutated")
+	}
+}

--- a/install/integrationctl/agentplugins/conformance/author.go
+++ b/install/integrationctl/agentplugins/conformance/author.go
@@ -297,17 +297,5 @@ func (d Decoder) DecodeMCP(ctx context.Context, doc Document, pluginSchema strin
 	f.finish(l)
 	return f, nil
 }
-func normativeCommand(value string) (string, error) {
-	if !strings.HasPrefix(value, "./") || strings.Contains(value, "\\") {
-		return "", semanticError("stdio_command_path", "bundled command requires a plugin-relative path")
-	}
-	// Dot segments and physical device names are not normative rejection rules.
-	// Actual traversal order and link containment are supplied observations.
-	return strings.TrimPrefix(value, "./"), nil
-}
-func normativeCWD(value string) error {
-	if strings.HasPrefix(value, "./") || value == "${PLUGIN_ROOT}" || value == "${PLUGIN_DATA}" || strings.HasPrefix(value, "${PLUGIN_ROOT}/") || strings.HasPrefix(value, "${PLUGIN_DATA}/") {
-		return nil
-	}
-	return semanticError("stdio_cwd_root", "cwd requires a declared standard root")
-}
+func normativeCommand(value string) (string, error) { return ParseCommandPath(value) }
+func normativeCWD(value string) error               { _, _, err := ParseCWDPath(value); return err }

--- a/install/integrationctl/agentplugins/conformance/extensions_policy_test.go
+++ b/install/integrationctl/agentplugins/conformance/extensions_policy_test.go
@@ -1,0 +1,96 @@
+package conformance_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/loader"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/specregistry"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/conformance"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+// These expectations intentionally distinguish original author validity from
+// published 1.0 loading exceptions. No namespace interpreter is implemented here.
+func TestExtensionsAuthorAndLoadingPolicy(t *testing.T) {
+	registry, err := specregistry.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name, fields, report string
+		authorValid, load    bool
+	}{
+		{"absent", "", "", true, true},
+		{"empty", `,"extensions":{}`, "", true, true},
+		{"container-null", `,"extensions":null`, "plugin_extensions_ignored", false, true},
+		{"container-string", `,"extensions":"opaque"`, "plugin_extensions_ignored", false, true},
+		{"container-array", `,"extensions":[]`, "plugin_extensions_ignored", false, true},
+		{"unknown-object", `,"extensions":{"com.example.future":{"nested":[null,1]}}`, "", true, true},
+		{"unknown-scalar-disputed", `,"extensions":{"com.example.future":"opaque"}`, "", false, false},
+		{"unknown-null-disputed", `,"extensions":{"com.example.future":null}`, "", false, false},
+		{"unknown-array-disputed", `,"extensions":{"com.example.future":[]}`, "", false, false},
+		{"unknown-top-level", `,"future":{"opaque":true}`, "plugin_unknown_field", false, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := []byte(`{"$schema":"` + domain.PluginSchemaV1 + `","name":"extension-policy"` + tc.fields + `}`)
+			facts, err := (conformance.Decoder{Registry: registry}).DecodePlugin(context.Background(), conformance.NewDocument("plugin.json", conformance.Present, body))
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantCoverage := conformance.Fail
+			if tc.authorValid {
+				wantCoverage = conformance.Pass
+			}
+			if facts.Coverage.Plugin != wantCoverage {
+				t.Fatalf("author coverage=%s, want=%s", facts.Coverage.Plugin, wantCoverage)
+			}
+			manifest, diagnostics, _, err := (conformance.InstallerDecoder{Registry: registry}).Plugin(body)
+			if (err == nil) != tc.load {
+				t.Fatalf("load error=%v, expected loaded=%v", err, tc.load)
+			}
+			if !tc.load {
+				return
+			}
+			if string(manifest.Raw) != string(body) {
+				t.Fatal("original manifest bytes changed")
+			}
+			if tc.report != "" {
+				found := false
+				for _, d := range diagnostics {
+					if d.Code == tc.report {
+						found = true
+					}
+				}
+				if !found {
+					t.Fatalf("missing %s report: %+v", tc.report, diagnostics)
+				}
+			}
+			// Exercise discovery after tolerant manifest loading, without client launch.
+			root := t.TempDir()
+			files := map[string]string{
+				"plugin.json":             string(body),
+				"skills/healthy/SKILL.md": "---\nname: healthy\ndescription: Healthy sibling\n---\nInstructions.\n",
+				"mcp.json":                `{"$schema":"` + domain.MCPSchemaV1 + `","mcpServers":{"healthy":{"type":"streamable-http","url":"https://example.test/mcp"}}}`,
+			}
+			for name, value := range files {
+				path := filepath.Join(root, filepath.FromSlash(name))
+				if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, []byte(value), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			pkg, err := (loader.Loader{Registry: registry}).Load(context.Background(), domain.LoadInput{SnapshotRoot: root})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(pkg.Skills) != 1 || len(pkg.MCP.Servers) != 1 {
+				t.Fatalf("healthy components lost: skills=%d mcp=%d", len(pkg.Skills), len(pkg.MCP.Servers))
+			}
+		})
+	}
+}

--- a/install/integrationctl/agentplugins/conformance/path_syntax.go
+++ b/install/integrationctl/agentplugins/conformance/path_syntax.go
@@ -1,0 +1,29 @@
+package conformance
+
+import "strings"
+
+// ParseCommandPath preserves traversal segments for the observing filesystem adapter.
+func ParseCommandPath(value string) (string, error) {
+	if !strings.HasPrefix(value, "./") || strings.Contains(value, "\\") {
+		return "", semanticError("stdio_command_path", "bundled command requires a plugin-relative path")
+	}
+	return value[2:], nil
+}
+
+// ParseCWDPath decodes only the published root grammar, without filesystem policy.
+func ParseCWDPath(value string) (anchor, relative string, err error) {
+	switch {
+	case value == "" || value == "${PLUGIN_ROOT}":
+		return "plugin", "", nil
+	case value == "${PLUGIN_DATA}":
+		return "data", "", nil
+	case strings.HasPrefix(value, "./"):
+		return "plugin", value[2:], nil
+	case strings.HasPrefix(value, "${PLUGIN_ROOT}/"):
+		return "plugin", strings.TrimPrefix(value, "${PLUGIN_ROOT}/"), nil
+	case strings.HasPrefix(value, "${PLUGIN_DATA}/"):
+		return "data", strings.TrimPrefix(value, "${PLUGIN_DATA}/"), nil
+	default:
+		return "", "", semanticError("stdio_cwd_root", "cwd requires a declared standard root")
+	}
+}

--- a/install/integrationctl/agentplugins/conformance/profiles/README.md
+++ b/install/integrationctl/agentplugins/conformance/profiles/README.md
@@ -27,7 +27,7 @@ Schemas retain the existing registry's exact identifiers and pinned digests.
 | plugins/5.1 | Exact root plugin.json, sole authority. Captured path checked; no alternate format selection. |
 | plugins/5.2 | Closed object, required exact schema, exact keys and metadata types. Original schema validation is independent of installer filtering; case variants remain opaque (AUD-018 correction). |
 | plugins/5.3-5.5 | Required name and type-only optional metadata via pinned schema. No SemVer, URL, email, SPDX or physical-name policy added. |
-| plugins/8.1 | Object extension container and object values; contents opaque. No invented namespace regex or ownership validation. |
+| plugins/8.1 | Author schema requires an object container and object members. Installer reports and ignores a non-object container; non-object members remain rejected under the documented disputed interpretation below. Object contents stay opaque. |
 | plugins/6.2 | Absent components are optional; wrong kind invalidates that component. Unreadable is unavailable, never absence. |
 | plugins/7.1 | Only supplied immediate Skills; complete discovery must be supplied by the rooted reader. |
 | plugins/7.2.1 | Closed explicit transport schemas; inert single-token command, allowed cwd anchors, absolute HTTP(S), no userinfo/fragment, loopback-only cleartext and valid case-unique literal headers. |
@@ -60,3 +60,35 @@ identity and deterministic duplicate-span ordinal, never messages or values. Pub
 raw bytes, env, headers, extensions and underlying errors are not serialized.
 Facts.Package is an internal canonical PackageEnvelope capability, excluded from
 Facts JSON. Consumers must build allowlisted report DTOs and must not serialize it.
+
+## Extension loading policy (published 1.0)
+
+| Original input | Canonical author schema | Installer disposition | Extension interpretation |
+| --- | --- | --- | --- |
+| Absent or empty object | Valid | Load | None |
+| Container null, string or array | Invalid | Report `plugin_extensions_ignored`, ignore, load healthy skills/MCP | None |
+| Unknown namespace with object value | Valid | Load, retain raw bytes | Opaque |
+| Unknown namespace with scalar, null or array value | Invalid | Reject manifest (disputed policy retained) | None |
+| Unknown top-level field | Invalid | Report `plugin_unknown_field`, preserve, load healthy skills/MCP | None |
+| Implemented namespace valid/invalid contents | Not applicable | No portable namespace interpreter currently implemented | No invented semantics |
+
+The original author document is validated independently of the installer view.
+Tolerant loading does not make invalid author input valid. Namespace names are
+not subject to an invented reverse-domain regex. Regression tests exercise both
+views and healthy component discovery in disposable roots without execution.
+Canonical schemas, profile source digests and runtime member policy are unchanged.
+
+At corpus `Booyaka101/agent-plugins-conformance-kit@4d163c6281a9b4929f482f387efe340b4dc175a1`,
+`disputed/AP-8.1-EXTENSIONS-MEMBER-OBJECTS/fixture.json` has
+`expect.rejected: null`, expects skill `alpha`, and records optional rejection
+and an `extensions` report. Its rationale explicitly records the two readings;
+it is not an authoritative scalar-member rejection requirement or certification.
+The corpus pin and strict-reporting gate remain unchanged.
+
+[Issue #77 discussion](https://github.com/agentplugins/agent-plugins-spec/issues/77#issuecomment-5488098709)
+remained OPEN at the 2026-09-06 review and tracks the distinction between the
+object-member requirement and ignoring unimplemented namespaces. [PR #82](https://github.com/agentplugins/agent-plugins-spec/pull/82)
+was OPEN, unmerged, at head `6b0210e4bee84d8bea3f200091badbe796a5c88f`
+on 2026-09-06. Its draft 1.1 container change does not settle published 1.0
+member interpretation. Unknown schema versions, including draft 1.1, remain
+unsupported. Revisit this bounded interpretation after authoritative clarification.

--- a/install/integrationctl/agentplugins/domain/clients.go
+++ b/install/integrationctl/agentplugins/domain/clients.go
@@ -88,6 +88,10 @@ func withActivation(definition ClientDefinition, activation ActivationMode) Clie
 
 func clientDefinition(id ClientID, displayName, backendFamily, delivery, catalogPackage string, legacyRequired bool, packageMode PackageMode, skill, mcp, extension SupportLevel) ClientDefinition {
 	transports := map[string]SupportLevel{"stdio": mcp, "streamable-http": mcp, "sse": mcp}
+	// OpenCode remote starts with Streamable HTTP; its fallback cannot preserve SSE-first.
+	if id == ClientOpenCode {
+		transports["sse"] = SupportUnsupported
+	}
 	appSupport := SupportUnsupported
 	if id == ClientChatGPT {
 		appSupport = SupportProjected

--- a/install/integrationctl/agentplugins/domain/identity.go
+++ b/install/integrationctl/agentplugins/domain/identity.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 )
 
@@ -47,5 +48,32 @@ func ComputePhysicalArtifactID(declaredName, installationID string) string {
 	if len(name) > maximumNameBytes {
 		name = strings.TrimRight(name[:maximumNameBytes], ".-")
 	}
-	return name + "-" + suffix
+	candidate := name + "-" + suffix
+	// Preserve historical safe output, including its exact truncation.
+	// Only schema-valid portable names use the reserved-basename fallback.
+	if portableDeclaredName(declaredName) && reservedPhysicalStem(candidate) {
+		maximumNameBytes -= len("p-")
+		if len(name) > maximumNameBytes {
+			name = strings.TrimRight(name[:maximumNameBytes], ".-")
+		}
+		return "p-" + name + "-" + suffix
+	}
+	return candidate
+}
+
+var physicalDeclaredNamePattern = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$`)
+
+func portableDeclaredName(name string) bool {
+	return len(name) <= 64 && physicalDeclaredNamePattern.MatchString(name) && !strings.Contains(name, "--") && !strings.Contains(name, "..")
+}
+
+// reservedPhysicalStem mirrors the narrow Windows basename invariant. The
+// external-package tests keep this pure domain check in parity with pathpolicy.
+func reservedPhysicalStem(name string) bool {
+	stem := strings.ToUpper(strings.SplitN(name, ".", 2)[0])
+	switch stem {
+	case "CON", "PRN", "AUX", "NUL", "CLOCK$":
+		return true
+	}
+	return len(stem) == 4 && (strings.HasPrefix(stem, "COM") || strings.HasPrefix(stem, "LPT")) && stem[3] >= '1' && stem[3] <= '9'
 }

--- a/install/integrationctl/agentplugins/domain/identity_portable_test.go
+++ b/install/integrationctl/agentplugins/domain/identity_portable_test.go
@@ -1,0 +1,71 @@
+package domain_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/pathpolicy"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func historicalPhysicalID(name, id string) string {
+	sum := sha256.Sum256([]byte(id))
+	name = strings.TrimSpace(name)
+	if len(name) > 51 {
+		name = strings.TrimRight(name[:51], ".-")
+	}
+	return name + "-" + hex.EncodeToString(sum[:6])
+}
+
+func TestPhysicalIdentityHistoricalSafeOutputs(t *testing.T) {
+	names := []string{"demo", "con", "ordinary.plugin", strings.Repeat("a", 64), strings.Repeat("a", 50) + ".tail", " trimmed ", "legacy_ID"}
+	for _, name := range names {
+		for _, id := range []string{"00000000-0000-4000-8000-000000000001", "other", "installation\x00cursor"} {
+			want := historicalPhysicalID(name, id)
+			if err := pathpolicy.ValidateLeafID(want); err != nil {
+				t.Fatal(err)
+			}
+			if got := domain.ComputePhysicalArtifactID(name, id); got != want {
+				t.Fatalf("%q: %q != %q", name, got, want)
+			}
+		}
+	}
+}
+
+func TestPortableReservedIdentityFilesystemAndPolicyParity(t *testing.T) {
+	names := []string{"con", "con.foo", "aux.tools", "nul.x", "prn.plugin", "clock.plugin", "com0.plugin", "lpt0.plugin", "com10.plugin", "lpt10.plugin", "con." + strings.Repeat("x", 60)}
+	for n := '1'; n <= '9'; n++ {
+		names = append(names, "com"+string(n)+".plugin", "lpt"+string(n)+".plugin")
+	}
+	root := t.TempDir()
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			got := domain.ComputePhysicalArtifactID(name, "installation")
+			old := historicalPhysicalID(name, "installation")
+			if err := pathpolicy.ValidateLeafID(got); err != nil || len(got) > 64 {
+				t.Fatalf("unsafe %q: %v", got, err)
+			}
+			if pathpolicy.ValidateLeafID(old) == nil && got != old {
+				t.Fatalf("safe output changed %q -> %q", old, got)
+			}
+			if pathpolicy.ValidateLeafID(old) != nil && !strings.HasPrefix(got, "p-") {
+				t.Fatalf("missing safe prefix: %s", got)
+			}
+			// On Windows CI this creates real directories, rather than cross-compiling.
+			if err := os.Mkdir(filepath.Join(root, got), 0700); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestPhysicalIdentityDoesNotSanitizeNonstandardLegacyNames(t *testing.T) {
+	for _, name := range []string{"CON.foo", "con..foo", "con.bad--name", " con.foo ", "con.bad_name", "con." + strings.Repeat("x", 61)} {
+		if got, want := domain.ComputePhysicalArtifactID(name, "id"), historicalPhysicalID(name, "id"); got != want {
+			t.Fatalf("silently sanitized %q: %q", name, got)
+		}
+	}
+}

--- a/install/integrationctl/agentplugins/domain/opencode_transport_test.go
+++ b/install/integrationctl/agentplugins/domain/opencode_transport_test.go
@@ -1,0 +1,22 @@
+package domain
+
+import "testing"
+
+func TestOpenCodeDeclaredSSEUnsupportedAndCapabilitiesIsolated(t *testing.T) {
+	for _, definition := range ClientDefinitions() {
+		got := definition.Capabilities.MCPTransports
+		if definition.ID == ClientOpenCode {
+			if got["sse"] != SupportUnsupported || got["stdio"] == SupportUnsupported || got["streamable-http"] == SupportUnsupported {
+				t.Fatalf("OpenCode transports: %v", got)
+			}
+		} else if (definition.ID == ClientCline || definition.ID == ClientWindsurf || definition.ID == ClientGemini) && got["sse"] == SupportUnsupported {
+			t.Fatalf("SSE accidentally disabled for %s", definition.ID)
+		}
+	}
+	d, _ := ClientDefinitionFor(ClientOpenCode)
+	d.Capabilities.MCPTransports["sse"] = SupportNative
+	fresh, _ := ClientDefinitionFor(ClientOpenCode)
+	if fresh.Capabilities.MCPTransports["sse"] != SupportUnsupported {
+		t.Fatal("capability map is shared")
+	}
+}

--- a/install/integrationctl/agentplugins/domain/selection.go
+++ b/install/integrationctl/agentplugins/domain/selection.go
@@ -1,0 +1,24 @@
+package domain
+
+import "sort"
+
+// SelectedMCPNames is the deterministic delivery set, after static support and
+// local readiness decisions. Consumers must not infer delivery from the envelope.
+func SelectedMCPNames(plan DeliveryPlan) []string {
+	names := []string{}
+	seen := map[string]bool{}
+	for _, c := range plan.Components {
+		if c.Kind == ComponentMCPServer && c.Support != SupportUnsupported && !seen[c.Name] {
+			names = append(names, c.Name)
+			seen[c.Name] = true
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ComponentReadinessError describes an expected local delivery limitation.
+// Unexpected ownership, filesystem, and consistency errors remain fatal.
+type ComponentReadinessError struct{ Code, Message string }
+
+func (e *ComponentReadinessError) Error() string { return e.Message }

--- a/install/integrationctl/agentplugins/managedstdio/launcher.go
+++ b/install/integrationctl/agentplugins/managedstdio/launcher.go
@@ -1,0 +1,99 @@
+// Package managedstdio implements the private, versioned Windsurf process adapter.
+// It has no installer, network, configuration or state dependencies.
+package managedstdio
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/pathcontract"
+)
+
+const Mode = "--internal-stdio-v1"
+const RelativeDirectory = "io.github.777genius.agentplugins/managed-stdio-v1"
+const ExecutableName = "agentplugins"
+
+// Arguments uses positional fields so child flags and empty arguments remain opaque.
+func Arguments(plugin, data, cwd string, anchor pathcontract.Anchor, command string, args []string) []string {
+	return append([]string{Mode, plugin, data, cwd, string(anchor), "--", command}, args...)
+}
+
+// Dispatch returns false only for an ordinary CLI invocation. Malformed private
+// invocations never fall through to user configuration or Directory access.
+func Dispatch(args []string, stderr io.Writer) (bool, int) {
+	if len(args) == 0 || args[0] != Mode {
+		return false, 0
+	}
+	if err := run(args[1:]); err != nil {
+		fmt.Fprintln(stderr, "managed stdio:", err)
+		return true, 126
+	}
+	return true, 0
+}
+
+func run(args []string) error {
+	if !Supported() {
+		return fmt.Errorf("managed stdio is unsupported on this platform")
+	}
+	if len(args) < 6 || args[4] != "--" {
+		return fmt.Errorf("invalid protocol v1 arguments")
+	}
+	plugin, data, cwd := args[0], args[1], args[2]
+	if !filepath.IsAbs(plugin) || !filepath.IsAbs(data) || !filepath.IsAbs(cwd) {
+		return fmt.Errorf("protocol roots and cwd must be absolute")
+	}
+	root := plugin
+	switch pathcontract.Anchor(args[3]) {
+	case pathcontract.Plugin:
+	case pathcontract.Data:
+		root = data
+	default:
+		return fmt.Errorf("invalid cwd anchor")
+	}
+	// Strip without Clean/Rel: symlink/.. traversal must reach the resolver intact.
+	relative := ""
+	if cwd != root {
+		prefix := strings.TrimRight(root, string(filepath.Separator)) + string(filepath.Separator)
+		if !strings.HasPrefix(cwd, prefix) {
+			return fmt.Errorf("cwd does not use its declared root")
+		}
+		relative = filepath.ToSlash(strings.TrimPrefix(cwd, prefix))
+	}
+	resolved := pathcontract.Resolve(root, relative)
+	if resolved.State != pathcontract.Resolved {
+		return fmt.Errorf("cwd unavailable: %v", resolved.Err)
+	}
+	info, err := os.Stat(resolved.Path)
+	if err != nil || !info.IsDir() {
+		return fmt.Errorf("cwd is not a directory")
+	}
+	command := args[5]
+	if strings.HasPrefix(command, "./") {
+		relative, err := pathcontract.ParseCommand(command)
+		if err != nil {
+			return err
+		}
+		result := pathcontract.Resolve(plugin, relative)
+		if result.State != pathcontract.Resolved {
+			return fmt.Errorf("bundled command unavailable: %v", result.Err)
+		}
+		command = result.Path
+	} else {
+		if command == "" || strings.ContainsAny(command, "/\\\x00") {
+			return fmt.Errorf("command must be a bare executable or bundled path")
+		}
+		// Resolve PATH before chdir. Go rejects implicit current-directory lookup.
+		command, err = exec.LookPath(command)
+		if err != nil {
+			return fmt.Errorf("runtime unavailable: %w", err)
+		}
+		if !filepath.IsAbs(command) {
+			return fmt.Errorf("runtime PATH resolved to a relative executable")
+		}
+	}
+	return replaceProcess(command, append([]string{command}, args[6:]...), resolved.Path)
+}

--- a/install/integrationctl/agentplugins/managedstdio/launcher_test.go
+++ b/install/integrationctl/agentplugins/managedstdio/launcher_test.go
@@ -1,0 +1,211 @@
+package managedstdio
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/pathcontract"
+)
+
+// Test subprocesses are explicitly invoked fixtures, never an implicit source
+// executable fallback in production staging.
+func TestSubprocess(t *testing.T) {
+	if os.Getenv("UAP_TEST_LAUNCHER") != "1" {
+		return
+	}
+	args := os.Args
+	for i, v := range args {
+		if v == "fixture" {
+			args = args[i+1:]
+			break
+		}
+	}
+	if len(args) > 0 && args[0] == "child" {
+		if len(args) > 1 && args[1] == "sleep" {
+			fmtReady()
+			time.Sleep(time.Minute)
+			os.Exit(0)
+		}
+		cwd, _ := os.Getwd()
+		body, _ := os.ReadFile("relative.txt")
+		input, _ := io.ReadAll(os.Stdin)
+		_ = json.NewEncoder(os.Stdout).Encode(map[string]any{"cwd": cwd, "file": string(body), "args": args[1:], "stdin": string(input), "env": os.Getenv("OPAQUE")})
+		_, _ = os.Stderr.WriteString("child-stderr")
+		os.Exit(23)
+	}
+	handled, code := Dispatch(args, os.Stderr)
+	if !handled {
+		os.Exit(99)
+	}
+	os.Exit(code)
+}
+func fmtReady() { _, _ = os.Stdout.WriteString("ready\n") }
+func fixtureCommand(t *testing.T, args []string) *exec.Cmd {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(exe, append([]string{"-test.run=^TestSubprocess$", "fixture"}, args...)...)
+	cmd.Env = append(os.Environ(), "UAP_TEST_LAUNCHER=1", "OPAQUE=${PLUGIN_ROOT};$(untouched)")
+	cmd.Dir = t.TempDir()
+	return cmd
+}
+func TestExecPreservesCWDArgumentsStreamsAndExit(t *testing.T) {
+	if !Supported() {
+		t.Skip("unsupported native lifecycle")
+	}
+	for _, anchor := range []pathcontract.Anchor{pathcontract.Plugin, pathcontract.Data} {
+		t.Run(string(anchor), func(t *testing.T) {
+			plugin, data := t.TempDir(), t.TempDir()
+			root := plugin
+			if anchor == pathcontract.Data {
+				root = data
+			}
+			if err := os.WriteFile(filepath.Join(root, "relative.txt"), []byte("relative-ok"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			exe, _ := os.Executable()
+			body, err := os.ReadFile(exe)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(plugin, "child"), body, 0700); err != nil {
+				t.Fatal(err)
+			}
+			opaque := []string{"", "a b", "'quoted'", "\"double\"", "雪", "$(touch forbidden)", "--flag", "../opaque"}
+			childArgs := append([]string{"-test.run=^TestSubprocess$", "fixture", "child"}, opaque...)
+			cmd := fixtureCommand(t, Arguments(plugin, data, root+"/./", anchor, "./child", childArgs))
+			cmd.Stdin = strings.NewReader("roundtrip\n")
+			var stdout, stderr bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+			err = cmd.Run()
+			if ee, ok := err.(*exec.ExitError); !ok || ee.ExitCode() != 23 {
+				t.Fatalf("exit: %v; stderr %s", err, stderr.String())
+			}
+			var got struct {
+				CWD, File, Stdin, Env string
+				Args                  []string
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			canonical, _ := filepath.EvalSymlinks(root)
+			if got.CWD != canonical || got.File != "relative-ok" || got.Stdin != "roundtrip\n" || !reflect.DeepEqual(got.Args, opaque) || got.Env != "${PLUGIN_ROOT};$(untouched)" || stderr.String() != "child-stderr" {
+				t.Fatalf("bad child contract %+v stderr %q", got, stderr.String())
+			}
+		})
+	}
+}
+func TestMalformedMissingAndEscapeFailWithoutStdout(t *testing.T) {
+	root, data := t.TempDir(), t.TempDir()
+	outside := t.TempDir()
+	_ = os.Symlink(outside, filepath.Join(root, "escape"))
+	tests := [][]string{{Mode}, Arguments(root, data, root, "invalid", "runtime", nil), Arguments(root, data, root+"/missing", pathcontract.Plugin, "runtime", nil), Arguments(root, data, root+"/escape", pathcontract.Plugin, "runtime", nil), Arguments(root, data, root, pathcontract.Plugin, "./missing", nil), Arguments(root, data, root, pathcontract.Plugin, "./../escape", nil)}
+	for _, args := range tests {
+		cmd := fixtureCommand(t, args)
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		err := cmd.Run()
+		if ee, ok := err.(*exec.ExitError); !ok || ee.ExitCode() != 126 || stdout.Len() != 0 || stderr.Len() == 0 {
+			t.Fatalf("bad refusal %v %s %s", err, stdout.String(), stderr.String())
+		}
+	}
+}
+func TestPlatformGate(t *testing.T) {
+	want := runtime.GOOS == "darwin" || runtime.GOOS == "linux"
+	if Supported() != want {
+		t.Fatal("unsupported platform claimed")
+	}
+}
+func TestCopiedHelperPinsBytesAndSurvivesSourceRemoval(t *testing.T) {
+	if !Supported() {
+		t.Skip("unsupported")
+	}
+	exe, _ := os.Executable()
+	body, err := os.ReadFile(exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := filepath.Join(t.TempDir(), "cli")
+	if err := os.WriteFile(original, body, 0700); err != nil {
+		t.Fatal(err)
+	}
+	source, err := NewSource(original, "A")
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	if err := source.Deliver(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(original); err != nil {
+		t.Fatal(err)
+	}
+	helper := filepath.Join(root, filepath.FromSlash(RelativeDirectory), ExecutableName)
+	cmd := exec.Command(helper, "-test.run=^TestSubprocess$", "fixture", Mode)
+	cmd.Env = append(os.Environ(), "UAP_TEST_LAUNCHER=1")
+	output, err := cmd.CombinedOutput()
+	if ee, ok := err.(*exec.ExitError); !ok || ee.ExitCode() != 126 || !strings.Contains(string(output), "invalid protocol") {
+		t.Fatalf("copied executable: %v %s", err, output)
+	}
+	if err := source.Deliver(t.TempDir()); err == nil {
+		t.Fatal("missing trusted source accepted")
+	}
+	if err := source.Deliver(root); err == nil {
+		t.Fatal("collision overwritten")
+	}
+}
+
+func TestBareExecutableUsesInheritedPATHWithoutShell(t *testing.T) {
+	if !Supported() {
+		t.Skip("unsupported")
+	}
+	plugin, data, bin := t.TempDir(), t.TempDir(), t.TempDir()
+	exe, _ := os.Executable()
+	body, err := os.ReadFile(exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bin, "uap-test-native"), body, 0700); err != nil {
+		t.Fatal(err)
+	}
+	cmd := fixtureCommand(t, Arguments(plugin, data, plugin, pathcontract.Plugin, "uap-test-native", []string{"-test.run=^TestSubprocess$", "fixture", "child"}))
+	cmd.Env = append(cmd.Env, "PATH="+bin)
+	output, err := cmd.Output()
+	if ee, ok := err.(*exec.ExitError); !ok || ee.ExitCode() != 23 {
+		t.Fatalf("bare PATH lookup: %v %s", err, output)
+	}
+}
+func TestSourceBytesCannotChangeAfterTrustCapture(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cli")
+	if err := os.WriteFile(path, []byte("A"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	source, err := NewSource(path, "A")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("B"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	if err := source.Deliver(root); err == nil {
+		t.Fatal("changed source was copied")
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil || len(entries) != 0 {
+		t.Fatal("source failure wrote artifact")
+	}
+}

--- a/install/integrationctl/agentplugins/managedstdio/process_unix.go
+++ b/install/integrationctl/agentplugins/managedstdio/process_unix.go
@@ -1,0 +1,16 @@
+//go:build darwin || linux
+
+package managedstdio
+
+import (
+	"os"
+	"syscall"
+)
+
+func Supported() bool { return true }
+func replaceProcess(command string, args []string, cwd string) error {
+	if err := os.Chdir(cwd); err != nil {
+		return err
+	}
+	return syscall.Exec(command, args, os.Environ())
+}

--- a/install/integrationctl/agentplugins/managedstdio/process_unix_test.go
+++ b/install/integrationctl/agentplugins/managedstdio/process_unix_test.go
@@ -1,0 +1,58 @@
+//go:build darwin || linux
+
+package managedstdio
+
+import (
+	"bufio"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/pathcontract"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestExecKeepsPIDAndControlledSignalExit(t *testing.T) {
+	root, data := t.TempDir(), t.TempDir()
+	exe, _ := os.Executable()
+	body, err := os.ReadFile(exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "child"), body, 0700); err != nil {
+		t.Fatal(err)
+	}
+	cmd := fixtureCommand(t, Arguments(root, data, root, pathcontract.Plugin, "./child", []string{"-test.run=^TestSubprocess$", "fixture", "child", "sleep"}))
+	pipe, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer cmd.Process.Kill()
+	ready := make(chan string, 1)
+	go func() { line, _ := bufio.NewReader(pipe).ReadString('\n'); ready <- line }()
+	select {
+	case line := <-ready:
+		if line != "ready\n" {
+			t.Fatalf("child readiness %q", line)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("child did not start")
+	}
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case <-done:
+		status := cmd.ProcessState.Sys().(syscall.WaitStatus)
+		if !status.Signaled() || status.Signal() != syscall.SIGTERM {
+			t.Fatalf("lost native signal status: %v", status)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("controlled signal failed to stop transport PID")
+	}
+}

--- a/install/integrationctl/agentplugins/managedstdio/process_unsupported.go
+++ b/install/integrationctl/agentplugins/managedstdio/process_unsupported.go
@@ -1,0 +1,12 @@
+//go:build !darwin && !linux
+
+package managedstdio
+
+import "fmt"
+
+// Windows remains gated until suspended creation + Job Object lifecycle has
+// native evidence. Cross-compilation is not evidence of process-tree cleanup.
+func Supported() bool { return false }
+func replaceProcess(string, []string, string) error {
+	return fmt.Errorf("managed stdio is unsupported on this platform")
+}

--- a/install/integrationctl/agentplugins/managedstdio/source.go
+++ b/install/integrationctl/agentplugins/managedstdio/source.go
@@ -1,0 +1,106 @@
+package managedstdio
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Source is explicitly created by the composition root from its own executable.
+// Its private digest binds subsequent copies to those exact trusted bytes.
+type Source struct{ path, digest, version string }
+
+func NewSource(executable, version string) (*Source, error) {
+	if !filepath.IsAbs(executable) {
+		return nil, fmt.Errorf("launcher source must be absolute")
+	}
+	body, err := readExecutable(executable)
+	if err != nil {
+		return nil, err
+	}
+	hash := sha256.Sum256(body)
+	return &Source{path: executable, digest: hex.EncodeToString(hash[:]), version: version}, nil
+}
+func readExecutable(path string) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0111 == 0 {
+		return nil, fmt.Errorf("launcher source is not executable")
+	}
+	return os.ReadFile(path)
+}
+func (source *Source) Available() error {
+	if source == nil {
+		return fmt.Errorf("trusted launcher source is unavailable")
+	}
+	body, err := readExecutable(source.path)
+	if err != nil {
+		return err
+	}
+	hash := sha256.Sum256(body)
+	if hex.EncodeToString(hash[:]) != source.digest {
+		return fmt.Errorf("trusted launcher source changed")
+	}
+	return nil
+}
+
+// CheckCollision never follows an authored namespace symlink or overwrites files.
+func CheckCollision(root string) (bool, error) {
+	parent := filepath.Join(root, "io.github.777genius.agentplugins")
+	info, err := os.Lstat(parent)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return true, nil
+	}
+	_, err = os.Lstat(filepath.Join(root, filepath.FromSlash(RelativeDirectory)))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return err == nil, err
+}
+func (source *Source) Deliver(root string) error {
+	collision, err := CheckCollision(root)
+	if err != nil {
+		return err
+	}
+	if collision {
+		return fmt.Errorf("managed launcher reserved path collision")
+	}
+	if err := source.Available(); err != nil {
+		return err
+	}
+	body, err := readExecutable(source.path)
+	if err != nil {
+		return err
+	}
+	hash := sha256.Sum256(body)
+	if hex.EncodeToString(hash[:]) != source.digest {
+		return fmt.Errorf("trusted launcher source changed")
+	}
+	directory := filepath.Join(root, filepath.FromSlash(RelativeDirectory))
+	if err := os.MkdirAll(directory, 0700); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(directory, ExecutableName), body, 0700); err != nil {
+		return err
+	}
+	metadata, err := json.Marshal(struct {
+		Protocol int    `json:"protocol"`
+		SHA256   string `json:"sha256"`
+		Version  string `json:"cliVersion"`
+	}{1, source.digest, source.version})
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(directory, "metadata.json"), metadata, 0600)
+}

--- a/install/integrationctl/agentplugins/pathcontract/path.go
+++ b/install/integrationctl/agentplugins/pathcontract/path.go
@@ -1,0 +1,182 @@
+// Package pathcontract keeps portable path syntax separate from filesystem readiness.
+package pathcontract
+
+import (
+	"fmt"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/conformance"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type Anchor string
+
+const (
+	Plugin Anchor = "plugin"
+	Data   Anchor = "data"
+)
+
+type Path struct {
+	Anchor   Anchor
+	Relative string
+}
+type State string
+
+const (
+	Resolved    State = "resolved"
+	Missing     State = "missing"
+	Unavailable State = "unavailable"
+	Invalid     State = "invalid"
+)
+
+type Result struct {
+	Path  string
+	State State
+	Err   error
+}
+
+func ParseCommand(value string) (string, error) { return conformance.ParseCommandPath(value) }
+func ParseCWD(value string) (Path, error) {
+	anchor, relative, err := conformance.ParseCWDPath(value)
+	return Path{Anchor: Anchor(anchor), Relative: relative}, err
+}
+
+// ExpandCWD expands only the raw suffix once, retaining the original anchor.
+// Replacement text (including tokens occurring in root directory names) is inert.
+func ExpandCWD(value, pluginRoot, dataRoot string) (Path, error) {
+	parsed, err := ParseCWD(value)
+	if err != nil {
+		return parsed, err
+	}
+	parsed.Relative = strings.NewReplacer("${PLUGIN_ROOT}", pluginRoot, "${PLUGIN_DATA}", dataRoot).Replace(parsed.Relative)
+	// The suffix follows a rooted separator, so repeated separators remain relative.
+	parsed.Relative = strings.TrimLeft(filepath.ToSlash(parsed.Relative), "/")
+	return parsed, nil
+}
+
+func contained(root, candidate string) bool {
+	rel, err := filepath.Rel(root, candidate)
+	return err == nil && !filepath.IsAbs(rel) && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// Resolve observes segments in traversal order. It never cleans away an unobserved
+// segment, and never returns an executable path for an incomplete observation.
+func Resolve(root, relative string) Result {
+	fail := func(state State, err error) Result { return Result{State: state, Err: err} }
+	if strings.ContainsAny(relative, "\\\x00") || strings.HasPrefix(relative, "/") {
+		return fail(Invalid, fmt.Errorf("path must remain relative to its declared root"))
+	}
+	canonical, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return fail(Unavailable, fmt.Errorf("resolve path root: %w", err))
+	}
+	canonical, err = filepath.Abs(canonical)
+	if err != nil {
+		return fail(Unavailable, err)
+	}
+	current := canonical
+	parts := strings.Split(relative, "/")
+	for i, part := range parts {
+		if part == "" || part == "." {
+			continue
+		}
+		if part == ".." {
+			current = filepath.Dir(current)
+			if !contained(canonical, current) {
+				return fail(Invalid, fmt.Errorf("path escapes its declared root"))
+			}
+			continue
+		}
+		next := current + string(filepath.Separator) + part
+		info, statErr := os.Lstat(next)
+		if statErr != nil {
+			if !os.IsNotExist(statErr) {
+				return fail(Unavailable, statErr)
+			}
+			// Missing does not erase the remaining traversal. Reject a demonstrable
+			// escape, but never invent a canonical target from lexical cancellation.
+			probe := next
+			for _, rest := range parts[i+1:] {
+				if rest == ".." {
+					probe = filepath.Dir(probe)
+				} else if rest != "" && rest != "." {
+					probe = probe + string(filepath.Separator) + rest
+				}
+				if !contained(canonical, probe) {
+					return fail(Invalid, fmt.Errorf("unresolved path escapes its declared root"))
+				}
+			}
+			return fail(Missing, statErr)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			target, readErr := os.Readlink(next)
+			if readErr != nil {
+				return fail(Unavailable, readErr)
+			}
+			if !filepath.IsAbs(target) {
+				target = current + string(filepath.Separator) + target
+			}
+			next, err = filepath.EvalSymlinks(next)
+			if err != nil {
+				// A dangling link still cannot defer an already observable outside target.
+				// Observe ancestors rather than comparing aliases lexically.
+				if outsideObservedAncestor(canonical, target, 0) {
+					return fail(Invalid, fmt.Errorf("symlink target escapes its declared root"))
+				}
+
+				if os.IsNotExist(err) {
+					return fail(Missing, err)
+				}
+				return fail(Unavailable, err)
+			}
+
+		}
+		if !contained(canonical, next) {
+			return fail(Invalid, fmt.Errorf("path resolves outside its declared root"))
+		}
+		if i < len(parts)-1 && !info.IsDir() {
+			targetInfo, e := os.Stat(next)
+			if e != nil {
+				return fail(Unavailable, e)
+			}
+			if !targetInfo.IsDir() {
+				return fail(Unavailable, fmt.Errorf("path component is not a directory"))
+			}
+		}
+		current = next
+	}
+	return Result{Path: current, State: Resolved}
+}
+
+// outsideObservedAncestor follows dangling symlink chains as well as parent
+// directories. The bound prevents cycles from turning observation into a hang.
+func outsideObservedAncestor(root, target string, hops int) bool {
+	if hops >= 40 {
+		return false
+	}
+	for {
+		resolved, err := filepath.EvalSymlinks(target)
+		if err == nil {
+			return !contained(root, resolved)
+		}
+		info, statErr := os.Lstat(target)
+		if statErr == nil && info.Mode()&os.ModeSymlink != 0 {
+			link, readErr := os.Readlink(target)
+			if readErr != nil {
+				return false
+			}
+			if !filepath.IsAbs(link) {
+				link = filepath.Dir(target) + string(filepath.Separator) + link
+			}
+			return outsideObservedAncestor(root, link, hops+1)
+		}
+		if !os.IsNotExist(err) {
+			return false
+		}
+		parent := filepath.Dir(target)
+		if parent == target {
+			return false
+		}
+		target = parent
+	}
+}

--- a/install/integrationctl/agentplugins/pathcontract/path_test.go
+++ b/install/integrationctl/agentplugins/pathcontract/path_test.go
@@ -1,0 +1,105 @@
+package pathcontract
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveTraversalOrder(t *testing.T) {
+	root := t.TempDir()
+	for _, dir := range []string{"bin", "data", "real/deep"} {
+		if err := os.MkdirAll(filepath.Join(root, dir), 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, "bin/server"), []byte("inert"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	for _, rel := range []string{"", "data/..", "bin/../bin/server"} {
+		if r := Resolve(root, rel); r.State != Resolved {
+			t.Fatalf("%s: %+v", rel, r)
+		}
+	}
+	if err := os.Symlink(filepath.Join(root, "real/deep"), filepath.Join(root, "link")); err != nil {
+		t.Skip(err)
+	}
+	r := Resolve(root, "link/..")
+	want, _ := filepath.EvalSymlinks(filepath.Join(root, "real"))
+	if r.State != Resolved || r.Path != want {
+		t.Fatalf("symlink parent: %+v want %s", r, want)
+	}
+	for _, rel := range []string{"missing/../bin/server", "bin/absent"} {
+		r := Resolve(root, rel)
+		if r.State != Missing || r.Path != "" {
+			t.Fatalf("missing %s: %+v", rel, r)
+		}
+	}
+	for _, rel := range []string{"../outside", "missing/../../outside"} {
+		if r := Resolve(root, rel); r.State != Invalid {
+			t.Fatalf("escape %s: %+v", rel, r)
+		}
+	}
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "outside")); err != nil {
+		t.Fatal(err)
+	}
+	if r := Resolve(root, "outside/missing"); r.State != Invalid {
+		t.Fatalf("outside missing: %+v", r)
+	}
+	if err := os.Symlink("loop", filepath.Join(root, "loop")); err != nil {
+		t.Fatal(err)
+	}
+	if r := Resolve(root, "loop"); r.State != Unavailable || r.Path != "" {
+		t.Fatalf("loop: %+v", r)
+	}
+}
+func TestParseCWDPreservesAnchorAndSuffix(t *testing.T) {
+	for _, value := range []string{"./", "./data/..", "${PLUGIN_ROOT}/link/..", "${PLUGIN_DATA}/../outside"} {
+		p, e := ParseCWD(value)
+		if e != nil {
+			t.Fatal(e)
+		}
+		if value == "${PLUGIN_DATA}/../outside" && (p.Anchor != Data || p.Relative != "../outside") {
+			t.Fatalf("%+v", p)
+		}
+	}
+}
+
+func TestResolveAcceptsAlternateRootAliasAndRejectsDanglingOutside(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	if err := os.MkdirAll(filepath.Join(root, "inside"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(base, "alias")
+	if err := os.Symlink(root, alias); err != nil {
+		t.Skip(err)
+	}
+	if err := os.Symlink(filepath.Join(alias, "inside"), filepath.Join(root, "link")); err != nil {
+		t.Fatal(err)
+	}
+	if result := Resolve(root, "link"); result.State != Resolved {
+		t.Fatalf("same root alias: %+v", result)
+	}
+	if err := os.Symlink(filepath.Join(base, "absent", "outside"), filepath.Join(root, "dangling")); err != nil {
+		t.Fatal(err)
+	}
+	if result := Resolve(root, "dangling/missing"); result.State != Invalid {
+		t.Fatalf("outside missing target: %+v", result)
+	}
+}
+
+func TestResolveRejectsDanglingOutsideSymlinkChain(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(filepath.Join(outside, "missing"), filepath.Join(root, "second")); err != nil {
+		t.Skip(err)
+	}
+	if err := os.Symlink("second", filepath.Join(root, "first")); err != nil {
+		t.Fatal(err)
+	}
+	if r := Resolve(root, "first"); r.State != Invalid || r.Path != "" {
+		t.Fatalf("outside dangling chain: %+v", r)
+	}
+}

--- a/install/integrationctl/agentplugins/planner/planner.go
+++ b/install/integrationctl/agentplugins/planner/planner.go
@@ -423,7 +423,11 @@ func componentDecisions(envelope domain.PackageEnvelope, capabilities domain.Cli
 				support = domain.SupportProjected
 			}
 		}
-		decisions = append(decisions, decision(domain.ComponentMCPServer, name, support))
+		value := decision(domain.ComponentMCPServer, name, support)
+		if capabilities.ClientID == domain.ClientOpenCode && server.Type == "sse" && support == domain.SupportUnsupported {
+			value.Reason = "declared_sse_not_supported_by_client"
+		}
+		decisions = append(decisions, value)
 	}
 	appNames := sortedKeys(envelope.App.Bindings)
 	for _, name := range appNames {

--- a/install/integrationctl/agentplugins/providers/claude.go
+++ b/install/integrationctl/agentplugins/providers/claude.go
@@ -57,7 +57,7 @@ func projectClaude(root string, envelope domain.PackageEnvelope, plan domain.Del
 		return fmt.Errorf("write Claude Code plugin manifest: %w", err)
 	}
 	activeRuntimeRoot := filepath.Join(plan.ActivePath, claudeRuntimeDirectory)
-	if err := projectClaudeMCP(root, envelope, serverNames, activeRuntimeRoot, dataPath); err != nil {
+	if err := projectClaudeMCP(root, envelope, serverNames, activeRuntimeRoot, dataPath, runtimeRoot); err != nil {
 		return err
 	}
 	return validateClaudeProjectionRoot(root, len(serverNames) > 0)
@@ -146,7 +146,11 @@ func validateClaudeProjectionRoot(root string, wantMCP bool) error {
 	return nil
 }
 
-func projectClaudeMCP(root string, envelope domain.PackageEnvelope, serverNames []string, pluginRoot, dataPath string) error {
+func projectClaudeMCP(root string, envelope domain.PackageEnvelope, serverNames []string, pluginRoot, dataPath string, observationRoot ...string) error {
+	observedRuntimeRoot := root
+	if len(observationRoot) > 0 {
+		observedRuntimeRoot = observationRoot[0]
+	}
 	path := filepath.Join(root, ".mcp.json")
 	if len(serverNames) == 0 {
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
@@ -161,7 +165,7 @@ func projectClaudeMCP(root string, envelope domain.PackageEnvelope, serverNames 
 		switch server.Type {
 		case "stdio":
 			delete(config, "type")
-			if err := applyStdioDataContract(config, pluginRoot, dataPath); err != nil {
+			if err := applyStdioDataContract(config, pluginRoot, dataPath, observedRuntimeRoot); err != nil {
 				return fmt.Errorf("project Claude stdio MCP server %s: %w", name, err)
 			}
 		case "streamable-http":

--- a/install/integrationctl/agentplugins/providers/claude_path_topology_test.go
+++ b/install/integrationctl/agentplugins/providers/claude_path_topology_test.go
@@ -1,0 +1,56 @@
+package providers
+
+import (
+	"context"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestClaudeBundledStdioObservesIsolatedRuntime(t *testing.T) {
+	for _, cwd := range []string{"./work", "./data/..", "${PLUGIN_ROOT}"} {
+		t.Run(cwd, func(t *testing.T) {
+			envelope := stagingEnvelope(t)
+			for _, dir := range []string{"work", "data"} {
+				if err := os.MkdirAll(filepath.Join(envelope.SnapshotRoot, dir), 0700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			envelope.MCP.Servers = map[string]domain.MCPServer{"local": {Name: "local", Type: "stdio", Decoded: map[string]any{
+				"type": "stdio", "command": "./bin/../bin/run", "cwd": cwd, "args": []any{"${PLUGIN_ROOT}/config", "${UNKNOWN}"},
+			}}}
+			plan := stagingPlan(t, domain.ClientClaude, domain.PackageProjection)
+			plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "local", Support: domain.SupportProjected}}
+			delivery, err := (Stager{}).Stage(context.Background(), envelope, plan, "claude-bundled-paths", domain.CompatibilityHints{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			observed := filepath.Join(delivery.StagingPath, claudeRuntimeDirectory)
+			if _, err := os.Stat(filepath.Join(delivery.StagingPath, "bin")); !os.IsNotExist(err) {
+				t.Fatalf("authored bin remained exposed: %v", err)
+			}
+			if _, err := os.Stat(filepath.Join(observed, "bin/run")); err != nil {
+				t.Fatal(err)
+			}
+			server := readObject(t, filepath.Join(delivery.StagingPath, ".mcp.json"))["local"].(map[string]any)
+			activeRuntime := filepath.Join(plan.ActivePath, claudeRuntimeDirectory)
+			expectedCWD := activeRuntime
+			if cwd == "./work" {
+				expectedCWD = filepath.Join(activeRuntime, "work")
+			}
+			if server["command"] != filepath.Join(activeRuntime, "bin/run") || server["cwd"] != expectedCWD {
+				t.Fatalf("isolated stdio projection: %+v", server)
+			}
+			if args := server["args"].([]any); args[0] != filepath.Join(activeRuntime, "config") || args[1] != "${UNKNOWN}" {
+				t.Fatalf("args: %+v", args)
+			}
+			if err := (Stager{}).Verify(context.Background(), delivery.StagingPath, delivery.ArtifactDigest); err != nil {
+				t.Fatal(err)
+			}
+			if err := (Stager{}).Discard(context.Background(), delivery); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/install/integrationctl/agentplugins/providers/cline_native.go
+++ b/install/integrationctl/agentplugins/providers/cline_native.go
@@ -31,28 +31,15 @@ func projectClineNative(root string, envelope domain.PackageEnvelope, plan domai
 		portable := envelope.MCP.Servers[name]
 		if portable.Type == "stdio" {
 			portable.Decoded = cloneObject(portable.Decoded)
-			authorCWD := false
-			if rawCWD, exists := portable.Decoded["cwd"]; exists {
-				cwd, ok := rawCWD.(string)
-				if !ok {
-					return fmt.Errorf("project Cline MCP server %s: stdio cwd must be a string", name)
-				}
-				authorCWD = strings.TrimSpace(cwd) != ""
-			}
-			if err := applyStdioDataContract(portable.Decoded, plan.ActivePath, dataPath); err != nil {
+			if err := applyStdioDataContract(portable.Decoded, plan.ActivePath, dataPath, root); err != nil {
 				return fmt.Errorf("project Cline MCP server %s: %w", name, err)
-			}
-			// The portable stdio contract defaults cwd to PLUGIN_ROOT, but Cline's
-			// native format cannot encode cwd. Only discard that synthesized value;
-			// an explicit author requirement must continue to fail closed below.
-			if !authorCWD {
-				delete(portable.Decoded, "cwd")
 			}
 		}
 		server, err := clineNeutralServer(portable)
 		if err != nil {
 			return fmt.Errorf("project Cline MCP server %s: %w", name, err)
 		}
+		server.StdioValuesResolved = portable.Type == "stdio"
 		// This first pass validates the codec without touching client state. The
 		// exact configured path is bound later when ownership objects are built.
 		settingsPath := filepath.Join(root, ".cline-settings-validation.json")
@@ -493,6 +480,10 @@ func readClineProjection(root string) (clineProjection, error) {
 	if err := json.Unmarshal(body, &projection); err != nil || projection.Servers == nil {
 		return clineProjection{}, fmt.Errorf("decode projected Cline MCP configuration: %w", err)
 	}
+	for name, server := range projection.Servers {
+		server.StdioValuesResolved = server.Type == "stdio"
+		projection.Servers[name] = server
+	}
 	return projection, nil
 }
 
@@ -569,9 +560,7 @@ func clineNeutralServer(server domain.MCPServer) (nativeconfig.Server, error) {
 			if !ok {
 				return result, fmt.Errorf("Cline stdio MCP server cwd must be a string")
 			}
-			if strings.TrimSpace(cwd) != "" {
-				return result, fmt.Errorf("Cline stdio MCP server does not support cwd")
-			}
+			result.CWD = cwd
 		}
 	}
 	if server.Type == "streamable-http" || server.Type == "sse" {

--- a/install/integrationctl/agentplugins/providers/cline_native_test.go
+++ b/install/integrationctl/agentplugins/providers/cline_native_test.go
@@ -229,7 +229,7 @@ func TestClineProjectsChromeLikeStdioWithoutAuthorCWD(t *testing.T) {
 		t.Fatal(err)
 	}
 	server := projection.Servers["chrome"]
-	if server.Command != "npx" || server.CWD != "" || len(server.Args) != 4 || server.Args[3] != filepath.Join(dataPath, "cache") {
+	if server.Command != "npx" || server.CWD != plan.ActivePath || len(server.Args) != 4 || server.Args[3] != filepath.Join(dataPath, "cache") {
 		t.Fatalf("Cline stdio projection = %+v", server)
 	}
 	if server.Env["PLUGIN_ROOT"] != plan.ActivePath || server.Env["PLUGIN_DATA"] != dataPath || server.Env["MODE"] != "safe" {
@@ -237,8 +237,11 @@ func TestClineProjectsChromeLikeStdioWithoutAuthorCWD(t *testing.T) {
 	}
 }
 
-func TestClineRejectsExplicitStdioCWDBeforeProjectionMutation(t *testing.T) {
+func TestClinePreservesExplicitStdioCWD(t *testing.T) {
 	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "workspace"), 0o700); err != nil {
+		t.Fatal(err)
+	}
 	envelope := domain.PackageEnvelope{MCP: domain.MCPComponent{Servers: map[string]domain.MCPServer{
 		"local": {Name: "local", Type: "stdio", Decoded: map[string]any{"type": "stdio", "command": "node", "cwd": "./workspace"}},
 	}}}
@@ -246,12 +249,17 @@ func TestClineRejectsExplicitStdioCWDBeforeProjectionMutation(t *testing.T) {
 		{Kind: domain.ComponentMCPServer, Name: "local", Support: domain.SupportPrepared},
 	}}
 	err := projectClineNative(root, envelope, plan, filepath.Join(root, "data"))
-	if err == nil || !strings.Contains(err.Error(), "Cline stdio MCP server does not support cwd") {
-		t.Fatalf("Cline explicit cwd projection error = %v", err)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if _, statErr := os.Stat(filepath.Join(root, clineProjectionFile)); !os.IsNotExist(statErr) {
-		t.Fatalf("rejected Cline cwd mutated projection: %v", statErr)
+	projection, err := readClineProjection(root)
+	if err != nil {
+		t.Fatal(err)
 	}
+	if projection.Servers["local"].CWD != filepath.Join(plan.ActivePath, "workspace") {
+		t.Fatalf("cwd = %q", projection.Servers["local"].CWD)
+	}
+
 }
 
 func TestClineCollisionAndBusyLockLeaveNoPartialActivation(t *testing.T) {
@@ -395,4 +403,42 @@ func clineFixtureObjects(t *testing.T, configRoot, active, skillName, serverName
 			Path: clineMCPSettingsPath(configRoot), SourceRelative: clineProjectionFile, ManagedDigest: receipt.Digest, ProtectionClass: "managed"})
 	}
 	return objects
+}
+
+func TestClineNeutralCWDTypeValidation(t *testing.T) {
+	for _, value := range []any{false, 42, []string{"work"}} {
+		if _, err := clineNeutralServer(domain.MCPServer{Type: "stdio", Decoded: map[string]any{"command": "node", "cwd": value}}); err == nil {
+			t.Fatalf("accepted cwd %#v", value)
+		}
+	}
+}
+
+func TestClineProjectionRoundTripExpandsPortableValuesOnlyOnce(t *testing.T) {
+	root := t.TempDir()
+	active := filepath.Join(root, "${PLUGIN_DATA}", "${PLUGIN_ROOT}")
+	envelope := domain.PackageEnvelope{MCP: domain.MCPComponent{Servers: map[string]domain.MCPServer{"local": {Type: "stdio", Decoded: map[string]any{"command": "node", "args": []any{"${PLUGIN_ROOT}/run.js", "${UNKNOWN}"}, "env": map[string]any{"ROOT": "${PLUGIN_ROOT}", "OTHER": "${HOME}"}}}}}}
+	plan := domain.DeliveryPlan{ActivePath: active, Components: []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "local", Support: domain.SupportNative}}}
+	if err := projectClineNative(root, envelope, plan, filepath.Join(root, "data")); err != nil {
+		t.Fatal(err)
+	}
+	projection, err := readClineProjection(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	settings := filepath.Join(root, "native.json")
+	if _, err := nativeconfig.New().Apply(nativeconfig.Request{Paths: nativeconfig.Paths{JSON: settings}, Codec: nativeconfig.CodecCline, Action: nativeconfig.ActionAdd, Name: "local", Server: projection.Servers["local"], Placeholders: nativeconfig.Placeholders{PackageRoot: active, DataRoot: "/wrong-second-pass"}}); err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	body, err := os.ReadFile(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(body, &doc); err != nil {
+		t.Fatal(err)
+	}
+	transport := doc["mcpServers"].(map[string]any)["local"].(map[string]any)["transport"].(map[string]any)
+	if transport["cwd"] != active || transport["args"].([]any)[0] != filepath.Join(active, "run.js") || transport["env"].(map[string]any)["ROOT"] != active {
+		t.Fatalf("second-pass expansion: %#v", transport)
+	}
 }

--- a/install/integrationctl/agentplugins/providers/gemini_native.go
+++ b/install/integrationctl/agentplugins/providers/gemini_native.go
@@ -71,7 +71,7 @@ func buildGeminiNativeObjects(stagingRoot string, envelope domain.PackageEnvelop
 			if err != nil {
 				return nil, fmt.Errorf("project Gemini MCP server %q: %w", component.Name, err)
 			}
-			native, err = materializeGeminiServer(native, plan.ActivePath, pluginDataPath)
+			native, err = materializeGeminiServer(native, plan.ActivePath, pluginDataPath, stagingRoot)
 			if err != nil {
 				return nil, fmt.Errorf("bind Gemini MCP server %q: %w", component.Name, err)
 			}
@@ -555,21 +555,16 @@ func geminiNativeServer(server domain.MCPServer) (nativeconfig.Server, error) {
 	return result, nil
 }
 
-func materializeGeminiServer(server nativeconfig.Server, packageRoot, dataRoot string) (nativeconfig.Server, error) {
+func materializeGeminiServer(server nativeconfig.Server, packageRoot, dataRoot string, observationRoot ...string) (nativeconfig.Server, error) {
 	if server.Type != "stdio" {
 		return server, nil
 	}
-	resolve := strings.NewReplacer("${PLUGIN_ROOT}", packageRoot, "${PLUGIN_DATA}", dataRoot).Replace
-	if strings.HasPrefix(server.Command, "./") {
-		server.Command = filepath.Clean(filepath.Join(packageRoot, filepath.FromSlash(strings.TrimPrefix(server.Command, "./"))))
-		if !pathContainedBy(packageRoot, server.Command) {
-			return server, fmt.Errorf("stdio command escapes PLUGIN_ROOT")
-		}
+	command, cwd, err := resolveStdioPaths(server.Command, server.CWD, packageRoot, dataRoot, observationRoot...)
+	if err != nil {
+		return server, err
 	}
-	server.CWD = filepath.Clean(resolve(server.CWD))
-	if !pathContainedBy(packageRoot, server.CWD) && !pathContainedBy(dataRoot, server.CWD) {
-		return server, fmt.Errorf("stdio cwd escapes PLUGIN_ROOT and PLUGIN_DATA")
-	}
+	server.Command, server.CWD = command, cwd
+	server.CWDResolved = true
 	return server, nil
 }
 

--- a/install/integrationctl/agentplugins/providers/gemini_native_test.go
+++ b/install/integrationctl/agentplugins/providers/gemini_native_test.go
@@ -182,6 +182,9 @@ func TestGeminiTransportProjection(t *testing.T) {
 		t.Fatalf("stdio projection = %+v, %v", stdio, err)
 	}
 	packageRoot := filepath.Join(t.TempDir(), "plugin", "${PLUGIN_DATA}")
+	if err := os.MkdirAll(filepath.Join(packageRoot, "${PLUGIN_CACHE}"), 0700); err != nil {
+		t.Fatal(err)
+	}
 	dataRoot := filepath.Join(t.TempDir(), "data")
 	stdio, err = materializeGeminiServer(stdio, packageRoot, dataRoot)
 	if err != nil {

--- a/install/integrationctl/agentplugins/providers/managed_selection.go
+++ b/install/integrationctl/agentplugins/providers/managed_selection.go
@@ -1,0 +1,63 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+// ManagedMCPNames reads delivery selection only from a digest-verified artifact.
+// A second verification detects artifact drift during the read. It does not
+// promise protection from same-principal ABA races.
+func (stager Stager) ManagedMCPNames(ctx context.Context, client domain.ClientID, root, digest string) ([]string, error) {
+	if err := stager.Verify(ctx, root, digest); err != nil {
+		return nil, err
+	}
+	filename := "mcp.json"
+	if client == domain.ClientClaude || client == domain.ClientCodex || client == domain.ClientChatGPT {
+		filename = ".mcp.json"
+	}
+	candidate := filepath.Join(root, filename)
+	info, statErr := os.Lstat(candidate)
+	if statErr != nil && !os.IsNotExist(statErr) {
+		return nil, statErr
+	}
+	if statErr == nil && !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("managed MCP selection is not a regular file")
+	}
+	body, err := os.ReadFile(candidate)
+	names := []string{}
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	if err == nil {
+		var document map[string]json.RawMessage
+		if err := json.Unmarshal(body, &document); err != nil || document == nil {
+			return nil, fmt.Errorf("managed MCP selection is invalid: %v", err)
+		}
+		servers := document
+		if client != domain.ClientClaude {
+			raw, ok := document["mcpServers"]
+			if !ok {
+				return nil, fmt.Errorf("managed MCP selection lacks mcpServers")
+			}
+			servers = nil
+			if err := json.Unmarshal(raw, &servers); err != nil || servers == nil {
+				return nil, fmt.Errorf("managed MCP server selection is invalid: %v", err)
+			}
+		}
+		for name := range servers {
+			names = append(names, name)
+		}
+	}
+	if err := stager.Verify(ctx, root, digest); err != nil {
+		return nil, err
+	}
+	sort.Strings(names)
+	return names, nil
+}

--- a/install/integrationctl/agentplugins/providers/managed_selection_test.go
+++ b/install/integrationctl/agentplugins/providers/managed_selection_test.go
@@ -1,0 +1,62 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/ports"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestManagedMCPSelectionRequiresExactArtifact(t *testing.T) {
+	for _, client := range []domain.ClientID{domain.ClientCursor, domain.ClientClaude, domain.ClientCodex, domain.ClientChatGPT} {
+		t.Run(string(client), func(t *testing.T) {
+			root := t.TempDir()
+			filename := "mcp.json"
+			body := `{"mcpServers":{"z":{},"a":{}}}`
+			if client == domain.ClientClaude || client == domain.ClientCodex || client == domain.ClientChatGPT {
+				filename = ".mcp.json"
+			}
+			if client == domain.ClientClaude {
+				body = `{"z":{},"a":{}}`
+			}
+			if err := os.WriteFile(filepath.Join(root, filename), []byte(body), 0600); err != nil {
+				t.Fatal(err)
+			}
+			stager := Stager{}
+			var mismatch *ports.VerificationError
+			if err := stager.Verify(context.Background(), root, "observe"); !errors.As(err, &mismatch) {
+				t.Fatal(err)
+			}
+			names, err := stager.ManagedMCPNames(context.Background(), client, root, mismatch.ActualDigest)
+			if err != nil || !reflect.DeepEqual(names, []string{"a", "z"}) {
+				t.Fatalf("names=%v err=%v", names, err)
+			}
+			if err := os.WriteFile(filepath.Join(root, filename), []byte(`{"mcpServers":{}}`), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := stager.ManagedMCPNames(context.Background(), client, root, mismatch.ActualDigest); err == nil {
+				t.Fatal("unverified modified names trusted")
+			}
+		})
+	}
+}
+
+func TestVerifiedAbsentMCPSelectionIsKnownEmpty(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "plugin.json"), []byte(`{}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	stager := Stager{}
+	var mismatch *ports.VerificationError
+	if err := stager.Verify(context.Background(), root, "observe"); !errors.As(err, &mismatch) {
+		t.Fatal(err)
+	}
+	names, err := stager.ManagedMCPNames(context.Background(), domain.ClientCursor, root, mismatch.ActualDigest)
+	if err != nil || names == nil || len(names) != 0 {
+		t.Fatalf("names=%v err=%v", names, err)
+	}
+}

--- a/install/integrationctl/agentplugins/providers/managed_stdio.go
+++ b/install/integrationctl/agentplugins/providers/managed_stdio.go
@@ -1,0 +1,42 @@
+package providers
+
+import (
+	"errors"
+	"fmt"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/managedstdio"
+	"os"
+)
+
+// PreflightManagedStdio is read-only and called before any installation writes.
+func (stager Stager) PreflightManagedStdio(snapshotRoot string) error {
+	if !managedstdio.Supported() {
+		return &domain.ComponentReadinessError{Code: "managed_stdio_platform_unsupported", Message: "managed stdio lacks native process lifecycle support on this platform"}
+	}
+	if err := stager.LauncherSource.Available(); err != nil {
+		var pathError *os.PathError
+		if errors.As(err, &pathError) && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		return &domain.ComponentReadinessError{Code: "managed_stdio_helper_unavailable", Message: err.Error()}
+	}
+	collision, err := managedstdio.CheckCollision(snapshotRoot)
+	if err != nil {
+		return err
+	}
+	if collision {
+		return &domain.ComponentReadinessError{Code: "managed_stdio_path_collision", Message: "authored package occupies the reserved managed stdio path"}
+	}
+	return nil
+}
+func (stager Stager) deliverManagedStdio(root string, envelope domain.PackageEnvelope, plan domain.DeliveryPlan) error {
+	for _, name := range supportedMCPNames(plan) {
+		if envelope.MCP.Servers[name].Type == "stdio" {
+			if !managedstdio.Supported() {
+				return fmt.Errorf("managed stdio platform unsupported")
+			}
+			return stager.LauncherSource.Deliver(root)
+		}
+	}
+	return nil
+}

--- a/install/integrationctl/agentplugins/providers/nativeconfig/cline_cwd_test.go
+++ b/install/integrationctl/agentplugins/providers/nativeconfig/cline_cwd_test.go
@@ -1,0 +1,114 @@
+package nativeconfig
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestClineCWDReceiptUpdateDriftAndRemove(t *testing.T) {
+	for _, historicalRemove := range []bool{false, true} {
+		t.Run(map[bool]string{false: "update", true: "historical-remove"}[historicalRemove], func(t *testing.T) {
+			p := filepath.Join(t.TempDir(), "cline.json")
+			mustWrite(t, p, `{"mcpServers":{"foreign":{"transport":{"type":"sse","url":"https://foreign.test"}}}}`)
+			req := Request{Paths: Paths{JSON: p}, Codec: CodecCline, Action: ActionAdd, Name: "owned", Server: Server{Type: "stdio", Command: "node", Args: []string{"relative.js"}}}
+			old, err := New().Apply(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if historicalRemove {
+				req.Action = ActionRemove
+				req.Owned = &old
+				if _, err := New().Apply(req); err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+			req.Action = ActionUpdate
+			req.Owned = &old
+			req.Server.CWD = "${PLUGIN_DATA}/cache"
+			req.Placeholders = Placeholders{DataRoot: "/owned/data"}
+			updated, err := New().Apply(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if old.Digest == updated.Digest {
+				t.Fatal("cwd missing from ownership digest")
+			}
+			var doc map[string]any
+			mustReadJSON(t, p, &doc)
+			transport := doc["mcpServers"].(map[string]any)["owned"].(map[string]any)["transport"].(map[string]any)
+			if transport["cwd"] != "/owned/data/cache" || transport["args"].([]any)[0] != "relative.js" {
+				t.Fatalf("projection: %#v", transport)
+			}
+			intact, err := os.ReadFile(p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tampered := strings.Replace(string(intact), "/owned/data/cache", "/user/change", 1)
+			mustWrite(t, p, tampered)
+			req.Owned = &updated
+			if _, err := New().Apply(req); !errors.Is(err, ErrNotOwned) {
+				t.Fatalf("cwd drift accepted: %v", err)
+			}
+			after, _ := os.ReadFile(p)
+			if string(after) != tampered {
+				t.Fatal("drift mutated config")
+			}
+			mustWrite(t, p, string(intact))
+			req.Action = ActionRemove
+			if _, err := New().Apply(req); err != nil {
+				t.Fatal(err)
+			}
+			mustReadJSON(t, p, &doc)
+			servers := doc["mcpServers"].(map[string]any)
+			if _, ok := servers["owned"]; ok || servers["foreign"] == nil {
+				t.Fatalf("remove changed foreign: %#v", servers)
+			}
+		})
+	}
+}
+
+func TestResolvedStdioProjectionDoesNotExpandAgain(t *testing.T) {
+	for _, codec := range []Codec{CodecCline, CodecOpenCode, CodecGemini, CodecWindsurf} {
+		t.Run(string(codec), func(t *testing.T) {
+			root := "/owned/${PLUGIN_DATA}/${PLUGIN_ROOT}"
+			server := Server{Type: "stdio", Command: "node", Args: []string{root + "/run.js", "${UNKNOWN}"}, Env: map[string]string{"ROOT": root, "UNKNOWN": "${HOME}"}, StdioValuesResolved: true}
+			if codec != CodecWindsurf {
+				server.CWD = root
+			}
+			projected, err := projectServer(codec, server, Placeholders{PackageRoot: "/wrong-root", DataRoot: "/wrong-data"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if codec == CodecCline {
+				projected = projected["transport"].(map[string]any)
+			}
+			args := projected["args"]
+			env := projected["env"]
+			if codec == CodecOpenCode {
+				args = projected["command"].([]string)[1:]
+				env = projected["environment"]
+			}
+			if args.([]string)[0] != root+"/run.js" || args.([]string)[1] != "${UNKNOWN}" || env.(map[string]string)["ROOT"] != root || env.(map[string]string)["UNKNOWN"] != "${HOME}" {
+				t.Fatalf("second expansion: %#v", projected)
+			}
+			if codec != CodecWindsurf && projected["cwd"] != root {
+				t.Fatalf("cwd expanded: %#v", projected)
+			}
+		})
+	}
+}
+
+func TestResolvedCWDStillExpandsRawStdioValues(t *testing.T) {
+	root := "/owned/${PLUGIN_DATA}/${PLUGIN_ROOT}"
+	projected, err := projectServer(CodecGemini, Server{Type: "stdio", Command: "node", CWD: root, CWDResolved: true, Args: []string{"${PLUGIN_ROOT}/run.js"}, Env: map[string]string{"DATA": "${PLUGIN_DATA}"}}, Placeholders{PackageRoot: root, DataRoot: "/data"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if projected["cwd"] != root || projected["args"].([]string)[0] != root+"/run.js" || projected["env"].(map[string]string)["DATA"] != "/data" {
+		t.Fatalf("wrong raw/resolved boundary: %#v", projected)
+	}
+}

--- a/install/integrationctl/agentplugins/providers/nativeconfig/kernel_test.go
+++ b/install/integrationctl/agentplugins/providers/nativeconfig/kernel_test.go
@@ -452,8 +452,8 @@ func TestCodecSpecificUnsupportedFieldsFailClosed(t *testing.T) {
 		t.Fatalf("Windsurf silently discarded cwd: %v", err)
 	}
 	_, err = DesiredReceipt(path, CodecCline, "local", Server{Type: "stdio", Command: "node", CWD: "/server"}, Placeholders{})
-	if err == nil || !strings.Contains(err.Error(), "does not accept cwd") {
-		t.Fatalf("Cline silently discarded cwd: %v", err)
+	if err != nil {
+		t.Fatalf("Cline native cwd rejected: %v", err)
 	}
 }
 

--- a/install/integrationctl/agentplugins/providers/nativeconfig/project.go
+++ b/install/integrationctl/agentplugins/providers/nativeconfig/project.go
@@ -42,6 +42,9 @@ func projectServer(codec Codec, server Server, placeholders Placeholders) (map[s
 		return nil, fmt.Errorf("MCP server type must be stdio or remote")
 	}
 	resolve := func(value string) (string, error) {
+		if server.StdioValuesResolved {
+			return value, nil
+		}
 		replacements := []struct{ token, value string }{
 			{"${PLUGIN_ROOT}", placeholders.PackageRoot},
 			{"${PLUGIN_DATA}", placeholders.DataRoot},
@@ -57,6 +60,12 @@ func projectServer(codec Codec, server Server, placeholders Placeholders) (map[s
 			"${PLUGIN_ROOT}", placeholders.PackageRoot,
 			"${PLUGIN_DATA}", placeholders.DataRoot,
 		).Replace(value), nil
+	}
+	resolveCWD := func(value string) (string, error) {
+		if server.CWDResolved {
+			return value, nil
+		}
+		return resolve(value)
 	}
 	projectStrings := func(values []string) ([]string, error) {
 		out := make([]string, len(values))
@@ -103,7 +112,7 @@ func projectServer(codec Codec, server Server, placeholders Placeholders) (map[s
 				entry["environment"] = env
 			}
 			if server.CWD != "" {
-				cwd, err := resolve(server.CWD)
+				cwd, err := resolveCWD(server.CWD)
 				if err != nil {
 					return nil, err
 				}
@@ -111,7 +120,7 @@ func projectServer(codec Codec, server Server, placeholders Placeholders) (map[s
 			}
 			return entry, nil
 		}
-		if (codec == CodecWindsurf || codec == CodecCline) && server.CWD != "" {
+		if codec == CodecWindsurf && server.CWD != "" {
 			return nil, fmt.Errorf("%s stdio MCP server does not accept cwd", codec)
 		}
 		if codec == CodecCline {
@@ -121,6 +130,13 @@ func projectServer(codec Codec, server Server, placeholders Placeholders) (map[s
 			}
 			if len(env) > 0 {
 				transport["env"] = env
+			}
+			if server.CWD != "" {
+				cwd, err := resolveCWD(server.CWD)
+				if err != nil {
+					return nil, err
+				}
+				transport["cwd"] = cwd
 			}
 			return map[string]any{"transport": transport}, nil
 		}
@@ -132,7 +148,7 @@ func projectServer(codec Codec, server Server, placeholders Placeholders) (map[s
 			entry["env"] = env
 		}
 		if server.CWD != "" {
-			cwd, err := resolve(server.CWD)
+			cwd, err := resolveCWD(server.CWD)
 			if err != nil {
 				return nil, err
 			}

--- a/install/integrationctl/agentplugins/providers/nativeconfig/types.go
+++ b/install/integrationctl/agentplugins/providers/nativeconfig/types.go
@@ -58,17 +58,21 @@ func IsCommittedCleanup(err error) bool {
 }
 
 // Server is the transport-aware neutral MCP shape accepted by the supported
-// codecs. Type must be "stdio" or "remote". Placeholders are resolved
-// recursively in all strings. RemoteTransport is codec-specific and is
+// codecs. Type must be "stdio" or "remote". Portable placeholders are resolved
+// once in raw args, env values, and cwd. RemoteTransport is codec-specific and is
 // rejected unless the selected codec explicitly defines it.
 type Server struct {
-	Type    string            `json:"type"`
-	Command string            `json:"command,omitempty"`
-	Args    []string          `json:"args,omitempty"`
-	Env     map[string]string `json:"env,omitempty"`
-	CWD     string            `json:"cwd,omitempty"`
-	URL     string            `json:"url,omitempty"`
-	Headers map[string]string `json:"headers,omitempty"`
+	// Trusted adapters set these only after portable expansion. They are not
+	// native fields or persisted payload flags; projection readers restore them.
+	StdioValuesResolved bool              `json:"-"`
+	CWDResolved         bool              `json:"-"`
+	Type                string            `json:"type"`
+	Command             string            `json:"command,omitempty"`
+	Args                []string          `json:"args,omitempty"`
+	Env                 map[string]string `json:"env,omitempty"`
+	CWD                 string            `json:"cwd,omitempty"`
+	URL                 string            `json:"url,omitempty"`
+	Headers             map[string]string `json:"headers,omitempty"`
 	// RemoteTransport distinguishes Gemini's streamable HTTP and legacy SSE
 	// native keys. It is ignored by codecs whose native shape uses one URL key.
 	RemoteTransport string `json:"remote_transport,omitempty"`

--- a/install/integrationctl/agentplugins/providers/opencode_native.go
+++ b/install/integrationctl/agentplugins/providers/opencode_native.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/pathcontract"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -26,6 +26,7 @@ const (
 )
 
 type openCodeProjection struct {
+	ResolvedCWD map[string]bool                `json:"resolved_cwd,omitempty"`
 	Version     int                            `json:"version"`
 	ConfigPath  string                         `json:"config_path"`
 	ConfigJSON  string                         `json:"config_json"`
@@ -46,7 +47,7 @@ func projectOpenCodeNative(root string, envelope domain.PackageEnvelope, plan do
 		return err
 	}
 	projection := openCodeProjection{Version: 1, ConfigPath: selected, ConfigJSON: jsonPath, ConfigJSONC: jsoncPath,
-		PackageRoot: plan.ActivePath, DataRoot: dataRoot, MCPServers: map[string]nativeconfig.Server{}}
+		PackageRoot: plan.ActivePath, DataRoot: dataRoot, MCPServers: map[string]nativeconfig.Server{}, ResolvedCWD: map[string]bool{}}
 	for _, component := range plan.Components {
 		if component.Kind != domain.ComponentMCPServer || component.Support == domain.SupportUnsupported {
 			continue
@@ -59,6 +60,15 @@ func projectOpenCodeNative(root string, envelope domain.PackageEnvelope, plan do
 		if err != nil {
 			return fmt.Errorf("project OpenCode MCP server %q: %w", component.Name, err)
 		}
+		if neutral.Type == "stdio" {
+			command, cwd, pathErr := resolveStdioPaths(neutral.Command, neutral.CWD, plan.ActivePath, dataRoot, root)
+			if pathErr != nil {
+				return fmt.Errorf("project OpenCode MCP server %q: %w", component.Name, pathErr)
+			}
+			neutral.Command, neutral.CWD = command, cwd
+			projection.ResolvedCWD[component.Name] = true
+		}
+
 		projection.MCPServers[component.Name] = neutral
 	}
 	body, err := json.MarshalIndent(projection, "", "  ")
@@ -144,7 +154,9 @@ func neutralOpenCodeServer(server domain.MCPServer) (nativeconfig.Server, error)
 			cwd = "${PLUGIN_ROOT}"
 		}
 		return nativeconfig.Server{Type: "stdio", Command: command, Args: args, Env: env, CWD: cwd}, nil
-	case "streamable-http", "sse":
+	case "sse":
+		return nativeconfig.Server{}, fmt.Errorf("internal consistency: declared SSE is not supported by OpenCode (remote starts with Streamable HTTP)")
+	case "streamable-http":
 		url, ok := server.Decoded["url"].(string)
 		if !ok || strings.TrimSpace(url) == "" {
 			return nativeconfig.Server{}, fmt.Errorf("remote url is required")
@@ -171,18 +183,18 @@ func openCodeOptionalString(value any) (string, error) {
 }
 
 func normalizeOpenCodeCWD(value string) (string, error) {
-	value = strings.TrimSpace(value)
-	if value == "" || path.IsAbs(value) || filepath.IsAbs(value) || strings.Contains(value, "${") {
-		return value, nil
+	parsed, err := pathcontract.ParseCWD(value)
+	if err != nil {
+		return "", err
 	}
-	clean := path.Clean(strings.ReplaceAll(value, "\\", "/"))
-	if clean == ".." || strings.HasPrefix(clean, "../") {
-		return "", fmt.Errorf("plugin-relative path escapes the package root")
+	root := "${PLUGIN_ROOT}"
+	if parsed.Anchor == pathcontract.Data {
+		root = "${PLUGIN_DATA}"
 	}
-	if clean == "." {
-		return "${PLUGIN_ROOT}", nil
+	if parsed.Relative != "" {
+		root += "/" + parsed.Relative
 	}
-	return "${PLUGIN_ROOT}/" + clean, nil
+	return root, nil
 }
 
 func openCodeStrings(value any) ([]string, error) {
@@ -252,6 +264,14 @@ func readOpenCodeProjection(root string) (openCodeProjection, error) {
 	}
 	if projection.ConfigPath != projection.ConfigJSON && projection.ConfigPath != projection.ConfigJSONC {
 		return openCodeProjection{}, fmt.Errorf("OpenCode projection selects an unexpected config path")
+	}
+	for name, resolved := range projection.ResolvedCWD {
+		server, ok := projection.MCPServers[name]
+		if !ok || !resolved || server.Type != "stdio" || !filepath.IsAbs(server.CWD) {
+			return openCodeProjection{}, fmt.Errorf("invalid resolved OpenCode cwd provenance")
+		}
+		server.CWDResolved = true
+		projection.MCPServers[name] = server
 	}
 	return projection, nil
 }

--- a/install/integrationctl/agentplugins/providers/opencode_native_test.go
+++ b/install/integrationctl/agentplugins/providers/opencode_native_test.go
@@ -513,6 +513,9 @@ func TestOpenCodeProjectionPreservesOfficialLocalCWD(t *testing.T) {
 	configRoot := filepath.Join(root, "opencode")
 	active := filepath.Join(root, "managed", "demo")
 	envelope, plan := openCodeTestPackage(t, active, configRoot, "owned")
+	if err := os.MkdirAll(filepath.Join(active, "workspace"), 0700); err != nil {
+		t.Fatal(err)
+	}
 	envelope.MCP.Servers["docs"] = domain.MCPServer{Name: "docs", Type: "stdio", Decoded: map[string]any{
 		"command": "node", "args": []any{"${PLUGIN_ROOT}/server.js"}, "cwd": "./workspace",
 	}}

--- a/install/integrationctl/agentplugins/providers/opencode_transport_test.go
+++ b/install/integrationctl/agentplugins/providers/opencode_transport_test.go
@@ -1,0 +1,122 @@
+package providers
+
+import (
+	"encoding/json"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers/nativeconfig"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenCodeDeclaredTransportDoesNotSilentlyConvertSSE(t *testing.T) {
+	server := domain.MCPServer{Type: "sse", Decoded: map[string]any{"url": "https://example.test/sse"}}
+	if _, err := neutralOpenCodeServer(server); err == nil {
+		t.Fatal("SSE silently mapped to HTTP-first remote")
+	}
+	server.Type = "streamable-http"
+	server.Decoded["url"] = "https://example.test/${PLUGIN_ROOT}"
+	server.Decoded["headers"] = map[string]any{"Authorization": "Bearer ${PLUGIN_DATA}"}
+	neutral, err := neutralOpenCodeServer(server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if neutral.URL != server.Decoded["url"] || neutral.Headers["Authorization"] != "Bearer ${PLUGIN_DATA}" || neutral.RemoteTransport != "" {
+		t.Fatalf("remote values changed: %+v", neutral)
+	}
+	p := filepath.Join(t.TempDir(), "opencode.json")
+	if _, err := nativeconfig.New().Apply(nativeconfig.Request{Paths: nativeconfig.Paths{JSON: p}, Codec: nativeconfig.CodecOpenCode, Action: nativeconfig.ActionAdd, Name: "http", Server: neutral}); err != nil {
+		t.Fatal(err)
+	}
+	neutral.RemoteTransport = "sse"
+	if _, err := nativeconfig.DesiredReceipt(p, nativeconfig.CodecOpenCode, "sse", neutral, nativeconfig.Placeholders{}); err == nil {
+		t.Fatal("invented native transport selector accepted")
+	}
+}
+
+func TestOpenCodeResolvedSymlinkCWDRoundTripIsNotExpandedAgain(t *testing.T) {
+	root := t.TempDir()
+	configRoot := filepath.Join(root, "opencode")
+	active := filepath.Join(root, "managed", "demo")
+	data := filepath.Join(root, "data")
+	envelope, plan := openCodeTestPackage(t, active, configRoot, "owned")
+	target := filepath.Join(data, "${PLUGIN_ROOT}")
+	if err := os.MkdirAll(target, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("${PLUGIN_ROOT}", filepath.Join(data, "link")); err != nil {
+		t.Fatal(err)
+	}
+	envelope.MCP.Servers["docs"] = domain.MCPServer{Name: "docs", Type: "stdio", Decoded: map[string]any{"command": "node", "cwd": "${PLUGIN_DATA}/link", "args": []any{"${PLUGIN_ROOT}/server.js", "${UNKNOWN}"}, "env": map[string]any{"DATA": "${PLUGIN_DATA}", "OTHER": "${HOME}"}}}
+	if err := os.Remove(filepath.Join(active, openCodeProjectionFile)); err != nil {
+		t.Fatal(err)
+	}
+	if err := projectOpenCodeNative(active, envelope, plan, data); err != nil {
+		t.Fatal(err)
+	}
+	projection, err := readOpenCodeProjection(active)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonical, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := projection.MCPServers["docs"]
+	observed, err := filepath.EvalSymlinks(server.CWD)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observed != canonical || server.CWD != target || !server.CWDResolved || server.StdioValuesResolved {
+		t.Fatalf("wrong resolved boundary: %+v", server)
+	}
+	objects, err := buildOpenCodeNativeObjects(active, envelope, plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := applyOpenCodeNative(configRoot, active, nil, objects); err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(readOpenCodeTestFile(t, filepath.Join(configRoot, "opencode.json"))), &doc); err != nil {
+		t.Fatal(err)
+	}
+	entry := doc["mcp"].(map[string]any)["docs"].(map[string]any)
+	if entry["cwd"] != server.CWD || entry["command"].([]any)[1] != filepath.Join(active, "server.js") || entry["command"].([]any)[2] != "${UNKNOWN}" || entry["environment"].(map[string]any)["DATA"] != data || entry["environment"].(map[string]any)["OTHER"] != "${HOME}" {
+		t.Fatalf("second expansion or lost raw args/env: %#v", entry)
+	}
+	if _, ok := entry["resolved_cwd"]; ok {
+		t.Fatal("private projection metadata leaked to native config")
+	}
+}
+
+func TestOpenCodeHistoricalRawCWDProjectionStillExpandsOnce(t *testing.T) {
+	root := t.TempDir()
+	config := filepath.Join(root, "opencode.json")
+	projection := openCodeProjection{Version: 1, ConfigPath: config, ConfigJSON: config, ConfigJSONC: filepath.Join(root, "opencode.jsonc"), PackageRoot: root, MCPServers: map[string]nativeconfig.Server{"local": {Type: "stdio", Command: "node", CWD: "${PLUGIN_ROOT}/work"}}}
+	body, err := json.Marshal(projection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, openCodeProjectionFile), body, 0600); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := readOpenCodeProjection(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := loaded.MCPServers["local"]
+	if server.CWDResolved {
+		t.Fatal("historical raw cwd marked resolved")
+	}
+	if _, err := nativeconfig.New().Apply(nativeconfig.Request{Paths: nativeconfig.Paths{JSON: config}, Codec: nativeconfig.CodecOpenCode, Action: nativeconfig.ActionAdd, Name: "local", Server: server, Placeholders: nativeconfig.Placeholders{PackageRoot: root}}); err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(readOpenCodeTestFile(t, config)), &doc); err != nil {
+		t.Fatal(err)
+	}
+	if doc["mcp"].(map[string]any)["local"].(map[string]any)["cwd"] != filepath.Join(root, "work") {
+		t.Fatalf("historical cwd changed: %#v", doc)
+	}
+}

--- a/install/integrationctl/agentplugins/providers/plugin_data_preflight.go
+++ b/install/integrationctl/agentplugins/providers/plugin_data_preflight.go
@@ -1,0 +1,32 @@
+package providers
+
+import (
+	"fmt"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/pathpolicy"
+	"os"
+	"path/filepath"
+)
+
+// PreflightDataPath observes the same locator EnsureData owns, without creating it.
+func (manager PluginDataManager) PreflightDataPath(physicalBackend string) (string, bool, error) {
+	if manager.Base == "" {
+		return "", false, fmt.Errorf("plugin data base is required")
+	}
+	locator := filepath.Join(manager.Base, physicalBackend)
+	if err := pathpolicy.RequireContainedChild(manager.Base, locator); err != nil {
+		return "", false, err
+	}
+	if _, err := os.Lstat(locator); os.IsNotExist(err) {
+		return locator, false, nil
+	} else if err != nil {
+		return "", false, err
+	}
+	receipt, err := manager.readOwned(locator)
+	if err != nil {
+		return "", false, err
+	}
+	if receipt.PhysicalBackend != physicalBackend {
+		return "", false, fmt.Errorf("PLUGIN_DATA physical ownership mismatch")
+	}
+	return locator, true, nil
+}

--- a/install/integrationctl/agentplugins/providers/portable_identity_test.go
+++ b/install/integrationctl/agentplugins/providers/portable_identity_test.go
@@ -1,0 +1,16 @@
+package providers
+
+import (
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"testing"
+)
+
+func TestPortableIdentityPreservesMarketplaceGolden(t *testing.T) {
+	physical := domain.ComputePhysicalArtifactID("demo", "00000000-0000-4000-8000-000000000001")
+	if physical != "demo-11e594f48195" {
+		t.Fatalf("historical physical id changed: %s", physical)
+	}
+	if got := ManagedMarketplaceName(physical); got != "agentplugins-4293497808d3" {
+		t.Fatalf("historical marketplace id changed: %s", got)
+	}
+}

--- a/install/integrationctl/agentplugins/providers/selected_environment_test.go
+++ b/install/integrationctl/agentplugins/providers/selected_environment_test.go
@@ -1,0 +1,21 @@
+package providers
+
+import (
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"testing"
+)
+
+func TestReservedEnvironmentValidationUsesSelectedMCPSet(t *testing.T) {
+	envelope := domain.PackageEnvelope{MCP: domain.MCPComponent{Servers: map[string]domain.MCPServer{
+		"unselected": {Type: "stdio", Decoded: map[string]any{"env": map[string]any{"PLUGIN_ROOT": "authored"}}},
+		"remote":     {Type: "http"},
+	}}}
+	plan := domain.DeliveryPlan{Components: []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "unselected", Support: domain.SupportUnsupported}, {Kind: domain.ComponentMCPServer, Name: "remote", Support: domain.SupportNative}}}
+	if err := validateReservedStdioEnvironment(envelope, plan); err != nil {
+		t.Fatal(err)
+	}
+	plan.Components[0].Support = domain.SupportNative
+	if err := validateReservedStdioEnvironment(envelope, plan); err == nil {
+		t.Fatal("selected reserved environment accepted")
+	}
+}

--- a/install/integrationctl/agentplugins/providers/stager.go
+++ b/install/integrationctl/agentplugins/providers/stager.go
@@ -9,18 +9,19 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/atomicfile"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/filetree"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/pathpolicy"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/managedstdio"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/ports"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/packagesnapshot"
 )
 
 type Stager struct {
+	LauncherSource  *managedstdio.Source
 	SnapshotBuilder packagesnapshot.Builder
 	PluginDataRoot  string
 }
@@ -143,7 +144,7 @@ func (stager Stager) stage(
 	if err := validatePlanPaths(plan); err != nil {
 		return domain.StagedDelivery{}, err
 	}
-	if err := validateReservedStdioEnvironment(envelope); err != nil {
+	if err := validateReservedStdioEnvironment(envelope, plan); err != nil {
 		return domain.StagedDelivery{}, err
 	}
 	if err := os.MkdirAll(plan.TargetRoot, 0o700); err != nil {
@@ -240,6 +241,9 @@ func (stager Stager) stage(
 		}
 	}
 	if plan.ClientID == domain.ClientWindsurf {
+		if err := stager.deliverManagedStdio(stagingPath, envelope, plan); err != nil {
+			return domain.StagedDelivery{}, err
+		}
 		if err := projectWindsurfMCP(stagingPath, envelope, plan, pluginDataPath); err != nil {
 			return domain.StagedDelivery{}, err
 		}
@@ -301,8 +305,9 @@ func (stager Stager) stage(
 	}, nil
 }
 
-func validateReservedStdioEnvironment(envelope domain.PackageEnvelope) error {
-	for name, server := range envelope.MCP.Servers {
+func validateReservedStdioEnvironment(envelope domain.PackageEnvelope, plan domain.DeliveryPlan) error {
+	for _, name := range domain.SelectedMCPNames(plan) {
+		server := envelope.MCP.Servers[name]
 		if server.Type != "stdio" {
 			continue
 		}
@@ -564,7 +569,7 @@ func projectOpenAIMCP(root string, envelope domain.PackageEnvelope, serverNames 
 		switch server.Type {
 		case "stdio":
 			delete(config, "type")
-			if err := applyStdioDataContract(config, pluginRoot, dataPath); err != nil {
+			if err := applyStdioDataContract(config, pluginRoot, dataPath, root); err != nil {
 				return fmt.Errorf("stdio MCP server %s: %w", name, err)
 			}
 		case "streamable-http":
@@ -597,7 +602,7 @@ func projectKiroMCP(root string, envelope domain.PackageEnvelope, plan domain.De
 		server := envelope.MCP.Servers[name]
 		config := cloneObject(server.Decoded)
 		if server.Type == "stdio" {
-			if err := applyStdioDataContract(config, plan.ActivePath, dataPath); err != nil {
+			if err := applyStdioDataContract(config, plan.ActivePath, dataPath, root); err != nil {
 				return fmt.Errorf("project Kiro stdio MCP server %s: %w", name, err)
 			}
 		}
@@ -655,7 +660,7 @@ func projectCursorMCP(root string, envelope domain.PackageEnvelope, serverNames 
 		switch server.Type {
 		case "stdio":
 			delete(config, "type")
-			if err := applyStdioDataContract(config, pluginRoot, dataPath); err != nil {
+			if err := applyStdioDataContract(config, pluginRoot, dataPath, root); err != nil {
 				return fmt.Errorf("project Cursor stdio MCP server %s: %w", name, err)
 			}
 		case "streamable-http":
@@ -734,14 +739,7 @@ func projectedOpenAIManifest(envelope domain.PackageEnvelope) (map[string]any, e
 }
 
 func supportedMCPNames(plan domain.DeliveryPlan) []string {
-	var names []string
-	for _, component := range plan.Components {
-		if component.Kind == domain.ComponentMCPServer && component.Support != domain.SupportUnsupported {
-			names = append(names, component.Name)
-		}
-	}
-	sort.Strings(names)
-	return names
+	return domain.SelectedMCPNames(plan)
 }
 
 func hasSupported(plan domain.DeliveryPlan, kind domain.ComponentKind) bool {
@@ -786,7 +784,7 @@ func cloneJSONValue(value any) any {
 	}
 }
 
-func applyStdioDataContract(config map[string]any, pluginRoot, dataPath string) error {
+func applyStdioDataContract(config map[string]any, pluginRoot, dataPath string, observationRoot ...string) error {
 	expand := strings.NewReplacer("${PLUGIN_ROOT}", pluginRoot, "${PLUGIN_DATA}", dataPath).Replace
 	switch env := config["env"].(type) {
 	case map[string]any:
@@ -830,32 +828,27 @@ func applyStdioDataContract(config map[string]any, pluginRoot, dataPath string) 
 			args[index] = expand(args[index])
 		}
 	}
-	if command, ok := config["command"].(string); ok && strings.HasPrefix(command, "./") {
-		command = filepath.Clean(filepath.Join(pluginRoot, filepath.FromSlash(strings.TrimPrefix(command, "./"))))
-		if !pathContainedBy(pluginRoot, command) {
-			return fmt.Errorf("stdio command escapes PLUGIN_ROOT")
-		}
-		config["command"] = command
+	command, _ := config["command"].(string)
+	cwd, _ := config["cwd"].(string)
+	resolvedCommand, resolvedCWD, err := resolveStdioPaths(command, cwd, pluginRoot, dataPath, observationRoot...)
+	if err != nil {
+		return err
 	}
-	if cwd, ok := config["cwd"].(string); ok && cwd != "" {
-		cwd = expand(cwd)
-		if !filepath.IsAbs(cwd) {
-			cwd = filepath.Join(pluginRoot, cwd)
-		}
-		cwd = filepath.Clean(cwd)
-		if !pathContainedBy(pluginRoot, cwd) && !pathContainedBy(dataPath, cwd) {
-			return fmt.Errorf("stdio cwd escapes PLUGIN_ROOT and PLUGIN_DATA")
-		}
-		config["cwd"] = cwd
-	} else {
-		config["cwd"] = pluginRoot
-	}
+	config["command"], config["cwd"] = resolvedCommand, resolvedCWD
 	return nil
 }
 
 func pathContainedBy(root, candidate string) bool {
-	relative, err := filepath.Rel(filepath.Clean(root), filepath.Clean(candidate))
-	return err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return false
+	}
+	resolvedCandidate, err := filepath.EvalSymlinks(candidate)
+	if err != nil {
+		return false
+	}
+	relative, err := filepath.Rel(resolvedRoot, resolvedCandidate)
+	return err == nil && !filepath.IsAbs(relative) && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
 }
 
 func writeJSON(path string, value any) error {

--- a/install/integrationctl/agentplugins/providers/stager_test.go
+++ b/install/integrationctl/agentplugins/providers/stager_test.go
@@ -243,6 +243,9 @@ func TestStagerProjectsExactOwnedPluginDataContract(t *testing.T) {
 	plan := stagingPlan(t, domain.ClientCodex, domain.PackageProjection)
 	plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "local", Support: domain.SupportProjected}}
 	ownedData := filepath.Join(t.TempDir(), "owned-plugin-data")
+	if err := os.MkdirAll(filepath.Join(ownedData, "work"), 0700); err != nil {
+		t.Fatal(err)
+	}
 	delivery, err := (Stager{}).StageWithPluginData(context.Background(), envelope, plan, "operation-data", domain.CompatibilityHints{}, ownedData)
 	if err != nil {
 		t.Fatal(err)
@@ -274,6 +277,9 @@ func TestStagerProjectsKiroStdioRuntimeContractBeforeNativeImport(t *testing.T) 
 	plan := stagingPlan(t, domain.ClientKiro, domain.PackageNative)
 	plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "local", Support: domain.SupportNative}}
 	ownedData := filepath.Join(t.TempDir(), "owned-plugin-data")
+	if err := os.MkdirAll(filepath.Join(ownedData, "work"), 0700); err != nil {
+		t.Fatal(err)
+	}
 	delivery, err := (Stager{}).StageWithPluginData(context.Background(), envelope, plan, "operation-kiro-data", domain.CompatibilityHints{}, ownedData)
 	if err != nil {
 		t.Fatal(err)
@@ -317,6 +323,9 @@ func TestStagerProjectsCursorNativeManifestAndRuntimeContract(t *testing.T) {
 		{Kind: domain.ComponentMCPServer, Name: "local", Support: domain.SupportNative},
 	}
 	ownedData := filepath.Join(t.TempDir(), "owned-plugin-data")
+	if err := os.MkdirAll(filepath.Join(ownedData, "work"), 0700); err != nil {
+		t.Fatal(err)
+	}
 	delivery, err := (Stager{}).StageWithPluginData(context.Background(), envelope, plan, "operation-cursor-data", domain.CompatibilityHints{}, ownedData)
 	if err != nil {
 		t.Fatal(err)
@@ -345,6 +354,12 @@ func TestStagerResolvesBundledStdioCommandForNativeProjection(t *testing.T) {
 	t.Parallel()
 	config := map[string]any{"command": "./bin/server", "args": []any{"${PLUGIN_ROOT}/config"}}
 	pluginRoot, dataPath := filepath.Join(t.TempDir(), "plugin", "${PLUGIN_DATA}"), filepath.Join(t.TempDir(), "data")
+	if err := os.MkdirAll(filepath.Join(pluginRoot, "bin"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginRoot, "bin/server"), []byte("inert"), 0600); err != nil {
+		t.Fatal(err)
+	}
 	if err := applyStdioDataContract(config, pluginRoot, dataPath); err != nil {
 		t.Fatal(err)
 	}

--- a/install/integrationctl/agentplugins/providers/stdio_paths.go
+++ b/install/integrationctl/agentplugins/providers/stdio_paths.go
@@ -1,0 +1,71 @@
+package providers
+
+import (
+	"fmt"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/pathcontract"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// A copied staging tree has no symlinks (filetree.CopyDir enforces this). Resolve
+// there before projecting canonical contained paths to its future active root.
+func resolveStdioPaths(command, cwd, pluginRoot, dataRoot string, observationRoot ...string) (string, string, error) {
+	observedRoot := pluginRoot
+	if len(observationRoot) > 0 {
+		observedRoot = observationRoot[0]
+	}
+	resolve := func(anchor pathcontract.Anchor, relative string) (string, error) {
+		root := observedRoot
+		if anchor == pathcontract.Data {
+			root = dataRoot
+		}
+		r := pathcontract.Resolve(root, relative)
+		if r.State != pathcontract.Resolved {
+			return "", fmt.Errorf("stdio path %s: %v", r.State, r.Err)
+		}
+
+		base, err := filepath.EvalSymlinks(root)
+		if err != nil {
+			return "", err
+		}
+		rel, err := filepath.Rel(base, r.Path)
+		if err != nil {
+			return "", err
+		}
+		destination := pluginRoot
+		if anchor == pathcontract.Data {
+			destination = dataRoot
+		}
+		return filepath.Join(destination, rel), nil
+	}
+	if strings.HasPrefix(command, "./") {
+		relative, err := pathcontract.ParseCommand(command)
+		if err != nil {
+			return "", "", err
+		}
+		command, err = resolve(pathcontract.Plugin, relative)
+		if err != nil {
+			return "", "", err
+		}
+	}
+	parsed, err := pathcontract.ExpandCWD(cwd, pluginRoot, dataRoot)
+	if err != nil {
+		return "", "", err
+	}
+	resolvedCWD, err := resolve(parsed.Anchor, parsed.Relative)
+	if err != nil {
+		return "", "", err
+	}
+	// Directory readiness is checked against the observed topology, not a future path.
+	root := observedRoot
+	if parsed.Anchor == pathcontract.Data {
+		root = dataRoot
+	}
+	r := pathcontract.Resolve(root, parsed.Relative)
+	info, err := os.Stat(r.Path)
+	if err != nil || !info.IsDir() {
+		return "", "", fmt.Errorf("stdio cwd is not an available directory")
+	}
+	return command, resolvedCWD, nil
+}

--- a/install/integrationctl/agentplugins/providers/stdio_paths_test.go
+++ b/install/integrationctl/agentplugins/providers/stdio_paths_test.go
@@ -1,0 +1,48 @@
+package providers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStdioPathProjectionPreservesTraversalAndAnchor(t *testing.T) {
+	root := t.TempDir()
+	for _, dir := range []string{"bin", "data", "real/deep"} {
+		if e := os.MkdirAll(filepath.Join(root, dir), 0700); e != nil {
+			t.Fatal(e)
+		}
+	}
+	if e := os.WriteFile(filepath.Join(root, "bin/server"), []byte("inert"), 0600); e != nil {
+		t.Fatal(e)
+	}
+	active := filepath.Join(t.TempDir(), "future")
+	data := t.TempDir()
+	for _, cwd := range []string{"./", "./data/..", "${PLUGIN_ROOT}"} {
+		command, dir, e := resolveStdioPaths("./bin/../bin/server", cwd, active, data, root)
+		if e != nil {
+			t.Fatal(e)
+		}
+		if command != filepath.Join(active, "bin/server") || dir != active {
+			t.Fatalf("%s %s", command, dir)
+		}
+	}
+	for _, input := range []struct{ command, cwd string }{{"./missing/../bin/server", "./"}, {"node", "${PLUGIN_ROOT}/../" + filepath.Base(data)}, {"node", "${PLUGIN_DATA}/../" + filepath.Base(root)}} {
+		if _, _, e := resolveStdioPaths(input.command, input.cwd, root, data); e == nil {
+			t.Fatalf("accepted %+v", input)
+		}
+	}
+	if e := os.Symlink(filepath.Join(root, "real/deep"), filepath.Join(root, "link")); e != nil {
+		t.Skip(e)
+	}
+	_, dir, e := resolveStdioPaths("node", "./link/..", root, data)
+	if e != nil || dir != filepath.Join(root, "real") {
+		t.Fatalf("symlink/.. = %s %v", dir, e)
+	}
+	if e := os.Symlink(data, filepath.Join(root, "out")); e != nil {
+		t.Fatal(e)
+	}
+	if _, _, e := resolveStdioPaths("node", "./out", root, data); e == nil {
+		t.Fatal("cross-anchor symlink accepted")
+	}
+}

--- a/install/integrationctl/agentplugins/providers/windsurf_launcher_test.go
+++ b/install/integrationctl/agentplugins/providers/windsurf_launcher_test.go
@@ -1,0 +1,81 @@
+package providers
+
+import (
+	"context"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/managedstdio"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWindsurfHelperOwnedArtifactDigestAndCollision(t *testing.T) {
+	stager := windsurfFixtureStager(t)
+	envelope := windsurfTestEnvelope(t, "helper")
+	plan := stagingPlan(t, domain.ClientWindsurf, domain.PackagePrepared)
+	plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "local", Support: domain.SupportPrepared}}
+	if err := stager.PreflightManagedStdio(envelope.SnapshotRoot); err != nil {
+		t.Fatal(err)
+	}
+	delivery, err := stager.Stage(context.Background(), envelope, plan, "helper", domain.CompatibilityHints{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	helper := filepath.Join(delivery.StagingPath, filepath.FromSlash(managedstdio.RelativeDirectory), managedstdio.ExecutableName)
+	if _, err := os.Stat(helper); err != nil {
+		t.Fatal(err)
+	}
+	if err := stager.Verify(context.Background(), delivery.StagingPath, delivery.ArtifactDigest); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(helper, []byte("tampered"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := stager.Verify(context.Background(), delivery.StagingPath, delivery.ArtifactDigest); err == nil {
+		t.Fatal("helper tamper was not part of artifact digest")
+	}
+	reserved := filepath.Join(envelope.SnapshotRoot, filepath.FromSlash(managedstdio.RelativeDirectory))
+	writeTestFile(t, reserved, "authored")
+	if err := stager.PreflightManagedStdio(envelope.SnapshotRoot); err == nil {
+		t.Fatal("authored collision accepted")
+	}
+	if _, err := stager.Stage(context.Background(), envelope, plan, "collision-helper", domain.CompatibilityHints{}); err == nil {
+		t.Fatal("late collision accepted")
+	}
+	body, _ := os.ReadFile(reserved)
+	if string(body) != "authored" {
+		t.Fatal("authored collision changed")
+	}
+}
+
+func TestWindsurfHelperChangeChangesArtifactWithoutSourceMutation(t *testing.T) {
+	envelope := windsurfTestEnvelope(t, "pins")
+	plan := stagingPlan(t, domain.ClientWindsurf, domain.PackagePrepared)
+	plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "local", Support: domain.SupportPrepared}}
+	stager := windsurfFixtureStager(t)
+	first, err := stager.Stage(context.Background(), envelope, plan, "first-pin", domain.CompatibilityHints{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "cli-b")
+	if err := os.WriteFile(path, []byte("fixture-B"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	stager.LauncherSource, err = managedstdio.NewSource(path, "B")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := stager.Stage(context.Background(), envelope, plan, "second-pin", domain.CompatibilityHints{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.ArtifactDigest == second.ArtifactDigest {
+		t.Fatal("helper version absent from artifact digest")
+	}
+	if err := stager.Verify(context.Background(), first.StagingPath, first.ArtifactDigest); err != nil {
+		t.Fatal("old immutable artifact changed", err)
+	}
+	if _, err := os.Stat(filepath.Join(envelope.SnapshotRoot, filepath.FromSlash(managedstdio.RelativeDirectory))); !os.IsNotExist(err) {
+		t.Fatal("source snapshot mutated")
+	}
+}

--- a/install/integrationctl/agentplugins/providers/windsurf_native.go
+++ b/install/integrationctl/agentplugins/providers/windsurf_native.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/pathpolicy"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/managedstdio"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/pathcontract"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers/nativeconfig"
 )
 
@@ -29,6 +31,32 @@ func projectWindsurfMCP(root string, envelope domain.PackageEnvelope, plan domai
 		resolved, err := windsurfServer(server, plan.ActivePath, dataPath)
 		if err != nil {
 			return fmt.Errorf("project Windsurf MCP server %q: %w", name, err)
+		}
+		if server.Type == "stdio" {
+			command, _ := server.Decoded["command"].(string)
+			if strings.HasPrefix(command, "./") {
+				relative, e := pathcontract.ParseCommand(command)
+				if e != nil {
+					return e
+				}
+				observation := pathcontract.Resolve(root, relative)
+				if observation.State != pathcontract.Resolved {
+					return fmt.Errorf("stdio command escapes PLUGIN_ROOT or is unavailable: %v", observation.Err)
+				}
+			}
+			rawCWD, _ := server.Decoded["cwd"].(string)
+			cwd, e := pathcontract.ExpandCWD(rawCWD, plan.ActivePath, dataPath)
+			if e != nil {
+				return e
+			}
+			anchor := root
+			if cwd.Anchor == pathcontract.Data {
+				anchor = dataPath
+			}
+			observation := pathcontract.Resolve(anchor, cwd.Relative)
+			if observation.State != pathcontract.Resolved {
+				return fmt.Errorf("stdio cwd unavailable: %v", observation.Err)
+			}
 		}
 		projected, err := standardWindsurfServer(resolved, server.Type)
 		if err != nil {
@@ -396,15 +424,6 @@ func windsurfServer(server domain.MCPServer, packageRoot, dataRoot string) (nati
 			return result, fmt.Errorf("stdio command is required")
 		}
 		result.Command = command
-		if rawCWD, exists := decoded["cwd"]; exists {
-			cwd, ok := rawCWD.(string)
-			if !ok {
-				return result, fmt.Errorf("stdio cwd must be a string")
-			}
-			if strings.TrimSpace(cwd) != "" {
-				return result, fmt.Errorf("Windsurf stdio MCP server does not support cwd")
-			}
-		}
 		if rawArgs, ok := decoded["args"].([]any); ok {
 			for _, raw := range rawArgs {
 				value, ok := raw.(string)
@@ -469,17 +488,41 @@ func windsurfServer(server domain.MCPServer, packageRoot, dataRoot string) (nati
 	if err != nil {
 		return result, err
 	}
-	if resolved.Type == "stdio" && strings.HasPrefix(resolved.Command, "./") {
-		if strings.TrimSpace(packageRoot) == "" || !filepath.IsAbs(packageRoot) {
-			return result, fmt.Errorf("absolute PLUGIN_ROOT is required for bundled stdio command")
+	if resolved.Type == "stdio" {
+		if !filepath.IsAbs(packageRoot) || !filepath.IsAbs(dataRoot) {
+			return result, fmt.Errorf("managed stdio roots must be absolute")
 		}
-		command := filepath.Clean(filepath.Join(packageRoot, filepath.FromSlash(strings.TrimPrefix(resolved.Command, "./"))))
-		if !pathContainedBy(packageRoot, command) {
-			return result, fmt.Errorf("stdio command escapes PLUGIN_ROOT")
+		rawCWD := ""
+		if value, exists := decoded["cwd"]; exists {
+			var ok bool
+			rawCWD, ok = value.(string)
+			if !ok {
+				return result, fmt.Errorf("stdio cwd must be a string")
+			}
 		}
-		resolved.Command = command
+		cwd, err := pathcontract.ExpandCWD(rawCWD, packageRoot, dataRoot)
+		if err != nil {
+			return result, err
+		}
+		root := packageRoot
+		if cwd.Anchor == pathcontract.Data {
+			root = dataRoot
+		}
+		absoluteCWD := root
+		if cwd.Relative != "" {
+			absoluteCWD = strings.TrimRight(root, string(filepath.Separator)) + string(filepath.Separator) + filepath.FromSlash(cwd.Relative)
+		}
+		resolved.StdioValuesResolved = true
+		resolved.Args = managedstdio.Arguments(packageRoot, dataRoot, absoluteCWD, cwd.Anchor, commandForLauncher(decoded), resolved.Args)
+		resolved.Command = filepath.Join(packageRoot, filepath.FromSlash(managedstdio.RelativeDirectory), managedstdio.ExecutableName)
 	}
+
 	return resolved, nil
+}
+
+func commandForLauncher(decoded map[string]any) string {
+	value, _ := decoded["command"].(string)
+	return value
 }
 
 func resolveWindsurfPlaceholders(server nativeconfig.Server, packageRoot, dataRoot string) (nativeconfig.Server, error) {
@@ -503,6 +546,9 @@ func resolveWindsurfPlaceholders(server nativeconfig.Server, packageRoot, dataRo
 		}
 	}
 	for key, value := range server.Env {
+		if key == "PLUGIN_ROOT" || key == "PLUGIN_DATA" {
+			continue
+		}
 		if server.Env[key], err = resolve(value); err != nil {
 			return server, err
 		}
@@ -544,7 +590,7 @@ func decodeProjectedWindsurfServer(raw json.RawMessage) (nativeconfig.Server, er
 		return nativeconfig.Server{}, err
 	}
 	if entry.Type == "stdio" {
-		return nativeconfig.Server{Type: "stdio", Command: entry.Command, Args: entry.Args, Env: entry.Env}, nil
+		return nativeconfig.Server{Type: "stdio", Command: entry.Command, Args: entry.Args, Env: entry.Env, StdioValuesResolved: true}, nil
 	}
 	if entry.Type == "streamable-http" || entry.Type == "sse" {
 		return nativeconfig.Server{Type: "remote", URL: entry.URL, Headers: entry.Headers, RemoteTransport: entry.Type}, nil

--- a/install/integrationctl/agentplugins/providers/windsurf_native_test.go
+++ b/install/integrationctl/agentplugins/providers/windsurf_native_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"os"
-	"os/exec"
+
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/managedstdio"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers/nativeconfig"
 )
 
@@ -23,7 +24,7 @@ func TestWindsurfStagerProjectsResolvedMCPAndExactOwnership(t *testing.T) {
 		{Kind: domain.ComponentMCPServer, Name: "docs", Support: domain.SupportPrepared},
 	}
 	dataRoot := filepath.Join(t.TempDir(), "plugin-data")
-	delivery, err := (Stager{}).StageWithPluginData(context.Background(), envelope, plan, "windsurf-stage", domain.CompatibilityHints{}, dataRoot)
+	delivery, err := windsurfFixtureStager(t).StageWithPluginData(context.Background(), envelope, plan, "windsurf-stage", domain.CompatibilityHints{}, dataRoot)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +32,7 @@ func TestWindsurfStagerProjectsResolvedMCPAndExactOwnership(t *testing.T) {
 	servers := document["mcpServers"].(map[string]any)
 	local := servers["local"].(map[string]any)
 	args := local["args"].([]any)
-	if args[0] != filepath.Join(plan.ActivePath, "runtime", "server.js") || args[1] != filepath.Join(dataRoot, "cache") {
+	if args[7] != filepath.Join(plan.ActivePath, "runtime", "server.js") || args[8] != filepath.Join(dataRoot, "cache") {
 		t.Fatalf("Windsurf placeholders were not bound: %+v", args)
 	}
 	env := local["env"].(map[string]any)
@@ -206,10 +207,10 @@ func TestWindsurfExpandsOnlyPortableStdioValues(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stdio.Command != "${PLUGIN_ROOT}" || stdio.Args[0] != filepath.Join(packageRoot, "run.js") || stdio.Args[1] != "${PLUGIN_CACHE}/literal" || stdio.Env["DATA"] != filepath.Join(dataRoot, "state") || stdio.Env["UNKNOWN"] != "${HOME}" {
+	if stdio.Args[6] != "${PLUGIN_ROOT}" || stdio.Args[7] != filepath.Join(packageRoot, "run.js") || stdio.Args[8] != "${PLUGIN_CACHE}/literal" || stdio.Env["DATA"] != filepath.Join(dataRoot, "state") || stdio.Env["UNKNOWN"] != "${HOME}" {
 		t.Fatalf("Windsurf stdio placeholder projection = %+v", stdio)
 	}
-	if strings.Contains(stdio.Args[0], dataRoot) {
+	if strings.Contains(stdio.Args[7], dataRoot) {
 		t.Fatalf("Windsurf recursively expanded replacement text: %+v", stdio.Args)
 	}
 
@@ -229,7 +230,7 @@ func TestWindsurfExpandsOnlyPortableStdioValues(t *testing.T) {
 	}
 }
 
-func TestWindsurfStagerRejectsUnsupportedCWDWithoutChangingProjection(t *testing.T) {
+func TestWindsurfStagerRejectsMissingCWDWithoutChangingProjection(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	projectionPath := filepath.Join(root, "mcp.json")
@@ -242,7 +243,7 @@ func TestWindsurfStagerRejectsUnsupportedCWDWithoutChangingProjection(t *testing
 	plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "local", Support: domain.SupportPrepared}}
 
 	err := projectWindsurfMCP(root, envelope, plan, filepath.Join(t.TempDir(), "data"))
-	if err == nil || !strings.Contains(err.Error(), "does not support cwd") {
+	if err == nil || !strings.Contains(err.Error(), "cwd unavailable") {
 		t.Fatalf("Windsurf cwd projection error = %v", err)
 	}
 	body, readErr := os.ReadFile(projectionPath)
@@ -317,12 +318,8 @@ func TestWindsurfBundledCommandUsesManagedPluginRoot(t *testing.T) {
 	}
 	configPath := filepath.Join(plan.NativeRegistryRoot, "mcp_config.json")
 	entry := readObject(t, configPath)["mcpServers"].(map[string]any)["local"].(map[string]any)
-	if got := entry["command"]; got != commandPath {
+	if got := entry["command"]; got != filepath.Join(activeRoot, filepath.FromSlash(managedstdio.RelativeDirectory), managedstdio.ExecutableName) {
 		t.Fatalf("bundled Windsurf command = %v, want %s", got, commandPath)
-	}
-	output, err := exec.Command(commandPath).CombinedOutput()
-	if err != nil || string(output) != "managed-root\n" {
-		t.Fatalf("projected bundled command output = %q, %v", output, err)
 	}
 	if got := envelope.MCP.Servers["local"].Decoded["command"]; got != "./bin/server" {
 		t.Fatalf("Windsurf projection mutated source command: %v", got)
@@ -365,7 +362,7 @@ func stagedWindsurfDelivery(t *testing.T, configRoot, revision, operation string
 		{Kind: domain.ComponentMCPServer, Name: "local", Support: domain.SupportPrepared},
 		{Kind: domain.ComponentMCPServer, Name: "docs", Support: domain.SupportPrepared},
 	}
-	delivery, err := (Stager{}).StageWithPluginData(context.Background(), envelope, plan, operation, domain.CompatibilityHints{}, filepath.Join(t.TempDir(), "data"))
+	delivery, err := windsurfFixtureStager(t).StageWithPluginData(context.Background(), envelope, plan, operation, domain.CompatibilityHints{}, filepath.Join(t.TempDir(), "data"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -433,4 +430,22 @@ func removeWindsurfEntryForTest(path, name string) error {
 		return err
 	}
 	return os.WriteFile(path, next, 0o600)
+}
+
+// These fixture bytes are explicitly injected and never executed. Native helper
+// execution is covered by managedstdio subprocess tests and CLI integration.
+func windsurfFixtureStager(t *testing.T) Stager {
+	t.Helper()
+	if !managedstdio.Supported() {
+		t.Skip("managed stdio platform unsupported")
+	}
+	path := filepath.Join(t.TempDir(), "fixture-cli")
+	if err := os.WriteFile(path, []byte("fixture-v1"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	source, err := managedstdio.NewSource(path, "fixture")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return Stager{LauncherSource: source}
 }

--- a/install/integrationctl/agentplugins/usecase/component_readiness.go
+++ b/install/integrationctl/agentplugins/usecase/component_readiness.go
@@ -1,0 +1,302 @@
+package usecase
+
+import (
+	"errors"
+	"fmt"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/pathcontract"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+)
+
+type dataPathPreflighter interface {
+	PreflightDataPath(string) (string, bool, error)
+}
+
+type managedStdioPreflighter interface{ PreflightManagedStdio(string) error }
+
+// Readiness changes the selected plan, never source bytes or portable validity.
+// Existing installations are retained atomically on local unavailability.
+func (service Service) preflightComponents(envelope domain.PackageEnvelope, plan *domain.DeliveryPlan, preserveExisting bool, priorSelections ...map[string]bool) error {
+	var helperErr error
+	helperChecked, skipped, losesDelivered := false, false, false
+	for _, name := range domain.SelectedMCPNames(*plan) {
+		server := envelope.MCP.Servers[name]
+		if server.Type != "stdio" {
+			continue
+		}
+		var failure *domain.ComponentReadinessError
+		if plan.ClientID == domain.ClientWindsurf {
+			if !helperChecked {
+				if checker, ok := service.Stager.(managedStdioPreflighter); ok {
+					helperErr = checker.PreflightManagedStdio(envelope.SnapshotRoot)
+				}
+				helperChecked = true
+			}
+			if helperErr != nil && !errors.As(helperErr, &failure) {
+				return helperErr
+			}
+		}
+		if failure == nil {
+			dataRoot := ""
+			if strings.Contains(authoredPATH(server.Decoded["env"]), "${PLUGIN_DATA}") {
+				if checker, ok := service.PluginData.(dataPathPreflighter); ok {
+					var err error
+					dataRoot, _, err = checker.PreflightDataPath(plan.PhysicalArtifactID)
+					if err != nil {
+						return err
+					}
+				}
+			}
+			readinessErr := stdioReadiness(envelope.SnapshotRoot, server.Decoded, dataRoot)
+			if readinessErr != nil && !errors.As(readinessErr, &failure) {
+				return readinessErr
+			}
+			if failure == nil {
+				cwd, _ := server.Decoded["cwd"].(string)
+				parsed, _ := pathcontract.ParseCWD(cwd)
+				if parsed.Anchor == pathcontract.Data {
+					checker, ok := service.PluginData.(dataPathPreflighter)
+					if !ok {
+						failure = &domain.ComponentReadinessError{Code: "stdio_data_unavailable", Message: "readonly PLUGIN_DATA readiness is unavailable"}
+					} else {
+						root, exists, err := checker.PreflightDataPath(plan.PhysicalArtifactID)
+						if err != nil {
+							return err
+						}
+						if !exists && strings.Trim(parsed.Relative, "./") == "" && !strings.Contains(parsed.Relative, "..") {
+							// EnsureData creates the owned root, but never authored subdirectories.
+						} else {
+							parsed, parseErr := pathcontract.ExpandCWD(cwd, envelope.SnapshotRoot, root)
+							if parseErr != nil {
+								return parseErr
+							}
+							resolved := pathcontract.Resolve(root, parsed.Relative)
+							if unexpectedPathIO(resolved.Err) {
+								return resolved.Err
+							}
+							if resolved.State != pathcontract.Resolved {
+								failure = &domain.ComponentReadinessError{Code: "stdio_data_cwd_unavailable", Message: fmt.Sprintf("PLUGIN_DATA cwd is unavailable: %v", resolved.Err)}
+							} else if info, err := os.Stat(resolved.Path); err != nil || !info.IsDir() {
+								if unexpectedPathIO(err) {
+									return err
+								}
+								failure = &domain.ComponentReadinessError{Code: "stdio_data_cwd_unavailable", Message: "PLUGIN_DATA cwd is not a directory"}
+							}
+						}
+					}
+				}
+			}
+		}
+		if failure == nil {
+			continue
+		}
+		skipped = true
+		if preserveExisting && (len(priorSelections) == 0 || priorSelections[0][name]) {
+			losesDelivered = true
+		}
+		for i := range plan.Components {
+			c := &plan.Components[i]
+			if c.Kind == domain.ComponentMCPServer && c.Name == name {
+				c.Support = domain.SupportUnsupported
+				c.Reason = failure.Code
+			}
+		}
+		plan.Diagnostics = append(plan.Diagnostics, domain.Diagnostic{Severity: domain.SeverityWarning, Boundary: domain.BoundaryMCPServer, Item: name, Code: failure.Code, Message: failure.Message})
+	}
+	if skipped {
+		plan.Warnings = append(plan.Warnings, "components_skipped_local_readiness")
+		if losesDelivered {
+			return fmt.Errorf("local component readiness changed; retaining the entire installed package: %s", readinessMessages(*plan))
+		}
+	}
+	supported := false
+	for _, c := range plan.Components {
+		if c.Support != domain.SupportUnsupported {
+			supported = true
+		}
+	}
+	if !supported && len(plan.Components) > 0 {
+		plan.Status = domain.PlanUnsupported
+		plan.Activation = domain.ActivationFailed
+		plan.Warnings = append(plan.Warnings, "no_supported_components")
+		messages := []string{}
+		for _, d := range plan.Diagnostics {
+			if d.Boundary == domain.BoundaryMCPServer {
+				messages = append(messages, d.Item+": "+d.Message)
+			}
+		}
+		return fmt.Errorf("no_supported_components: no components can be delivered; %s", strings.Join(messages, "; "))
+	}
+	return nil
+}
+
+func stdioReadiness(root string, decoded map[string]any, dataRoots ...string) error {
+	fail := func(message string) *domain.ComponentReadinessError {
+		return &domain.ComponentReadinessError{Code: "stdio_runtime_unavailable", Message: message}
+	}
+	for _, key := range []string{"PLUGIN_ROOT", "PLUGIN_DATA"} {
+		reserved := false
+		switch env := decoded["env"].(type) {
+		case map[string]any:
+			_, reserved = env[key]
+		case map[string]string:
+			_, reserved = env[key]
+		}
+		if reserved {
+			return &domain.ComponentReadinessError{Code: "stdio_reserved_environment", Message: "stdio environment defines reserved " + key}
+		}
+	}
+	command, _ := decoded["command"].(string)
+	if strings.ContainsAny(command, "/\\") || strings.HasPrefix(command, ".") {
+		relative, err := pathcontract.ParseCommand(command)
+		if err != nil {
+			return fail(err.Error())
+		}
+		resolved := pathcontract.Resolve(root, relative)
+		if unexpectedPathIO(resolved.Err) {
+			return resolved.Err
+		}
+		if resolved.State != pathcontract.Resolved {
+			return fail(fmt.Sprintf("bundled command %q is unavailable: %v", command, resolved.Err))
+		}
+		info, err := os.Stat(resolved.Path)
+		if unexpectedPathIO(err) {
+			return err
+		}
+		if err != nil || info.IsDir() || (runtime.GOOS != "windows" && info.Mode().Perm()&0111 == 0) {
+			return fail(fmt.Sprintf("bundled command %q is missing or non-executable", command))
+		}
+	} else if err := lookupStdioCommand(root, command, decoded["env"], dataRoots...); err != nil {
+		if unexpectedPathIO(err) {
+			return err
+		}
+		return fail(fmt.Sprintf("requires executable %q on PATH; install it explicitly (agentplugins never installs runtimes)", command))
+	}
+	cwd, _ := decoded["cwd"].(string)
+	dataRoot := ""
+	if len(dataRoots) > 0 {
+		dataRoot = dataRoots[0]
+	}
+	path, err := pathcontract.ExpandCWD(cwd, root, dataRoot)
+	if err != nil {
+		return fail(err.Error())
+	}
+	if path.Anchor == pathcontract.Plugin {
+		resolved := pathcontract.Resolve(root, path.Relative)
+		if unexpectedPathIO(resolved.Err) {
+			return resolved.Err
+		}
+		if resolved.State != pathcontract.Resolved {
+			return fail(fmt.Sprintf("cwd %q is unavailable: %v", cwd, resolved.Err))
+		}
+		info, err := os.Stat(resolved.Path)
+		if unexpectedPathIO(err) {
+			return err
+		}
+		if err != nil || !info.IsDir() {
+			return fail(fmt.Sprintf("cwd %q is not a directory", cwd))
+		}
+	}
+	return nil
+}
+
+// Native clients inherit the authored env. Observe an explicit PATH without
+// changing the installer process environment or executing the command.
+func lookupStdioCommand(root, command string, environment any, dataRoots ...string) error {
+	value, explicit := "", false
+	switch env := environment.(type) {
+	case map[string]any:
+		value, explicit = env["PATH"].(string)
+	case map[string]string:
+		value, explicit = env["PATH"]
+	}
+	if !explicit {
+		_, err := exec.LookPath(command)
+		return err
+	}
+	dataRoot := ""
+	if len(dataRoots) > 0 {
+		dataRoot = dataRoots[0]
+	}
+	value = strings.NewReplacer("${PLUGIN_ROOT}", root, "${PLUGIN_DATA}", dataRoot).Replace(value)
+	suffixes := []string{""}
+	if runtime.GOOS == "windows" {
+		suffixes = append(suffixes, filepath.SplitList(strings.ReplaceAll(os.Getenv("PATHEXT"), ";", string(os.PathListSeparator)))...)
+	}
+	for _, dir := range filepath.SplitList(value) {
+		if !filepath.IsAbs(dir) {
+			continue
+		}
+		for _, suffix := range suffixes {
+			info, err := os.Stat(filepath.Join(dir, command+suffix))
+			if unexpectedPathIO(err) {
+				return err
+			}
+			if err == nil && info.Mode().IsRegular() && (runtime.GOOS == "windows" || info.Mode().Perm()&0111 != 0) {
+				return nil
+			}
+		}
+	}
+	return exec.ErrNotFound
+}
+
+func authoredPATH(environment any) string {
+	switch env := environment.(type) {
+	case map[string]any:
+		value, _ := env["PATH"].(string)
+		return value
+	case map[string]string:
+		return env["PATH"]
+	}
+	return ""
+}
+
+// Existing confirmation authorizes desired removals; expose them before staging.
+func describeMCPRemovals(plan *domain.DeliveryPlan, prior *domain.ClientBinding) {
+	if prior == nil {
+		return
+	}
+	selected := map[string]bool{}
+	for _, name := range domain.SelectedMCPNames(*plan) {
+		selected[name] = true
+	}
+	for _, object := range prior.NativeObjects {
+		if !strings.Contains(object.Kind, "mcp") || object.LogicalName == "" || selected[object.LogicalName] {
+			continue
+		}
+		alreadyDescribed := false
+		for _, d := range plan.Diagnostics {
+			if d.Item == object.LogicalName && d.Code == "managed_component_removal_planned" {
+				alreadyDescribed = true
+				break
+			}
+		}
+		if alreadyDescribed {
+			continue
+		}
+		plan.Diagnostics = append(plan.Diagnostics, domain.Diagnostic{Severity: domain.SeverityWarning, Boundary: domain.BoundaryMCPServer, Item: object.LogicalName, Code: "managed_component_removal_planned", Message: "confirmed update will remove this previously managed MCP entry"})
+	}
+}
+
+func readinessMessages(plan domain.DeliveryPlan) string {
+	messages := []string{}
+	for _, d := range plan.Diagnostics {
+		if d.Boundary == domain.BoundaryMCPServer {
+			messages = append(messages, d.Item+": "+d.Message)
+		}
+	}
+	return strings.Join(messages, "; ")
+}
+
+func unexpectedPathIO(err error) bool {
+	if err == nil || errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ELOOP) || errors.Is(err, syscall.ENOTDIR) {
+		return false
+	}
+	var pathErr *os.PathError
+	return errors.Is(err, os.ErrPermission) || errors.Is(err, syscall.EIO) || errors.As(err, &pathErr)
+}

--- a/install/integrationctl/agentplugins/usecase/component_readiness_test.go
+++ b/install/integrationctl/agentplugins/usecase/component_readiness_test.go
@@ -1,0 +1,443 @@
+package usecase
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/managedstdio"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/ports"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestSelectedReadinessIsolatesMissingAndUnsupportedStdio(t *testing.T) {
+	root := t.TempDir()
+	envelope := domain.PackageEnvelope{SnapshotRoot: root, MCP: domain.MCPComponent{Servers: map[string]domain.MCPServer{
+		"missing":     {Type: "stdio", Decoded: map[string]any{"command": "./absent"}},
+		"unsupported": {Type: "stdio", Decoded: map[string]any{"env": map[string]any{"PLUGIN_ROOT": "bad"}}},
+		"remote":      {Type: "http"},
+	}}}
+	plan := domain.DeliveryPlan{Components: []domain.ComponentDecision{
+		{Kind: domain.ComponentSkill, Name: "skill", Support: domain.SupportNative},
+		{Kind: domain.ComponentMCPServer, Name: "missing", Support: domain.SupportNative},
+		{Kind: domain.ComponentMCPServer, Name: "unsupported", Support: domain.SupportUnsupported},
+		{Kind: domain.ComponentMCPServer, Name: "remote", Support: domain.SupportNative},
+	}}
+	if err := (Service{}).preflightComponents(envelope, &plan, false); err != nil {
+		t.Fatal(err)
+	}
+	if got := domain.SelectedMCPNames(plan); !reflect.DeepEqual(got, []string{"remote"}) {
+		t.Fatal(got)
+	}
+	if len(plan.Diagnostics) != 1 || plan.Diagnostics[0].Item != "missing" || packageNeedsPluginData(envelope, plan) {
+		t.Fatalf("incorrect isolation: %+v", plan)
+	}
+	if envelope.MCP.Servers["missing"].Type != "stdio" {
+		t.Fatal("envelope changed")
+	}
+}
+
+func TestMixedAddAndGroupKeepHealthySiblings(t *testing.T) {
+	for _, grouped := range []bool{false, true} {
+		t.Run(map[bool]string{false: "add", true: "group"}[grouped], func(t *testing.T) {
+			service, _, client := serviceFixture(t)
+			input := clinePackageInput(t, client, "1.0.0", "sha256:mixed", "sha256:mixed-manifest", "agentplugins-definitely-unavailable-runtime")
+			input.Confirmed = true
+			var result AddResult
+			var err error
+			if grouped {
+				var g GroupResult
+				g, err = service.AddGroup(context.Background(), GroupInput{Targets: []AddInput{input}, Confirmed: true})
+				if len(g.Targets) > 0 {
+					result = g.Targets[0]
+				}
+			} else {
+				result, err = service.Add(context.Background(), input)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(result.Plan.Diagnostics) != 1 || len(domain.SelectedMCPNames(result.Plan)) != 0 {
+				t.Fatalf("plan: %+v", result.Plan)
+			}
+			if _, err := os.Stat(filepath.Join(result.Plan.ActivePath, "skills", "docs", "SKILL.md")); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Stat(filepath.Join(result.Plan.ActivePath, "mcp.json")); !os.IsNotExist(err) {
+				t.Fatalf("unselected MCP survived: %v", err)
+			}
+		})
+	}
+}
+
+func TestTransientUpdateAndRepairRetainInstalledBytes(t *testing.T) {
+	service, store, client := serviceFixture(t)
+	input := clinePackageInput(t, client, "1.0.0", "sha256:good", "sha256:good-manifest", "sh")
+	input.Confirmed = true
+	installed, err := service.Add(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeState, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeJSON, _ := json.Marshal(beforeState)
+	before, err := os.ReadFile(filepath.Join(installed.Plan.ActivePath, "mcp.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, repair := range []bool{false, true} {
+		candidate := input
+		candidate.InstallationID = installed.InstallationID
+		candidate.Envelope.MCP.Servers = map[string]domain.MCPServer{"docs": {Type: "stdio", Decoded: map[string]any{"command": "agentplugins-definitely-unavailable-runtime"}}}
+		var result AddResult
+		if repair {
+			result, err = service.Repair(context.Background(), candidate)
+		} else {
+			result, err = service.Update(context.Background(), candidate)
+		}
+		if err == nil || result.Mutated || len(result.Plan.Diagnostics) != 1 {
+			t.Fatalf("refusal repair=%v result=%+v err=%v", repair, result, err)
+		}
+		afterState, _ := store.Load()
+		afterJSON, _ := json.Marshal(afterState)
+		after, _ := os.ReadFile(filepath.Join(installed.Plan.ActivePath, "mcp.json"))
+		if string(beforeJSON) != string(afterJSON) || string(before) != string(after) {
+			t.Fatal("refusal changed installation")
+		}
+	}
+}
+
+func TestDataCWDReadinessDoesNotCreateMissingSuffix(t *testing.T) {
+	for _, cwd := range []string{"${PLUGIN_DATA}", "${PLUGIN_DATA}/missing"} {
+		t.Run(cwd, func(t *testing.T) {
+			service, _, client := serviceFixture(t)
+			input := clinePackageInput(t, client, "1.0.0", "sha256:data", "sha256:data-manifest", "sh")
+			server := input.Envelope.MCP.Servers["docs"]
+			server.Decoded["cwd"] = cwd
+			input.Envelope.MCP.Servers["docs"] = server
+			input.Confirmed = true
+			result, err := service.Add(context.Background(), input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := 0
+			if cwd == "${PLUGIN_DATA}" {
+				want = 1
+			}
+			if len(domain.SelectedMCPNames(result.Plan)) != want {
+				t.Fatalf("plan: %+v", result.Plan)
+			}
+		})
+	}
+}
+
+func TestReadinessUsesAuthoredAbsolutePATH(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "unique-runtime"), []byte("fixture"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if failure := stdioReadiness(root, map[string]any{"command": "unique-runtime", "env": map[string]any{"PATH": "${PLUGIN_ROOT}"}}); failure != nil {
+		t.Fatal(failure)
+	}
+	if failure := stdioReadiness(root, map[string]any{"command": "sh", "env": map[string]any{"PATH": root}}); failure == nil {
+		t.Fatal("host PATH used despite authored override")
+	}
+}
+
+func TestHelperUpgradeCannotMasqueradeAsExactRepair(t *testing.T) {
+	if !managedstdio.Supported() {
+		t.Skip("native launcher unsupported")
+	}
+	service, store, _ := serviceFixture(t)
+	source := func(body string) *managedstdio.Source {
+		path := filepath.Join(t.TempDir(), "helper")
+		if err := os.WriteFile(path, []byte(body), 0755); err != nil {
+			t.Fatal(err)
+		}
+		s, err := managedstdio.NewSource(path, body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return s
+	}
+	service.Stager = providers.Stager{LauncherSource: source("helper A fixture; never executed")}
+	client := domain.DetectedClient{ClientID: domain.ClientWindsurf, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), "windsurf")}
+	input := clinePackageInput(t, client, "1.0.0", "sha256:helper", "sha256:helper-manifest", "sh")
+	input.Confirmed = true
+	installed, err := service.Add(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input.InstallationID = installed.InstallationID
+	// A damaged artifact demands rematerialization; rebuilding with B must never
+	// replace the receipt for A under the same exact-repair request.
+	marker := filepath.Join(installed.Plan.ActivePath, "damage.txt")
+	if err := os.WriteFile(marker, []byte("prior damage"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	stateBefore, _ := store.Load()
+	before, _ := json.Marshal(stateBefore)
+	service.Stager = providers.Stager{LauncherSource: source("helper B fixture; never executed")}
+	result, err := service.Repair(context.Background(), input)
+	if err == nil || !strings.Contains(err.Error(), "projection digest differs") || result.Mutated {
+		t.Fatalf("repair=%+v err=%v", result, err)
+	}
+	stateAfter, _ := store.Load()
+	after, _ := json.Marshal(stateAfter)
+	if string(before) != string(after) {
+		t.Fatal("exact repair changed state")
+	}
+	if body, err := os.ReadFile(marker); err != nil || string(body) != "prior damage" {
+		t.Fatal("prior artifact changed")
+	}
+	// A controlled update can replace A with B; subsequent exact repair must use B.
+	if err := os.Remove(marker); err != nil {
+		t.Fatal(err)
+	}
+	oldBinding := onlyBinding(stateBefore.Installations[0])
+	oldData := stateBefore.Installations[0].DataReceipts[oldBinding.DataReceiptID]
+	dataMarker := filepath.Join(oldData.Locator, "continuity")
+	if err := os.WriteFile(dataMarker, []byte("persistent"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	setEnvelopeVersion(t, &input.Envelope, "2.0.0", "sha256:helper-b", "sha256:helper-b-manifest")
+	input.OperationID = "helper-b-update"
+	updated, err := service.Update(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updated.Mutated {
+		t.Fatal("B update did not commit")
+	}
+	stateB, _ := store.Load()
+	bindingB := onlyBinding(stateB.Installations[0])
+	if managedDigest(bindingB) == managedDigest(onlyBinding(stateBefore.Installations[0])) {
+		t.Fatal("helper bytes did not change managed digest")
+	}
+	if stateB.Installations[0].DataReceipts[bindingB.DataReceiptID].Locator != oldData.Locator {
+		t.Fatal("update changed data ownership")
+	}
+	if body, err := os.ReadFile(dataMarker); err != nil || string(body) != "persistent" {
+		t.Fatal("update lost persistent data")
+	}
+	if err := os.WriteFile(marker, []byte("new damage"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	input.OperationID = "helper-b-repair"
+	repaired, err := service.Repair(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !repaired.Mutated {
+		t.Fatal("B exact repair did not commit")
+	}
+	stateRepaired, _ := store.Load()
+	if managedDigest(onlyBinding(stateRepaired.Installations[0])) != managedDigest(bindingB) {
+		t.Fatal("exact B repair changed receipt digest")
+	}
+	if body, err := os.ReadFile(dataMarker); err != nil || string(body) != "persistent" {
+		t.Fatal("persistent data lost")
+	}
+
+	nativePath := filepath.Join(client.ConfigRoot, "mcp_config.json")
+	if err := os.Remove(nativePath); err != nil {
+		t.Fatal(err)
+	}
+	input.OperationID = "helper-b-native-repair"
+	nativeRepaired, err := service.Repair(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !nativeRepaired.Mutated {
+		t.Fatal("B absent native config repair did not commit")
+	}
+	if _, err := os.Stat(nativePath); err != nil {
+		t.Fatal("native config not restored")
+	}
+	if body, err := os.ReadFile(dataMarker); err != nil || string(body) != "persistent" {
+		t.Fatal("native repair lost persistent data")
+	}
+
+}
+
+func TestStaticUnsupportedUpdateUsesConfirmedRemoval(t *testing.T) {
+	service, _, _ := serviceFixture(t)
+	client := domain.DetectedClient{ClientID: domain.ClientOpenCode, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), "opencode")}
+	input := openCodePluginInput(t, client, "1.0.0", "sha256:old", "sha256:old-manifest", "sh")
+	input.Confirmed = true
+	installed, err := service.Add(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate := openCodePluginInput(t, client, "2.0.0", "sha256:new", "sha256:new-manifest", "sh")
+	candidate.InstallationID = installed.InstallationID
+	candidate.OperationID = "static-update"
+	candidate.Envelope.MCP.Servers["docs"] = domain.MCPServer{Type: "sse", Decoded: map[string]any{"type": "sse", "url": "https://example.invalid/events"}}
+	preview, err := service.Update(context.Background(), candidate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !preview.RequiresConfirmation || preview.Mutated || len(domain.SelectedMCPNames(preview.Plan)) != 0 {
+		t.Fatalf("preview=%+v", preview)
+	}
+	configPath := filepath.Join(client.ConfigRoot, "opencode.json")
+	before, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(before), "docs") {
+		t.Fatal("existing entry missing before confirmation")
+	}
+	candidate.Confirmed = true
+	updated, err := service.Update(context.Background(), candidate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updated.Mutated {
+		t.Fatal("update did not commit")
+	}
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(after), "docs") {
+		t.Fatalf("unsupported native entry retained: %s", after)
+	}
+}
+
+func TestClineHistoricalProjectionDigestCannotBeSilentlyRepaired(t *testing.T) {
+	t.Setenv("CLINE_MCP_SETTINGS_PATH", filepath.Join(t.TempDir(), "cline-settings.json"))
+	service, store, _ := serviceFixture(t)
+	client := domain.DetectedClient{ClientID: domain.ClientCline, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), "cline")}
+	input := clinePackageInput(t, client, "1.0.0", "sha256:cline-history", "sha256:cline-manifest", "sh")
+	input.Confirmed = true
+	installed, err := service.Add(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	projection := filepath.Join(installed.Plan.ActivePath, ".agentplugins-cline-native.json")
+	body, err := os.ReadFile(projection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(body, &document); err != nil {
+		t.Fatal(err)
+	}
+	for _, server := range document["servers"].(map[string]any) {
+		delete(server.(map[string]any), "cwd")
+	}
+	legacy, _ := json.Marshal(document)
+	if err := os.WriteFile(projection, legacy, 0600); err != nil {
+		t.Fatal(err)
+	}
+	var verification *ports.VerificationError
+	if err := service.Stager.Verify(context.Background(), installed.Plan.ActivePath, "historical-digest"); !errors.As(err, &verification) || verification.ActualDigest == "" {
+		t.Fatalf("digest observation: %v", err)
+	}
+	state, _ := store.Load()
+	for key, binding := range state.Installations[0].Clients {
+		for i := range binding.NativeObjects {
+			if binding.NativeObjects[i].Kind == "managed_package_directory" {
+				binding.NativeObjects[i].ManagedDigest = verification.ActualDigest
+			}
+		}
+		state.Installations[0].Clients[key] = binding
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+	// Force exact rematerialization from the unchanged source revision.
+	if err := os.WriteFile(filepath.Join(installed.Plan.ActivePath, "damage"), []byte("damage"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	beforeState, _ := json.Marshal(state)
+	nativeBefore, _ := os.ReadFile(os.Getenv("CLINE_MCP_SETTINGS_PATH"))
+	input.InstallationID = installed.InstallationID
+	input.OperationID = "historical-cline-repair"
+	result, err := service.Repair(context.Background(), input)
+	if err == nil || !strings.Contains(err.Error(), "projection digest differs") || result.Mutated {
+		t.Fatalf("repair=%+v err=%v", result, err)
+	}
+	afterState, _ := store.Load()
+	afterJSON, _ := json.Marshal(afterState)
+	nativeAfter, _ := os.ReadFile(os.Getenv("CLINE_MCP_SETTINGS_PATH"))
+	if string(beforeState) != string(afterJSON) || string(nativeBefore) != string(nativeAfter) {
+		t.Fatal("historical repair changed state or native config")
+	}
+}
+
+func TestMissingHelperOnlyExcludesWindsurfStdio(t *testing.T) {
+	service, _, _ := serviceFixture(t)
+	client := domain.DetectedClient{ClientID: domain.ClientWindsurf, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), "windsurf")}
+	input := clinePackageInput(t, client, "1.0.0", "sha256:missing-helper", "sha256:helper-manifest", "sh")
+	input.Confirmed = true
+	input.Envelope.MCP.Servers["remote"] = domain.MCPServer{Type: "streamable-http", Decoded: map[string]any{"type": "streamable-http", "url": "https://example.invalid/mcp"}, Raw: json.RawMessage(`{"type":"streamable-http","url":"https://example.invalid/mcp"}`)}
+	installed, err := service.Add(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := domain.SelectedMCPNames(installed.Plan); !reflect.DeepEqual(got, []string{"remote"}) {
+		t.Fatal(got)
+	}
+	if packageNeedsPluginData(input.Envelope, installed.Plan) {
+		t.Fatal("unselected stdio demanded data")
+	}
+}
+
+func TestFreshTargetCanSelectSubsetOfExistingInstallation(t *testing.T) {
+	for _, grouped := range []bool{false, true} {
+		t.Run(fmt.Sprint(grouped), func(t *testing.T) {
+			service, store, client := serviceFixture(t)
+			input := clinePackageInput(t, client, "1.0.0", "sha256:new-target", "sha256:new-target-manifest", "sh")
+			input.Confirmed = true
+			if _, err := service.Add(context.Background(), input); err != nil {
+				t.Fatal(err)
+			}
+			before, _ := store.Load()
+			old := onlyBinding(before.Installations[0])
+			input.Client = domain.DetectedClient{ClientID: domain.ClientWindsurf, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), "windsurf")}
+			input.OperationID = "fresh-target"
+			var result AddResult
+			var err error
+			if grouped {
+				var group GroupResult
+				group, err = service.AddGroup(context.Background(), GroupInput{Targets: []AddInput{input}, Confirmed: true, OperationGroupID: "fresh-target-group"})
+				if len(group.Targets) > 0 {
+					result = group.Targets[0]
+				}
+			} else {
+				result, err = service.Add(context.Background(), input)
+			}
+			if err != nil || !result.Mutated || len(domain.SelectedMCPNames(result.Plan)) != 0 {
+				t.Fatalf("result=%+v err=%v", result, err)
+			}
+			after, _ := store.Load()
+			if !reflect.DeepEqual(after.Installations[0].Clients[old.ClientBindingID], old) {
+				t.Fatal("existing target changed")
+			}
+		})
+	}
+}
+
+func TestUnexpectedReadinessIOIsNotAComponentSkip(t *testing.T) {
+	for _, err := range []error{&os.PathError{Op: "stat", Path: "test", Err: syscall.EIO}, &os.PathError{Op: "stat", Path: "test", Err: os.ErrPermission}} {
+		if !unexpectedPathIO(err) {
+			t.Fatalf("I/O was masked: %v", err)
+		}
+	}
+	for _, err := range []error{&os.PathError{Op: "stat", Path: "test", Err: os.ErrNotExist}, &os.PathError{Op: "stat", Path: "test", Err: syscall.ELOOP}} {
+		if unexpectedPathIO(err) {
+			t.Fatalf("expected readiness became fatal: %v", err)
+		}
+	}
+}

--- a/install/integrationctl/agentplugins/usecase/group.go
+++ b/install/integrationctl/agentplugins/usecase/group.go
@@ -248,7 +248,8 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 		}
 		result.Targets[targetIndex] = AddResult{InstallationID: installationID, Plan: plan}
 		if target.ReleaseRevoked && normalizedOriginMode(target.OriginMode) == domain.OriginModeDirect {
-			result.Targets[targetIndex].Plan.Warnings = append(result.Targets[targetIndex].Plan.Warnings, "direct_source_digest_matches_known_revoked_directory_release")
+			plan.Warnings = append(plan.Warnings, "direct_source_digest_matches_known_revoked_directory_release")
+			result.Targets[targetIndex].Plan = plan
 		}
 		if plan.Status == domain.PlanUnsupported {
 			return result, fmt.Errorf("target %s is unsupported; group preflight caused no mutation", target.Client.ClientID)
@@ -256,9 +257,11 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 		if err := service.preflightActivation(target, plan); err != nil {
 			return result, err
 		}
-		if err := preflightRuntime(target.Envelope, plan, service.automaticallyActivates(target, plan)); err != nil {
+		if err := service.preflightTargetComponents(ctx, target, &plan, installationIfExisting(state, installationIndex, existing), input.Repair, replace); err != nil {
+			result.Targets[targetIndex].Plan = plan
 			return result, err
 		}
+		result.Targets[targetIndex].Plan = plan
 		key := plan.ActivePath
 		if sameNativeBackend(target.Client.ClientID, domain.ClientCopilot) {
 			key = "shared-copilot-vscode:" + plan.PhysicalArtifactID
@@ -302,6 +305,9 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 				}
 			}
 		}
+		if replace {
+			describeMCPRemovals(&plan, managed)
+		}
 		if replace && managed == nil {
 			return result, fmt.Errorf("update target %s is not installed", target.Client.ClientID)
 		}
@@ -318,7 +324,7 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 		} else if err := service.observeGroupNativeIdentity(ctx, target.Client, plan, managed, input.Repair); err != nil {
 			return result, err
 		}
-		noChange := managed != nil && !input.Repair && !input.Switch && groupPackageUnchanged(*managed, target) && containsSurface(managed.AffectedSurfaces, string(target.Client.ClientID))
+		noChange := !requiresComponentRemoval(plan) && managed != nil && !input.Repair && !input.Switch && groupPackageUnchanged(*managed, target) && containsSurface(managed.AffectedSurfaces, string(target.Client.ClientID))
 		if noChange {
 			result.Targets[targetIndex].NoChange = true
 			result.Targets[targetIndex].Activation = domain.ActivationOutcome{Activation: managed.Activation, Authentication: managed.Authentication, Policy: managed.Policy, Verification: managed.Verification}
@@ -351,7 +357,7 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 			if err := service.preflightActivation(check, plan); err != nil {
 				return result, err
 			}
-			if err := preflightRuntime(check.Envelope, plan, service.automaticallyActivates(check, plan)); err != nil {
+			if err := service.preflightTargetComponents(ctx, check, &plan, &state.Installations[installationIndex], false, true); err != nil {
 				return result, err
 			}
 			for _, binding := range state.Installations[installationIndex].Clients {
@@ -388,7 +394,7 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 			continue
 		}
 		operationID := fmt.Sprintf("%s-%03d", groupID, targetIndex+1)
-		if packageNeedsPluginData(target.input.Envelope) {
+		if packageNeedsPluginData(target.input.Envelope, target.plan) {
 			if service.PluginData == nil {
 				cleanup()
 				return result, fmt.Errorf("PLUGIN_DATA manager is required for stdio MCP packages")

--- a/install/integrationctl/agentplugins/usecase/group_test.go
+++ b/install/integrationctl/agentplugins/usecase/group_test.go
@@ -169,7 +169,7 @@ func TestGroupedDryRunDoesNotObserveNativeClientIdentity(t *testing.T) {
 	}); err == nil || !strings.Contains(err.Error(), "changed or is missing") {
 		t.Fatalf("tampered group dry-run error = %v", err)
 	}
-	if observer.calls != 0 || observer.preparedCalls != 1 {
+	if observer.calls != 0 || observer.preparedCalls != 0 {
 		t.Fatalf("tampered group dry-run observations: native=%d prepared=%d", observer.calls, observer.preparedCalls)
 	}
 }

--- a/install/integrationctl/agentplugins/usecase/historical_sse_lifecycle_test.go
+++ b/install/integrationctl/agentplugins/usecase/historical_sse_lifecycle_test.go
@@ -1,0 +1,106 @@
+package usecase
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/ports"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Exact-base 55c5b5b OpenCode SSE artifacts retain portable type:sse in mcp.json
+// and render the native entry as {type:remote,url:...}. Reconstruct those bytes
+// with owned native receipts here; the new implementation never renders SSE.
+func TestHistoricalSSESameRevisionLifecycle(t *testing.T) {
+	for _, op := range []string{"add", "update", "repair", "group_add", "group_update", "group_repair"} {
+		t.Run(op, func(t *testing.T) {
+			service, store, _ := serviceFixture(t)
+			client := domain.DetectedClient{ClientID: domain.ClientOpenCode, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), "opencode")}
+			input := openCodePluginInput(t, client, "1.0.0", "sha256:historical-sse", "sha256:historical-sse-manifest", "unused")
+			portable := func(kind string) domain.MCPServer {
+				raw := json.RawMessage(`{"type":"` + kind + `","url":"https://example.test/events"}`)
+				return domain.MCPServer{Name: "docs", Type: kind, Raw: raw, Decoded: map[string]any{"type": kind, "url": "https://example.test/events"}}
+			}
+			input.Envelope.MCP.Servers = map[string]domain.MCPServer{"docs": portable("streamable-http")}
+			input.Confirmed = true
+			installed, err := service.Add(context.Background(), input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// The historical native representation equals HTTP-first remote, but the
+			// authoritative source and retained portable artifact explicitly declare SSE.
+			input.Envelope.MCP.Servers["docs"] = portable("sse")
+			legacy := []byte(`{"$schema":"https://agent-plugins.org/schemas/1.0.0/mcp.schema.json","mcpServers":{"docs":{"type":"sse","url":"https://example.test/events"}}}`)
+			input.Envelope.MCP.Raw = legacy
+			for _, root := range []string{input.Envelope.SnapshotRoot, installed.Plan.ActivePath} {
+				if err := os.WriteFile(filepath.Join(root, "mcp.json"), legacy, 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			var mismatch *ports.VerificationError
+			if err := service.Stager.Verify(context.Background(), installed.Plan.ActivePath, "observe-historical"); !errors.As(err, &mismatch) || mismatch.ActualDigest == "" {
+				t.Fatal(err)
+			}
+			state, _ := store.Load()
+			for key, binding := range state.Installations[0].Clients {
+				for i := range binding.NativeObjects {
+					if binding.NativeObjects[i].Kind == "managed_package_directory" {
+						binding.NativeObjects[i].ManagedDigest = mismatch.ActualDigest
+					}
+				}
+				state.Installations[0].Clients[key] = binding
+			}
+			if err := store.Save(state); err != nil {
+				t.Fatal(err)
+			}
+			input.InstallationID = installed.InstallationID
+			input.OperationID = "historical-followup"
+			configPath := filepath.Join(client.ConfigRoot, "opencode.json")
+			if strings.HasSuffix(op, "repair") {
+				if err := os.WriteFile(configPath, []byte(`{"mcp":{}}`), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			before, _ := os.ReadFile(configPath)
+			var result AddResult
+			if strings.HasPrefix(op, "group_") {
+				args := GroupInput{Targets: []AddInput{input}, Confirmed: true, OperationGroupID: "historical-next"}
+				var g GroupResult
+				switch op {
+				case "group_add":
+					g, err = service.AddGroup(context.Background(), args)
+				case "group_update":
+					g, err = service.UpdateGroup(context.Background(), args)
+				default:
+					g, err = service.RepairGroup(context.Background(), args)
+				}
+				if len(g.Targets) > 0 {
+					result = g.Targets[0]
+				}
+			} else {
+				switch op {
+				case "add":
+					result, err = service.Add(context.Background(), input)
+				case "update":
+					result, err = service.Update(context.Background(), input)
+				default:
+					result, err = service.Repair(context.Background(), input)
+				}
+			}
+			after, _ := os.ReadFile(configPath)
+			if strings.HasSuffix(op, "update") {
+				if err != nil || !result.Mutated || result.NoChange || strings.Contains(string(after), "events") {
+					t.Fatalf("update result=%+v err=%v config=%s", result, err, after)
+				}
+			} else {
+				if err == nil || !strings.Contains(err.Error(), "explicit update") || result.Mutated || string(before) != string(after) {
+					t.Fatalf("refusal result=%+v err=%v", result, err)
+				}
+			}
+		})
+	}
+}

--- a/install/integrationctl/agentplugins/usecase/managed_selection.go
+++ b/install/integrationctl/agentplugins/usecase/managed_selection.go
@@ -1,0 +1,112 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/pathpolicy"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/ports"
+	"strings"
+)
+
+type managedSelectionReader interface {
+	ManagedMCPNames(context.Context, domain.ClientID, string, string) ([]string, error)
+}
+
+func installationIfExisting(state domain.StateFileV2, index int, existing bool) *domain.Installation {
+	if !existing {
+		return nil
+	}
+	return &state.Installations[index]
+}
+
+func (service Service) preflightTargetComponents(ctx context.Context, input AddInput, plan *domain.DeliveryPlan, installation *domain.Installation, repair, updating bool) error {
+	var prior *domain.ClientBinding
+	if installation != nil {
+		for _, binding := range installation.Clients {
+			if binding.Materialization != domain.MaterializationAbsent && binding.Scope == string(plan.Scope) && binding.PhysicalArtifact == plan.PhysicalArtifactID && sameNativeBackend(domain.ClientID(binding.ClientID), plan.ClientID) {
+				copy := binding
+				prior = &copy
+				break
+			}
+		}
+	}
+	if prior == nil {
+		return service.preflightComponents(input.Envelope, plan, false)
+	}
+	reader, ok := service.Stager.(managedSelectionReader)
+	if !ok {
+		return service.preflightComponents(input.Envelope, plan, true)
+	}
+	if service.Targets == nil {
+		return fmt.Errorf("target resolver required to verify prior MCP selection")
+	}
+	client := input.Client
+	client.ClientID = domain.ClientID(prior.ClientID)
+	target, err := service.Targets.ResolveTarget(ctx, client, input.Scope, prior.PhysicalArtifact)
+	if err != nil {
+		return err
+	}
+	if err := pathpolicy.RequireExactPath(target.ActivePath, prior.TargetLocator); err != nil {
+		return fmt.Errorf("untrusted persisted target while reading managed MCP selection: %w", err)
+	}
+	names, err := reader.ManagedMCPNames(ctx, client.ClientID, prior.TargetLocator, managedDigest(*prior))
+	if err != nil {
+		var verification *ports.VerificationError
+		if repair && errors.As(err, &verification) && (verification.Kind == ports.VerificationAbsent || verification.Kind == ports.VerificationDigestMismatch) {
+			// No names from damaged bytes are trusted. The existing exact rebuilt
+			// artifact digest gate remains mandatory before any repair commit.
+			return service.preflightComponents(input.Envelope, plan, false)
+		}
+		operation := "add"
+		if updating {
+			operation = "update"
+		}
+		return fmt.Errorf("managed package was changed or is missing; refusing silent %s before previous MCP selection can be verified: %w", operation, err)
+	}
+	selected := map[string]bool{}
+	for _, name := range names {
+		selected[name] = true
+	}
+	staticRemoved := []string{}
+	supported := map[string]bool{}
+	for _, c := range plan.Components {
+		if c.Kind == domain.ComponentMCPServer && c.Support != domain.SupportUnsupported {
+			supported[c.Name] = true
+		}
+	}
+	for _, name := range names {
+		if !supported[name] {
+			staticRemoved = append(staticRemoved, name)
+		}
+	}
+	if len(staticRemoved) > 0 {
+		plan.Warnings = append(plan.Warnings, "managed_component_removal_required")
+		for _, name := range staticRemoved {
+			plan.Diagnostics = append(plan.Diagnostics, domain.Diagnostic{Severity: domain.SeverityWarning, Boundary: domain.BoundaryMCPServer, Item: name, Code: "managed_component_removal_planned", Message: "current support requires controlled removal of this previously managed MCP entry"})
+		}
+		if repair || !updating {
+			return fmt.Errorf("recorded MCP selection is no longer supported; use an explicit update for controlled removal: %s", strings.Join(staticRemoved, ", "))
+		}
+	}
+	if repair {
+		for i := range plan.Components {
+			c := &plan.Components[i]
+			if c.Kind == domain.ComponentMCPServer && !selected[c.Name] {
+				c.Support = domain.SupportUnsupported
+				c.Reason = "not_in_recorded_delivery"
+			}
+		}
+	}
+	return service.preflightComponents(input.Envelope, plan, true, selected)
+}
+
+func requiresComponentRemoval(plan domain.DeliveryPlan) bool {
+	for _, warning := range plan.Warnings {
+		if warning == "managed_component_removal_required" {
+			return true
+		}
+	}
+	return false
+}

--- a/install/integrationctl/agentplugins/usecase/partial_selection_lifecycle_test.go
+++ b/install/integrationctl/agentplugins/usecase/partial_selection_lifecycle_test.go
@@ -1,0 +1,70 @@
+package usecase
+
+import (
+	"context"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPreviouslySkippedMCPLifecycle(t *testing.T) {
+	for _, op := range []string{"add_again", "repair", "update", "group_add_again", "group_repair", "group_update"} {
+		t.Run(op, func(t *testing.T) {
+			service, _, client := serviceFixture(t)
+			input := clinePackageInput(t, client, "1.0.0", "sha256:xhigh-partial", "sha256:xhigh-partial-manifest", "agentplugins-definitely-unavailable-runtime")
+			input.Confirmed = true
+			installed, err := service.Add(context.Background(), input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			input.InstallationID = installed.InstallationID
+			input.OperationID = "partial-followup"
+			if op == "group_repair" {
+				service.NativeObserver = providers.NativeIdentityObserver{Stager: service.Stager}
+				if err := os.RemoveAll(installed.Plan.ActivePath); err != nil {
+					t.Fatal(err)
+				}
+			} else if strings.HasSuffix(op, "repair") {
+				if err := os.WriteFile(filepath.Join(installed.Plan.ActivePath, "review-damage"), []byte("damage"), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if strings.HasSuffix(op, "update") {
+				input = clinePackageInput(t, client, "2.0.0", "sha256:xhigh-partial-v2", "sha256:xhigh-partial-manifest-v2", "agentplugins-definitely-unavailable-runtime")
+				input.Confirmed = true
+				input.OperationID = "partial-update"
+				input.InstallationID = installed.InstallationID
+			}
+			var result AddResult
+			if strings.HasPrefix(op, "group_") {
+				args := GroupInput{Targets: []AddInput{input}, Confirmed: true, OperationGroupID: "partial-next"}
+				var g GroupResult
+				switch op {
+				case "group_repair":
+					g, err = service.RepairGroup(context.Background(), args)
+				case "group_update":
+					g, err = service.UpdateGroup(context.Background(), args)
+				default:
+					g, err = service.AddGroup(context.Background(), args)
+				}
+				if len(g.Targets) > 0 {
+					result = g.Targets[0]
+				}
+			} else {
+				switch op {
+				case "repair":
+					result, err = service.Repair(context.Background(), input)
+				case "update":
+					result, err = service.Update(context.Background(), input)
+				default:
+					result, err = service.Add(context.Background(), input)
+				}
+			}
+			if err != nil {
+				t.Fatalf("previously skipped MCP still absent; healthy skill lifecycle refused: mutated=%v noChange=%v err=%v", result.Mutated, result.NoChange, err)
+			}
+		})
+	}
+}

--- a/install/integrationctl/agentplugins/usecase/path_semantics_integration_test.go
+++ b/install/integrationctl/agentplugins/usecase/path_semantics_integration_test.go
@@ -1,0 +1,159 @@
+package usecase
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/loader"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/specregistry"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers"
+)
+
+func TestPortableDotPathsInstallAndExactRepair(t *testing.T) {
+	for _, cwd := range []string{"./", "./data/..", "${PLUGIN_ROOT}"} {
+		t.Run(cwd, func(t *testing.T) {
+			service, store, _ := serviceFixture(t)
+			service.NativeObserver = providers.NativeIdentityObserver{Stager: service.Stager}
+			client := domain.DetectedClient{ClientID: domain.ClientOpenCode, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), "opencode")}
+			input := addInput(t, client, "https://example.test/portable-dot-paths")
+			root := input.Envelope.SnapshotRoot
+			for _, dir := range []string{"bin", "data"} {
+				if err := os.MkdirAll(filepath.Join(root, dir), 0700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			// Executable permission is observed; neither loader nor this lifecycle launches it.
+			if err := os.WriteFile(filepath.Join(root, "bin/server"), []byte("inert test executable; never run\n"), 0755); err != nil {
+				t.Fatal(err)
+			}
+			mcp := map[string]any{"$schema": domain.MCPSchemaV1, "mcpServers": map[string]any{
+				"local":  map[string]any{"type": "stdio", "command": "./bin/../bin/server", "cwd": cwd},
+				"remote": map[string]any{"type": "streamable-http", "url": "https://example.test/mcp"},
+			}}
+			body, err := json.Marshal(mcp)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err = os.WriteFile(filepath.Join(root, "mcp.json"), body, 0600); err != nil {
+				t.Fatal(err)
+			}
+			registry, err := specregistry.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			envelope, err := (loader.Loader{Registry: registry}).Load(context.Background(), domain.LoadInput{SnapshotRoot: root, Source: input.Envelope.Source, TreeDigest: input.Envelope.TreeDigest, ExecutableFiles: []string{"bin/server"}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(envelope.MCP.Servers) != 2 {
+				t.Fatalf("loader diagnostics: %+v", envelope.Diagnostics)
+			}
+			input.Envelope = envelope
+			added, err := service.AddGroup(context.Background(), GroupInput{Targets: []AddInput{input}, OperationGroupID: "dot-path-add", Confirmed: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			state, err := store.Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			active := onlyBinding(state.Installations[0]).TargetLocator
+			verify := func() {
+				t.Helper()
+				config := readUsecaseObject(t, filepath.Join(client.ConfigRoot, "opencode.json"))
+				server := config["mcp"].(map[string]any)["local"].(map[string]any)
+				argv := server["command"].([]any)
+				if argv[0] != filepath.Join(active, "bin/server") || server["cwd"] != active {
+					t.Fatalf("projection: %+v", server)
+				}
+			}
+			verify()
+			if err := os.WriteFile(filepath.Join(client.ConfigRoot, "opencode.json"), []byte(`{"mcp":{}}`), 0600); err != nil {
+				t.Fatal(err)
+			}
+			input.InstallationID = added.InstallationID
+			repaired, err := service.RepairGroup(context.Background(), GroupInput{Targets: []AddInput{input}, OperationGroupID: "dot-path-repair", Confirmed: true, Repair: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !repaired.Mutated {
+				t.Fatal("repair did not restore missing native artifacts")
+			}
+			verify()
+			restored, err := os.ReadFile(filepath.Join(active, "bin/server"))
+			if err != nil || string(restored) != "inert test executable; never run\n" {
+				t.Fatalf("restored executable = %q, %v", restored, err)
+			}
+		})
+	}
+}
+
+func TestClaudeBundledDotPathsInstallAndRepair(t *testing.T) {
+	service, _, _ := serviceFixture(t)
+	client := domain.DetectedClient{ClientID: domain.ClientClaude, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), "claude"), ExecutablePath: "/test/bin/claude"}
+	runner := &fakeClaudeLifecycleRunner{configRoot: client.ConfigRoot}
+	service.Activator = providers.Activator{Runner: runner}
+	service.NativeObserver = providers.NativeIdentityObserver{Runner: runner, Stager: service.Stager}
+	input := addInput(t, client, "https://example.test/claude-bundled-paths")
+	input.BackendExecutable = client.ExecutablePath
+	root := input.Envelope.SnapshotRoot
+	for _, dir := range []string{"bin", "work"} {
+		if err := os.MkdirAll(filepath.Join(root, dir), 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, "bin/server"), []byte("inert fixture; never executed\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	body := []byte(`{"$schema":"https://agent-plugins.org/schemas/1.0.0/mcp.schema.json","mcpServers":{"local":{"type":"stdio","command":"./bin/../bin/server","cwd":"./work","args":["${PLUGIN_ROOT}/config"]}}}`)
+	if err := os.WriteFile(filepath.Join(root, "mcp.json"), body, 0600); err != nil {
+		t.Fatal(err)
+	}
+	registry, err := specregistry.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	input.Envelope, err = (loader.Loader{Registry: registry}).Load(context.Background(), domain.LoadInput{SnapshotRoot: root, Source: input.Envelope.Source, TreeDigest: input.Envelope.TreeDigest, ExecutableFiles: []string{"bin/server"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(input.Envelope.MCP.Servers) != 1 {
+		t.Fatalf("loader diagnostics: %+v", input.Envelope.Diagnostics)
+	}
+	input.Confirmed = true
+	installed, err := service.Add(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	verify := func() {
+		t.Helper()
+		runtime := filepath.Join(installed.Plan.ActivePath, ".agentplugins-runtime")
+		server := readUsecaseObject(t, filepath.Join(installed.Plan.ActivePath, ".mcp.json"))["local"].(map[string]any)
+		if server["command"] != filepath.Join(runtime, "bin/server") || server["cwd"] != filepath.Join(runtime, "work") {
+			t.Fatalf("Claude final paths: %+v", server)
+		}
+		if server["args"].([]any)[0] != filepath.Join(runtime, "config") {
+			t.Fatalf("Claude PLUGIN_ROOT expansion: %+v", server)
+		}
+		if _, err := os.Stat(filepath.Join(runtime, "bin/server")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	verify()
+	if err := os.RemoveAll(installed.Plan.ActivePath); err != nil {
+		t.Fatal(err)
+	}
+	input.OperationID = "claude-dot-repair"
+	repaired, err := service.Repair(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !repaired.Mutated {
+		t.Fatal("Claude missing managed package was not repaired")
+	}
+	verify()
+}

--- a/install/integrationctl/agentplugins/usecase/portable_identity_test.go
+++ b/install/integrationctl/agentplugins/usecase/portable_identity_test.go
@@ -1,0 +1,196 @@
+package usecase
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/pathpolicy"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPortableReservedIdentityLifecycle(t *testing.T) {
+	for _, name := range []string{"demo", "con", "con.foo"} {
+		t.Run(name, func(t *testing.T) {
+			service, store, client := serviceFixture(t)
+			input := addInput(t, client, "https://example.com/identity")
+			input.Confirmed = true
+			portableIdentityMCP(t, &input)
+			input.Envelope.Manifest.Name = name
+			raw, _ := json.Marshal(map[string]any{"$schema": domain.PluginSchemaV1, "name": name, "version": "1.0.0"})
+			input.Envelope.Manifest.Raw = raw
+			if err := os.WriteFile(filepath.Join(input.Envelope.SnapshotRoot, "plugin.json"), raw, 0600); err != nil {
+				t.Fatal(err)
+			}
+			installed, err := service.Add(context.Background(), input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := pathpolicy.ValidateLeafID(installed.Plan.PhysicalArtifactID); err != nil {
+				t.Fatal(err)
+			}
+			if installed.Plan.DeclaredName != name {
+				t.Fatal("logical name changed")
+			}
+			stateBefore, err := store.Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(stateBefore.Installations[0].DataReceipts) != 1 {
+				t.Fatal("data receipt missing")
+			}
+			var data domain.DataReceipt
+			for _, receipt := range stateBefore.Installations[0].DataReceipts {
+				data = receipt
+			}
+			marker := filepath.Join(data.Locator, "keep")
+			if err := os.WriteFile(marker, []byte("persistent"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			input.OperationID = "identity-update"
+			updated, err := service.Update(context.Background(), input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if updated.Plan.ActivePath != installed.Plan.ActivePath {
+				t.Fatal("update moved storage")
+			}
+			if err := os.WriteFile(filepath.Join(installed.Plan.ActivePath, "plugin.json"), []byte("tampered"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			input.OperationID = "identity-repair"
+			repaired, err := service.Repair(context.Background(), input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if repaired.Plan.ActivePath != installed.Plan.ActivePath {
+				t.Fatal("repair moved storage")
+			}
+			state, err := store.Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(state.Installations[0].DataReceipts) != 1 || state.Installations[0].DataReceipts[data.DataReceiptID].DataReceiptID != data.DataReceiptID {
+				t.Fatal("data identity changed")
+			}
+			if body, err := os.ReadFile(marker); err != nil || string(body) != "persistent" {
+				t.Fatal("update/repair lost data")
+			}
+			if state.Installations[0].DeclaredName != name {
+				t.Fatal("persisted logical name changed")
+			}
+			if _, err := service.Remove(context.Background(), RemoveInput{Selector: installed.InstallationID, Client: client, Scope: domain.ScopeUser, Confirmed: true, OperationID: "identity-remove"}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Stat(installed.Plan.ActivePath); !os.IsNotExist(err) {
+				t.Fatalf("owned path retained: %v", err)
+			}
+		})
+	}
+}
+
+func TestPortableReservedGroupedLifecycle(t *testing.T) {
+	t.Parallel()
+	service, store, cursor := serviceFixture(t)
+	kiro := domain.DetectedClient{ClientID: domain.ClientKiro, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".kiro")}
+
+	cursorAdd := portableNamedGroupInput(t, cursor, "https://example.com/grouped")
+	kiroAdd := portableNamedGroupInput(t, kiro, "https://example.com/grouped")
+	added, err := service.AddGroup(context.Background(), GroupInput{
+		Targets: []AddInput{cursorAdd, kiroAdd}, OperationGroupID: "group-add", Confirmed: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !added.Mutated || len(added.Receipts) != 2 {
+		t.Fatalf("grouped add = %+v", added)
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Installations) != 1 || len(state.Installations[0].Clients) != 2 || state.Installations[0].OperationGroupID != "group-add" {
+		t.Fatalf("grouped add state = %+v", state.Installations)
+	}
+	for _, binding := range state.Installations[0].Clients {
+		if binding.PackageRevision == nil || binding.PackageRevision.TreeDigest != "sha256:source-tree" || len(binding.Receipts) != 1 || binding.Receipts[0].OperationGroupID != "group-add" {
+			t.Fatalf("grouped add binding = %+v", binding)
+		}
+	}
+
+	cursorUpdate := portableNamedGroupInput(t, cursor, "https://example.com/grouped")
+	kiroUpdate := portableNamedGroupInput(t, kiro, "https://example.com/grouped")
+	setEnvelopeVersion(t, &cursorUpdate.Envelope, "2.0.0", "sha256:group-tree-v2", "sha256:group-manifest-v2")
+	setEnvelopeVersion(t, &kiroUpdate.Envelope, "2.0.0", "sha256:group-tree-v2", "sha256:group-manifest-v2")
+	updated, err := service.UpdateGroup(context.Background(), GroupInput{
+		Targets: []AddInput{cursorUpdate, kiroUpdate}, CompatibilityChecks: []AddInput{cursorUpdate, kiroUpdate},
+		OperationGroupID: "group-update", Confirmed: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updated.Mutated || len(updated.Receipts) != 2 {
+		t.Fatalf("grouped update = %+v", updated)
+	}
+	state, err = store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, binding := range state.Installations[0].Clients {
+		if binding.PackageRevision == nil || binding.PackageRevision.Version != "2.0.0" || binding.PackageRevision.TreeDigest != "sha256:group-tree-v2" || len(binding.Receipts) != 2 {
+			t.Fatalf("grouped update binding = %+v", binding)
+		}
+	}
+
+	removed, err := service.RemoveGroup(context.Background(), RemoveGroupInput{
+		Selector: added.InstallationID,
+		Targets: []RemoveInput{
+			{Client: cursor, Scope: domain.ScopeUser, ExternalUninstalled: true},
+			{Client: kiro, Scope: domain.ScopeUser, ExternalUninstalled: true},
+		},
+		OperationGroupID: "group-remove", Confirmed: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !removed.Mutated || len(removed.Receipts) != 2 {
+		t.Fatalf("grouped remove = %+v", removed)
+	}
+	state, err = store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Installations) != 1 || len(state.Installations[0].Clients) != 0 || !state.Installations[0].DataRetained {
+		t.Fatalf("grouped remove state = %+v", state.Installations)
+	}
+	for _, target := range added.Targets {
+		if _, err := os.Lstat(target.Plan.ActivePath); !os.IsNotExist(err) {
+			t.Fatalf("grouped remove retained %s: %v", target.Plan.ActivePath, err)
+		}
+	}
+}
+
+func portableNamedGroupInput(t *testing.T, client domain.DetectedClient, source string) AddInput {
+	input := addInput(t, client, source)
+	portableIdentityMCP(t, &input)
+	input.Envelope.Manifest.Name = "con.foo"
+	body, _ := json.Marshal(map[string]any{"$schema": domain.PluginSchemaV1, "name": "con.foo", "version": "1.0.0"})
+	input.Envelope.Manifest.Raw = body
+	if err := os.WriteFile(filepath.Join(input.Envelope.SnapshotRoot, "plugin.json"), body, 0600); err != nil {
+		t.Fatal(err)
+	}
+	return input
+}
+
+func portableIdentityMCP(t *testing.T, input *AddInput) {
+	t.Helper()
+	decoded := map[string]any{"type": "stdio", "command": "node", "args": []any{"${PLUGIN_DATA}"}}
+	input.Envelope.MCP = domain.MCPComponent{Present: true, Enabled: true, Servers: map[string]domain.MCPServer{"local": {Name: "local", Type: "stdio", Decoded: decoded}}}
+	input.Envelope.Inventory.MCPServers = []string{"local"}
+	raw, _ := json.Marshal(map[string]any{"mcpServers": map[string]any{"local": decoded}})
+	input.Envelope.MCP.Raw = raw
+	if err := os.WriteFile(filepath.Join(input.Envelope.SnapshotRoot, "mcp.json"), raw, 0600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/install/integrationctl/agentplugins/usecase/repair.go
+++ b/install/integrationctl/agentplugins/usecase/repair.go
@@ -54,6 +54,11 @@ func (service Service) Repair(ctx context.Context, input AddInput) (AddResult, e
 		return AddResult{}, err
 	}
 	result := AddResult{InstallationID: installation.InstallationID, Plan: plan}
+	if err := service.preflightTargetComponents(ctx, input, &plan, &installation, true, false); err != nil {
+		result.Plan = plan
+		return result, err
+	}
+	result.Plan = plan
 	clientKey := domain.ComputeClientBindingID(installation.InstallationID, string(input.Client.ClientID), string(input.Scope), plan.ActivePath)
 	client, ok := installation.Clients[clientKey]
 	if !ok && sameNativeBackend(input.Client.ClientID, domain.ClientCopilot) {
@@ -218,7 +223,7 @@ func (service Service) Repair(ctx context.Context, input AddInput) (AddResult, e
 		}
 	}
 	dataPath := ""
-	if packageNeedsPluginData(input.Envelope) {
+	if packageNeedsPluginData(input.Envelope, plan) {
 		if service.PluginData == nil {
 			return result, fmt.Errorf("PLUGIN_DATA manager is required for stdio repair")
 		}

--- a/install/integrationctl/agentplugins/usecase/service.go
+++ b/install/integrationctl/agentplugins/usecase/service.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -211,7 +210,8 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 	}
 	result := AddResult{InstallationID: installationID, Plan: plan}
 	if input.ReleaseRevoked && normalizedOriginMode(input.OriginMode) == domain.OriginModeDirect {
-		result.Plan.Warnings = append(result.Plan.Warnings, "direct_source_digest_matches_known_revoked_directory_release")
+		plan.Warnings = append(plan.Warnings, "direct_source_digest_matches_known_revoked_directory_release")
+		result.Plan = plan
 	}
 	if plan.Status == domain.PlanUnsupported {
 		action := strings.Join(plan.UserActions, "; ")
@@ -223,9 +223,11 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 	if err := service.preflightActivation(input, plan); err != nil {
 		return result, err
 	}
-	if err := preflightRuntime(input.Envelope, plan, service.automaticallyActivates(input, plan)); err != nil {
+	if err := service.preflightTargetComponents(ctx, input, &plan, installationIfExisting(state, installationIndex, existing), false, replace); err != nil {
+		result.Plan = plan
 		return result, err
 	}
+	result.Plan = plan
 	if err := rejectNativeNameCollision(state, installationID, input.Envelope.Manifest.Name, input.Client.ClientID); err != nil {
 		return result, err
 	}
@@ -247,6 +249,10 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 	if isMaterialized {
 		binding := state.Installations[installationIndex].Clients[clientBindingID]
 		managedBinding = &binding
+	}
+	if replace {
+		describeMCPRemovals(&plan, managedBinding)
+		result.Plan = plan
 	}
 	if input.DistributionSuspended && normalizedOriginMode(input.OriginMode) == domain.OriginModeDirectory && !isMaterialized {
 		return result, fmt.Errorf("distribution is suspended; adding a target is blocked")
@@ -322,7 +328,7 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 		if err := service.observeNativeIdentity(ctx, input.Client, plan, managedBinding); err != nil {
 			return result, err
 		}
-		if packageRevisionMatches(previousClient.PackageRevision, input.Envelope) && previousClient.PackageRevision.ResolvedRevision == input.Envelope.Source.ResolvedRevision {
+		if !requiresComponentRemoval(plan) && packageRevisionMatches(previousClient.PackageRevision, input.Envelope) && previousClient.PackageRevision.ResolvedRevision == input.Envelope.Source.ResolvedRevision {
 			if lifecycleConverged(previousClient) {
 				verified, verifyErr := service.verifyClientReadOnly(ctx, input, result, previousClient)
 				if verifyErr != nil {
@@ -358,7 +364,7 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 	}
 	var dataReceipt domain.DataReceipt
 	dataCreated := false
-	if packageNeedsPluginData(input.Envelope) {
+	if packageNeedsPluginData(input.Envelope, plan) {
 		if service.PluginData == nil {
 			return result, fmt.Errorf("PLUGIN_DATA manager is required for stdio MCP packages")
 		}
@@ -1228,8 +1234,9 @@ func newOperationID() (string, error) {
 	return "op-" + hex.EncodeToString(random[:]), nil
 }
 
-func packageNeedsPluginData(envelope domain.PackageEnvelope) bool {
-	for _, server := range envelope.MCP.Servers {
+func packageNeedsPluginData(envelope domain.PackageEnvelope, plan domain.DeliveryPlan) bool {
+	for _, name := range domain.SelectedMCPNames(plan) {
+		server := envelope.MCP.Servers[name]
 		if server.Type == "stdio" {
 			return true
 		}
@@ -1264,40 +1271,6 @@ func (service Service) automaticallyActivates(input AddInput, plan domain.Delive
 	return classifier.AutomaticallyActivates(domain.ActivationRequest{
 		Client: input.Client, Plan: plan, BackendExecutable: input.BackendExecutable,
 	})
-}
-
-func preflightRuntime(envelope domain.PackageEnvelope, plan domain.DeliveryPlan, automaticActivation bool) error {
-	for name, server := range envelope.MCP.Servers {
-		if server.Type != "stdio" {
-			continue
-		}
-		command, _ := server.Decoded["command"].(string)
-		command = strings.TrimSpace(command)
-		if command == "" {
-			if automaticActivation {
-				return fmt.Errorf("stdio MCP server %s has no executable command", name)
-			}
-			continue
-		}
-		if strings.ContainsAny(command, "/\\") || strings.HasPrefix(command, ".") {
-			candidate := command
-			if !filepath.IsAbs(candidate) {
-				candidate = filepath.Join(envelope.SnapshotRoot, filepath.FromSlash(command))
-			}
-			if err := pathpolicy.RequireContainedChild(envelope.SnapshotRoot, candidate); err != nil {
-				return fmt.Errorf("stdio MCP server %s bundled command escapes PLUGIN_ROOT: %w", name, err)
-			}
-			info, err := os.Stat(candidate)
-			if err != nil || info.IsDir() || info.Mode().Perm()&0o111 == 0 {
-				return fmt.Errorf("stdio MCP server %s requires missing or non-executable bundled command %s", name, command)
-			}
-			continue
-		}
-		if _, err := exec.LookPath(command); err != nil && automaticActivation {
-			return fmt.Errorf("stdio MCP server %s requires executable %q on PATH; install it explicitly before retrying (agentplugins never installs runtimes)", name, command)
-		}
-	}
-	return nil
 }
 
 func versionCompare(left, right string) (int, bool) {

--- a/install/integrationctl/agentplugins/usecase/service_test.go
+++ b/install/integrationctl/agentplugins/usecase/service_test.go
@@ -189,7 +189,7 @@ func TestOpenAIOAuthHintsDoNotOverrideGenericAuthentication(t *testing.T) {
 		service, _, _ := serviceFixture(t)
 		client := domain.DetectedClient{ClientID: clientID, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".client")}
 		input := addInput(t, client, "https://example.com/generic-auth-"+string(clientID))
-		input.Envelope.MCP = domain.MCPComponent{Present: true, Enabled: true, Servers: map[string]domain.MCPServer{"server": {Name: "server", Type: "stdio"}}}
+		input.Envelope.MCP = domain.MCPComponent{Present: true, Enabled: true, Servers: map[string]domain.MCPServer{"server": {Name: "server", Type: "stdio", Decoded: map[string]any{"command":"sh"}}}}
 		input.Envelope.CatalogEvidence = &domain.CatalogEvidence{Compatibility: map[string]domain.CatalogCompatibility{string(clientID): {Package: map[bool]string{true: "projected", false: "native"}[clientID == domain.ClientCodex], Authentication: domain.AuthenticationRequirementNotRequired}}}
 		input.Hints.OpenAIMCPAuth = map[string]domain.OpenAIMCPAuthHint{"server": {OAuthResource: "https://example.com/oauth"}}
 		result, err := service.Add(context.Background(), input)
@@ -726,8 +726,8 @@ func TestNoChangeDryRunChecksManagedDigestWithoutNativeObservation(t *testing.T)
 	if observer.calls != 0 {
 		t.Fatalf("dry-run observed native client identity %d times", observer.calls)
 	}
-	if observer.preparedCalls != 1 {
-		t.Fatalf("dry-run prepared observations = %d, want 1", observer.preparedCalls)
+	if observer.preparedCalls != 0 {
+		t.Fatalf("dry-run prepared observations = %d, want 0 (selection integrity fails before observation)", observer.preparedCalls)
 	}
 	state, err := store.Load()
 	if err != nil {


### PR DESCRIPTION
## Summary

Valid Agent Plugins 1.0 packages could be rejected for portable paths or names, lose their working directory in client projections, or fail installation because one MCP server was unavailable. This change aligns loader admission with the published contract and preserves safe, consistent component selection through add, update, and repair.

- Accept standard-valid paths and names while retaining filesystem containment, managed ownership, and historical identity checks.
- Preserve Cline cwd, add an owned Unix stdio helper for Windsurf, and report declared OpenCode SSE as unsupported instead of silently changing its transport.
- Keep healthy components installable, protect previously delivered components from transient failures, and handle historical unsupported OpenCode entries through explicit update.
- Document version-bound client evidence, extension policy, and release limitations. Canonical schema bytes and the conformance corpus pin are unchanged.

## Verification

Review-budget exception: 4,408 changed lines consist of 1,617 production, 2,564 tests, and 227 documentation lines. The tests cover shared loader, selection, projection, and lifecycle invariants. Independent review accepted one coherent PR because splitting the completed correction would recreate partially integrated states across overlapping provider/service tests.

The first Linux/Windows CI run exposed stale authoring assertions for now-valid portable names and a Windows concurrent-init error-classification race. Follow-up commit `68e2a93` updates the assertions without weakening negative/no-write cases and converts the native NTSTATUS collision into the canonical errno, with a deterministic no-overwrite regression test.

- [x] Added regression and lifecycle tests, including independently reproduced and fixed partial-install, Claude staging, and historical OpenCode SSE defects.
- [x] Final affected Go packages and vet pass locally.
- [x] `make vet`, `make generated-check`, install compatibility, manifest workflow, polyglot smoke, npm facade tests/package dry run, and docs checks pass locally.
- [x] Exact pinned loader conformance corpus: 133/133 pass.
- [ ] Full `make test-required` on the PR commit in CI. Local macOS failures were reproduced on clean base `55c5b5bc9bec353560f66f86008a4090b5634e12`; they are not represented as passing results.

## Release Impact

- [x] Docs updated and release-sensitive paths independently reviewed.
- Portable admission and client delivery behavior change intentionally; no official status, certification, activation, or OAuth claim is added.
- Windows Windsurf stdio remains unsupported. Linux/Windows build checks are compilation evidence; native client runtime evidence for this candidate remains incomplete.
- Windsurf copies the CLI helper once per package/client artifact, approximately 16.91 MiB for the locally tested macOS binary.
- Same-source helper-only updates can remain NoChange. Historical exact repair requires matching artifact bytes; this is not an automatic migration of all existing installations.
- Merging this PR does not publish a release.
- A separate follow-up audit reproduced existing Skill metadata/empty compatibility admission gaps and unusual OpenCode MCP-name staging failures on both the base and this candidate. These are outside this bounded correction; passing the pinned corpus does not establish complete compatibility. Current Codex native transport and data-root behavior also needs its own client acceptance checkpoint.
