### PR TITLE
test(authoring): use physical roots for mutation fixtures

### DIFF
--- a/cli/plugin-kit-ai/internal/authoring/commands/public_contract_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/public_contract_test.go
@@ -342,7 +342,7 @@ func TestPublicLiteralExamplesAndEveryLeaf(t *testing.T) {
 			var first [][]byte
 			var firstTree map[string]string
 			for _, mount := range []bool{false, true} {
-				parent := t.TempDir()
+				parent := physicalMutationRoot(t)
 				t.Chdir(parent)
 				a := publicApp(t)
 				args := append([]string{"init", lane.name, "--format=json"}, lane.flags...)
@@ -408,7 +408,7 @@ func TestPublicLiteralExamplesAndEveryLeaf(t *testing.T) {
 }
 
 func TestPublicCWDAndExplicitInputs(t *testing.T) {
-	parent := t.TempDir()
+	parent := physicalMutationRoot(t)
 	t.Chdir(parent)
 	a := publicApp(t)
 	root := filepath.Join(parent, "explicit-destination")
@@ -681,7 +681,7 @@ func TestPublicAnnotatedErrorAndRealCleanup(t *testing.T) {
 	noPolicy(t, e)
 	for _, canceled := range []bool{false, true} {
 		for _, mount := range []bool{false, true} {
-			parent := t.TempDir()
+			parent := physicalMutationRoot(t)
 			ctx, cancel := context.WithCancel(context.Background())
 			stage := ""
 			fault := faultContext{Context: ctx, check: func() {

--- a/cli/plugin-kit-ai/internal/authoring/commands/skills_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/skills_test.go
@@ -17,9 +17,20 @@ import (
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/conformance"
 )
 
+// physicalMutationRoot resolves only a fresh owned infrastructure directory,
+// before fixture inputs (including deliberate symlinks) are constructed.
+func physicalMutationRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
 func TestSkillsFactoriesAndEntrypointParity(t *testing.T) {
 	a := commands.App{Projects: project.Service{Scratch: t.TempDir()}, Revision: "skills-factories"}
-	roots := []string{t.TempDir(), t.TempDir()}
+	roots := []string{physicalMutationRoot(t), physicalMutationRoot(t)}
 	for _, root := range roots {
 		write(t, root, "plugin.json", plugin(""))
 		write(t, root, "keep", marker)
@@ -105,7 +116,7 @@ func TestSkillsFactoriesAndEntrypointParity(t *testing.T) {
 	}
 }
 func TestSkillsExactCWD(t *testing.T) {
-	root := t.TempDir()
+	root := physicalMutationRoot(t)
 	write(t, root, "plugin.json", plugin(""))
 	child := filepath.Join(root, "child")
 	if e := os.Mkdir(child, 0700); e != nil {
@@ -160,7 +171,7 @@ func TestSkillsHumanAllowlist(t *testing.T) {
 func TestSkillsPostCommitErrorIsExplicit(t *testing.T) {
 	for _, mount := range []bool{false, true} {
 		for _, jsonOutput := range []bool{false, true} {
-			root := t.TempDir()
+			root := physicalMutationRoot(t)
 			write(t, root, "plugin.json", plugin(""))
 			a := commands.App{Projects: project.Service{Scratch: t.TempDir(), Limits: packageview.Limits{Entries: 1}}}
 			args := []string{"skills", "init", "new", "--description", "text", root}

--- a/cli/plugin-kit-ai/internal/authoring/commands/vertical_fix_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/vertical_fix_test.go
@@ -104,7 +104,7 @@ func TestReviewInitCleanupFailurePrecedence(t *testing.T) {
 				boundary = "command"
 			}
 			t.Run(fixture+"/"+boundary, func(t *testing.T) {
-				parent, scratch := t.TempDir(), t.TempDir()
+				parent, scratch := physicalMutationRoot(t), t.TempDir()
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 				replaced := ""

--- a/cli/plugin-kit-ai/internal/authoring/scaffold/apply_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/scaffold/apply_test.go
@@ -107,7 +107,16 @@ func TestMissingParentSymlinkParentAndSourceOverlap(t *testing.T) {
 		t.Fatal(err)
 	}
 	p := planFor(t, "skill")
-	validate := realValidation(t)
+	validationCalls := 0
+	realValidate := realValidation(t)
+	validate := func(ctx context.Context, stage string) error {
+		validationCalls++
+		return realValidate(ctx, stage)
+	}
+	// Prove this physical fixture reaches real validation before adding aliases.
+	if result, err := Apply(context.Background(), p, ApplyOptions{Destination: filepath.Join(root, "positive"), Validate: validate}); err != nil || !result.Committed || validationCalls != 1 {
+		t.Fatalf("physical root positive control: %+v %v calls=%d", result, err, validationCalls)
+	}
 	for _, o := range []ApplyOptions{
 		{Destination: filepath.Join(root, "missing", "out")},
 		{Destination: filepath.Join(source, "out"), SourceRoots: []string{source}},
@@ -132,6 +141,9 @@ func TestMissingParentSymlinkParentAndSourceOverlap(t *testing.T) {
 	}
 	if _, err := Apply(context.Background(), p, ApplyOptions{Destination: filepath.Join(source, "out"), SourceRoots: []string{alias}, Validate: validate}); err == nil {
 		t.Fatal("source alias overlap")
+	}
+	if validationCalls != 1 {
+		t.Fatalf("unsafe input reached validation: calls=%d", validationCalls)
 	}
 	assertOnly(t, source, "sentinel")
 	b, _ := os.ReadFile(filepath.Join(source, "sentinel"))

--- a/cli/plugin-kit-ai/internal/authoring/scaffold/apply_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/scaffold/apply_test.go
@@ -109,9 +109,9 @@ func TestMissingParentSymlinkParentAndSourceOverlap(t *testing.T) {
 	p := planFor(t, "skill")
 	validationCalls := 0
 	realValidate := realValidation(t)
-	validate := func(ctx context.Context, stage string) error {
+	validate := func(ctx context.Context, stage string, dir *os.Root) error {
 		validationCalls++
-		return realValidate(ctx, stage)
+		return realValidate(ctx, stage, dir)
 	}
 	// Prove this physical fixture reaches real validation before adding aliases.
 	if result, err := Apply(context.Background(), p, ApplyOptions{Destination: filepath.Join(root, "positive"), Validate: validate}); err != nil || !result.Committed || validationCalls != 1 {

--- a/cli/plugin-kit-ai/internal/authoring/scaffold/skill_plan_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/scaffold/skill_plan_test.go
@@ -21,7 +21,7 @@ import (
 
 func skillFixture(t *testing.T) (string, SkillPlan, SkillSourceGate) {
 	t.Helper()
-	root, scratch := t.TempDir(), t.TempDir()
+	root, scratch := tempRoot(t), t.TempDir()
 	body := []byte(`{"$schema":"` + domain.PluginSchemaV1 + `","name":"fixture"}`)
 	if e := os.WriteFile(filepath.Join(root, "plugin.json"), body, 0600); e != nil {
 		t.Fatal(e)
@@ -135,7 +135,9 @@ func TestSkillAtomicFailureAndStagedValidation(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			injected := errors.New("injected I/O failure")
+			writeReached := false
 			ops := applyOps{write: func(ctx context.Context, r *os.Root, files []File) error {
+				writeReached = true
 				if mode == "write-failure" {
 					if e := r.Mkdir("partial", 0700); e != nil {
 						return e
@@ -189,6 +191,9 @@ func TestSkillAtomicFailureAndStagedValidation(t *testing.T) {
 				return nil
 			}}
 			r, e := applySkill(ctx, p, root, gate, sharedSkillValidation("new-skill"), ops)
+			if !writeReached {
+				t.Fatalf("write fault callback not reached: %v", e)
+			}
 			if e == nil {
 				t.Fatal("injected failure reported success")
 			}

--- a/cli/plugin-kit-ai/internal/authoring/skills/skills_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/skills/skills_test.go
@@ -31,9 +31,21 @@ func put(t *testing.T, root, path, body string) {
 		t.Fatal(err)
 	}
 }
+
+// physicalMutationRoot resolves only a fresh owned infrastructure directory,
+// before fixture inputs (including deliberate symlinks) are constructed.
+func physicalMutationRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
 func setup(t *testing.T) (skills.Service, string) {
 	t.Helper()
-	root := t.TempDir()
+	root := physicalMutationRoot(t)
 	put(t, root, "plugin.json", `{"$schema":"`+domain.PluginSchemaV1+`","name":"fixture"}`)
 	return skills.Service{Projects: project.Service{Scratch: t.TempDir()}, Revision: "skills-test"}, root
 }
@@ -212,7 +224,7 @@ func TestSkillContainmentAndSourceGate(t *testing.T) {
 			selected := root
 			switch kind {
 			case "root-link":
-				selected = filepath.Join(t.TempDir(), "link")
+				selected = filepath.Join(physicalMutationRoot(t), "link")
 				if e := os.Symlink(root, selected); e != nil {
 					t.Fatal(e)
 				}


### PR DESCRIPTION
Mutation fixtures using raw temporary paths can hit a symlinked infrastructure ancestor before reaching the behavior they intend to test. Resolve only each newly owned fixture root before constructing destinations and intentional aliases, following the existing scaffold convention.

The six test files retain strict symlink rejection, source sentinels and transaction assertions. Add a real physical-root positive control and callback reachability checks so an early path/reader failure cannot masquerade as the expected injected failure. Production behavior is unchanged.

Stacked on #182 at 1643476a932c9d46adcada85395363e5b9731e8f. Delivery head 1dbd1b28f0eeb2b0e5a7286d6241f82a639e1af5 preserves both reviewed histories; the six fixture files exactly match reviewed 225c932527b9256e0361a913742dd85bc80e4f64, and README contracts exactly match the base. No merge conflicts or additional code changes.

Validation:
- Independent gpt-6-astra medium review accepted the six-file patch with no introduced findings.
- Independent scaffold, skills and commands package runs passed on Linux/Go 1.25.13: 352 PASS records including subtests, zero skips.
- Exact composition checks and git diff --check passed; exact-head CI passed: Polyglot Smoke 34141566170 on Windows/Linux and Authoring native offline 34141566162, including all four native platforms, packed Linux amd64 and the required aggregate.

This is a bounded fixture correction, not exhaustive fixture conversion or native macOS qualification. Writable APFS packageview remains unproven, and existing raw-alias product semantics and platform gates remain unchanged. Useful legacy code, dependencies and tests are preserved. No public activation or release acceptance is claimed.


Artifact checks at the exact delivery head: all four native summaries and Go test streams were inspected, with matching revision/build identity for both entrypoints and five templates each. Windows had zero skips; each Linux run retained one optional-unproven Unix socket fixture. The packed archive passed independent verification of 7,662 indexed file hashes, 741 invocation records, 10 project inputs and 30 plans, with all phase exits zero. Archive verification covers recorded bytes/execution, not a relocated live-tree run. Release eligibility, platform acceptance and attestation remain false; writable macOS remains unproven.
