### PR TITLE
fix(agentplugins): harden native recovery and client lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ well-formed; it does not prove runtime, OAuth, or activation in every client.
 The CLI prints installed, prepared, activation required, and authentication
 pending as separate outcomes.
 
+For Codex, declared MCP SSE is unsupported; stdio and Streamable HTTP retain
+their existing adapter support. Valid SSE components are excluded from Codex
+delivery without invalidating the package. See [transport evidence and lifecycle
+behavior](docs/CODEX_TRANSPORT_EVIDENCE.md).
+
 ## Find and verify plugins
 
 search combines the reviewed Registry Directory with a signed public Discovery

--- a/docs/CODEX_TRANSPORT_EVIDENCE.md
+++ b/docs/CODEX_TRANSPORT_EVIDENCE.md
@@ -1,0 +1,37 @@
+# Codex MCP transport evidence
+
+UAP treats declared MCP SSE as unsupported for Codex. Existing stdio and
+Streamable HTTP adapter support is unchanged. This is a client delivery decision,
+not an additional portable package validation rule.
+
+## Source evidence
+
+The reviewed Codex source is `rust-v0.153.4`, commit
+`3d2ee51ca2d5db578f328aa75e20aa22c0197c9a`, checked on 2026-09-07:
+
+- The [native Agent Plugins parser](https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/codex-rs/codex-mcp/src/agent_plugin_config.rs)
+  explicitly rejects declared SSE.
+- The [legacy plugin configuration](https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/codex-rs/codex-mcp/src/plugin_config.rs)
+  normalizes transport fields; its URL route uses
+  [Streamable HTTP](https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/codex-rs/config/src/mcp_types.rs).
+  This does not establish SSE-first behavior.
+- [Manifest selection](https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/codex-rs/utils/plugins/src/plugin_namespace.rs)
+  prefers root `plugin.json` over the compatibility manifest. UAP preserves the
+  standard manifest and selects delivered servers in both `mcp.json` and
+  `.mcp.json`.
+
+This source snapshot does not establish a minimum supported Codex version or
+prove a native handshake, tool call, skill execution, cache refresh, or data
+persistence. Adapter tests and native runtime evidence remain separate.
+
+## Delivery and existing installations
+
+Healthy skills, stdio servers, and Streamable HTTP servers remain eligible when
+SSE is excluded. An SSE-only delivery refuses without installation writes.
+Direct local and immutable Git installation remain independent of the Directory.
+
+For an existing installation that recorded an SSE component, same-source Add and
+exact historical Repair refuse rather than silently dropping that component.
+A confirmed Update may withdraw the now-unsupported SSE component when healthy
+delivery remains. An all-unsupported Update refuses safely. A temporarily
+unavailable stdio executable does not authorize destructive withdrawal.

--- a/go.work.sum
+++ b/go.work.sum
@@ -3,4 +3,6 @@ github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wx
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 golang.org/x/mod v0.26.0/go.mod h1:/j6NAhSk8iQ723BGAUyoAcn7SlD7s15Dp9Nd/SfeaFQ=
 golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw=
+golang.org/x/tools v0.47.0/go.mod h1:dFHnyTvFWY212G+h7ZY4Vsp/K3U4/7W9TyVaAul8uCA=

--- a/install/integrationctl/adapters/dirswap/absent_race_audit_test.go
+++ b/install/integrationctl/adapters/dirswap/absent_race_audit_test.go
@@ -1,0 +1,47 @@
+package dirswap
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Regression: content that appears after the absent precondition must survive
+// a rejected publication and the rollback subsequently called by the kernel.
+func TestAuditAbsentPublicationRacePreservesForeignDirectory(t *testing.T) {
+	root := t.TempDir()
+	base := filepath.Join(root, "managed")
+	active := filepath.Join(base, "plugin")
+	staging := filepath.Join(base, "plugin.staging")
+	writeBody(t, staging, "owned-stage")
+	manager := Manager{JournalDir: filepath.Join(root, "journal")}
+	manager.Fault = func(phase string) error {
+		if phase == PhaseActivationPending {
+			writeBody(t, active, "foreign-arrived-after-precondition")
+		}
+		return nil
+	}
+	input := Input{OperationID: "audit-absent-race", ClientBindingID: "binding-1", Sequence: 1,
+		OwnedBase: base, ActivePath: active, StagingPath: staging, RequireAbsent: true}
+	receipt, err := manager.Apply(context.Background(), input)
+	if err == nil {
+		t.Fatal("publication unexpectedly succeeded over nonempty foreign directory")
+	}
+	assertBody(t, active, "foreign-arrived-after-precondition")
+	assertBody(t, staging, "owned-stage")
+	manager.Fault = nil
+	rollbackErr := manager.Rollback(context.Background(), receipt)
+	if _, err := os.Stat(active); err != nil {
+		t.Fatalf("rollback deleted foreign directory after failed publication: stat=%v rollback=%v", err, rollbackErr)
+	}
+	assertBody(t, active, "foreign-arrived-after-precondition")
+	if rollbackErr == nil {
+		t.Fatal("rollback must retain a recovery error for unowned active content")
+	}
+	if err := manager.Recover(context.Background(), input.OperationID, false); err == nil {
+		t.Fatal("persisted recovery must not accept unowned active content")
+	}
+	assertBody(t, active, "foreign-arrived-after-precondition")
+	assertBody(t, staging, "owned-stage")
+}

--- a/install/integrationctl/adapters/dirswap/dirswap.go
+++ b/install/integrationctl/adapters/dirswap/dirswap.go
@@ -59,6 +59,14 @@ type Input struct {
 	ActivePath      string
 	StagingPath     string
 	Remove          bool
+	// RequireAbsent rejects the whole operation, before any journal write or
+	// filesystem mutation, if ActivePath already exists. It exists for a caller
+	// reconstructing a target it has independently confirmed absent: an earlier
+	// absence check can go stale before this call runs, and normal Apply
+	// semantics would otherwise treat newly appeared content as an existing
+	// directory to back up and later discard on Commit. This narrows, but does
+	// not eliminate, the window between this check and the rename below.
+	RequireAbsent bool
 }
 
 type Manager struct {
@@ -340,6 +348,9 @@ func (manager Manager) newReceipt(input Input) (Receipt, error) {
 		hadActive = true
 	} else if !os.IsNotExist(activeErr) {
 		return Receipt{}, activeErr
+	}
+	if input.RequireAbsent && hadActive {
+		return Receipt{}, fmt.Errorf("active path unexpectedly exists; concurrent modification detected")
 	}
 	sum := sha256.Sum256([]byte(input.OperationID))
 	backupPath := filepath.Join(ownedBase, ".agentplugins-backup-"+hex.EncodeToString(sum[:8]))

--- a/install/integrationctl/adapters/dirswap/dirswap.go
+++ b/install/integrationctl/adapters/dirswap/dirswap.go
@@ -38,17 +38,19 @@ const (
 )
 
 type Receipt struct {
-	SchemaVersion   int    `json:"schema_version"`
-	Operation       string `json:"operation"`
-	OperationID     string `json:"operation_id"`
-	ClientBindingID string `json:"client_binding_id"`
-	Sequence        int    `json:"sequence"`
-	OwnedBase       string `json:"owned_base"`
-	ActivePath      string `json:"active_path"`
-	StagingPath     string `json:"staging_path,omitempty"`
-	BackupPath      string `json:"backup_path"`
-	HadActive       bool   `json:"had_active"`
-	Phase           string `json:"phase"`
+	SchemaVersion     int    `json:"schema_version"`
+	Operation         string `json:"operation"`
+	OperationID       string `json:"operation_id"`
+	ClientBindingID   string `json:"client_binding_id"`
+	Sequence          int    `json:"sequence"`
+	OwnedBase         string `json:"owned_base"`
+	ActivePath        string `json:"active_path"`
+	StagingPath       string `json:"staging_path,omitempty"`
+	BackupPath        string `json:"backup_path"`
+	HadActive         bool   `json:"had_active"`
+	Phase             string `json:"phase"`
+	PublishedIdentity string `json:"published_identity,omitempty"`
+	PublishedDigest   string `json:"published_digest,omitempty"`
 }
 
 type Input struct {
@@ -64,8 +66,8 @@ type Input struct {
 	// reconstructing a target it has independently confirmed absent: an earlier
 	// absence check can go stale before this call runs, and normal Apply
 	// semantics would otherwise treat newly appeared content as an existing
-	// directory to back up and later discard on Commit. This narrows, but does
-	// not eliminate, the window between this check and the rename below.
+	// directory to back up and later discard on Commit. Publication also uses
+	// an exclusive rename so a newly appeared target is never overwritten.
 	RequireAbsent bool
 }
 
@@ -125,7 +127,11 @@ func (manager Manager) Apply(ctx context.Context, input Input) (Receipt, error) 
 		return receipt, err
 	}
 	if receipt.Operation == OperationSwap {
-		if err := os.Rename(receipt.StagingPath, receipt.ActivePath); err != nil {
+		rename := os.Rename
+		if !receipt.HadActive {
+			rename = renameDirectoryExclusive
+		}
+		if err := rename(receipt.StagingPath, receipt.ActivePath); err != nil {
 			return receipt, fmt.Errorf("activate staged directory: %w", err)
 		}
 	}
@@ -362,7 +368,15 @@ func (manager Manager) newReceipt(input Input) (Receipt, error) {
 	} else if !os.IsNotExist(err) {
 		return Receipt{}, err
 	}
+	publishedIdentity, publishedDigest := "", ""
+	if !hadActive && operation == OperationSwap {
+		publishedIdentity, publishedDigest, err = publicationProof(stagingPath)
+		if err != nil {
+			return Receipt{}, fmt.Errorf("capture staged ownership: %w", err)
+		}
+	}
 	return Receipt{
+		PublishedIdentity: publishedIdentity, PublishedDigest: publishedDigest,
 		SchemaVersion:   receiptSchemaVersion,
 		Operation:       operation,
 		OperationID:     input.OperationID,
@@ -497,15 +511,7 @@ func (manager Manager) restoreOld(receipt Receipt) error {
 		return fmt.Errorf("inspect backup directory during rollback: %w", err)
 	}
 	if !receipt.HadActive {
-		if backupExists {
-			return fmt.Errorf("unexpected backup for operation without an old active directory")
-		}
-		if activeExists {
-			if err := removeOwnedDirectory(receipt.OwnedBase, receipt.ActivePath); err != nil {
-				return fmt.Errorf("remove activated directory during rollback: %w", err)
-			}
-		}
-		return nil
+		return manager.rollbackAbsent(receipt, activeExists, backupExists)
 	}
 	if !backupExists {
 		if activeExists {

--- a/install/integrationctl/adapters/dirswap/dirswap_test.go
+++ b/install/integrationctl/adapters/dirswap/dirswap_test.go
@@ -27,6 +27,49 @@ func TestApplyAndCommitAtomicallyReplacesDirectory(t *testing.T) {
 	}
 }
 
+func TestApplyRequireAbsentRejectsWithoutTouchingUnexpectedExistingContent(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	base := filepath.Join(root, "managed")
+	active := filepath.Join(base, "plugin")
+	staging := filepath.Join(base, "plugin.staging")
+	writeBody(t, active, "foreign")
+	writeBody(t, staging, "new")
+	manager := Manager{JournalDir: filepath.Join(root, "journal")}
+	input := Input{OperationID: "operation-1", ClientBindingID: "binding-1", Sequence: 1,
+		OwnedBase: base, ActivePath: active, StagingPath: staging, RequireAbsent: true}
+	if _, err := manager.Apply(context.Background(), input); err == nil {
+		t.Fatal("RequireAbsent accepted an already-existing active path")
+	}
+	assertBody(t, active, "foreign")
+	if _, err := os.Stat(staging); err != nil {
+		t.Fatalf("staged directory was consumed despite the rejected apply: %v", err)
+	}
+	if _, err := os.Stat(manager.journalPath(input.OperationID)); !os.IsNotExist(err) {
+		t.Fatalf("rejected RequireAbsent apply left a journal entry: %v", err)
+	}
+}
+
+func TestApplyRequireAbsentAcceptsGenuinelyAbsentActivePath(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	base := filepath.Join(root, "managed")
+	active := filepath.Join(base, "plugin")
+	staging := filepath.Join(base, "plugin.staging")
+	writeBody(t, staging, "new")
+	manager := Manager{JournalDir: filepath.Join(root, "journal")}
+	input := Input{OperationID: "operation-1", ClientBindingID: "binding-1", Sequence: 1,
+		OwnedBase: base, ActivePath: active, StagingPath: staging, RequireAbsent: true}
+	receipt, err := manager.Apply(context.Background(), input)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	assertBody(t, active, "new")
+	if err := manager.Commit(context.Background(), receipt); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+}
+
 func TestRecoverRollsBackAfterOldDirectoryWasBackedUp(t *testing.T) {
 	t.Parallel()
 	manager, input := fixture(t)

--- a/install/integrationctl/adapters/dirswap/identity_other.go
+++ b/install/integrationctl/adapters/dirswap/identity_other.go
@@ -1,0 +1,12 @@
+//go:build !darwin && !linux && !windows
+
+package dirswap
+
+import (
+	"fmt"
+	"os"
+)
+
+func directoryIdentity(path string, info os.FileInfo) (string, error) {
+	return "", fmt.Errorf("durable directory identity is unsupported on this platform")
+}

--- a/install/integrationctl/adapters/dirswap/identity_unix.go
+++ b/install/integrationctl/adapters/dirswap/identity_unix.go
@@ -1,0 +1,17 @@
+//go:build darwin || linux
+
+package dirswap
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func directoryIdentity(path string, info os.FileInfo) (string, error) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "", fmt.Errorf("directory identity unavailable")
+	}
+	return fmt.Sprintf("%d:%d", stat.Dev, stat.Ino), nil
+}

--- a/install/integrationctl/adapters/dirswap/identity_windows.go
+++ b/install/integrationctl/adapters/dirswap/identity_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package dirswap
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func directoryIdentity(path string, info os.FileInfo) (string, error) {
+	name, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return "", err
+	}
+	handle, err := syscall.CreateFile(name, 0, syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE|syscall.FILE_SHARE_DELETE, nil, syscall.OPEN_EXISTING, syscall.FILE_FLAG_BACKUP_SEMANTICS|syscall.FILE_FLAG_OPEN_REPARSE_POINT, 0)
+	if err != nil {
+		return "", err
+	}
+	defer syscall.CloseHandle(handle)
+	var stat syscall.ByHandleFileInformation
+	if err := syscall.GetFileInformationByHandle(handle, &stat); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%d:%d:%d", stat.VolumeSerialNumber, stat.FileIndexHigh, stat.FileIndexLow), nil
+}

--- a/install/integrationctl/adapters/dirswap/publication.go
+++ b/install/integrationctl/adapters/dirswap/publication.go
@@ -1,0 +1,157 @@
+package dirswap
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// publicationProof covers every entry, including empty directories, exact modes,
+// symlink targets and internal metadata. It is a rollback proof, not a package digest.
+func publicationProof(root string) (string, string, error) {
+	info, err := os.Lstat(root)
+	if err != nil {
+		return "", "", err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return "", "", fmt.Errorf("publication root is not a real directory")
+	}
+	identity, err := directoryIdentity(root, info)
+	if err != nil {
+		return "", "", err
+	}
+	h := sha256.New()
+	field := func(value string) {
+		_ = binary.Write(h, binary.BigEndian, uint64(len(value)))
+		_, _ = io.WriteString(h, value)
+	}
+	err = filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		stat, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		field(filepath.ToSlash(rel))
+		field(fmt.Sprint(uint32(stat.Mode())))
+		switch {
+		case stat.IsDir():
+		case stat.Mode()&os.ModeSymlink != 0:
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			field(target)
+		case stat.Mode().IsRegular():
+			_ = binary.Write(h, binary.BigEndian, uint64(stat.Size()))
+			f, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			opened, err := f.Stat()
+			if err != nil {
+				f.Close()
+				return err
+			}
+			if !os.SameFile(stat, opened) {
+				f.Close()
+				return fmt.Errorf("publication file replaced while hashing")
+			}
+			n, readErr := io.Copy(h, f)
+			closeErr := f.Close()
+			if readErr != nil {
+				return readErr
+			}
+			if closeErr != nil {
+				return closeErr
+			}
+			if n != stat.Size() {
+				return fmt.Errorf("publication file changed while hashing")
+			}
+		default:
+			return fmt.Errorf("unsupported publication entry %q", rel)
+		}
+		return nil
+	})
+	if err != nil {
+		return "", "", err
+	}
+	after, err := os.Lstat(root)
+	if err != nil {
+		return "", "", err
+	}
+	if !os.SameFile(info, after) {
+		return "", "", fmt.Errorf("publication root replaced while hashing")
+	}
+	return identity, hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func matchesPublication(receipt Receipt, path string) error {
+	if receipt.PublishedIdentity == "" || receipt.PublishedDigest == "" {
+		return fmt.Errorf("directory rollback ownership evidence unavailable; recovery required")
+	}
+	identity, digest, err := publicationProof(path)
+	if err != nil {
+		return fmt.Errorf("verify directory rollback ownership: %w", err)
+	}
+	if identity != receipt.PublishedIdentity || digest != receipt.PublishedDigest {
+		return fmt.Errorf("directory changed or replaced since staging; recovery required")
+	}
+	return nil
+}
+
+func (manager Manager) rollbackAbsent(receipt Receipt, activeExists, backupExists bool) error {
+	if !activeExists && !backupExists {
+		return nil
+	}
+	if receipt.Operation != OperationSwap {
+		return fmt.Errorf("unexpected directory for absent removal; recovery required")
+	}
+	if backupExists {
+		// A crash may leave the provisional object quarantined before cleanup.
+		if err := matchesPublication(receipt, receipt.BackupPath); err != nil {
+			return err
+		}
+		if activeExists {
+			return fmt.Errorf("active directory appeared during rollback; recovery required")
+		}
+	} else {
+		if err := matchesPublication(receipt, receipt.ActivePath); err != nil {
+			return err
+		}
+		// Quarantine atomically before the final ownership check. A path replacement
+		// during the earlier hash is preserved, never passed to RemoveAll.
+		if err := renameDirectoryExclusive(receipt.ActivePath, receipt.BackupPath); err != nil {
+			return err
+		}
+		if err := atomicSyncRollback(receipt); err != nil {
+			return err
+		}
+		if err := manager.inject(FaultRollbackQuarantined); err != nil {
+			return err
+		}
+		if err := matchesPublication(receipt, receipt.BackupPath); err != nil {
+			// Best effort exclusive restoration preserves a concurrently created active.
+			_ = renameDirectoryExclusive(receipt.BackupPath, receipt.ActivePath)
+			_ = atomicSyncRollback(receipt)
+			return err
+		}
+	}
+	if err := removeOwnedDirectory(receipt.OwnedBase, receipt.BackupPath); err != nil {
+		return err
+	}
+	return manager.inject(FaultRollbackRemoved)
+}
+
+const FaultRollbackQuarantined = "rollback_quarantined"
+
+func atomicSyncRollback(receipt Receipt) error { return syncReceiptParents(receipt, false) }

--- a/install/integrationctl/adapters/dirswap/publication_test.go
+++ b/install/integrationctl/adapters/dirswap/publication_test.go
@@ -1,0 +1,172 @@
+package dirswap
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func absentFixture(t *testing.T) (Manager, Input) {
+	t.Helper()
+	root := t.TempDir()
+	base := filepath.Join(root, "managed")
+	stage := filepath.Join(base, "stage")
+	writeBody(t, stage, "owned")
+	return Manager{JournalDir: filepath.Join(root, "journal")}, Input{OperationID: "publication", ClientBindingID: "binding", Sequence: 1, OwnedBase: base, ActivePath: filepath.Join(base, "active"), StagingPath: stage, RequireAbsent: true}
+}
+
+func TestAbsentExclusivePublicationPreservesEmptyForeignDirectory(t *testing.T) {
+	m, in := absentFixture(t)
+	m.Fault = func(phase string) error {
+		if phase == PhaseActivationPending {
+			return os.Mkdir(in.ActivePath, 0700)
+		}
+		return nil
+	}
+	r, err := m.Apply(context.Background(), in)
+	if err == nil {
+		t.Fatal("overwrote foreign empty directory")
+	}
+	m.Fault = nil
+	if err = m.Rollback(context.Background(), r); err == nil {
+		t.Fatal("unknown ownership must retain recovery journal")
+	}
+	if err = m.Recover(context.Background(), in.OperationID, false); err == nil {
+		t.Fatal("recovery accepted foreign directory")
+	}
+	if _, err = os.Stat(in.ActivePath); err != nil {
+		t.Fatal(err)
+	}
+	assertBody(t, in.StagingPath, "owned")
+}
+
+func TestAbsentRollbackAndRecoveryPreserveDrift(t *testing.T) {
+	for _, variant := range []string{"bytes", "mode", "replacement", "legacy"} {
+		t.Run(variant, func(t *testing.T) {
+			m, in := absentFixture(t)
+			r, err := m.Apply(context.Background(), in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			switch variant {
+			case "bytes":
+				writeBody(t, in.ActivePath, "foreign")
+			case "mode":
+				if err = os.Chmod(in.ActivePath, 0700); err != nil {
+					t.Fatal(err)
+				}
+			case "replacement":
+				if err = os.Rename(in.ActivePath, in.ActivePath+".saved"); err != nil {
+					t.Fatal(err)
+				}
+				writeBody(t, in.ActivePath, "owned")
+			case "legacy":
+				r.PublishedIdentity = ""
+				r.PublishedDigest = ""
+			}
+			if err = m.Rollback(context.Background(), r); err == nil {
+				t.Fatal("rollback accepted drift")
+			}
+			if err = m.Recover(context.Background(), in.OperationID, false); err == nil {
+				t.Fatal("recovery accepted drift")
+			}
+			if _, err = os.Stat(in.ActivePath); err != nil {
+				t.Fatal(err)
+			}
+			if _, err = m.Load(in.OperationID); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestAbsentCrashRecoveryAfterPublicationAndQuarantine(t *testing.T) {
+	for _, phase := range []string{FaultActivationApplied, FaultRollbackQuarantined, FaultRollbackRemoved} {
+		t.Run(phase, func(t *testing.T) {
+			m, in := absentFixture(t)
+			m.Fault = func(at string) error {
+				if at == phase {
+					return errors.New("crash")
+				}
+				return nil
+			}
+			r, err := m.Apply(context.Background(), in)
+			if phase == FaultActivationApplied {
+				if err == nil {
+					t.Fatal("missing crash")
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err = m.Rollback(context.Background(), r); err == nil {
+					t.Fatal("missing rollback crash")
+				}
+			}
+			m.Fault = nil
+			if err = m.Recover(context.Background(), in.OperationID, false); err != nil {
+				t.Fatal(err)
+			}
+			if _, err = os.Lstat(in.ActivePath); !os.IsNotExist(err) {
+				t.Fatalf("active persists: %v", err)
+			}
+			if _, err = m.Load(in.OperationID); !os.IsNotExist(err) {
+				t.Fatalf("journal persists: %v", err)
+			}
+		})
+	}
+}
+
+func TestAbsentRecoveryPreservesChangedQuarantine(t *testing.T) {
+	m, in := absentFixture(t)
+	r, err := m.Apply(context.Background(), in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.Fault = func(at string) error {
+		if at == FaultRollbackQuarantined {
+			return errors.New("crash")
+		}
+		return nil
+	}
+	if err = m.Rollback(context.Background(), r); err == nil {
+		t.Fatal("missing crash")
+	}
+	writeBody(t, r.BackupPath, "foreign")
+	m.Fault = nil
+	if err = m.Recover(context.Background(), in.OperationID, false); err == nil {
+		t.Fatal("recovery accepted changed quarantine")
+	}
+	assertBody(t, r.BackupPath, "foreign")
+	if _, err = m.Load(in.OperationID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAbsentRollbackPreservesReplacementDuringQuarantine(t *testing.T) {
+	m, in := absentFixture(t)
+	r, err := m.Apply(context.Background(), in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.Fault = func(at string) error {
+		if at == FaultRollbackQuarantined {
+			if err := os.Rename(r.BackupPath, r.BackupPath+".saved"); err != nil {
+				return err
+			}
+			writeBody(t, r.BackupPath, "foreign")
+		}
+		return nil
+	}
+	if err = m.Rollback(context.Background(), r); err == nil {
+		t.Fatal("rollback accepted quarantine replacement")
+	}
+	assertBody(t, r.ActivePath, "foreign")
+	m.Fault = nil
+	if err = m.Recover(context.Background(), in.OperationID, false); err == nil {
+		t.Fatal("recovery accepted replacement")
+	}
+	assertBody(t, r.ActivePath, "foreign")
+}

--- a/install/integrationctl/adapters/dirswap/rename_exclusive_darwin.go
+++ b/install/integrationctl/adapters/dirswap/rename_exclusive_darwin.go
@@ -1,0 +1,30 @@
+//go:build darwin
+
+package dirswap
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func renameDirectoryExclusive(oldPath, newPath string) error {
+	oldPointer, err := syscall.BytePtrFromString(oldPath)
+	if err != nil {
+		return err
+	}
+	newPointer, err := syscall.BytePtrFromString(newPath)
+	if err != nil {
+		return err
+	}
+	const (
+		sysRenameatxNP = 488
+		renameExcl     = 0x00000004
+	)
+	atFDCWD := ^uintptr(1) // -2
+	_, _, errno := syscall.Syscall6(sysRenameatxNP, atFDCWD, uintptr(unsafe.Pointer(oldPointer)), atFDCWD, uintptr(unsafe.Pointer(newPointer)), renameExcl, 0)
+	if errno != 0 {
+		return &os.LinkError{Op: "rename", Old: oldPath, New: newPath, Err: errno}
+	}
+	return nil
+}

--- a/install/integrationctl/adapters/dirswap/rename_exclusive_fallback.go
+++ b/install/integrationctl/adapters/dirswap/rename_exclusive_fallback.go
@@ -1,0 +1,9 @@
+//go:build !windows && !darwin && !(linux && amd64) && !(linux && arm64)
+
+package dirswap
+
+import "fmt"
+
+func renameDirectoryExclusive(oldPath, newPath string) error {
+	return fmt.Errorf("exclusive directory publication is unsupported on this platform")
+}

--- a/install/integrationctl/adapters/dirswap/rename_exclusive_linux_amd64.go
+++ b/install/integrationctl/adapters/dirswap/rename_exclusive_linux_amd64.go
@@ -1,0 +1,30 @@
+//go:build linux && amd64
+
+package dirswap
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func renameDirectoryExclusive(oldPath, newPath string) error {
+	oldPointer, err := syscall.BytePtrFromString(oldPath)
+	if err != nil {
+		return err
+	}
+	newPointer, err := syscall.BytePtrFromString(newPath)
+	if err != nil {
+		return err
+	}
+	const (
+		sysRenameat2    = 316
+		renameNoReplace = 1
+	)
+	atFDCWD := ^uintptr(99) // -100
+	_, _, errno := syscall.Syscall6(sysRenameat2, atFDCWD, uintptr(unsafe.Pointer(oldPointer)), atFDCWD, uintptr(unsafe.Pointer(newPointer)), renameNoReplace, 0)
+	if errno != 0 {
+		return &os.LinkError{Op: "rename", Old: oldPath, New: newPath, Err: errno}
+	}
+	return nil
+}

--- a/install/integrationctl/adapters/dirswap/rename_exclusive_linux_arm64.go
+++ b/install/integrationctl/adapters/dirswap/rename_exclusive_linux_arm64.go
@@ -1,0 +1,27 @@
+//go:build linux && arm64
+
+package dirswap
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func renameDirectoryExclusive(oldPath, newPath string) error {
+	oldPointer, err := syscall.BytePtrFromString(oldPath)
+	if err != nil {
+		return err
+	}
+	newPointer, err := syscall.BytePtrFromString(newPath)
+	if err != nil {
+		return err
+	}
+	const renameNoReplace = 1
+	atFDCWD := ^uintptr(99) // -100
+	_, _, errno := syscall.Syscall6(syscall.SYS_RENAMEAT2, atFDCWD, uintptr(unsafe.Pointer(oldPointer)), atFDCWD, uintptr(unsafe.Pointer(newPointer)), renameNoReplace, 0)
+	if errno != 0 {
+		return &os.LinkError{Op: "rename", Old: oldPath, New: newPath, Err: errno}
+	}
+	return nil
+}

--- a/install/integrationctl/adapters/dirswap/rename_exclusive_windows.go
+++ b/install/integrationctl/adapters/dirswap/rename_exclusive_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package dirswap
+
+import "os"
+
+// Windows rename rejects an existing directory destination.
+func renameDirectoryExclusive(oldPath, newPath string) error { return os.Rename(oldPath, newPath) }

--- a/install/integrationctl/agentplugins/adapters/loader/policy_compat_test.go
+++ b/install/integrationctl/agentplugins/adapters/loader/policy_compat_test.go
@@ -38,9 +38,9 @@ func TestInstallerFacadeCharacterization(t *testing.T) {
 		installerValid bool
 		author         conformance.Outcome
 	}{
-		{"numeric-metadata", "metadata: {count: 5}\n", true, conformance.Fail},
-		{"nested-metadata", "metadata: {nested: {value: x}}\n", true, conformance.Fail},
-		{"empty-compatibility", "compatibility: ''\n", true, conformance.Fail},
+		{"numeric-metadata", "metadata: {count: 5}\n", false, conformance.Fail},
+		{"nested-metadata", "metadata: {nested: {value: x}}\n", false, conformance.Fail},
+		{"empty-compatibility", "compatibility: ''\n", false, conformance.Fail},
 		{"unknown-field", "future: true\n", false, conformance.Pass},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/install/integrationctl/agentplugins/adapters/loader/skills_admission_test.go
+++ b/install/integrationctl/agentplugins/adapters/loader/skills_admission_test.go
@@ -1,0 +1,37 @@
+package loader
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+func TestSkillAdmissionKeepsHealthyComponents(t *testing.T) {
+	for _, extra := range []string{"metadata: {count: 5}\n", "metadata: {nested: {value: x}}\n", "compatibility: ''\n"} {
+		t.Run(extra, func(t *testing.T) {
+			root := t.TempDir()
+			writeMinimalPlugin(t, root, "mixed")
+			writeLoaderFile(t, filepath.Join(root, "skills", "bad", "SKILL.md"), "---\nname: bad\ndescription: Invalid\n"+extra+"---\n")
+			writeLoaderFile(t, filepath.Join(root, "skills", "good", "SKILL.md"), "---\nname: good\ndescription: Healthy\n---\n")
+			writeLoaderFile(t, filepath.Join(root, "mcp.json"), `{"$schema":"`+domain.MCPSchemaV1+`","mcpServers":{"remote":{"type":"streamable-http","url":"https://example.test/mcp"}}}`)
+			pkg, err := testLoader(t).Load(context.Background(), domain.LoadInput{SnapshotRoot: root})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(pkg.Skills) != 1 || pkg.Skills["good"].Name != "good" || len(pkg.MCP.Servers) != 1 || pkg.MCP.Servers["remote"].Type != "streamable-http" {
+				t.Fatalf("healthy components lost: %+v", pkg)
+			}
+			if len(pkg.Inventory.InvalidSkills) != 1 || pkg.Inventory.InvalidSkills[0] != "bad" {
+				t.Fatalf("invalid inventory = %+v", pkg.Inventory)
+			}
+			for _, d := range pkg.Diagnostics {
+				if d.Code == "skill_invalid" && d.Boundary == domain.BoundarySkill && d.Item == "bad" {
+					return
+				}
+			}
+			t.Fatal("missing skill-boundary diagnostic for bad")
+		})
+	}
+}

--- a/install/integrationctl/agentplugins/conformance/profiles/README.md
+++ b/install/integrationctl/agentplugins/conformance/profiles/README.md
@@ -48,8 +48,8 @@ explicitly says Unicode lowercase alphanumeric characters, despite parenthetical
 ASCII examples. This profile accepts Unicode lowercase letters and numbers,
 counts characters as Unicode code points, and does not normalize names. Unknown
 frontmatter fields are not normatively prohibited by this prose and remain opaque.
-Installer retains its ASCII names and unknown-field rejection, empty optional
-compatibility acceptance, and unrestricted metadata values. YAML LF/CRLF framing
+Installer retains its ASCII names and unknown-field rejection. Both paths require
+string-to-string metadata and compatibility of 1-500 characters when supplied. YAML LF/CRLF framing
 and EOF closing delimiter reuse the installer grammar; author input also accepts a leading UTF-8 BOM while retaining its original bytes. Body content has no format
 restrictions; empty body is valid per the source minimal example. Markdown
 references and scripts are not parsed or executed; their captured path containment

--- a/install/integrationctl/agentplugins/conformance/skills.go
+++ b/install/integrationctl/agentplugins/conformance/skills.go
@@ -55,8 +55,8 @@ func parseSkill(directoryName string, body []byte, front func([]byte) (map[strin
 	if err != nil {
 		return domain.Skill{}, err
 	}
-	if utf8.RuneCountInString(compatibility) > 500 || (author && frontmatter["compatibility"] != nil && compatibility == "") {
-		return domain.Skill{}, skillError("skill_compatibility_length", "compatibility exceeds 500 characters")
+	if utf8.RuneCountInString(compatibility) > 500 || (frontmatter["compatibility"] != nil && compatibility == "") {
+		return domain.Skill{}, skillError("skill_compatibility_length", "compatibility length must be between 1 and 500 characters when supplied")
 	}
 	allowedTools, err := optionalString(frontmatter, "allowed-tools")
 	if err != nil {
@@ -70,11 +70,9 @@ func parseSkill(directoryName string, body []byte, front func([]byte) (map[strin
 			return domain.Skill{}, skillError("skill_metadata_type", "metadata must be an object")
 		}
 	}
-	if author {
-		for _, value := range metadata {
-			if _, ok := value.(string); !ok {
-				return domain.Skill{}, skillError("skill_metadata_type", "metadata values must be strings")
-			}
+	for _, value := range metadata {
+		if _, ok := value.(string); !ok {
+			return domain.Skill{}, skillError("skill_metadata_type", "metadata values must be strings")
 		}
 	}
 	return domain.Skill{

--- a/install/integrationctl/agentplugins/conformance/skills_admission_test.go
+++ b/install/integrationctl/agentplugins/conformance/skills_admission_test.go
@@ -1,0 +1,63 @@
+package conformance
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+func TestSharedSkillAdmission(t *testing.T) {
+	for _, tc := range []struct{ name, extra, code string }{
+		{"absent", "", ""},
+		{"empty-map", "metadata: {}\n", ""},
+		{"strings", "metadata: {empty: '', unicode: 'навык', number: '5'}\n", ""},
+		{"number", "metadata: {count: 5}\n", "skill_metadata_type"},
+		{"boolean", "metadata: {flag: true}\n", "skill_metadata_type"},
+		{"null", "metadata: {value: null}\n", "skill_metadata_type"},
+		{"array", "metadata: {value: [x]}\n", "skill_metadata_type"},
+		{"nested", "metadata: {value: {nested: x}}\n", "skill_metadata_type"},
+		{"numeric-key", "metadata: {5: x}\n", "skill_metadata_type"},
+		{"boolean-key", "metadata: {true: x}\n", "skill_metadata_type"},
+		{"empty-compatibility", "compatibility: ''\n", "skill_compatibility_length"},
+		{"one-codepoint", "compatibility: '界'\n", ""},
+		{"whitespace", "compatibility: ' '\n", ""},
+		{"max-codepoints", "compatibility: '" + strings.Repeat("界", 500) + "'\n", ""},
+		{"over-codepoints", "compatibility: '" + strings.Repeat("界", 501) + "'\n", "skill_compatibility_length"},
+		{"null-compatibility", "compatibility: null\n", "skill_optional_type"},
+		{"number-compatibility", "compatibility: 5\n", "skill_optional_type"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			input := skillInput("good", tc.extra)
+			body := []byte("---\nname: good\ndescription: Works offline\n" + tc.extra + "---\n")
+			skill, err := ParseInstallerSkill("good", body)
+			if tc.code != "" {
+				var failure *skillFailure
+				if !errors.As(err, &failure) || failure.Code != tc.code {
+					t.Fatalf("installer error = %v, want %s", err, tc.code)
+				}
+			} else if err != nil || string(skill.Raw) != string(body) {
+				t.Fatalf("installer = %+v, %v", skill, err)
+			}
+			if tc.code == "" && strings.HasPrefix(tc.extra, "compatibility: ") {
+				want := strings.TrimSuffix(strings.TrimPrefix(tc.extra, "compatibility: '"), "'\n")
+				if skill.Compatibility != want {
+					t.Fatalf("compatibility normalized: %q, want %q", skill.Compatibility, want)
+				}
+			}
+			facts, err := (Decoder{}).DecodeSkill(context.Background(), input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.code != "" {
+				if facts.Coverage.Skills != Fail || !hasFinding(facts, tc.code, Normative, domain.BoundarySkill) {
+					t.Fatalf("author = %+v", facts)
+				}
+			} else if facts.Coverage.Skills != Pass || string(facts.Package.Skills["good"].Raw) != string(body) {
+				t.Fatalf("author = %+v", facts)
+			}
+		})
+	}
+}

--- a/install/integrationctl/agentplugins/domain/clients.go
+++ b/install/integrationctl/agentplugins/domain/clients.go
@@ -88,8 +88,8 @@ func withActivation(definition ClientDefinition, activation ActivationMode) Clie
 
 func clientDefinition(id ClientID, displayName, backendFamily, delivery, catalogPackage string, legacyRequired bool, packageMode PackageMode, skill, mcp, extension SupportLevel) ClientDefinition {
 	transports := map[string]SupportLevel{"stdio": mcp, "streamable-http": mcp, "sse": mcp}
-	// OpenCode remote starts with Streamable HTTP; its fallback cannot preserve SSE-first.
-	if id == ClientOpenCode {
+	// Codex rejects native SSE; OpenCode remote fallback cannot preserve SSE-first.
+	if id == ClientOpenCode || id == ClientCodex {
 		transports["sse"] = SupportUnsupported
 	}
 	appSupport := SupportUnsupported

--- a/install/integrationctl/agentplugins/domain/codex_transport_test.go
+++ b/install/integrationctl/agentplugins/domain/codex_transport_test.go
@@ -1,0 +1,26 @@
+package domain
+
+import "testing"
+
+func TestCodexTransportCapabilities(t *testing.T) {
+	d, ok := ClientDefinitionFor(ClientCodex)
+	if !ok {
+		t.Fatal("missing Codex definition")
+	}
+	for transport, want := range map[string]SupportLevel{"sse": SupportUnsupported, "stdio": SupportProjected, "streamable-http": SupportProjected} {
+		if got := d.Capabilities.MCPTransports[transport]; got != want {
+			t.Fatalf("%s: %s, want %s", transport, got, want)
+		}
+	}
+	d.Capabilities.MCPTransports["sse"] = SupportNative
+	fresh, _ := ClientDefinitionFor(ClientCodex)
+	if fresh.Capabilities.MCPTransports["sse"] != SupportUnsupported {
+		t.Fatal("caller mutated registry")
+	}
+	for _, id := range []ClientID{ClientClaude, ClientCursor, ClientCopilot, ClientGemini, ClientCline, ClientWindsurf} {
+		other, _ := ClientDefinitionFor(id)
+		if other.Capabilities.MCPTransports["sse"] == SupportUnsupported {
+			t.Fatalf("unrelated SSE capability narrowed: %s", id)
+		}
+	}
+}

--- a/install/integrationctl/agentplugins/planner/codex_transport_test.go
+++ b/install/integrationctl/agentplugins/planner/codex_transport_test.go
@@ -1,0 +1,65 @@
+package planner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+func TestCodexTransportSelectionPreservesSiblings(t *testing.T) {
+	for _, onlySSE := range []bool{false, true} {
+		t.Run(map[bool]string{false: "mixed", true: "sse-only"}[onlySSE], func(t *testing.T) {
+			root := t.TempDir()
+			e := testEnvelope()
+			e.MCP.Servers = map[string]domain.MCPServer{"events": {Type: "sse"}}
+			if onlySSE {
+				e.Skills = nil
+			} else {
+				e.MCP.Servers["http"] = domain.MCPServer{Type: "streamable-http"}
+				e.MCP.Servers["stdio"] = domain.MCPServer{Type: "stdio"}
+			}
+			plan, err := (Planner{ManagedRoot: filepath.Join(root, "managed")}).Plan(context.Background(), e, detectedClient(domain.ClientCodex, filepath.Join(root, "config")), domain.ScopeUser, "demo-0123456789ab")
+			if err != nil {
+				t.Fatal(err)
+			}
+			var want []string
+			if !onlySSE {
+				want = []string{"http", "stdio"}
+			}
+			if got := domain.SelectedMCPNames(plan); len(got) != len(want) || (len(want) > 0 && !reflect.DeepEqual(got, want)) {
+				t.Fatalf("selection=%v", got)
+			}
+			for _, c := range plan.Components {
+				if c.Name == "events" && (c.Support != domain.SupportUnsupported || c.Reason != "declared_sse_not_supported_by_client") {
+					t.Fatalf("SSE decision=%+v", c)
+				}
+			}
+			if (plan.Status == domain.PlanUnsupported) != onlySSE {
+				t.Fatalf("status=%s", plan.Status)
+			}
+			reports, err := Compatibility(e, []domain.ClientID{domain.ClientCodex})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, c := range reports[0].Components {
+				if c.Kind == domain.ComponentMCPServer && c.Index == 1 {
+					if c.Support != domain.SupportUnsupported || !compatContains(c.Limitations, "declared_sse_not_supported_by_client") {
+						t.Fatalf("SSE compatibility=%+v", c)
+					}
+				} else if c.Kind == domain.ComponentMCPServer || c.Kind == domain.ComponentSkill {
+					if c.Support != domain.SupportProjected {
+						t.Fatalf("healthy compatibility=%+v", c)
+					}
+				}
+			}
+			entries, err := os.ReadDir(root)
+			if err != nil || len(entries) != 0 {
+				t.Fatalf("planning wrote files: %v %v", entries, err)
+			}
+		})
+	}
+}

--- a/install/integrationctl/agentplugins/planner/planner.go
+++ b/install/integrationctl/agentplugins/planner/planner.go
@@ -424,7 +424,7 @@ func componentDecisions(envelope domain.PackageEnvelope, capabilities domain.Cli
 			}
 		}
 		value := decision(domain.ComponentMCPServer, name, support)
-		if capabilities.ClientID == domain.ClientOpenCode && server.Type == "sse" && support == domain.SupportUnsupported {
+		if (capabilities.ClientID == domain.ClientOpenCode || capabilities.ClientID == domain.ClientCodex) && server.Type == "sse" && support == domain.SupportUnsupported {
 			value.Reason = "declared_sse_not_supported_by_client"
 		}
 		decisions = append(decisions, value)

--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -143,15 +143,44 @@ func (activator Activator) Deactivate(ctx context.Context, request domain.Deacti
 		if err != nil {
 			return outcome, err
 		}
-		if registered {
-			if strings.TrimSpace(request.BackendExecutable) == "" || activator.Runner == nil {
+		pluginEntryPresent, err := managedCodexPluginEntryPresent(request.Client.ConfigRoot, request.DeclaredName, marketplace)
+		if err != nil {
+			return outcome, err
+		}
+		if strings.TrimSpace(request.BackendExecutable) == "" || activator.Runner == nil {
+			// Block on either stale record, not just the marketplace: a
+			// live [plugins."id"] entry with no CLI available to clear it
+			// is exactly as dangerous as a registered marketplace with no
+			// CLI -- both would otherwise let ExternalRemovalComplete=true
+			// fall through below with nothing actually cleaned.
+			if registered || pluginEntryPresent {
 				outcome.Activation = domain.ActivationManual
 				outcome.ArtifactRemovalAllowed = false
-				outcome.UserActions = []string{fmt.Sprintf("run `codex plugin marketplace remove %s --json`, then retry removal", marketplace)}
+				outcome.UserActions = []string{fmt.Sprintf("run `codex plugin remove %s@%s --json`, then `codex plugin marketplace remove %s --json`, then retry removal", request.DeclaredName, marketplace, marketplace)}
 				return outcome, nil
 			}
-			if err := activator.removeCodexMarketplace(ctx, request.BackendExecutable, marketplace); err != nil {
+		} else {
+			// Remove the plugin's own registration whenever a live CLI is
+			// available, independent of whether the marketplace source is
+			// still registered: a stale `[plugins."id"] enabled = true`
+			// config.toml entry can outlive the marketplace record (for
+			// example after a user follows this same code's own earlier
+			// manual-cleanup guidance and only runs `marketplace remove`),
+			// and a freshly started Codex app-server treats that lingering
+			// entry as still-enabled, silently re-materializing the
+			// "removed" plugin from its original local source. Gating this
+			// call behind `registered` reproduced exactly that bug.
+			// `codex plugin remove` is confirmed idempotent and safe to call
+			// even when the marketplace is already gone (verified by hand
+			// against a real Codex 0.153.4 binary: exit 0, clears the
+			// `[plugins."id"]` entry, no error either way).
+			if err := activator.removeCodexPlugin(ctx, request.BackendExecutable, request.DeclaredName+"@"+marketplace); err != nil {
 				return outcome, err
+			}
+			if registered {
+				if err := activator.removeCodexMarketplace(ctx, request.BackendExecutable, marketplace); err != nil {
+					return outcome, err
+				}
 			}
 		}
 		outcome.ExternalRemovalComplete = true
@@ -663,6 +692,18 @@ func (activator Activator) removeCodexMarketplace(ctx context.Context, executabl
 	remove, err := activator.runClientResult(ctx, "Codex CLI", executable, "plugin", "marketplace", "remove", marketplace, "--json")
 	if err != nil && !commandOutputContains(remove, "not configured or installed") {
 		return fmt.Errorf("remove managed Codex marketplace %s: %w", marketplace, err)
+	}
+	return nil
+}
+
+// removeCodexPlugin uninstalls the plugin itself (distinct from its
+// marketplace source): it is what clears Codex's own per-plugin
+// config.toml enablement entry and native cache, not just the marketplace
+// registration. Already-absent is treated as success for idempotent retries.
+func (activator Activator) removeCodexPlugin(ctx context.Context, executable, pluginSpec string) error {
+	remove, err := activator.runClientResult(ctx, "Codex CLI", executable, "plugin", "remove", pluginSpec, "--json")
+	if err != nil && !commandOutputContains(remove, "not configured or installed") {
+		return fmt.Errorf("remove managed Codex plugin %s: %w", pluginSpec, err)
 	}
 	return nil
 }

--- a/install/integrationctl/agentplugins/providers/activator_test.go
+++ b/install/integrationctl/agentplugins/providers/activator_test.go
@@ -852,12 +852,71 @@ func TestDeactivatorPreviewsThenCleansManagedCodexMarketplace(t *testing.T) {
 	if !outcome.ArtifactRemovalAllowed || !outcome.ExternalRemovalComplete {
 		t.Fatalf("outcome = %+v", outcome)
 	}
-	want := [][]string{{
-		"/test/bin/codex", "plugin", "marketplace", "remove",
-		managedMarketplaceName(request.PhysicalArtifactID), "--json",
-	}}
+	marketplace := managedMarketplaceName(request.PhysicalArtifactID)
+	want := [][]string{
+		{"/test/bin/codex", "plugin", "remove", request.DeclaredName + "@" + marketplace, "--json"},
+		{"/test/bin/codex", "plugin", "marketplace", "remove", marketplace, "--json"},
+	}
 	if got := commandArgv(runner.commands); !reflect.DeepEqual(got, want) {
 		t.Fatalf("commands = %#v, want %#v", got, want)
+	}
+}
+
+// TestDeactivatorCleansStalePluginEntryWhenMarketplaceAlreadyGone covers the
+// gap a live-native run found: if config.toml's marketplace source is
+// already gone (e.g. a user manually ran only `codex plugin marketplace
+// remove` off this code's own earlier guidance) but the separate
+// `[plugins."id"] enabled = true` entry survives, managedCodexMarketplaceRegistered
+// reports not-registered and the old code skipped cleanup entirely,
+// reproducing the self-heal bug on every subsequent remove. The plugin's own
+// registration must still be cleared whenever a live CLI is available,
+// independent of marketplace registration.
+func TestDeactivatorCleansStalePluginEntryWhenMarketplaceAlreadyGone(t *testing.T) {
+	t.Parallel()
+	runner := &recordingRunner{}
+	request := codexDeactivationRequest(t)
+	request.Confirmed = true
+	marketplace := managedMarketplaceName(request.PhysicalArtifactID)
+	writeTestFile(t, filepath.Join(request.Client.ConfigRoot, "config.toml"), fmt.Sprintf(`
+[plugins."%s@%s"]
+enabled = true
+`, request.DeclaredName, marketplace))
+	outcome, err := (Activator{Runner: runner}).Deactivate(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.ArtifactRemovalAllowed || !outcome.ExternalRemovalComplete {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+	want := [][]string{{"/test/bin/codex", "plugin", "remove", request.DeclaredName + "@" + marketplace, "--json"}}
+	if got := commandArgv(runner.commands); !reflect.DeepEqual(got, want) {
+		t.Fatalf("commands = %#v, want %#v (marketplace remove must NOT run -- there is no marketplace source left to clean)", got, want)
+	}
+}
+
+// TestDeactivatorBlocksRemovalWhenPluginEntryStaleAndCLIUnavailable covers a
+// second gap from the same live-native finding: without a live CLI, a stale
+// `[plugins."id"]` entry must block removal exactly like a registered
+// marketplace does, not just fall through to ExternalRemovalComplete=true
+// with nothing actually cleaned.
+func TestDeactivatorBlocksRemovalWhenPluginEntryStaleAndCLIUnavailable(t *testing.T) {
+	t.Parallel()
+	request := codexDeactivationRequest(t)
+	request.Confirmed = true
+	request.BackendExecutable = ""
+	marketplace := managedMarketplaceName(request.PhysicalArtifactID)
+	writeTestFile(t, filepath.Join(request.Client.ConfigRoot, "config.toml"), fmt.Sprintf(`
+[plugins."%s@%s"]
+enabled = true
+`, request.DeclaredName, marketplace))
+	outcome, err := (Activator{}).Deactivate(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantPluginRemove := fmt.Sprintf("codex plugin remove %s@%s --json", request.DeclaredName, marketplace)
+	if outcome.ArtifactRemovalAllowed || outcome.ExternalRemovalComplete || outcome.Activation != domain.ActivationManual ||
+		len(outcome.UserActions) != 1 || !strings.Contains(outcome.UserActions[0], wantPluginRemove) {
+		t.Fatalf("outcome = %+v, want blocked with guidance containing %q", outcome, wantPluginRemove)
 	}
 }
 
@@ -877,9 +936,28 @@ func TestDeactivatorTreatsAbsentManagedCodexMarketplaceAsClean(t *testing.T) {
 	}
 }
 
+func TestDeactivatorRetainsManagedCodexArtifactWhenPluginCleanupFails(t *testing.T) {
+	t.Parallel()
+	runner := &recordingRunner{run: func(command legacyports.Command) legacyports.CommandResult {
+		return legacyports.CommandResult{ExitCode: 1, Stderr: []byte("config write failed")}
+	}}
+	request := codexDeactivationRequest(t)
+	request.Confirmed = true
+	outcome, err := (Activator{Runner: runner}).Deactivate(context.Background(), request)
+	if err == nil || !strings.Contains(err.Error(), "remove managed Codex plugin") {
+		t.Fatalf("outcome = %+v, error = %v", outcome, err)
+	}
+	if outcome.ExternalRemovalComplete {
+		t.Fatalf("failed cleanup claimed external completion: %+v", outcome)
+	}
+}
+
 func TestDeactivatorRetainsManagedCodexArtifactWhenMarketplaceCleanupFails(t *testing.T) {
 	t.Parallel()
 	runner := &recordingRunner{run: func(command legacyports.Command) legacyports.CommandResult {
+		if len(command.Argv) >= 3 && command.Argv[1] == "plugin" && command.Argv[2] == "remove" {
+			return legacyports.CommandResult{}
+		}
 		return legacyports.CommandResult{ExitCode: 1, Stderr: []byte("config write failed")}
 	}}
 	request := codexDeactivationRequest(t)
@@ -923,9 +1001,13 @@ func TestDeactivatorRetainsManagedCodexArtifactWhenCLIIsUnavailable(t *testing.T
 		t.Fatal(err)
 	}
 	marketplace := managedMarketplaceName(request.PhysicalArtifactID)
+	wantPluginRemove := fmt.Sprintf("codex plugin remove %s@%s --json", request.DeclaredName, marketplace)
+	wantMarketplaceRemove := fmt.Sprintf("codex plugin marketplace remove %s --json", marketplace)
 	if outcome.ArtifactRemovalAllowed || outcome.ExternalRemovalComplete || outcome.Activation != domain.ActivationManual ||
-		len(outcome.UserActions) != 1 || !strings.Contains(outcome.UserActions[0], marketplace) {
-		t.Fatalf("outcome = %+v", outcome)
+		len(outcome.UserActions) != 1 ||
+		!strings.Contains(outcome.UserActions[0], wantPluginRemove) ||
+		!strings.Contains(outcome.UserActions[0], wantMarketplaceRemove) {
+		t.Fatalf("outcome = %+v, want guidance containing both %q and %q", outcome, wantPluginRemove, wantMarketplaceRemove)
 	}
 }
 

--- a/install/integrationctl/agentplugins/providers/claude.go
+++ b/install/integrationctl/agentplugins/providers/claude.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/pathpolicy"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/managedstdio"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/pathcontract"
 )
 
 const (
@@ -165,9 +167,34 @@ func projectClaudeMCP(root string, envelope domain.PackageEnvelope, serverNames 
 		switch server.Type {
 		case "stdio":
 			delete(config, "type")
+			rawCommand, _ := config["command"].(string)
+			rawCWD, _ := config["cwd"].(string)
 			if err := applyStdioDataContract(config, pluginRoot, dataPath, observedRuntimeRoot); err != nil {
 				return fmt.Errorf("project Claude stdio MCP server %s: %w", name, err)
 			}
+			// Claude does not honor cwd on stdio entries. The trusted process
+			// adapter makes both default and explicit cwd part of its argv,
+			// preserving otherwise identical servers as distinct native entries.
+			cwd, err := pathcontract.ParseCWD(rawCWD)
+			if err != nil {
+				return err
+			}
+			var args []string
+			switch values := config["args"].(type) {
+			case []string:
+				args = values
+			case []any:
+				for _, value := range values {
+					text, ok := value.(string)
+					if !ok {
+						return fmt.Errorf("Claude stdio args must be strings")
+					}
+					args = append(args, text)
+				}
+			}
+			config["args"] = managedstdio.Arguments(pluginRoot, dataPath, config["cwd"].(string), cwd.Anchor, rawCommand, args)
+			config["command"] = filepath.Join(pluginRoot, filepath.FromSlash(managedstdio.RelativeDirectory), managedstdio.ExecutableName)
+			delete(config, "cwd")
 		case "streamable-http":
 			config["type"] = "http"
 		case "sse":

--- a/install/integrationctl/agentplugins/providers/claude_launcher_test.go
+++ b/install/integrationctl/agentplugins/providers/claude_launcher_test.go
@@ -1,0 +1,96 @@
+package providers
+
+import (
+	"context"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/managedstdio"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestClaudeHelperOwnedArtifactDigestAndCollision(t *testing.T) {
+	stager := windsurfFixtureStager(t)
+	envelope := stagingEnvelope(t)
+	envelope.MCP.Servers = map[string]domain.MCPServer{"local": {Type: "stdio", Decoded: map[string]any{"command": "sh"}}}
+	plan := stagingPlan(t, domain.ClientClaude, domain.PackageProjection)
+	plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "local", Support: domain.SupportProjected}}
+	if err := stager.PreflightManagedStdio(envelope.SnapshotRoot); err != nil {
+		t.Fatal(err)
+	}
+	delivery, err := stager.Stage(context.Background(), envelope, plan, "helper", domain.CompatibilityHints{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	helper := filepath.Join(delivery.StagingPath, claudeRuntimeDirectory, filepath.FromSlash(managedstdio.RelativeDirectory), managedstdio.ExecutableName)
+	if _, err := os.Stat(helper); err != nil {
+		t.Fatal(err)
+	}
+	if err := stager.Verify(context.Background(), delivery.StagingPath, delivery.ArtifactDigest); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(helper, []byte("tampered"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := stager.Verify(context.Background(), delivery.StagingPath, delivery.ArtifactDigest); err == nil {
+		t.Fatal("helper tamper was not part of artifact digest")
+	}
+	reserved := filepath.Join(envelope.SnapshotRoot, filepath.FromSlash(managedstdio.RelativeDirectory))
+	writeTestFile(t, reserved, "authored")
+	if err := stager.PreflightManagedStdio(envelope.SnapshotRoot); err == nil {
+		t.Fatal("authored collision accepted")
+	}
+	if _, err := stager.Stage(context.Background(), envelope, plan, "collision-helper", domain.CompatibilityHints{}); err == nil {
+		t.Fatal("late collision accepted")
+	}
+	body, _ := os.ReadFile(reserved)
+	if string(body) != "authored" {
+		t.Fatal("authored collision changed")
+	}
+}
+
+func TestClaudeHelperChangeChangesArtifactWithoutSourceMutation(t *testing.T) {
+	envelope := stagingEnvelope(t)
+	envelope.MCP.Servers = map[string]domain.MCPServer{"local": {Type: "stdio", Decoded: map[string]any{"command": "sh"}}}
+	plan := stagingPlan(t, domain.ClientClaude, domain.PackageProjection)
+	plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "local", Support: domain.SupportProjected}}
+	stager := windsurfFixtureStager(t)
+	first, err := stager.Stage(context.Background(), envelope, plan, "first-pin", domain.CompatibilityHints{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "cli-b")
+	if err := os.WriteFile(path, []byte("fixture-B"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	stager.LauncherSource, err = managedstdio.NewSource(path, "B")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := stager.Stage(context.Background(), envelope, plan, "second-pin", domain.CompatibilityHints{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.ArtifactDigest == second.ArtifactDigest {
+		t.Fatal("helper version absent from artifact digest")
+	}
+	if err := stager.Verify(context.Background(), first.StagingPath, first.ArtifactDigest); err != nil {
+		t.Fatal("old immutable artifact changed", err)
+	}
+	if _, err := os.Stat(filepath.Join(envelope.SnapshotRoot, filepath.FromSlash(managedstdio.RelativeDirectory))); !os.IsNotExist(err) {
+		t.Fatal("source snapshot mutated")
+	}
+}
+
+func TestClaudeMissingLauncherDoesNotAffectHTTPOnlyProjection(t *testing.T) {
+	envelope := stagingEnvelope(t)
+	plan := stagingPlan(t, domain.ClientClaude, domain.PackageProjection)
+	if _, err := (Stager{}).Stage(context.Background(), envelope, plan, "http-only", domain.CompatibilityHints{}); err != nil {
+		t.Fatal(err)
+	}
+	envelope.MCP.Servers = map[string]domain.MCPServer{"local": {Type: "stdio", Decoded: map[string]any{"command": "sh"}}}
+	plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "local", Support: domain.SupportProjected}}
+	if _, err := (Stager{}).Stage(context.Background(), envelope, plan, "missing-helper", domain.CompatibilityHints{}); err == nil {
+		t.Fatal("stdio staged without trusted launcher")
+	}
+}

--- a/install/integrationctl/agentplugins/providers/claude_path_topology_test.go
+++ b/install/integrationctl/agentplugins/providers/claude_path_topology_test.go
@@ -22,7 +22,7 @@ func TestClaudeBundledStdioObservesIsolatedRuntime(t *testing.T) {
 			}}}
 			plan := stagingPlan(t, domain.ClientClaude, domain.PackageProjection)
 			plan.Components = []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "local", Support: domain.SupportProjected}}
-			delivery, err := (Stager{}).Stage(context.Background(), envelope, plan, "claude-bundled-paths", domain.CompatibilityHints{})
+			delivery, err := windsurfFixtureStager(t).Stage(context.Background(), envelope, plan, "claude-bundled-paths", domain.CompatibilityHints{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -39,10 +39,10 @@ func TestClaudeBundledStdioObservesIsolatedRuntime(t *testing.T) {
 			if cwd == "./work" {
 				expectedCWD = filepath.Join(activeRuntime, "work")
 			}
-			if server["command"] != filepath.Join(activeRuntime, "bin/run") || server["cwd"] != expectedCWD {
+			if server["cwd"] != nil || server["args"].([]any)[3] != expectedCWD || server["args"].([]any)[6] != "./bin/../bin/run" {
 				t.Fatalf("isolated stdio projection: %+v", server)
 			}
-			if args := server["args"].([]any); args[0] != filepath.Join(activeRuntime, "config") || args[1] != "${UNKNOWN}" {
+			if args := server["args"].([]any); args[7] != filepath.Join(activeRuntime, "config") || args[8] != "${UNKNOWN}" {
 				t.Fatalf("args: %+v", args)
 			}
 			if err := (Stager{}).Verify(context.Background(), delivery.StagingPath, delivery.ArtifactDigest); err != nil {

--- a/install/integrationctl/agentplugins/providers/claude_stdio_contract_test.go
+++ b/install/integrationctl/agentplugins/providers/claude_stdio_contract_test.go
@@ -1,0 +1,65 @@
+package providers
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/managedstdio"
+)
+
+func TestClaudeStdioDistinctCWDAndOpaqueArguments(t *testing.T) {
+	envelope := stagingEnvelope(t)
+	if err := os.Mkdir(filepath.Join(envelope.SnapshotRoot, "work"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	envelope.MCP.Servers = map[string]domain.MCPServer{}
+	plan := stagingPlan(t, domain.ClientClaude, domain.PackageProjection)
+	plan.Components = nil
+	data := filepath.Join(t.TempDir(), "data-${PLUGIN_ROOT}")
+	if err := os.Mkdir(data, 0700); err != nil {
+		t.Fatal(err)
+	}
+	opaque := []any{"", "--", "$(touch escaped)", "a b", "${UNKNOWN}", "${PLUGIN_DATA}/cache"}
+	for name, cwd := range map[string]string{"default": "", "explicit": "./work", "data": "${PLUGIN_DATA}"} {
+		envelope.MCP.Servers[name] = domain.MCPServer{Type: "stdio", Decoded: map[string]any{"command": "sh", "cwd": cwd, "args": opaque, "env": map[string]any{"VALUE": "${PLUGIN_DATA}|${UNKNOWN}"}}}
+		plan.Components = append(plan.Components, domain.ComponentDecision{Kind: domain.ComponentMCPServer, Name: name, Support: domain.SupportProjected})
+	}
+	delivery, err := windsurfFixtureStager(t).StageWithPluginData(context.Background(), envelope, plan, "opaque", domain.CompatibilityHints{}, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	document := readObject(t, filepath.Join(delivery.StagingPath, ".mcp.json"))
+	runtime := filepath.Join(plan.ActivePath, claudeRuntimeDirectory)
+	for name, wantCWD := range map[string]string{"default": runtime, "explicit": filepath.Join(runtime, "work"), "data": data} {
+		server := document[name].(map[string]any)
+		args := server["args"].([]any)
+		if server["command"] != filepath.Join(runtime, filepath.FromSlash(managedstdio.RelativeDirectory), managedstdio.ExecutableName) || server["cwd"] != nil || args[3] != wantCWD || args[6] != "sh" {
+			t.Fatalf("%s: %+v", name, server)
+		}
+		anchor := "plugin"
+		if name == "data" {
+			anchor = "data"
+		}
+		if args[4] != anchor {
+			t.Fatalf("anchor: %v", args)
+		}
+		want := []any{"", "--", "$(touch escaped)", "a b", "${UNKNOWN}", data + "/cache"}
+		if !reflect.DeepEqual(args[7:], want) {
+			t.Fatalf("opaque argv changed: %v", args)
+		}
+		env := server["env"].(map[string]any)
+		if env["VALUE"] != data+"|${UNKNOWN}" || env["PLUGIN_ROOT"] != runtime || env["PLUGIN_DATA"] != data {
+			t.Fatalf("env expanded again: %v", env)
+		}
+	}
+	if !reflect.DeepEqual(envelope.MCP.Servers["default"].Decoded["args"], opaque) {
+		t.Fatal("source args changed")
+	}
+	if _, err := os.Stat(filepath.Join(envelope.SnapshotRoot, filepath.FromSlash(managedstdio.RelativeDirectory))); !os.IsNotExist(err) {
+		t.Fatal("source gained helper", err)
+	}
+}

--- a/install/integrationctl/agentplugins/providers/codex_marketplace_cleanup.go
+++ b/install/integrationctl/agentplugins/providers/codex_marketplace_cleanup.go
@@ -55,6 +55,37 @@ func managedCodexMarketplaceRegistered(configRoot, marketplace, managedArtifactP
 	return true, nil
 }
 
+// managedCodexPluginEntryPresent reports whether Codex's config.toml still
+// carries a per-plugin `[plugins."<declaredName>@<marketplace>"]` enablement
+// entry, independent of whether its marketplace source is still registered.
+// The two records are cleared by separate CLI commands; a stale plugin entry
+// left behind is what lets a freshly started Codex app-server silently
+// re-materialize an already-removed plugin. Presence alone is the ownership
+// signal here (unlike managedCodexMarketplaceRegistered's source-path check):
+// the key embeds this installation's own generated marketplace name
+// (managedMarketplaceName), so an unrelated plugin can only collide by
+// coincidentally sharing both that generated name and the declared name.
+func managedCodexPluginEntryPresent(configRoot, declaredName, marketplace string) (bool, error) {
+	if strings.TrimSpace(configRoot) == "" || strings.TrimSpace(declaredName) == "" || strings.TrimSpace(marketplace) == "" {
+		return false, fmt.Errorf("managed Codex plugin ownership evidence is incomplete")
+	}
+	body, err := os.ReadFile(filepath.Join(configRoot, "config.toml"))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("inspect managed Codex plugin config: %w", err)
+	}
+	var document struct {
+		Plugins map[string]map[string]any `toml:"plugins"`
+	}
+	if err := toml.Unmarshal(body, &document); err != nil {
+		return false, fmt.Errorf("inspect managed Codex plugin config: %w", err)
+	}
+	_, present := document.Plugins[declaredName+"@"+marketplace]
+	return present, nil
+}
+
 // equivalentLocalPath compares the filesystem identity rather than only the
 // spelling of a path. macOS commonly exposes /tmp through /private/tmp, and
 // the same aliasing can occur in containerized or symlinked test homes. Both

--- a/install/integrationctl/agentplugins/providers/codex_transport_test.go
+++ b/install/integrationctl/agentplugins/providers/codex_transport_test.go
@@ -1,0 +1,69 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/planner"
+)
+
+func TestCodexTransportSelectionSanitizesBothManifestSurfaces(t *testing.T) {
+	e := stagingEnvelope(t)
+	raw := []byte(`{"$schema":"https://agent-plugins.org/schemas/1.0.0/mcp.schema.json","mcpServers":{"notion":{"type":"streamable-http","url":"https://example.invalid/mcp"},"stdio":{"type":"stdio","command":"./bin/run"},"events":{"type":"sse","url":"https://example.invalid/events"},"broken":{"type":"unknown"}}}`)
+	writeTestFile(t, filepath.Join(e.SnapshotRoot, "mcp.json"), string(raw))
+	var doc struct {
+		Servers map[string]json.RawMessage `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatal(err)
+	}
+	e.MCP.Servers = map[string]domain.MCPServer{}
+	for name, body := range doc.Servers {
+		if name == "broken" {
+			continue
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal(body, &decoded); err != nil {
+			t.Fatal(err)
+		}
+		e.MCP.Servers[name] = domain.MCPServer{Name: name, Type: decoded["type"].(string), Raw: body, Decoded: decoded}
+	}
+	root := t.TempDir()
+	plan, err := (planner.Planner{ManagedRoot: filepath.Join(root, "managed")}).Plan(context.Background(), e, domain.DetectedClient{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(root, "config")}, domain.ScopeUser, "demo-0123456789ab")
+	if err != nil {
+		t.Fatal(err)
+	}
+	delivery, err := (Stager{}).Stage(context.Background(), e, plan, "codex-selection", domain.CompatibilityHints{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"mcp.json", ".mcp.json"} {
+		servers := readObject(t, filepath.Join(delivery.StagingPath, name))["mcpServers"].(map[string]any)
+		var keys []string
+		for key := range servers {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		if !reflect.DeepEqual(keys, []string{"notion", "stdio"}) {
+			t.Fatalf("%s servers=%v", name, keys)
+		}
+	}
+	rootManifest := readObject(t, filepath.Join(delivery.StagingPath, "plugin.json"))
+	if rootManifest["name"] != "demo" || rootManifest["$schema"] != domain.PluginSchemaV1 {
+		t.Fatalf("standard manifest lost: %v", rootManifest)
+	}
+	_ = readObject(t, filepath.Join(delivery.StagingPath, ".codex-plugin", "plugin.json"))
+	if _, err := os.Stat(filepath.Join(delivery.StagingPath, "skills", "good", "SKILL.md")); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(filepath.Join(e.SnapshotRoot, "mcp.json"))
+	if err != nil || string(after) != string(raw) {
+		t.Fatal("portable source changed")
+	}
+}

--- a/install/integrationctl/agentplugins/providers/native_identity.go
+++ b/install/integrationctl/agentplugins/providers/native_identity.go
@@ -264,9 +264,53 @@ func (observer NativeIdentityObserver) inspectCodexCLI(ctx context.Context, plan
 		return registryIndeterminate, err
 	}
 	if result.ExitCode != 0 {
+		if diagnostic := boundedNativeDiagnostic(result.Stdout, result.Stderr); diagnostic != "" {
+			return registryIndeterminate, fmt.Errorf("Codex plugin registry command failed with exit code %d: %s", result.ExitCode, diagnostic)
+		}
 		return registryIndeterminate, fmt.Errorf("Codex plugin registry command failed with exit code %d", result.ExitCode)
 	}
 	return codexRegistryFinding(result.Stdout, plan.DeclaredName, managedMarketplaceName(plan.PhysicalArtifactID), managed != nil), nil
+}
+
+// nativeDiagnosticLimit bounds the excerpt kept from a failed native CLI
+// invocation's own output. It exists purely for operator diagnosis of a
+// discovery failure and is never treated as proof of package absence.
+const nativeDiagnosticLimit = 2048
+
+// boundedNativeDiagnostic returns a short, sanitized excerpt of a failed
+// native CLI invocation's own stdout/stderr. It never includes argv,
+// environment, or configuration; only the bounded child-process output, with
+// control characters stripped and length capped.
+func boundedNativeDiagnostic(stdout, stderr []byte) string {
+	parts := make([]string, 0, 2)
+	if text := sanitizeNativeDiagnosticText(stderr); text != "" {
+		parts = append(parts, text)
+	}
+	if text := sanitizeNativeDiagnosticText(stdout); text != "" {
+		parts = append(parts, text)
+	}
+	text := strings.Join(parts, " | ")
+	if len(text) > nativeDiagnosticLimit {
+		// Re-validate after the byte-index cut: it may have split a multibyte
+		// rune, which strings.ToValidUTF8 would otherwise leave as U+FFFD.
+		text = strings.ToValidUTF8(text[:nativeDiagnosticLimit], "") + "...(truncated)"
+	}
+	return text
+}
+
+func sanitizeNativeDiagnosticText(output []byte) string {
+	text := strings.ToValidUTF8(string(output), "")
+	text = strings.Map(func(r rune) rune {
+		switch {
+		case r == '\n' || r == '\t':
+			return ' '
+		case r < 0x20 || r == 0x7f:
+			return -1
+		default:
+			return r
+		}
+	}, text)
+	return strings.Join(strings.Fields(text), " ")
 }
 
 func codexRegistryFinding(body []byte, name, expectedMarketplace string, owned bool) registryFinding {
@@ -624,8 +668,16 @@ func inspectClaudeSkillsRegistry(plan domain.DeliveryPlan, name string, owned bo
 	}
 	finding := registryClear
 	for _, entry := range entries {
-		if entry.Type()&os.ModeSymlink != 0 || !entry.IsDir() {
+		if entry.Type()&os.ModeSymlink != 0 {
 			return registryIndeterminate, nil
+		}
+		if !entry.IsDir() {
+			// A plain file cannot contain the .claude-plugin/plugin.json this
+			// scheme requires, so it can never claim a competing plugin
+			// identity. OS-generated artifacts such as .DS_Store are common
+			// in a Finder-browsed skills directory and must not block every
+			// other plugin's repair/update.
+			continue
 		}
 		path := filepath.Join(root, entry.Name())
 		manifest := filepath.Join(path, ".claude-plugin", "plugin.json")
@@ -671,8 +723,15 @@ func inspectUnqualifiedPluginRoot(root, name, activePath string, owned bool) (re
 		if strings.HasPrefix(entry.Name(), ".agentplugins-staging-") {
 			continue
 		}
-		if entry.Type()&os.ModeSymlink != 0 || !entry.IsDir() {
+		if entry.Type()&os.ModeSymlink != 0 {
 			return registryIndeterminate, nil
+		}
+		if !entry.IsDir() {
+			// A plain file cannot contain the manifest this scheme requires,
+			// so it can never claim a competing plugin identity. OS-generated
+			// artifacts such as .DS_Store are common here and must not block
+			// every other plugin's repair/update.
+			continue
 		}
 		path := filepath.Join(root, entry.Name())
 		manifestName, qualified, namespace, err := nativeManifestIdentity(path)

--- a/install/integrationctl/agentplugins/providers/native_identity_test.go
+++ b/install/integrationctl/agentplugins/providers/native_identity_test.go
@@ -52,6 +52,109 @@ func TestNativeIdentityCursorReadsEveryAuthoritativeLocalManifest(t *testing.T) 
 	}
 }
 
+// TestNativeIdentityUnqualifiedPluginRootIgnoresForeignNonDirectoryEntries
+// reproduces a real defect found reviewing Claude Code's own equivalent scan:
+// a plain OS-generated file such as .DS_Store sitting in a shared plugins
+// root (created automatically the moment a user browses the folder in
+// Finder) made every entry indeterminate, refusing repair/update for every
+// unrelated, healthy plugin sharing that root. A plain file cannot contain
+// the manifest this scheme requires, so it can never claim a competing
+// plugin identity and must not block classification of real entries.
+func TestNativeIdentityUnqualifiedPluginRootIgnoresForeignNonDirectoryEntries(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".cursor", "plugins", "local")
+	plan := identityPlan(root)
+	if err := os.MkdirAll(plan.ActivePath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeIdentityFile(t, filepath.Join(plan.ActivePath, ".cursor-plugin", "plugin.json"), `{"name":"demo"}`)
+	if err := os.WriteFile(filepath.Join(root, ".DS_Store"), []byte{0}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	managed := &domain.ClientBinding{NativeObjects: []domain.NativeObjectOwnership{{Kind: "managed_package_directory", ManagedDigest: "sha256:owned"}}}
+	observer := NativeIdentityObserver{Stager: acceptingPackageVerifier{}}
+	observation, err := observer.ObserveNativeIdentity(context.Background(), domain.DetectedClient{ClientID: domain.ClientCursor}, plan, managed)
+	if err != nil || observation.State != domain.NativeIdentityManaged {
+		t.Fatalf("foreign non-directory entry blocked classification: observation = %+v, err = %v", observation, err)
+	}
+
+	// A genuine competing directory entry must still be caught.
+	writeIdentityFile(t, filepath.Join(root, "foreign-path", ".cursor-plugin", "plugin.json"), `{"name":"demo"}`)
+	observation, err = observer.ObserveNativeIdentity(context.Background(), domain.DetectedClient{ClientID: domain.ClientCursor}, plan, managed)
+	if observation.State != domain.NativeIdentityUnmanaged || err != nil {
+		t.Fatalf("real collision was not caught alongside a foreign file: observation = %+v, err = %v", observation, err)
+	}
+
+	// A symlink entry must still fail closed.
+	if err := os.RemoveAll(filepath.Join(root, "foreign-path")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(plan.ActivePath, filepath.Join(root, "suspicious-link")); err != nil {
+		t.Fatal(err)
+	}
+	observation, err = observer.ObserveNativeIdentity(context.Background(), domain.DetectedClient{ClientID: domain.ClientCursor}, plan, managed)
+	if observation.State != domain.NativeIdentityIndeterminate {
+		t.Fatalf("symlink entry was not refused: observation = %+v, err = %v", observation, err)
+	}
+}
+
+// TestNativeIdentityOpenCodeIgnoresForeignNonDirectoryEntries confirms the
+// same fix protects OpenCode too: OpenCode's own native registry check
+// (inspectNativeRegistry) never scans a directory, but its prepared-identity
+// check still goes through the shared inspectUnqualifiedPluginRoot exactly
+// like Cursor's does (observeIdentity calls inspectPreparedRegistry
+// unconditionally for every client before any client-specific override), so
+// a foreign .DS_Store in OpenCode's managed clients root would have hit the
+// identical bug if inspectUnqualifiedPluginRoot had not already been fixed.
+func TestNativeIdentityOpenCodeIgnoresForeignNonDirectoryEntries(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "managed", "clients", "opencode")
+	plan := identityPlan(root)
+	if err := os.MkdirAll(plan.ActivePath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeIdentityFile(t, filepath.Join(plan.ActivePath, "plugin.json"), `{"name":"demo"}`)
+	if err := os.WriteFile(filepath.Join(root, ".DS_Store"), []byte{0}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	managed := &domain.ClientBinding{NativeObjects: []domain.NativeObjectOwnership{{Kind: "managed_package_directory", ManagedDigest: "sha256:owned"}}}
+	observer := NativeIdentityObserver{Stager: acceptingPackageVerifier{}}
+	observation, err := observer.ObserveNativeIdentity(context.Background(), domain.DetectedClient{ClientID: domain.ClientOpenCode}, plan, managed)
+	if err != nil || observation.State != domain.NativeIdentityManaged {
+		t.Fatalf("foreign non-directory entry blocked OpenCode classification: observation = %+v, err = %v", observation, err)
+	}
+}
+
+// TestNativeIdentityClaudeSkillsRegistryIgnoresForeignNonDirectoryEntries is
+// the Claude-specific counterpart: reproduces the exact reported scenario
+// (a bare .DS_Store in <CLAUDE_CONFIG_DIR>/skills blocking every plugin's
+// repair) against inspectClaudeSkillsRegistry directly.
+func TestNativeIdentityClaudeSkillsRegistryIgnoresForeignNonDirectoryEntries(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "skills")
+	plan := identityPlan(root)
+	if err := os.MkdirAll(plan.ActivePath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeIdentityFile(t, filepath.Join(plan.ActivePath, ".claude-plugin", "plugin.json"), `{"name":"demo"}`)
+	if err := os.WriteFile(filepath.Join(root, ".DS_Store"), []byte{0}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	managed := &domain.ClientBinding{NativeObjects: []domain.NativeObjectOwnership{{Kind: "managed_package_directory", ManagedDigest: "sha256:owned"}}}
+	observer := NativeIdentityObserver{Stager: acceptingPackageVerifier{}}
+	observation, err := observer.ObservePreparedIdentity(context.Background(), domain.DetectedClient{ClientID: domain.ClientClaude}, plan, managed)
+	if err != nil || observation.State != domain.NativeIdentityManaged {
+		t.Fatalf("foreign .DS_Store blocked Claude skill classification: observation = %+v, err = %v", observation, err)
+	}
+
+	// A directory that legitimately has no manifest and no SKILL.md is still
+	// genuinely ambiguous and must remain refused (unchanged behavior).
+	if err := os.MkdirAll(filepath.Join(root, "unrelated-empty-dir"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	observation, err = observer.ObservePreparedIdentity(context.Background(), domain.DetectedClient{ClientID: domain.ClientClaude}, plan, managed)
+	if observation.State != domain.NativeIdentityIndeterminate {
+		t.Fatalf("ambiguous foreign directory was not refused: observation = %+v, err = %v", observation, err)
+	}
+}
+
 func TestNativeIdentityQualifiedPreparedMarketplaceCoexistsOnlyWithPositiveNamespace(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "prepared")
 	writeIdentityFile(t, filepath.Join(root, "foreign", ".agents", "plugins", "marketplace.json"), `{"name":"foreign-market","plugins":[{"name":"demo"}]}`)
@@ -86,6 +189,55 @@ func TestNativeIdentityCodexUsesExactCLIRegistryIdentity(t *testing.T) {
 	observation, err = (NativeIdentityObserver{Runner: runner}).ObserveNativeIdentity(context.Background(), domain.DetectedClient{ClientID: domain.ClientCodex}, plan, nil)
 	if err != nil || observation.State != domain.NativeIdentityUnmanaged {
 		t.Fatalf("occupied managed namespace observation = %+v, err = %v", observation, err)
+	}
+}
+
+// TestNativeIdentityCodexAbsentRecoveryMatchesRealCLIFailureThenSucceedsAfterRestoration
+// reproduces run05's exact defect against the real production observer: Codex's
+// own `plugin list --json` fails outright (its configured local marketplace
+// source is absent) before the managed directory is reconstructed, then
+// succeeds once the directory exists again. The caller (usecase/group.go)
+// relies on ObservePreparedIdentity never invoking this failing command and on
+// ObserveNativeIdentity's error carrying a bounded, sanitized excerpt of the
+// CLI's own output for diagnosis.
+func TestNativeIdentityCodexAbsentRecoveryMatchesRealCLIFailureThenSucceedsAfterRestoration(t *testing.T) {
+	t.Parallel()
+	plan := identityPlan(filepath.Join(t.TempDir(), "prepared"))
+	plan.NativeRegistryExecutable = "/test/bin/codex"
+	marketplace := managedMarketplaceName(plan.PhysicalArtifactID)
+	managed := &domain.ClientBinding{TargetLocator: plan.ActivePath, NativeObjects: []domain.NativeObjectOwnership{{Kind: "managed_package_directory", ManagedDigest: "sha256:owned"}}}
+	client := domain.DetectedClient{ClientID: domain.ClientCodex}
+
+	failingRunner := &identityRunner{result: legacyports.CommandResult{ExitCode: 1, Stderr: []byte("Error: failed to load marketplace snapshot for " + marketplace + "\n")}}
+	observer := NativeIdentityObserver{Runner: failingRunner, Stager: acceptingPackageVerifier{}}
+
+	// The recovery-eligibility gate (usecase's preparedIdentityObservation) must
+	// never invoke this failing command at all.
+	prepared, err := observer.ObservePreparedIdentity(context.Background(), client, plan, managed)
+	if err != nil || prepared.State != domain.NativeIdentityAbsent {
+		t.Fatalf("prepared observation = %+v, err = %v", prepared, err)
+	}
+	if len(failingRunner.commands) != 0 {
+		t.Fatalf("prepared observation launched the native CLI: %v", failingRunner.commands)
+	}
+
+	// The full, CLI-inclusive check must surface the CLI's own failure with a
+	// bounded diagnostic excerpt, and must not be mistaken for proof of absence.
+	_, err = observer.ObserveNativeIdentity(context.Background(), client, plan, managed)
+	if err == nil {
+		t.Fatal("failing native registry command was not surfaced as an error")
+	}
+	if !strings.Contains(err.Error(), "exit code 1") || !strings.Contains(err.Error(), marketplace) {
+		t.Fatalf("native discovery error missing bounded diagnostic: %v", err)
+	}
+
+	// Once the directory is reconstructed and the CLI reports it, the same
+	// observer call must confirm managed ownership with the recorded digest.
+	writeIdentityFile(t, filepath.Join(plan.ActivePath, "plugin.json"), `{"name":"demo"}`)
+	failingRunner.result = legacyports.CommandResult{Stdout: []byte(`{"installed":[{"pluginId":"demo@` + marketplace + `","name":"demo","marketplaceName":"` + marketplace + `","installed":true,"enabled":true}]}`)}
+	observation, err := observer.ObserveNativeIdentity(context.Background(), client, plan, managed)
+	if err != nil || observation.State != domain.NativeIdentityManaged || observation.Digest != "sha256:owned" {
+		t.Fatalf("post-restoration observation = %+v, err = %v", observation, err)
 	}
 }
 

--- a/install/integrationctl/agentplugins/providers/nativeconfig/opencode_exact_keys_test.go
+++ b/install/integrationctl/agentplugins/providers/nativeconfig/opencode_exact_keys_test.go
@@ -1,0 +1,60 @@
+package nativeconfig
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenCodeExactKeysBindReceipts(t *testing.T) {
+	for _, ext := range []string{"json", "jsonc"} {
+		t.Run(ext, func(t *testing.T) {
+			root := t.TempDir()
+			paths := Paths{JSON: filepath.Join(root, "opencode.json"), JSONC: filepath.Join(root, "opencode.jsonc")}
+			selected := filepath.Join(root, "opencode."+ext)
+			mustWrite(t, selected, `{"mcp":{}}`)
+			keys := []string{"api/server", "api server", "con", `api"server`, `api\server`, "сервер", "api-server"}
+			receipts := make([]Receipt, len(keys))
+			kernel := New()
+			for i, name := range keys {
+				receipt, err := kernel.Apply(Request{Paths: paths, Codec: CodecOpenCode, Action: ActionAdd, Name: name, Server: Server{Type: "remote", URL: "https://example.test/v1"}})
+				if err != nil {
+					t.Fatal(err)
+				}
+				receipts[i] = receipt
+				if receipt.Name != name || receipt.Path != selected {
+					t.Fatalf("identity changed: %+v", receipt)
+				}
+			}
+			for i, name := range keys {
+				receipt := receipts[i]
+				present, owned, err := kernel.Inspect(paths, CodecOpenCode, name, &receipt)
+				if err != nil || !present || !owned {
+					t.Fatalf("exact lookup %q: %v %v %v", name, present, owned, err)
+				}
+				wrong := receipts[(i+1)%len(keys)]
+				before := mustRead(t, selected)
+				if _, err := kernel.Apply(Request{Paths: paths, Codec: CodecOpenCode, Action: ActionRemove, Name: name, Owned: &wrong}); !errors.Is(err, ErrNotOwned) {
+					t.Fatalf("cross-key receipt accepted: %v", err)
+				}
+				if mustRead(t, selected) != before {
+					t.Fatal("rejected receipt changed file")
+				}
+				updated, err := kernel.Apply(Request{Paths: paths, Codec: CodecOpenCode, Action: ActionUpdate, Name: name, Owned: &receipt, Server: Server{Type: "remote", URL: "https://example.test/v2"}})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if updated.Digest == receipt.Digest {
+					t.Fatal("changed value kept digest")
+				}
+				if _, err := kernel.Apply(Request{Paths: paths, Codec: CodecOpenCode, Action: ActionRemove, Name: name, Owned: &updated}); err != nil {
+					t.Fatal(err)
+				}
+				present, _, err = kernel.Inspect(paths, CodecOpenCode, name, nil)
+				if err != nil || present {
+					t.Fatalf("removed key remains: %q %v", name, err)
+				}
+			}
+		})
+	}
+}

--- a/install/integrationctl/agentplugins/providers/opencode_logical_keys_test.go
+++ b/install/integrationctl/agentplugins/providers/opencode_logical_keys_test.go
@@ -1,0 +1,214 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/loader"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/specregistry"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers/nativeconfig"
+)
+
+// These are configuration identities, not filesystem names. Native tool-name
+// normalization and blank-key support are separate from this lifecycle contract.
+var openCodeLogicalKeys = []string{"api/server", "api server", "con", `api"server`, `api\server`, "сервер", "api-server"}
+
+func TestOpenCodeLogicalKeysLifecycle(t *testing.T) {
+	for _, ext := range []string{"json", "jsonc"} {
+		t.Run(ext, func(t *testing.T) {
+			root := t.TempDir()
+			configRoot, active := filepath.Join(root, "config"), filepath.Join(root, "managed", "demo")
+			configPath := filepath.Join(configRoot, "opencode."+ext)
+			original := `{"theme":"night","mcp":{"foreign":{"type":"remote","url":"https://foreign.test"}}}`
+			if ext == "jsonc" {
+				original = "// retained comment\n" + original
+			}
+			writeOpenCodeTestFile(t, configPath, original)
+			build := func(version string) []domain.NativeObjectOwnership {
+				envelope, plan := openCodeTestPackage(t, active, configRoot, version)
+				envelope.MCP.Servers = map[string]domain.MCPServer{}
+				plan.Components = plan.Components[:1]
+				for _, name := range openCodeLogicalKeys {
+					envelope.MCP.Servers[name] = domain.MCPServer{Name: name, Type: "streamable-http", Decoded: map[string]any{"url": "https://example.test/" + version}}
+					plan.Components = append(plan.Components, domain.ComponentDecision{Kind: domain.ComponentMCPServer, Name: name, Support: domain.SupportPrepared})
+				}
+				if err := os.Remove(filepath.Join(active, openCodeProjectionFile)); err != nil {
+					t.Fatal(err)
+				}
+				if err := projectOpenCodeNative(active, envelope, plan, filepath.Join(root, "data")); err != nil {
+					t.Fatal(err)
+				}
+				objects, err := buildOpenCodeNativeObjects(active, envelope, plan)
+				if err != nil {
+					t.Fatal(err)
+				}
+				// Persisted ownership retains exact historical IDs, without new encoding.
+				raw, err := json.Marshal(objects)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var restored []domain.NativeObjectOwnership
+				if err := json.Unmarshal(raw, &restored); err != nil {
+					t.Fatal(err)
+				}
+				seen := map[string]bool{}
+				for _, obj := range restored {
+					if obj.Kind != openCodeMCPObjectKind {
+						continue
+					}
+					if obj.ObjectID != "opencode-mcp:"+obj.LogicalName || obj.Path != configPath {
+						t.Fatalf("changed identity: %+v", obj)
+					}
+					seen[obj.LogicalName] = true
+				}
+				for _, name := range openCodeLogicalKeys {
+					if !seen[name] {
+						t.Fatalf("lost key %q", name)
+					}
+				}
+				return restored
+			}
+			first := build("v1")
+			if err := applyOpenCodeNative(configRoot, active, nil, first); err != nil {
+				t.Fatal(err)
+			}
+			if err := verifyOpenCodeNativeObjects(configRoot, active, first); err != nil {
+				t.Fatal(err)
+			}
+			second := build("v2")
+			if err := applyOpenCodeNative(configRoot, active, first, second); err != nil {
+				t.Fatal(err)
+			}
+			if err := verifyOpenCodeNativeObjects(configRoot, active, second); err != nil {
+				t.Fatal(err)
+			}
+			// Exact repair recreates absent entries while preserving the foreign entry.
+			writeOpenCodeTestFile(t, configPath, original)
+			if err := applyOpenCodeNative(configRoot, active, second, second); err != nil {
+				t.Fatal(err)
+			}
+			if err := verifyOpenCodeNativeObjects(configRoot, active, second); err != nil {
+				t.Fatal(err)
+			}
+			if err := applyOpenCodeNative(configRoot, "", second, nil); err != nil {
+				t.Fatal(err)
+			}
+			body := readOpenCodeTestFile(t, configPath)
+			if !strings.Contains(body, "foreign.test") || !strings.Contains(body, "night") || (ext == "jsonc" && !strings.Contains(body, "retained comment")) {
+				t.Fatalf("foreign content lost: %s", body)
+			}
+			for _, obj := range second {
+				if obj.Kind != openCodeMCPObjectKind {
+					continue
+				}
+				present, _, err := nativeconfig.New().Inspect(nativeconfig.Paths{JSON: filepath.Join(configRoot, "opencode.json"), JSONC: filepath.Join(configRoot, "opencode.jsonc")}, nativeconfig.CodecOpenCode, obj.LogicalName, nil)
+				if err != nil || present {
+					t.Fatalf("key survived remove: %q %v", obj.LogicalName, err)
+				}
+			}
+			if _, err := os.Stat(filepath.Join(configRoot, "skills", "docs")); !os.IsNotExist(err) {
+				t.Fatalf("skill survived remove: %v", err)
+			}
+		})
+	}
+}
+
+func TestOpenCodeLogicalKeysStageKeepsHealthySibling(t *testing.T) {
+	registry, err := specregistry.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range openCodeLogicalKeys {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			source := filepath.Join(root, "source")
+			manifest, _ := json.Marshal(map[string]any{"$schema": domain.PluginSchemaV1, "name": "probe"})
+			writeOpenCodeTestFile(t, filepath.Join(source, "plugin.json"), string(manifest))
+			mcp, _ := json.Marshal(map[string]any{"$schema": domain.MCPSchemaV1, "mcpServers": map[string]any{name: map[string]any{"type": "streamable-http", "url": "https://example.test/mcp"}}})
+			writeOpenCodeTestFile(t, filepath.Join(source, "mcp.json"), string(mcp))
+			writeOpenCodeTestFile(t, filepath.Join(source, "skills", "healthy", "SKILL.md"), "---\nname: healthy\ndescription: Healthy\n---\n")
+			envelope, err := (loader.Loader{Registry: registry}).Load(context.Background(), domain.LoadInput{SnapshotRoot: source})
+			if err != nil {
+				t.Fatal(err)
+			}
+			anchor := filepath.Join(root, "managed")
+			target := filepath.Join(anchor, "clients", "opencode")
+			plan := domain.DeliveryPlan{ClientID: domain.ClientOpenCode, Scope: domain.ScopeUser, Status: domain.PlanReady, PackageMode: domain.PackagePrepared, PhysicalArtifactID: "probe", TargetAnchor: anchor, TargetRoot: target, ActivePath: filepath.Join(target, "probe"), NativeRegistryRoot: filepath.Join(root, "native"), Components: []domain.ComponentDecision{{Kind: domain.ComponentSkill, Name: "healthy", Support: domain.SupportPrepared}, {Kind: domain.ComponentMCPServer, Name: name, Support: domain.SupportPrepared}}}
+			delivery, err := (Stager{}).Stage(context.Background(), envelope, plan, "logical-key", domain.CompatibilityHints{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer (Stager{}).Discard(context.Background(), delivery)
+			if _, err := os.Stat(filepath.Join(delivery.StagingPath, "skills", "healthy", "SKILL.md")); err != nil {
+				t.Fatal(err)
+			}
+			found := false
+			for _, obj := range delivery.NativeObjects {
+				if obj.Kind == openCodeMCPObjectKind && obj.LogicalName == name {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("stage lost exact MCP key %q", name)
+			}
+		})
+	}
+}
+
+func TestOpenCodeLogicalKeysForeignCollisionAndDrift(t *testing.T) {
+	for _, ext := range []string{"json", "jsonc"} {
+		for _, name := range openCodeLogicalKeys {
+			t.Run(ext+"/"+name, func(t *testing.T) {
+				root := t.TempDir()
+				configRoot, active := filepath.Join(root, "config"), filepath.Join(root, "managed")
+				path := filepath.Join(configRoot, "opencode."+ext)
+				writeOpenCodeTestFile(t, path, `{ "mcp": {} }`)
+				envelope, plan := openCodeTestPackage(t, active, configRoot, "owned")
+				server := envelope.MCP.Servers["docs"]
+				server.Name = name
+				envelope.MCP.Servers = map[string]domain.MCPServer{name: server}
+				plan.Components[1].Name = name
+				if err := os.Remove(filepath.Join(active, openCodeProjectionFile)); err != nil {
+					t.Fatal(err)
+				}
+				if err := projectOpenCodeNative(active, envelope, plan, filepath.Join(root, "data")); err != nil {
+					t.Fatal(err)
+				}
+				objects, err := buildOpenCodeNativeObjects(active, envelope, plan)
+				if err != nil {
+					t.Fatal(err)
+				}
+				foreign, _ := json.Marshal(map[string]any{"mcp": map[string]any{name: map[string]any{"type": "local", "command": []string{"foreign"}}}})
+				writeOpenCodeTestFile(t, path, string(foreign))
+				if err := applyOpenCodeNative(configRoot, active, nil, objects); !errors.Is(err, nativeconfig.ErrCollision) {
+					t.Fatalf("collision accepted: %v", err)
+				}
+				if got := readOpenCodeTestFile(t, path); got != string(foreign) {
+					t.Fatal("collision changed foreign bytes")
+				}
+				if _, err := os.Stat(filepath.Join(configRoot, "skills", "docs")); !os.IsNotExist(err) {
+					t.Fatal("collision installed sibling skill")
+				}
+				writeOpenCodeTestFile(t, path, `{"mcp":{}}`)
+				if err := applyOpenCodeNative(configRoot, active, nil, objects); err != nil {
+					t.Fatal(err)
+				}
+				writeOpenCodeTestFile(t, path, string(foreign))
+				for _, desired := range [][]domain.NativeObjectOwnership{objects, nil} {
+					if err := applyOpenCodeNative(configRoot, active, objects, desired); !errors.Is(err, nativeconfig.ErrNotOwned) {
+						t.Fatalf("drift accepted: %v", err)
+					}
+					if got := readOpenCodeTestFile(t, path); got != string(foreign) {
+						t.Fatal("drift changed foreign bytes")
+					}
+				}
+			})
+		}
+	}
+}

--- a/install/integrationctl/agentplugins/providers/opencode_native.go
+++ b/install/integrationctl/agentplugins/providers/opencode_native.go
@@ -292,9 +292,6 @@ func buildOpenCodeNativeObjects(stagingRoot string, envelope domain.PackageEnvel
 	objects := make([]domain.NativeObjectOwnership, 0, len(projection.MCPServers)+len(envelope.Skills))
 	placeholders := nativeconfig.Placeholders{PackageRoot: projection.PackageRoot, DataRoot: projection.DataRoot}
 	for name, server := range projection.MCPServers {
-		if err := pathpolicy.ValidateLeafID(name); err != nil {
-			return nil, fmt.Errorf("invalid OpenCode MCP server name %q: %w", name, err)
-		}
 		receipt, err := nativeconfig.DesiredReceipt(projection.ConfigPath, nativeconfig.CodecOpenCode, name, server, placeholders)
 		if err != nil {
 			return nil, err

--- a/install/integrationctl/agentplugins/providers/stager.go
+++ b/install/integrationctl/agentplugins/providers/stager.go
@@ -193,6 +193,9 @@ func (stager Stager) stage(
 				return domain.StagedDelivery{}, err
 			}
 		case domain.ClientClaude:
+			if err := stager.deliverManagedStdio(stagingPath, envelope, plan); err != nil {
+				return domain.StagedDelivery{}, err
+			}
 			if err := projectClaude(stagingPath, envelope, plan, pluginDataPath); err != nil {
 				return domain.StagedDelivery{}, err
 			}

--- a/install/integrationctl/agentplugins/providers/stager_test.go
+++ b/install/integrationctl/agentplugins/providers/stager_test.go
@@ -136,7 +136,7 @@ func TestClaudeProjectionExposesOnlyPlannedSurfacesAndRebindsRuntime(t *testing.
 		{Kind: domain.ComponentMCPServer, Name: "local", Support: domain.SupportProjected},
 	}
 	ownedData := filepath.Join(t.TempDir(), "data")
-	delivery, err := (Stager{}).StageWithPluginData(context.Background(), envelope, plan, "claude-isolated", domain.CompatibilityHints{}, ownedData)
+	delivery, err := windsurfFixtureStager(t).StageWithPluginData(context.Background(), envelope, plan, "claude-isolated", domain.CompatibilityHints{}, ownedData)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,11 +164,11 @@ func TestClaudeProjectionExposesOnlyPlannedSurfacesAndRebindsRuntime(t *testing.
 	document := readObject(t, filepath.Join(delivery.StagingPath, ".mcp.json"))
 	local := document["local"].(map[string]any)
 	activeRuntime := filepath.Join(plan.ActivePath, ".agentplugins-runtime")
-	if local["cwd"] != activeRuntime {
+	if local["cwd"] != nil || local["args"].([]any)[3] != activeRuntime {
 		t.Fatalf("Claude stdio cwd = %v, want %v", local["cwd"], activeRuntime)
 	}
 	args := local["args"].([]any)
-	if args[0] != filepath.Join(activeRuntime, "bin", "run") {
+	if args[7] != filepath.Join(activeRuntime, "bin", "run") {
 		t.Fatalf("Claude stdio args = %v", args)
 	}
 	env := local["env"].(map[string]any)
@@ -213,7 +213,7 @@ func TestClaudeProjectionKeepsMultiTargetStdioContractsIndependent(t *testing.T)
 		projected := readObject(t, filepath.Join(target.root, ".mcp.json"))["local"].(map[string]any)
 		args := projected["args"].([]any)
 		env := projected["env"].(map[string]any)
-		if args[0] != filepath.Join(target.pluginRoot, "bin", "run") || args[1] != filepath.Join(target.dataPath, "cache") {
+		if args[7] != filepath.Join(target.pluginRoot, "bin", "run") || args[8] != filepath.Join(target.dataPath, "cache") {
 			t.Fatalf("target %s args = %v", target.root, args)
 		}
 		if env["PLUGIN_ROOT"] != target.pluginRoot || env["PLUGIN_DATA"] != target.dataPath || env["CACHE"] != filepath.Join(target.dataPath, "cache") {

--- a/install/integrationctl/agentplugins/transaction/kernel.go
+++ b/install/integrationctl/agentplugins/transaction/kernel.go
@@ -75,6 +75,10 @@ type DirectoryMutation struct {
 	// before a durable directory intent exists.
 	DesiredState domain.StateFileV2
 	Verify       func(context.Context, string) error
+	// RequireAbsent rejects this mutation, before any journal write or
+	// filesystem mutation, if ActivePath already exists. See dirswap.Input's
+	// field of the same name.
+	RequireAbsent bool
 }
 
 type DirectoryRemoval struct {
@@ -100,6 +104,14 @@ type DirectoryGroup struct {
 	OperationGroupID string
 	Mutations        []DirectoryMutation
 	DesiredState     domain.StateFileV2
+	// PostApplyVerify runs once every mutation in the group has been applied and
+	// individually verified, and before the group's state commit decision. It
+	// exists for verification that depends on the whole group's restored
+	// filesystem state at once (for example, a native client registry that must
+	// observe every reconstructed path together before any single one can be
+	// confirmed). A returned error rolls back every applied mutation in the
+	// group; no state or native side effect from this group is ever committed.
+	PostApplyVerify func(context.Context) error
 }
 
 type DirectoryRemovalGroup struct {
@@ -147,6 +159,7 @@ func (kernel Kernel) ApplyDirectory(ctx context.Context, mutation DirectoryMutat
 	directoryReceipt, err := kernel.Directory.Apply(ctx, dirswap.Input{
 		OperationID: mutation.OperationID, ClientBindingID: mutation.ClientBindingID, Sequence: mutation.Sequence,
 		OwnedBase: mutation.OwnedBase, ActivePath: mutation.ActivePath, StagingPath: mutation.StagingPath,
+		RequireAbsent: mutation.RequireAbsent,
 	})
 	if err != nil {
 		if directoryReceipt.OperationID != "" {
@@ -277,6 +290,7 @@ func (kernel Kernel) ApplyDirectoryGroup(ctx context.Context, group DirectoryGro
 		directoryReceipt, err := kernel.Directory.Apply(ctx, dirswap.Input{
 			OperationID: mutation.OperationID, ClientBindingID: mutation.ClientBindingID, Sequence: mutation.Sequence,
 			OwnedBase: mutation.OwnedBase, ActivePath: mutation.ActivePath, StagingPath: mutation.StagingPath,
+			RequireAbsent: mutation.RequireAbsent,
 		})
 		if err != nil {
 			if directoryReceipt.OperationID != "" {
@@ -312,6 +326,14 @@ func (kernel Kernel) ApplyDirectoryGroup(ctx context.Context, group DirectoryGro
 		installation.Clients[mutation.ClientBindingID] = client
 		state.Installations[installationIndex] = installation
 		applied[len(applied)-1].state = receipt
+	}
+	if group.PostApplyVerify != nil {
+		if err := group.PostApplyVerify(ctx); err != nil {
+			if rollbackErr := rollback(); rollbackErr != nil {
+				return nil, groupError(GroupFailureUnknown, fmt.Errorf("post-apply group verification: %v; rollback failed: %w", err, rollbackErr))
+			}
+			return nil, groupError(GroupFailureRolledBack, fmt.Errorf("post-apply group verification: %w", err))
+		}
 	}
 	if oldState, err := kernel.persistCommitDecision(state, beforeJSON); err != nil {
 		if oldState {

--- a/install/integrationctl/agentplugins/transaction/kernel_test.go
+++ b/install/integrationctl/agentplugins/transaction/kernel_test.go
@@ -90,6 +90,140 @@ func TestApplyDirectoryGroupRollsBackEveryTargetWhenSecondVerificationFails(t *t
 	}
 }
 
+func TestApplyDirectoryGroupPostApplyVerifyRunsAfterRestorationAndRollsBackOnFailure(t *testing.T) {
+	t.Parallel()
+	kernel, mutation, store := transactionFixture(t, "post-verify-op")
+	// Simulate an absent-managed-object recovery: the active path does not
+	// exist before this transaction runs, matching dirswap's HadActive=false
+	// path used to reconstruct a positively absent managed directory.
+	if err := os.RemoveAll(mutation.ActivePath); err != nil {
+		t.Fatal(err)
+	}
+	verifyCalls := 0
+	_, err := kernel.ApplyDirectoryGroup(context.Background(), DirectoryGroup{
+		OperationGroupID: "post-verify-group", Mutations: []DirectoryMutation{mutation}, DesiredState: mutation.DesiredState,
+		PostApplyVerify: func(context.Context) error {
+			verifyCalls++
+			if _, statErr := os.Stat(filepath.Join(mutation.ActivePath, "body")); statErr != nil {
+				t.Fatalf("post-apply verify ran before restoration: %v", statErr)
+			}
+			return errors.New("post-apply verification refused")
+		},
+	})
+	if err == nil {
+		t.Fatal("post-apply verification failure was ignored")
+	}
+	if phase := FailurePhase(err); phase != GroupFailureRolledBack {
+		t.Fatalf("failure phase = %q, want rolled back", phase)
+	}
+	if verifyCalls != 1 {
+		t.Fatalf("post-apply verify calls = %d, want 1", verifyCalls)
+	}
+	if _, statErr := os.Stat(mutation.ActivePath); !os.IsNotExist(statErr) {
+		t.Fatalf("rollback did not restore absence: %v", statErr)
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(onlyClient(state.Installations[0]).Receipts) != 0 {
+		t.Fatal("failed group persisted a receipt")
+	}
+}
+
+func TestApplyDirectoryGroupPostApplyVerifySucceedsBeforeCommit(t *testing.T) {
+	t.Parallel()
+	kernel, mutation, store := transactionFixture(t, "post-verify-success-op")
+	if err := os.RemoveAll(mutation.ActivePath); err != nil {
+		t.Fatal(err)
+	}
+	verifyCalls := 0
+	receipts, err := kernel.ApplyDirectoryGroup(context.Background(), DirectoryGroup{
+		OperationGroupID: "post-verify-success-group", Mutations: []DirectoryMutation{mutation}, DesiredState: mutation.DesiredState,
+		PostApplyVerify: func(context.Context) error {
+			verifyCalls++
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if verifyCalls != 1 || len(receipts) != 1 || receipts[0].Phase != ReceiptPhaseCommitted {
+		t.Fatalf("post-apply verify success path = calls=%d receipts=%+v", verifyCalls, receipts)
+	}
+	assertTransactionBody(t, mutation.ActivePath, "new")
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(onlyClient(state.Installations[0]).Receipts) != 1 {
+		t.Fatal("successful group did not persist a receipt")
+	}
+}
+
+func TestApplyDirectoryGroupRequireAbsentRejectsAndRollsBackWithoutTouchingOccupiedTarget(t *testing.T) {
+	t.Parallel()
+	kernel, mutation, store := transactionFixture(t, "require-absent-op")
+	mutation.RequireAbsent = true
+	// A second, ordinary mutation applies first and succeeds; the group must
+	// still fail closed on the RequireAbsent one and roll the first back too.
+	secondActive := filepath.Join(mutation.OwnedBase, "plugin-second")
+	secondStaging := filepath.Join(mutation.OwnedBase, "plugin-second.staging")
+	writeTransactionBody(t, secondActive, "old-second")
+	writeTransactionBody(t, secondStaging, "new-second")
+	desired := mutation.DesiredState
+	installation := desired.Installations[0]
+	secondClientID := domain.ComputeClientBindingID(installation.InstallationID, "cursor", "user", secondActive)
+	secondClient := onlyClient(installation)
+	secondClient.ClientBindingID = secondClientID
+	secondClient.ClientID = "cursor"
+	secondClient.TargetLocator = secondActive
+	secondClient.PhysicalArtifact = domain.ComputePhysicalArtifactID("demo", installation.InstallationID+"-cursor")
+	secondClient.Receipts = nil
+	installation.Clients[secondClientID] = secondClient
+	desired.Installations[0] = installation
+	second := DirectoryMutation{OperationID: "require-absent-second", InstallationID: installation.InstallationID, ClientBindingID: secondClientID,
+		Sequence: 1, OwnedBase: mutation.OwnedBase, ActivePath: secondActive, StagingPath: secondStaging,
+		Activation: domain.ActivationPrepared, Authentication: domain.AuthenticationNotRequired, Policy: domain.PolicyAllowed,
+		Verification: domain.VerificationInstalled, Verify: func(_ context.Context, activePath string) error {
+			body, readErr := os.ReadFile(filepath.Join(activePath, "body"))
+			if readErr != nil || string(body) != "new-second" {
+				return errors.New("new-second body not active")
+			}
+			return nil
+		}}
+	// mutation.ActivePath already has "old" from transactionFixture, so
+	// RequireAbsent must reject it before any journal write or rename.
+	_, err := kernel.ApplyDirectoryGroup(context.Background(), DirectoryGroup{OperationGroupID: "require-absent-group", Mutations: []DirectoryMutation{second, mutation}, DesiredState: desired})
+	if err == nil {
+		t.Fatal("RequireAbsent violation was ignored")
+	}
+	if phase := FailurePhase(err); phase != GroupFailureRolledBack {
+		t.Fatalf("failure phase = %q, want rolled back", phase)
+	}
+	assertTransactionBody(t, mutation.ActivePath, "old")
+	assertTransactionBody(t, secondActive, "old-second")
+	if _, statErr := os.Stat(mutation.StagingPath); statErr != nil {
+		t.Fatalf("RequireAbsent rejection consumed the staging directory: %v", statErr)
+	}
+	if _, statErr := os.Stat(kernel.Directory.JournalDir); statErr == nil {
+		entries, readErr := os.ReadDir(kernel.Directory.JournalDir)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("RequireAbsent rejection left journal entries: %v", entries)
+		}
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Installations[0].Clients) != 1 || len(onlyClient(state.Installations[0]).Receipts) != 0 {
+		t.Fatalf("RequireAbsent-rejected group changed state: %+v", state.Installations[0])
+	}
+}
+
 func TestGroupedRemovalRecoversFinalStateAndRenamedDataAfterRestart(t *testing.T) {
 	t.Parallel()
 	kernel, mutation, store := transactionFixture(t, "restart-remove")

--- a/install/integrationctl/agentplugins/usecase/codex_http_projection_test.go
+++ b/install/integrationctl/agentplugins/usecase/codex_http_projection_test.go
@@ -1,0 +1,117 @@
+package usecase
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+// TestCodexStreamableHTTPProjectionPreservesLiteralURLAndHeaders proves the
+// one piece of the "HTTP headers and redirects" requirement that is actually
+// UAP's own responsibility and testable without a live Codex process: the
+// declared streamable-http MCP server's URL and literal header map survive
+// projection into both files UAP writes for Codex -- the client-facing
+// .mcp.json (built by projectOpenAI from the decoded config) and the
+// portable package's own mcp.json (built by writeSanitizedMCP from the
+// original raw bytes) -- byte-for-byte, through the real production stager
+// (no fakes). Both Raw and Decoded are set on the fixture server, matching
+// what the real loader always produces (adapters/loader/mcp.go), so this
+// exercises both projection paths honestly. The .mcp.json projection of a
+// declared streamable-http server as "type": "http" is a documented,
+// intentional decision, not a bug -- see docs/CODEX_TRANSPORT_EVIDENCE.md
+// for the source evidence behind it; that specific assertion already exists
+// in providers/stager_test.go, it is repeated here only as a sanity check
+// alongside the header assertions. The literal header-map preservation
+// (across both files) is what this test actually adds.
+//
+// What this does NOT prove, and cannot prove without a live native Codex
+// client connection: whether Codex's own HTTP client actually sends these
+// exact headers on the first request, honors client-generated protocol/auth
+// header priority, or refuses to forward a configured header to a different
+// origin on redirect. Those are native client runtime properties, not UAP
+// config-projection properties; no test at this level, or currently at any
+// level in this codebase for any client, proves them. This remains an
+// honest, explicitly unproven gap for every client in this codebase, not
+// just Codex.
+func TestCodexStreamableHTTPProjectionPreservesLiteralURLAndHeaders(t *testing.T) {
+	t.Parallel()
+	service, _, _ := serviceFixture(t)
+	codex := domain.DetectedClient{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".codex")}
+	install := addInput(t, codex, "https://example.com/codex-http-headers")
+	serverRaw := json.RawMessage(`{"type":"streamable-http","url":"https://example.invalid/mcp","headers":{"X-Test-Literal":"keep-me-exact","Authorization":"Bearer test-token-not-a-real-secret"}}`)
+	install.Envelope.MCP = domain.MCPComponent{Present: true, Enabled: true, Servers: map[string]domain.MCPServer{
+		"remote": {Name: "remote", Type: "streamable-http", Raw: serverRaw, Decoded: map[string]any{
+			"type": "streamable-http",
+			"url":  "https://example.invalid/mcp",
+			"headers": map[string]any{
+				"X-Test-Literal": "keep-me-exact",
+				"Authorization":  "Bearer test-token-not-a-real-secret",
+			},
+		}},
+	}}
+	install.Envelope.Inventory.MCPServers = []string{"remote"}
+
+	added, err := service.AddGroup(context.Background(), GroupInput{Targets: []AddInput{install}, OperationGroupID: "codex-http-headers-add", Confirmed: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(filepath.Join(added.Targets[0].Plan.ActivePath, ".mcp.json"))
+	if err != nil {
+		t.Fatalf("read projected .mcp.json: %v", err)
+	}
+	var projected struct {
+		MCPServers map[string]map[string]any `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(body, &projected); err != nil {
+		t.Fatalf("decode projected .mcp.json: %v\n%s", err, body)
+	}
+	remote, ok := projected.MCPServers["remote"]
+	if !ok {
+		t.Fatalf("remote server missing from projection: %s", body)
+	}
+	if remote["url"] != "https://example.invalid/mcp" {
+		t.Fatalf("url not preserved literally: %+v", remote)
+	}
+	headers, ok := remote["headers"].(map[string]any)
+	if !ok {
+		t.Fatalf("headers missing or wrong shape from projection: %+v", remote)
+	}
+	if headers["X-Test-Literal"] != "keep-me-exact" {
+		t.Fatalf("custom header not preserved literally: %+v", headers)
+	}
+	if headers["Authorization"] != "Bearer test-token-not-a-real-secret" {
+		t.Fatalf("authorization header not preserved literally: %+v", headers)
+	}
+	if remote["type"] != "http" {
+		t.Fatalf(`.mcp.json type must be "http" for a declared streamable-http server: %+v`, remote)
+	}
+
+	portableBody, err := os.ReadFile(filepath.Join(added.Targets[0].Plan.ActivePath, "mcp.json"))
+	if err != nil {
+		t.Fatalf("read portable mcp.json: %v", err)
+	}
+	var portable struct {
+		MCPServers map[string]map[string]any `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(portableBody, &portable); err != nil {
+		t.Fatalf("decode portable mcp.json: %v\n%s", err, portableBody)
+	}
+	portableRemote, ok := portable.MCPServers["remote"]
+	if !ok || portableRemote == nil {
+		t.Fatalf("portable mcp.json did not preserve the raw server entry: %s", portableBody)
+	}
+	if portableRemote["url"] != "https://example.invalid/mcp" {
+		t.Fatalf("portable mcp.json url not preserved literally: %+v", portableRemote)
+	}
+	portableHeaders, ok := portableRemote["headers"].(map[string]any)
+	if !ok || portableHeaders["Authorization"] != "Bearer test-token-not-a-real-secret" || portableHeaders["X-Test-Literal"] != "keep-me-exact" {
+		t.Fatalf("portable mcp.json headers not preserved literally: %+v", portableRemote)
+	}
+	if portableRemote["type"] != "streamable-http" {
+		t.Fatalf("portable mcp.json must keep the original declared transport, not the client-projected one: %+v", portableRemote)
+	}
+}

--- a/install/integrationctl/agentplugins/usecase/codex_remove_lifecycle_test.go
+++ b/install/integrationctl/agentplugins/usecase/codex_remove_lifecycle_test.go
@@ -1,0 +1,222 @@
+package usecase
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+// TestCodexRemoveGroupPreservesForeignSiblingAndRefusesRepeatRemove exercises
+// Codex's real removal path (usecase/remove_group.go plus the real
+// providers.Activator.Deactivate branch for domain.ClientCodex) end to end
+// with unmocked production code. No fake CLI runner is required: Codex's
+// Deactivate only invokes its CLI when a managed marketplace entry is found
+// registered in config.toml, and a disposable test ConfigRoot never has one
+// (providers/codex_marketplace_cleanup.go's managedCodexMarketplaceRegistered
+// returns false, nil when config.toml is absent -- confirmed by reading that
+// exact function). This is real, non-mocked proof at the usecase/provider
+// level -- explicitly NOT a live-native-Codex-binary proof. A live proof now
+// exists separately (repotests/agentplugins_codex_native_e2e_test.go, run on
+// a genuine non-emulated arm64 Linux Codex binary in a native linux/arm64
+// container -- the earlier x86_64-emulation pidfd_open blocker on this
+// machine does not apply to a real arm64 binary on this machine's native
+// arm64 Docker Desktop) and found a real bug this usecase-level test cannot
+// reach: after a successful remove, a freshly started codex app-server
+// silently re-materialized the plugin from its stale config.toml
+// registration, because config.toml's separate per-plugin `[plugins."id"]`
+// entry was never cleaned up (fixed in providers/activator.go's
+// removeCodexPlugin). This file's fake-CLI-free scenario cannot exercise
+// that path at all, since it never has a registered marketplace entry to
+// clean up in the first place -- see the live e2e test for that coverage.
+//
+// TestRemovePlanExposesExternalUninstallAndPreservesCodexArtifactUntilAcknowledged
+// and TestRemoveCleansNativeCodexMarketplaceBeforeManagedArtifactDeletion
+// (service_test.go) already cover Codex remove, the --external-uninstalled
+// gate, and foreign-preservation at the native-config level (a real
+// config.toml with a foreign marketplace entry that survives) through the
+// single-target Service.Remove path -- this file does not repeat that. What
+// is new here: the RemoveGroup path specifically (its refusal contract
+// differs from single Remove -- RemoveGroup returns a hard error without the
+// flag, Remove returns err == nil with Mutated:false), a foreign *sibling
+// directory* surviving on the filesystem (not just a foreign native-config
+// entry), repeat-remove refusal, and an exact assertion on the
+// --external-uninstalled flag text in the returned guidance.
+func TestCodexRemoveGroupPreservesForeignSiblingAndRefusesRepeatRemove(t *testing.T) {
+	t.Parallel()
+	service, store, _ := serviceFixture(t)
+	codex := domain.DetectedClient{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".codex")}
+	install := addInput(t, codex, "https://example.com/codex-remove-lifecycle")
+	added, err := service.AddGroup(context.Background(), GroupInput{Targets: []AddInput{install}, OperationGroupID: "codex-remove-add", Confirmed: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	managedPath := added.Targets[0].Plan.ActivePath
+	originalPluginJSON, err := os.ReadFile(filepath.Join(managedPath, "plugin.json"))
+	if err != nil {
+		t.Fatalf("read original plugin.json: %v", err)
+	}
+	baselineState, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	baselineClient := onlyBinding(baselineState.Installations[0])
+
+	// Plant a completely unrelated, foreign sibling package under the same
+	// managed root, to prove owned-only removal (collision/foreign-content
+	// preservation, per task 3's requirement).
+	foreignSibling := filepath.Join(filepath.Dir(managedPath), "foreign-sibling-plugin")
+	if err := os.MkdirAll(foreignSibling, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(foreignSibling, "marker.txt"), []byte("not ours"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Tamper the managed content itself before attempting removal. The
+	// refusal below comes from the generic ownership-digest preflight shared
+	// by every client (remove_group.go), not anything Codex-specific --
+	// Deactivate is never reached on this path. It must refuse rather than
+	// silently remove drifted bytes, preserving both the (now-changed)
+	// managed directory and the foreign sibling exactly as-is.
+	if err := os.WriteFile(filepath.Join(managedPath, "plugin.json"), []byte("tampered"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	removeInput := RemoveGroupInput{
+		Selector:         added.InstallationID,
+		Targets:          []RemoveInput{{Client: codex, Scope: domain.ScopeUser, ExternalUninstalled: true}},
+		OperationGroupID: "codex-remove-tampered", Confirmed: true,
+	}
+	if _, err := service.RemoveGroup(context.Background(), removeInput); err == nil || !strings.Contains(err.Error(), "ownership verification failed") {
+		t.Fatalf("tampered managed content removal error = %v, want an ownership verification failure", err)
+	}
+	if _, statErr := os.Stat(managedPath); statErr != nil {
+		t.Fatalf("refused removal deleted the managed directory: %v", statErr)
+	}
+	if _, statErr := os.Stat(foreignSibling); statErr != nil {
+		t.Fatalf("foreign sibling did not survive a refused removal: %v", statErr)
+	}
+	afterTamperState, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterTamperClient := onlyBinding(afterTamperState.Installations[0])
+	if afterTamperClient.Materialization != baselineClient.Materialization || len(afterTamperClient.Receipts) != len(baselineClient.Receipts) {
+		t.Fatalf("refused removal changed persisted client state: before=%+v after=%+v", baselineClient, afterTamperClient)
+	}
+
+	// Restore the managed content to its originally recorded bytes (an
+	// operator undoing the tamper) and perform a genuine removal.
+	if err := os.WriteFile(filepath.Join(managedPath, "plugin.json"), originalPluginJSON, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	removeInput.OperationGroupID = "codex-remove-real"
+	removed, err := service.RemoveGroup(context.Background(), removeInput)
+	if err != nil {
+		t.Fatalf("real removal failed: %v", err)
+	}
+	if !removed.Mutated || removed.Phase != GroupPhaseCompleted {
+		t.Fatalf("real removal result = %+v, want mutated/completed", removed)
+	}
+	if _, statErr := os.Stat(managedPath); !os.IsNotExist(statErr) {
+		t.Fatalf("managed directory survived a completed removal: %v", statErr)
+	}
+	if _, statErr := os.Stat(foreignSibling); statErr != nil {
+		t.Fatalf("foreign sibling did not survive real removal: %v", statErr)
+	}
+	if body, readErr := os.ReadFile(filepath.Join(foreignSibling, "marker.txt")); readErr != nil || string(body) != "not ours" {
+		t.Fatalf("foreign sibling content changed: body=%q err=%v", body, readErr)
+	}
+	afterRemoveState, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(afterRemoveState.Installations) != 1 || len(afterRemoveState.Installations[0].Clients) != 0 || !afterRemoveState.Installations[0].DataRetained {
+		t.Fatalf("real removal did not leave minimal data-retained state: %+v", afterRemoveState.Installations)
+	}
+
+	// Repeat-remove must be safely refused, not silently accepted.
+	_, err = service.RemoveGroup(context.Background(), RemoveGroupInput{
+		Selector:         added.InstallationID,
+		Targets:          []RemoveInput{{Client: codex, Scope: domain.ScopeUser, ExternalUninstalled: true}},
+		OperationGroupID: "codex-remove-repeat", Confirmed: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "not materialized") {
+		t.Fatalf("repeat-remove error = %v, want a not-materialized refusal", err)
+	}
+	if _, statErr := os.Stat(foreignSibling); statErr != nil {
+		t.Fatalf("foreign sibling did not survive a repeat-remove attempt: %v", statErr)
+	}
+	if body, readErr := os.ReadFile(filepath.Join(foreignSibling, "marker.txt")); readErr != nil || string(body) != "not ours" {
+		t.Fatalf("foreign sibling content changed after repeat-remove attempt: body=%q err=%v", body, readErr)
+	}
+}
+
+// TestCodexRemoveGroupRequiresExternalUninstalledFlag confirms Codex's
+// documented remove contract: UAP has no supported Codex CLI verb to
+// silently uninstall a plugin on the user's behalf, so remove without
+// --external-uninstalled must be refused with actionable guidance, leaving
+// the managed directory untouched.
+func TestCodexRemoveGroupRequiresExternalUninstalledFlag(t *testing.T) {
+	t.Parallel()
+	service, store, _ := serviceFixture(t)
+	codex := domain.DetectedClient{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".codex")}
+	install := addInput(t, codex, "https://example.com/codex-remove-requires-flag")
+	added, err := service.AddGroup(context.Background(), GroupInput{Targets: []AddInput{install}, OperationGroupID: "codex-remove-flag-add", Confirmed: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	managedPath := added.Targets[0].Plan.ActivePath
+	beforePluginJSON, err := os.ReadFile(filepath.Join(managedPath, "plugin.json"))
+	if err != nil {
+		t.Fatalf("read plugin.json before refused remove: %v", err)
+	}
+	beforeState, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := service.RemoveGroup(context.Background(), RemoveGroupInput{
+		Selector:         added.InstallationID,
+		Targets:          []RemoveInput{{Client: codex, Scope: domain.ScopeUser}},
+		OperationGroupID: "codex-remove-no-flag", Confirmed: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "did not authorize managed artifact removal") {
+		t.Fatalf("remove without the flag error = %v, want a client-did-not-authorize refusal", err)
+	}
+	if result.Mutated || result.Phase != GroupPhaseManagedUnchanged {
+		t.Fatalf("refused remove result = %+v, want unmutated/managed_unchanged", result)
+	}
+	if len(result.Targets) != 1 {
+		t.Fatalf("expected exactly one target result: %+v", result.Targets)
+	}
+	actions := strings.Join(result.Targets[0].Deactivation.UserActions, " | ")
+	if !strings.Contains(actions, "--external-uninstalled") {
+		t.Fatalf("actionable guidance missing --external-uninstalled: %q", actions)
+	}
+	if _, statErr := os.Stat(managedPath); statErr != nil {
+		t.Fatalf("refused remove touched the managed directory: %v", statErr)
+	}
+	afterPluginJSON, err := os.ReadFile(filepath.Join(managedPath, "plugin.json"))
+	if err != nil {
+		t.Fatalf("read plugin.json after refused remove: %v", err)
+	}
+	if !bytes.Equal(beforePluginJSON, afterPluginJSON) {
+		t.Fatalf("refused remove changed managed directory content: before=%q after=%q", beforePluginJSON, afterPluginJSON)
+	}
+	afterState, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(afterState.Installations) != 1 || len(afterState.Installations[0].Clients) != 1 {
+		t.Fatalf("refused remove changed persisted state shape: before=%+v after=%+v", beforeState.Installations, afterState.Installations)
+	}
+	beforeClient := onlyBinding(beforeState.Installations[0])
+	afterClient := onlyBinding(afterState.Installations[0])
+	if beforeClient.Materialization != afterClient.Materialization || len(beforeClient.Receipts) != len(afterClient.Receipts) {
+		t.Fatalf("refused remove changed the client binding: before=%+v after=%+v", beforeClient, afterClient)
+	}
+}

--- a/install/integrationctl/agentplugins/usecase/codex_sse_lifecycle_test.go
+++ b/install/integrationctl/agentplugins/usecase/codex_sse_lifecycle_test.go
@@ -1,0 +1,220 @@
+package usecase
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/ports"
+)
+
+// Reconstruct the pre-narrowing Codex capability in memory, retaining the real
+// stager, transaction and receipts. No client binary or network is invoked.
+type historicalCodexSSEPlanner struct{ ports.DeliveryPlanner }
+
+func (p historicalCodexSSEPlanner) Plan(ctx context.Context, e domain.PackageEnvelope, c domain.DetectedClient, s domain.InstallScope, id string) (domain.DeliveryPlan, error) {
+	planning := e
+	planning.MCP.Servers = make(map[string]domain.MCPServer, len(e.MCP.Servers))
+	for name, server := range e.MCP.Servers {
+		if server.Type == "sse" {
+			server.Type = "streamable-http"
+		}
+		planning.MCP.Servers[name] = server
+	}
+	return p.DeliveryPlanner.Plan(ctx, planning, c, s, id)
+}
+
+func codexSSEInput(t *testing.T, client domain.DetectedClient, healthy bool) AddInput {
+	t.Helper()
+	input := addInput(t, client, "https://example.invalid/codex-sse-fixture")
+	input.Confirmed = true
+	servers := map[string]domain.MCPServer{"events": {Name: "events", Type: "sse", Decoded: map[string]any{"type": "sse", "url": "https://example.invalid/events"}}}
+	if healthy {
+		servers["http"] = domain.MCPServer{Name: "http", Type: "streamable-http", Decoded: map[string]any{"type": "streamable-http", "url": "https://example.invalid/mcp"}}
+		skill := []byte("---\nname: docs\ndescription: Fixture documentation\n---\nRead fixture documentation.\n")
+		path := filepath.Join(input.Envelope.SnapshotRoot, "skills", "docs", "SKILL.md")
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, skill, 0600); err != nil {
+			t.Fatal(err)
+		}
+		input.Envelope.Skills = map[string]domain.Skill{"docs": {Name: "docs", RelativePath: "skills/docs/SKILL.md", Raw: skill}}
+	}
+	rawServers := map[string]any{}
+	for name, server := range servers {
+		raw, err := json.Marshal(server.Decoded)
+		if err != nil {
+			t.Fatal(err)
+		}
+		server.Raw = raw
+		servers[name] = server
+		rawServers[name] = server.Decoded
+	}
+	raw, err := json.Marshal(map[string]any{"$schema": domain.MCPSchemaV1, "mcpServers": rawServers})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(input.Envelope.SnapshotRoot, "mcp.json"), raw, 0600); err != nil {
+		t.Fatal(err)
+	}
+	input.Envelope.MCP = domain.MCPComponent{Present: true, Enabled: true, Servers: servers, Raw: raw}
+	return input
+}
+
+func TestCodexSSEHistoricalLifecycle(t *testing.T) {
+	for _, op := range []string{"add", "repair", "update-preview", "update", "all-unsupported-update"} {
+		t.Run(op, func(t *testing.T) {
+			service, store, _ := serviceFixture(t)
+			client := domain.DetectedClient{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), "codex")}
+			input := codexSSEInput(t, client, op != "all-unsupported-update")
+			currentPlanner := service.Planner
+			service.Planner = historicalCodexSSEPlanner{currentPlanner}
+			installed, err := service.Add(context.Background(), input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			service.Planner = currentPlanner
+			for _, surface := range []string{"mcp.json", ".mcp.json"} {
+				servers := readUsecaseObject(t, filepath.Join(installed.Plan.ActivePath, surface))["mcpServers"].(map[string]any)
+				if servers["events"].(map[string]any)["type"] != "sse" {
+					t.Fatalf("historical %s not SSE: %v", surface, servers)
+				}
+			}
+			beforeState, err := store.Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			before := codexTransportFiles(t, installed.Plan.ActivePath)
+			input.InstallationID = installed.InstallationID
+			input.OperationID = "codex-historical-followup"
+			input.Confirmed = op != "update-preview"
+			var result AddResult
+			switch op {
+			case "add":
+				result, err = service.Add(context.Background(), input)
+			case "repair":
+				result, err = service.Repair(context.Background(), input)
+			default:
+				result, err = service.Update(context.Background(), input)
+			}
+			if op == "update" {
+				if err != nil || !result.Mutated || result.NoChange {
+					t.Fatalf("update=%+v err=%v", result, err)
+				}
+				for _, surface := range []string{"mcp.json", ".mcp.json"} {
+					servers := readUsecaseObject(t, filepath.Join(installed.Plan.ActivePath, surface))["mcpServers"].(map[string]any)
+					if len(servers) != 1 || servers["http"] == nil {
+						t.Fatalf("withdrawal %s=%v", surface, servers)
+					}
+				}
+				if _, err := os.Stat(filepath.Join(installed.Plan.ActivePath, "skills", "docs", "SKILL.md")); err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+			if op == "update-preview" {
+				if err != nil || !result.RequiresConfirmation {
+					t.Fatalf("preview=%+v err=%v", result, err)
+				}
+			} else if err == nil {
+				t.Fatalf("%s silently accepted historical SSE: %+v", op, result)
+			}
+			if (op == "add" || op == "repair") && !strings.Contains(err.Error(), "explicit update") {
+				t.Fatalf("unexpected refusal: %v", err)
+			}
+			afterState, loadErr := store.Load()
+			if loadErr != nil {
+				t.Fatal(loadErr)
+			}
+			if result.Mutated || !reflect.DeepEqual(beforeState, afterState) || !reflect.DeepEqual(before, codexTransportFiles(t, installed.Plan.ActivePath)) {
+				t.Fatalf("%s changed installation", op)
+			}
+		})
+	}
+}
+
+func TestCodexSSEOnlyAddDoesNotWriteInstallation(t *testing.T) {
+	service, store, _ := serviceFixture(t)
+	client := domain.DetectedClient{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), "codex")}
+	input := codexSSEInput(t, client, false)
+	before, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := service.Add(context.Background(), input)
+	if err == nil || result.Mutated {
+		t.Fatalf("SSE-only add=%+v err=%v", result, err)
+	}
+	after, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(before, after) {
+		t.Fatal("unsupported add wrote state")
+	}
+	if _, err := os.Stat(client.ConfigRoot); !os.IsNotExist(err) {
+		t.Fatalf("unsupported add wrote client root: %v", err)
+	}
+}
+
+func TestCodexTransportTransientUpdateRetainsInstalledBytes(t *testing.T) {
+	service, store, _ := serviceFixture(t)
+	client := domain.DetectedClient{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), "codex")}
+	input := codexSSEInput(t, client, true)
+	installed, err := service.Add(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeState, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := codexTransportFiles(t, installed.Plan.ActivePath)
+	input.Envelope.MCP.Servers["http"] = domain.MCPServer{Name: "http", Type: "stdio", Decoded: map[string]any{"type": "stdio", "command": "agentplugins-definitely-unavailable-runtime"}}
+	input.InstallationID = installed.InstallationID
+	input.OperationID = "codex-transient-update"
+	result, err := service.Update(context.Background(), input)
+	if err == nil || result.Mutated || len(result.Plan.Diagnostics) == 0 {
+		t.Fatalf("transient update=%+v err=%v", result, err)
+	}
+	afterState, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(beforeState, afterState) || !reflect.DeepEqual(before, codexTransportFiles(t, installed.Plan.ActivePath)) {
+		t.Fatal("transient failure removed installed component")
+	}
+}
+
+func codexTransportFiles(t *testing.T, root string) map[string]string {
+	t.Helper()
+	files := map[string]string{}
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		files[relative] = string(body)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return files
+}

--- a/install/integrationctl/agentplugins/usecase/component_readiness.go
+++ b/install/integrationctl/agentplugins/usecase/component_readiness.go
@@ -30,7 +30,7 @@ func (service Service) preflightComponents(envelope domain.PackageEnvelope, plan
 			continue
 		}
 		var failure *domain.ComponentReadinessError
-		if plan.ClientID == domain.ClientWindsurf {
+		if plan.ClientID == domain.ClientWindsurf || plan.ClientID == domain.ClientClaude {
 			if !helperChecked {
 				if checker, ok := service.Stager.(managedStdioPreflighter); ok {
 					helperErr = checker.PreflightManagedStdio(envelope.SnapshotRoot)

--- a/install/integrationctl/agentplugins/usecase/component_readiness_test.go
+++ b/install/integrationctl/agentplugins/usecase/component_readiness_test.go
@@ -154,119 +154,133 @@ func TestReadinessUsesAuthoredAbsolutePATH(t *testing.T) {
 }
 
 func TestHelperUpgradeCannotMasqueradeAsExactRepair(t *testing.T) {
-	if !managedstdio.Supported() {
-		t.Skip("native launcher unsupported")
-	}
-	service, store, _ := serviceFixture(t)
-	source := func(body string) *managedstdio.Source {
-		path := filepath.Join(t.TempDir(), "helper")
-		if err := os.WriteFile(path, []byte(body), 0755); err != nil {
-			t.Fatal(err)
-		}
-		s, err := managedstdio.NewSource(path, body)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return s
-	}
-	service.Stager = providers.Stager{LauncherSource: source("helper A fixture; never executed")}
-	client := domain.DetectedClient{ClientID: domain.ClientWindsurf, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), "windsurf")}
-	input := clinePackageInput(t, client, "1.0.0", "sha256:helper", "sha256:helper-manifest", "sh")
-	input.Confirmed = true
-	installed, err := service.Add(context.Background(), input)
-	if err != nil {
-		t.Fatal(err)
-	}
-	input.InstallationID = installed.InstallationID
-	// A damaged artifact demands rematerialization; rebuilding with B must never
-	// replace the receipt for A under the same exact-repair request.
-	marker := filepath.Join(installed.Plan.ActivePath, "damage.txt")
-	if err := os.WriteFile(marker, []byte("prior damage"), 0600); err != nil {
-		t.Fatal(err)
-	}
-	stateBefore, _ := store.Load()
-	before, _ := json.Marshal(stateBefore)
-	service.Stager = providers.Stager{LauncherSource: source("helper B fixture; never executed")}
-	result, err := service.Repair(context.Background(), input)
-	if err == nil || !strings.Contains(err.Error(), "projection digest differs") || result.Mutated {
-		t.Fatalf("repair=%+v err=%v", result, err)
-	}
-	stateAfter, _ := store.Load()
-	after, _ := json.Marshal(stateAfter)
-	if string(before) != string(after) {
-		t.Fatal("exact repair changed state")
-	}
-	if body, err := os.ReadFile(marker); err != nil || string(body) != "prior damage" {
-		t.Fatal("prior artifact changed")
-	}
-	// A controlled update can replace A with B; subsequent exact repair must use B.
-	if err := os.Remove(marker); err != nil {
-		t.Fatal(err)
-	}
-	oldBinding := onlyBinding(stateBefore.Installations[0])
-	oldData := stateBefore.Installations[0].DataReceipts[oldBinding.DataReceiptID]
-	dataMarker := filepath.Join(oldData.Locator, "continuity")
-	if err := os.WriteFile(dataMarker, []byte("persistent"), 0600); err != nil {
-		t.Fatal(err)
-	}
-	setEnvelopeVersion(t, &input.Envelope, "2.0.0", "sha256:helper-b", "sha256:helper-b-manifest")
-	input.OperationID = "helper-b-update"
-	updated, err := service.Update(context.Background(), input)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !updated.Mutated {
-		t.Fatal("B update did not commit")
-	}
-	stateB, _ := store.Load()
-	bindingB := onlyBinding(stateB.Installations[0])
-	if managedDigest(bindingB) == managedDigest(onlyBinding(stateBefore.Installations[0])) {
-		t.Fatal("helper bytes did not change managed digest")
-	}
-	if stateB.Installations[0].DataReceipts[bindingB.DataReceiptID].Locator != oldData.Locator {
-		t.Fatal("update changed data ownership")
-	}
-	if body, err := os.ReadFile(dataMarker); err != nil || string(body) != "persistent" {
-		t.Fatal("update lost persistent data")
-	}
-	if err := os.WriteFile(marker, []byte("new damage"), 0600); err != nil {
-		t.Fatal(err)
-	}
-	input.OperationID = "helper-b-repair"
-	repaired, err := service.Repair(context.Background(), input)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !repaired.Mutated {
-		t.Fatal("B exact repair did not commit")
-	}
-	stateRepaired, _ := store.Load()
-	if managedDigest(onlyBinding(stateRepaired.Installations[0])) != managedDigest(bindingB) {
-		t.Fatal("exact B repair changed receipt digest")
-	}
-	if body, err := os.ReadFile(dataMarker); err != nil || string(body) != "persistent" {
-		t.Fatal("persistent data lost")
-	}
+	for _, clientID := range []domain.ClientID{domain.ClientWindsurf, domain.ClientClaude} {
+		t.Run(string(clientID), func(t *testing.T) {
+			if !managedstdio.Supported() {
+				t.Skip("native launcher unsupported")
+			}
+			service, store, _ := serviceFixture(t)
+			source := func(body string) *managedstdio.Source {
+				path := filepath.Join(t.TempDir(), "helper")
+				if err := os.WriteFile(path, []byte(body), 0755); err != nil {
+					t.Fatal(err)
+				}
+				s, err := managedstdio.NewSource(path, body)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return s
+			}
+			service.Stager = providers.Stager{LauncherSource: source("helper A fixture; never executed")}
+			client := domain.DetectedClient{ClientID: clientID, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), "windsurf")}
+			if clientID == domain.ClientClaude {
+				client.ExecutablePath = "/test/bin/claude"
+				runner := &fakeClaudeLifecycleRunner{configRoot: client.ConfigRoot}
+				service.Activator = providers.Activator{Runner: runner}
+				service.NativeObserver = providers.NativeIdentityObserver{Runner: runner, Stager: service.Stager}
+			}
+			input := clinePackageInput(t, client, "1.0.0", "sha256:helper", "sha256:helper-manifest", "sh")
+			input.Confirmed = true
+			input.BackendExecutable = client.ExecutablePath
+			installed, err := service.Add(context.Background(), input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			input.InstallationID = installed.InstallationID
+			// A damaged artifact demands rematerialization; rebuilding with B must never
+			// replace the receipt for A under the same exact-repair request.
+			marker := filepath.Join(installed.Plan.ActivePath, "damage.txt")
+			if err := os.WriteFile(marker, []byte("prior damage"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			stateBefore, _ := store.Load()
+			before, _ := json.Marshal(stateBefore)
+			service.Stager = providers.Stager{LauncherSource: source("helper B fixture; never executed")}
+			result, err := service.Repair(context.Background(), input)
+			if err == nil || !strings.Contains(err.Error(), "projection digest differs") || result.Mutated {
+				t.Fatalf("repair=%+v err=%v", result, err)
+			}
+			stateAfter, _ := store.Load()
+			after, _ := json.Marshal(stateAfter)
+			if string(before) != string(after) {
+				t.Fatal("exact repair changed state")
+			}
+			if body, err := os.ReadFile(marker); err != nil || string(body) != "prior damage" {
+				t.Fatal("prior artifact changed")
+			}
+			// A controlled update can replace A with B; subsequent exact repair must use B.
+			if err := os.Remove(marker); err != nil {
+				t.Fatal(err)
+			}
+			oldBinding := onlyBinding(stateBefore.Installations[0])
+			oldData := stateBefore.Installations[0].DataReceipts[oldBinding.DataReceiptID]
+			dataMarker := filepath.Join(oldData.Locator, "continuity")
+			if err := os.WriteFile(dataMarker, []byte("persistent"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			setEnvelopeVersion(t, &input.Envelope, "2.0.0", "sha256:helper-b", "sha256:helper-b-manifest")
+			input.OperationID = "helper-b-update"
+			updated, err := service.Update(context.Background(), input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !updated.Mutated {
+				t.Fatal("B update did not commit")
+			}
+			stateB, _ := store.Load()
+			bindingB := onlyBinding(stateB.Installations[0])
+			if managedDigest(bindingB) == managedDigest(onlyBinding(stateBefore.Installations[0])) {
+				t.Fatal("helper bytes did not change managed digest")
+			}
+			if stateB.Installations[0].DataReceipts[bindingB.DataReceiptID].Locator != oldData.Locator {
+				t.Fatal("update changed data ownership")
+			}
+			if body, err := os.ReadFile(dataMarker); err != nil || string(body) != "persistent" {
+				t.Fatal("update lost persistent data")
+			}
+			if err := os.WriteFile(marker, []byte("new damage"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			input.OperationID = "helper-b-repair"
+			repaired, err := service.Repair(context.Background(), input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !repaired.Mutated {
+				t.Fatal("B exact repair did not commit")
+			}
+			stateRepaired, _ := store.Load()
+			if managedDigest(onlyBinding(stateRepaired.Installations[0])) != managedDigest(bindingB) {
+				t.Fatal("exact B repair changed receipt digest")
+			}
+			if body, err := os.ReadFile(dataMarker); err != nil || string(body) != "persistent" {
+				t.Fatal("persistent data lost")
+			}
 
-	nativePath := filepath.Join(client.ConfigRoot, "mcp_config.json")
-	if err := os.Remove(nativePath); err != nil {
-		t.Fatal(err)
-	}
-	input.OperationID = "helper-b-native-repair"
-	nativeRepaired, err := service.Repair(context.Background(), input)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !nativeRepaired.Mutated {
-		t.Fatal("B absent native config repair did not commit")
-	}
-	if _, err := os.Stat(nativePath); err != nil {
-		t.Fatal("native config not restored")
-	}
-	if body, err := os.ReadFile(dataMarker); err != nil || string(body) != "persistent" {
-		t.Fatal("native repair lost persistent data")
-	}
+			if clientID == domain.ClientClaude {
+				return
+			}
+			nativePath := filepath.Join(client.ConfigRoot, "mcp_config.json")
+			if err := os.Remove(nativePath); err != nil {
+				t.Fatal(err)
+			}
+			input.OperationID = "helper-b-native-repair"
+			nativeRepaired, err := service.Repair(context.Background(), input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !nativeRepaired.Mutated {
+				t.Fatal("B absent native config repair did not commit")
+			}
+			if _, err := os.Stat(nativePath); err != nil {
+				t.Fatal("native config not restored")
+			}
+			if body, err := os.ReadFile(dataMarker); err != nil || string(body) != "persistent" {
+				t.Fatal("native repair lost persistent data")
+			}
 
+		})
+	}
 }
 
 func TestStaticUnsupportedUpdateUsesConfirmedRemoval(t *testing.T) {
@@ -376,21 +390,33 @@ func TestClineHistoricalProjectionDigestCannotBeSilentlyRepaired(t *testing.T) {
 	}
 }
 
-func TestMissingHelperOnlyExcludesWindsurfStdio(t *testing.T) {
-	service, _, _ := serviceFixture(t)
-	client := domain.DetectedClient{ClientID: domain.ClientWindsurf, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), "windsurf")}
-	input := clinePackageInput(t, client, "1.0.0", "sha256:missing-helper", "sha256:helper-manifest", "sh")
-	input.Confirmed = true
-	input.Envelope.MCP.Servers["remote"] = domain.MCPServer{Type: "streamable-http", Decoded: map[string]any{"type": "streamable-http", "url": "https://example.invalid/mcp"}, Raw: json.RawMessage(`{"type":"streamable-http","url":"https://example.invalid/mcp"}`)}
-	installed, err := service.Add(context.Background(), input)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := domain.SelectedMCPNames(installed.Plan); !reflect.DeepEqual(got, []string{"remote"}) {
-		t.Fatal(got)
-	}
-	if packageNeedsPluginData(input.Envelope, installed.Plan) {
-		t.Fatal("unselected stdio demanded data")
+func TestMissingHelperOnlyExcludesManagedStdio(t *testing.T) {
+	for _, clientID := range []domain.ClientID{domain.ClientWindsurf, domain.ClientClaude} {
+		t.Run(string(clientID), func(t *testing.T) {
+			service, _, _ := serviceFixture(t)
+			client := domain.DetectedClient{ClientID: clientID, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), "windsurf")}
+			if clientID == domain.ClientClaude {
+				client.ExecutablePath = "/test/bin/claude"
+				runner := &fakeClaudeLifecycleRunner{configRoot: client.ConfigRoot}
+				service.Activator = providers.Activator{Runner: runner}
+				service.NativeObserver = providers.NativeIdentityObserver{Runner: runner, Stager: service.Stager}
+			}
+			input := clinePackageInput(t, client, "1.0.0", "sha256:missing-helper", "sha256:helper-manifest", "sh")
+			input.Confirmed = true
+			input.BackendExecutable = client.ExecutablePath
+			input.Envelope.MCP.Servers["remote"] = domain.MCPServer{Type: "streamable-http", Decoded: map[string]any{"type": "streamable-http", "url": "https://example.invalid/mcp"}, Raw: json.RawMessage(`{"type":"streamable-http","url":"https://example.invalid/mcp"}`)}
+			installed, err := service.Add(context.Background(), input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := domain.SelectedMCPNames(installed.Plan); !reflect.DeepEqual(got, []string{"remote"}) {
+				t.Fatal(got)
+			}
+			if packageNeedsPluginData(input.Envelope, installed.Plan) {
+				t.Fatal("unselected stdio demanded data")
+			}
+
+		})
 	}
 }
 
@@ -439,5 +465,20 @@ func TestUnexpectedReadinessIOIsNotAComponentSkip(t *testing.T) {
 		if unexpectedPathIO(err) {
 			t.Fatalf("expected readiness became fatal: %v", err)
 		}
+	}
+}
+
+func TestClaudeMissingHelperRetainsPreviouslySelectedStdio(t *testing.T) {
+	service, _, _ := serviceFixture(t)
+	envelope := domain.PackageEnvelope{SnapshotRoot: t.TempDir(), MCP: domain.MCPComponent{Servers: map[string]domain.MCPServer{
+		"local":  {Type: "stdio", Decoded: map[string]any{"command": "sh"}},
+		"remote": {Type: "streamable-http"},
+	}}}
+	plan := domain.DeliveryPlan{ClientID: domain.ClientClaude, Components: []domain.ComponentDecision{
+		{Kind: domain.ComponentMCPServer, Name: "local", Support: domain.SupportProjected},
+		{Kind: domain.ComponentMCPServer, Name: "remote", Support: domain.SupportProjected},
+	}}
+	if err := service.preflightComponents(envelope, &plan, true, map[string]bool{"local": true, "remote": true}); err == nil || !strings.Contains(err.Error(), "retaining the entire installed package") {
+		t.Fatalf("previous selection silently withdrawn: %v", err)
 	}
 }

--- a/install/integrationctl/agentplugins/usecase/group.go
+++ b/install/integrationctl/agentplugins/usecase/group.go
@@ -118,6 +118,11 @@ type plannedGroupTarget struct {
 	dataReceipt     domain.DataReceipt
 	dataCreated     bool
 	noChange        bool
+	// recovering marks a confirmed repair target whose managed native object is
+	// positively absent from the filesystem, proven without ever running native
+	// client discovery. Its full native identity is deferred until the group's
+	// directories are restored and is verified once, together, before commit.
+	recovering bool
 }
 
 func (service Service) applyGroup(ctx context.Context, input GroupInput, replace bool) (GroupResult, error) {
@@ -312,6 +317,7 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 			return result, fmt.Errorf("update target %s is not installed", target.Client.ClientID)
 		}
 		result.Targets[targetIndex].Plan = plan
+		recovering := false
 		if input.DryRun {
 			if err := service.observeGroupPreparedIdentity(ctx, target.Client, plan, managed, input.Repair); err != nil {
 				return result, err
@@ -321,6 +327,8 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 					return result, err
 				}
 			}
+		} else if input.Repair && managed != nil && service.observeGroupRecoveryEligibility(ctx, target.Client, plan, managed) {
+			recovering = true
 		} else if err := service.observeGroupNativeIdentity(ctx, target.Client, plan, managed, input.Repair); err != nil {
 			return result, err
 		}
@@ -330,7 +338,7 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 			result.Targets[targetIndex].Activation = domain.ActivationOutcome{Activation: managed.Activation, Authentication: managed.Authentication, Policy: managed.Policy, Verification: managed.Verification}
 		}
 		physical[key] = len(planned)
-		planned = append(planned, plannedGroupTarget{input: target, plan: plan, resultIndexes: []int{targetIndex}, clientBindingID: clientID, managed: managed, noChange: noChange})
+		planned = append(planned, plannedGroupTarget{input: target, plan: plan, resultIndexes: []int{targetIndex}, clientBindingID: clientID, managed: managed, noChange: noChange, recovering: recovering})
 	}
 	if replace && existing && !input.Repair {
 		compatibleBindings := map[string]bool{}
@@ -421,6 +429,23 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 	}
 	defer cleanup()
 	for _, target := range planned {
+		if target.recovering {
+			// The recovering target's directory is still absent at this point; its
+			// native registry is expected to keep failing until the group's
+			// directories are actually restored. Re-confirm, from the filesystem
+			// alone, that nothing has since occupied the target: a genuine native
+			// verification happens once, after restoration, in PostApplyVerify.
+			if !service.observeGroupRecoveryEligibility(ctx, target.input.Client, target.plan, target.managed) {
+				return result, fmt.Errorf("native identity changed before group commit: recorded absent target %s is no longer eligible for recovery", target.input.Client.ClientID)
+			}
+			// The staged reconstruction must reproduce the exact prior receipt
+			// digest, not merely a new, self-consistent build: repair only ever
+			// authorizes restoring what was already recorded as owned.
+			if expected := managedDigest(*target.managed); expected == "" || target.delivery.ArtifactDigest != expected {
+				return result, fmt.Errorf("staged reconstruction for %s does not match the recorded package digest", target.input.Client.ClientID)
+			}
+			continue
+		}
 		if err := service.observeGroupNativeIdentity(ctx, target.input.Client, target.plan, target.managed, input.Repair); err != nil {
 			return result, fmt.Errorf("native identity changed before group commit: %w", err)
 		}
@@ -507,7 +532,10 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 		}
 		client := desired.Installations[installationIndex].Clients[target.clientBindingID]
 		before := ""
-		if target.managed != nil {
+		if target.managed != nil && !target.recovering {
+			// A recovering target's active path is positively absent right now; its
+			// recorded receipt digest describes what was there before it disappeared,
+			// not the current (absent) state this mutation actually observed.
 			before = managedDigest(*target.managed)
 		}
 		operationID := fmt.Sprintf("%s-%03d", groupID, targetIndex+1)
@@ -519,16 +547,17 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 		mutations = append(mutations, transaction.DirectoryMutation{OperationID: operationID, InstallationID: installationID, ClientBindingID: target.clientBindingID,
 			Sequence: nextSequence(client), OwnedBase: delivery.OwnedBase, ActivePath: delivery.ActivePath, StagingPath: delivery.StagingPath,
 			BeforeDigest: before, AfterDigest: delivery.ArtifactDigest, NativeObjects: delivery.NativeObjects, Activation: target.plan.Activation,
-			Authentication: authentication, Policy: domain.PolicyAllowed, Verification: target.plan.Verification,
+			Authentication: authentication, Policy: domain.PolicyAllowed, Verification: target.plan.Verification, RequireAbsent: target.recovering,
 			Verify: func(verifyContext context.Context, activePath string) error {
 				return service.Stager.Verify(verifyContext, activePath, delivery.ArtifactDigest)
 			}})
 	}
 	kernel := service.Kernel
 	kernel.StateStore = service.StateStore
+	postApplyVerify := service.groupRecoveryPostApplyVerify(planned)
 	var receipts []domain.MutationReceipt
 	if len(mutations) > 0 {
-		receipts, err = kernel.ApplyDirectoryGroup(ctx, transaction.DirectoryGroup{OperationGroupID: groupID, Mutations: mutations, DesiredState: desired})
+		receipts, err = kernel.ApplyDirectoryGroup(ctx, transaction.DirectoryGroup{OperationGroupID: groupID, Mutations: mutations, DesiredState: desired, PostApplyVerify: postApplyVerify})
 		if err != nil {
 			result.Receipts = receipts
 			assignGroupReceipts(result.Targets, planned, receipts)
@@ -785,4 +814,132 @@ func validateGroupNativeIdentityObservation(observation domain.NativeIdentityObs
 	default:
 		return fmt.Errorf("native identity observer returned an unknown state")
 	}
+}
+
+// observeGroupRecoveryEligibility determines whether a confirmed repair target
+// qualifies for the absent-managed-object recovery path: an intact prior
+// managed ownership receipt with a nonempty digest, a native observer capable
+// of the later post-restoration verification, and the active path positively
+// confirmed absent through filesystem-only observation. It deliberately never
+// runs native client discovery, so a failed native registry command can never
+// be mistaken for proof of absence. At its first call site (the per-target
+// preflight loop) a false result simply falls through to the ordinary,
+// CLI-inclusive identity check; at its second call site (the pre-commit
+// recheck of an already-committed recovering target) a false result is a hard
+// refusal instead, since the target's own recovery path was already chosen.
+//
+// This is deliberately restricted to Codex: it is the only client with
+// evidence (run05) that its native registry command fails outright while the
+// target it would report on is absent. Other clients' registry commands have
+// not been shown to share that failure mode, so they keep going through the
+// ordinary, immediate CLI-inclusive check.
+func (service Service) observeGroupRecoveryEligibility(ctx context.Context, client domain.DetectedClient, plan domain.DeliveryPlan, managed *domain.ClientBinding) bool {
+	if client.ClientID != domain.ClientCodex || managed == nil || managedDigest(*managed) == "" || service.NativeObserver == nil {
+		return false
+	}
+	observation, err := service.preparedIdentityObservation(ctx, client, plan, managed)
+	if err != nil {
+		return false
+	}
+	return observation.State == domain.NativeIdentityAbsent
+}
+
+// groupRecoveryPostApplyVerify builds the transaction.DirectoryGroup's
+// PostApplyVerify hook for a group containing at least one recovering target,
+// or returns nil when the group has none. It runs full, native-registry-
+// inclusive identity discovery exactly once per recovering target, only after
+// every directory in the group has already been restored, and requires the
+// client to now confirm exact managed ownership reconciled against the same
+// recorded digest. A returned error rolls the whole group back before any
+// state commit or external activation.
+//
+// Known residual limitations, not fixed by this contract:
+//
+//   - Rollback after this hook fails is the ordinary, unguarded
+//     transaction.Kernel rollback: if something else concurrently modifies a
+//     directory this group just restored, in the narrow window between the
+//     journal write and dirswap's rename, or between this hook's own failure
+//     and the rollback that follows it, that content is not specially
+//     preserved (same risk profile as every other lifecycle operation using
+//     transaction.Kernel; RequireAbsent only closes the earlier, larger
+//     window between the last absence recheck and the rename). A
+//     digest-guarded "recovery_required" outcome that actually survives
+//     transaction.Kernel.Recover was prototyped and deliberately reverted: it
+//     required a new journal phase Recover would refuse to auto-resolve plus
+//     an explicit operator-facing command, which is out of this bounded
+//     contract's scope (see the delivery plan's own note that full parity is
+//     a separate research item).
+//   - Codex's own registry command is global across every installation's
+//     marketplace entries in its config.toml, not scoped to one installation:
+//     one installation has at most one Codex client binding, so a single
+//     RepairGroup call can never itself carry two recovering targets, but a
+//     wiped managed root can still leave two separate installations each with
+//     their own absent Codex-owned directory. Repairing installation A
+//     restores its directory, but this hook's `codex plugin list --json` call
+//     still fails because installation B's marketplace entry is missing, so
+//     the repair of A rolls back too; repairing B is symmetric. Neither gets
+//     fixed until an operator restores or de-registers the other missing
+//     source. This is reachable, not unreached -- but it fails closed (a
+//     rollback, never silent adoption) and is no worse than before this fix
+//     (a preflight refusal instead of a rollback), so it is left as a
+//     documented limitation rather than solved here.
+func (service Service) groupRecoveryPostApplyVerify(planned []plannedGroupTarget) func(context.Context) error {
+	recovering := make([]plannedGroupTarget, 0, len(planned))
+	for _, target := range planned {
+		if target.recovering {
+			recovering = append(recovering, target)
+		}
+	}
+	if len(recovering) == 0 {
+		return nil
+	}
+	return func(ctx context.Context) error {
+		for _, target := range recovering {
+			// Eligibility already required a non-nil NativeObserver; recovering
+			// can only be true when that held at preflight time.
+			observation, err := service.NativeObserver.ObserveNativeIdentity(ctx, target.input.Client, target.plan, target.managed)
+			if err != nil {
+				return fmt.Errorf("verify restored native identity for %s: %w", target.input.Client.ClientID, err)
+			}
+			if err := validateGroupRecoveryVerification(observation, target.managed); err != nil {
+				return fmt.Errorf("restored native identity for %s: %w", target.input.Client.ClientID, err)
+			}
+		}
+		return nil
+	}
+}
+
+// validateGroupRecoveryVerification requires the same managed-identity proof
+// the ordinary repair gate (validateGroupNativeIdentityObservation) already
+// accepts as sufficient: a Managed finding whose digest matches the recorded
+// receipt. Unlike the ordinary gate, an absent finding is no longer
+// acceptable here -- the entire purpose of this check is confirming the
+// reconstructed directory's digest, not merely its absence.
+//
+// Known residual gap, shared with every other Managed check in this
+// codebase (not unique to recovery): a Managed finding with a matching digest
+// can, for a real provider, be reached through the filesystem/digest fallback
+// in observeIdentity even when the native registry itself reported the
+// package as not found (registryClear) rather than confirming it -- see
+// NativeIdentityObservation.NativeDiscoveryReconciled. Requiring that field
+// here was tried and reverted: it is not part of the documented
+// NativeIdentityObserver contract, so any other implementation of that
+// interface (including this package's own test fakes and this repo's shared
+// CLI test fixture) can validly omit it, and requiring it broke unrelated
+// tests without a corresponding real-world exploit demonstrated. This check
+// therefore proves exact digest reconstruction, not that the native registry
+// itself already reports the package as installed; it does not by itself
+// prove the package is activated or otherwise in active use.
+func validateGroupRecoveryVerification(observation domain.NativeIdentityObservation, managed *domain.ClientBinding) error {
+	if managed == nil {
+		return fmt.Errorf("recovery verification requires a recorded managed binding")
+	}
+	if observation.State != domain.NativeIdentityManaged {
+		return fmt.Errorf("state is %q, want managed", observation.State)
+	}
+	expected := managedDigest(*managed)
+	if expected == "" || observation.Digest == "" || expected != observation.Digest {
+		return fmt.Errorf("restored digest does not match the recorded receipt")
+	}
+	return nil
 }

--- a/install/integrationctl/agentplugins/usecase/group.go
+++ b/install/integrationctl/agentplugins/usecase/group.go
@@ -855,20 +855,11 @@ func (service Service) observeGroupRecoveryEligibility(ctx context.Context, clie
 //
 // Known residual limitations, not fixed by this contract:
 //
-//   - Rollback after this hook fails is the ordinary, unguarded
-//     transaction.Kernel rollback: if something else concurrently modifies a
-//     directory this group just restored, in the narrow window between the
-//     journal write and dirswap's rename, or between this hook's own failure
-//     and the rollback that follows it, that content is not specially
-//     preserved (same risk profile as every other lifecycle operation using
-//     transaction.Kernel; RequireAbsent only closes the earlier, larger
-//     window between the last absence recheck and the rename). A
-//     digest-guarded "recovery_required" outcome that actually survives
-//     transaction.Kernel.Recover was prototyped and deliberately reverted: it
-//     required a new journal phase Recover would refuse to auto-resolve plus
-//     an explicit operator-facing command, which is out of this bounded
-//     contract's scope (see the delivery plan's own note that full parity is
-//     a separate research item).
+//   - Absent swaps use exclusive publication and persisted root identity/tree
+//     fingerprints for rollback and recovery. Changed or replaced provisional
+//     objects retain their journal and fail closed. A noncooperating writer
+//     changing the quarantine after its final fingerprint check and before
+//     removal remains an unresolved filesystem concurrency limitation.
 //   - Codex's own registry command is global across every installation's
 //     marketplace entries in its config.toml, not scoped to one installation:
 //     one installation has at most one Codex client binding, so a single

--- a/install/integrationctl/agentplugins/usecase/group_test.go
+++ b/install/integrationctl/agentplugins/usecase/group_test.go
@@ -441,9 +441,9 @@ func TestGroupedRepairRecoversAbsentManagedDirectoryWithoutTreatingFailedNativeD
 // closes the race an independent review identified: the absence recheck just
 // before the kernel commit ("compare absent targets again before publishing")
 // can itself go stale before dirswap actually renames the staged directory
-// into place. RequireAbsent (dirswap.Input/DirectoryMutation) forces a fresh
-// Lstat immediately before that rename and fails closed, without touching
-// anything, if the path is no longer absent.
+// into place. RequireAbsent rejects an occupied target before journaling;
+// exclusive publication prevents a destination appearing after that check
+// from being overwritten.
 func TestGroupedRepairPreservesForeignContentThatAppearsAfterTheLastAbsenceRecheck(t *testing.T) {
 	t.Parallel()
 	service, store, _ := serviceFixture(t)

--- a/install/integrationctl/agentplugins/usecase/group_test.go
+++ b/install/integrationctl/agentplugins/usecase/group_test.go
@@ -297,6 +297,402 @@ func TestGroupedRepairAllowsRecordedObjectToBeAbsentButNeverAdoptsForeignIdentit
 	}
 }
 
+// acceptingVerifier treats any active path as matching any expected digest.
+// It stands in for a real content check in tests that only exercise the
+// native-identity control flow, not staged-byte verification.
+type acceptingVerifier struct{}
+
+func (acceptingVerifier) Verify(context.Context, string, string) error { return nil }
+
+// recoveryProbeNativeObserver simulates Codex's own failure mode from run05:
+// the CLI-inclusive registry command fails outright whenever the managed
+// directory it would report on is absent, regardless of cause. Filesystem-only
+// prepared observation never touches that failing command, matching the real
+// provider split between ObservePreparedIdentity and ObserveNativeIdentity.
+type recoveryProbeNativeObserver struct {
+	stager interface {
+		Verify(context.Context, string, string) error
+	}
+	preparedCalls int
+	nativeCalls   int
+	// postRestorationState, when set, overrides what ObserveNativeIdentity
+	// reports once the target file exists, so a test can simulate the native
+	// registry finding something other than confirmed ownership after
+	// restoration (for example, a foreign namespace collision).
+	postRestorationState domain.NativeIdentityState
+	// injectAfterPreparedCall, when nonzero, runs injectFunc immediately after
+	// the given 1-based ObservePreparedIdentity call number returns its
+	// (truthful, at-that-instant) answer -- simulating a concurrent write that
+	// lands after the last absence check but before the kernel actually swaps.
+	injectAfterPreparedCall int
+	injectFunc              func()
+	// watchPaths, when set, simulates Codex's own registry command being
+	// global across every installation's marketplace entries: ObserveNativeIdentity
+	// fails whenever ANY of these paths is absent, not only plan.ActivePath.
+	watchPaths []string
+}
+
+func (observer *recoveryProbeNativeObserver) ObservePreparedIdentity(_ context.Context, _ domain.DetectedClient, plan domain.DeliveryPlan, managed *domain.ClientBinding) (domain.NativeIdentityObservation, error) {
+	observer.preparedCalls++
+	if observer.injectAfterPreparedCall != 0 && observer.preparedCalls == observer.injectAfterPreparedCall {
+		defer observer.injectFunc()
+	}
+	if _, err := os.Lstat(plan.ActivePath); os.IsNotExist(err) {
+		return domain.NativeIdentityObservation{State: domain.NativeIdentityAbsent}, nil
+	} else if err != nil {
+		return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate}, err
+	}
+	if managed == nil {
+		return domain.NativeIdentityObservation{State: domain.NativeIdentityUnmanaged}, nil
+	}
+	return domain.NativeIdentityObservation{State: domain.NativeIdentityManaged, Digest: managedDigest(*managed)}, nil
+}
+
+func (observer *recoveryProbeNativeObserver) ObserveNativeIdentity(ctx context.Context, _ domain.DetectedClient, plan domain.DeliveryPlan, managed *domain.ClientBinding) (domain.NativeIdentityObservation, error) {
+	observer.nativeCalls++
+	watched := observer.watchPaths
+	if len(watched) == 0 {
+		watched = []string{plan.ActivePath}
+	}
+	for _, path := range watched {
+		if _, err := os.Lstat(path); os.IsNotExist(err) {
+			// The real bug: Codex's `plugin list` fails outright while any of
+			// its configured local marketplace sources is absent. The exit
+			// code must never become proof of absence.
+			return domain.NativeIdentityObservation{}, errors.New("Codex plugin registry command failed with exit code 1")
+		}
+	}
+	if observer.postRestorationState != "" {
+		return domain.NativeIdentityObservation{State: observer.postRestorationState}, nil
+	}
+	if managed == nil {
+		return domain.NativeIdentityObservation{State: domain.NativeIdentityUnmanaged}, nil
+	}
+	expected := managedDigest(*managed)
+	if expected == "" || observer.stager == nil {
+		return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate}, nil
+	}
+	if err := observer.stager.Verify(ctx, plan.ActivePath, expected); err != nil {
+		return domain.NativeIdentityObservation{State: domain.NativeIdentityIndeterminate}, nil
+	}
+	return domain.NativeIdentityObservation{
+		State: domain.NativeIdentityManaged, Digest: expected, ReceiptReconciled: true,
+		NativeDiscoveryAttempted: true, NativeDiscoveryReconciled: true, NativeDiscoveryState: domain.NativeIdentityManaged,
+	}, nil
+}
+
+func TestGroupedRepairRecoversAbsentManagedDirectoryWithoutTreatingFailedNativeDiscoveryAsAbsence(t *testing.T) {
+	t.Parallel()
+	service, store, _ := serviceFixture(t)
+	codex := domain.DetectedClient{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".codex")}
+	install := addInput(t, codex, "https://example.com/absent-repair")
+	added, err := service.AddGroup(context.Background(), GroupInput{Targets: []AddInput{install}, OperationGroupID: "absent-repair-add", Confirmed: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	activePath := added.Targets[0].Plan.ActivePath
+	if _, statErr := os.Stat(activePath); statErr != nil {
+		t.Fatalf("installed target missing: %v", statErr)
+	}
+
+	// Simulate run05: the whole intact managed directory disappears from under
+	// UAP (renamed or removed outside its lifecycle) while state and receipts
+	// still record it as owned with a nonempty digest.
+	if err := os.RemoveAll(activePath); err != nil {
+		t.Fatal(err)
+	}
+
+	observer := &recoveryProbeNativeObserver{stager: service.Stager}
+	service.NativeObserver = observer
+
+	repairInput := install
+	repairInput.InstallationID = added.InstallationID
+
+	if _, err := service.RepairGroup(context.Background(), GroupInput{Targets: []AddInput{repairInput}, OperationGroupID: "absent-repair-dry-run", DryRun: true, Repair: true}); err != nil {
+		t.Fatalf("dry-run repair of an absent recorded object was refused: %v", err)
+	}
+	if observer.nativeCalls != 0 {
+		t.Fatalf("dry-run invoked native client discovery %d times, want 0", observer.nativeCalls)
+	}
+
+	repaired, err := service.RepairGroup(context.Background(), GroupInput{Targets: []AddInput{repairInput}, OperationGroupID: "absent-repair-confirmed", Confirmed: true, Repair: true})
+	if err != nil {
+		t.Fatalf("confirmed repair of an absent recorded object failed: %v", err)
+	}
+	if repaired.Phase != GroupPhaseCompleted {
+		t.Fatalf("repair phase = %s, want completed", repaired.Phase)
+	}
+	if observer.nativeCalls == 0 {
+		t.Fatal("post-restoration native identity verification was never invoked")
+	}
+	if _, err := os.Stat(filepath.Join(activePath, "plugin.json")); err != nil {
+		t.Fatalf("repair did not restore the managed directory: %v", err)
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(onlyBinding(state.Installations[0]).Receipts) != 2 {
+		t.Fatalf("repair did not persist a receipt: %+v", onlyBinding(state.Installations[0]))
+	}
+}
+
+// TestGroupedRepairPreservesForeignContentThatAppearsAfterTheLastAbsenceRecheck
+// closes the race an independent review identified: the absence recheck just
+// before the kernel commit ("compare absent targets again before publishing")
+// can itself go stale before dirswap actually renames the staged directory
+// into place. RequireAbsent (dirswap.Input/DirectoryMutation) forces a fresh
+// Lstat immediately before that rename and fails closed, without touching
+// anything, if the path is no longer absent.
+func TestGroupedRepairPreservesForeignContentThatAppearsAfterTheLastAbsenceRecheck(t *testing.T) {
+	t.Parallel()
+	service, store, _ := serviceFixture(t)
+	codex := domain.DetectedClient{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".codex")}
+	install := addInput(t, codex, "https://example.com/absent-repair-race")
+	added, err := service.AddGroup(context.Background(), GroupInput{Targets: []AddInput{install}, OperationGroupID: "race-add", Confirmed: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	activePath := added.Targets[0].Plan.ActivePath
+	if err := os.RemoveAll(activePath); err != nil {
+		t.Fatal(err)
+	}
+
+	observer := &recoveryProbeNativeObserver{
+		stager: service.Stager,
+		// Call 1 is the initial eligibility check (still absent); call 2 is the
+		// pre-commit recheck. Inject the foreign write right after call 2
+		// truthfully reports absence, simulating it landing in the remaining
+		// gap before dirswap's own rename.
+		injectAfterPreparedCall: 2,
+		injectFunc: func() {
+			if err := os.MkdirAll(activePath, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(activePath, "FOREIGN"), []byte("not ours"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		},
+	}
+	service.NativeObserver = observer
+
+	repairInput := install
+	repairInput.InstallationID = added.InstallationID
+	result, err := service.RepairGroup(context.Background(), GroupInput{Targets: []AddInput{repairInput}, OperationGroupID: "race-confirmed", Confirmed: true, Repair: true})
+	if err == nil {
+		t.Fatal("concurrent foreign content at the recovery target was silently adopted or discarded")
+	}
+	if result.Mutated {
+		t.Fatalf("failed race-guarded repair still mutated: %+v", result)
+	}
+	body, readErr := os.ReadFile(filepath.Join(activePath, "FOREIGN"))
+	if readErr != nil || string(body) != "not ours" {
+		t.Fatalf("foreign content was not preserved: body=%q err=%v", body, readErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(activePath, "plugin.json")); statErr == nil {
+		t.Fatal("recovery content was written over the foreign directory")
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(onlyBinding(state.Installations[0]).Receipts) != 1 {
+		t.Fatalf("race-guarded failure changed the persisted receipt count: %+v", onlyBinding(state.Installations[0]))
+	}
+}
+
+func TestGroupedRepairStillRefusesChangedExistingContentWithRecoveryAwareObserver(t *testing.T) {
+	t.Parallel()
+	service, _, _ := serviceFixture(t)
+	codex := domain.DetectedClient{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".codex")}
+	install := addInput(t, codex, "https://example.com/changed-repair")
+	added, err := service.AddGroup(context.Background(), GroupInput{Targets: []AddInput{install}, OperationGroupID: "changed-repair-add", Confirmed: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	activePath := added.Targets[0].Plan.ActivePath
+	if err := os.WriteFile(filepath.Join(activePath, "plugin.json"), []byte("tampered"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	observer := &recoveryProbeNativeObserver{stager: service.Stager}
+	service.NativeObserver = observer
+
+	repairInput := install
+	repairInput.InstallationID = added.InstallationID
+	if _, err := service.RepairGroup(context.Background(), GroupInput{Targets: []AddInput{repairInput}, OperationGroupID: "changed-repair-confirmed", Confirmed: true, Repair: true}); err == nil {
+		t.Fatal("repair silently adopted changed existing content")
+	}
+	if observer.nativeCalls == 0 {
+		t.Fatal("changed existing content bypassed the ordinary native identity check")
+	}
+}
+
+func TestGroupedRepairRollsBackAbsentRecoveryWhenPostRestorationNativeVerificationFails(t *testing.T) {
+	t.Parallel()
+	service, store, _ := serviceFixture(t)
+	codex := domain.DetectedClient{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".codex")}
+	install := addInput(t, codex, "https://example.com/absent-repair-collision")
+	added, err := service.AddGroup(context.Background(), GroupInput{Targets: []AddInput{install}, OperationGroupID: "absent-collision-add", Confirmed: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	activePath := added.Targets[0].Plan.ActivePath
+	if err := os.RemoveAll(activePath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Once the directory is restored, the native registry reports the identity
+	// as unmanaged (for example, a foreign namespace now claims it) instead of
+	// confirming ownership: the whole recovery must roll back, not commit.
+	observer := &recoveryProbeNativeObserver{stager: service.Stager, postRestorationState: domain.NativeIdentityUnmanaged}
+	service.NativeObserver = observer
+
+	repairInput := install
+	repairInput.InstallationID = added.InstallationID
+	result, err := service.RepairGroup(context.Background(), GroupInput{Targets: []AddInput{repairInput}, OperationGroupID: "absent-collision-confirmed", Confirmed: true, Repair: true})
+	if err == nil {
+		t.Fatal("post-restoration native verification failure was ignored")
+	}
+	if result.Phase != GroupPhaseManagedRolledBack {
+		t.Fatalf("repair phase = %s, want rolled back", result.Phase)
+	}
+	if _, statErr := os.Stat(activePath); !os.IsNotExist(statErr) {
+		t.Fatalf("failed recovery left a restored directory behind: %v", statErr)
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(onlyBinding(state.Installations[0]).Receipts) != 1 {
+		t.Fatalf("failed recovery changed the persisted receipt count: %+v", onlyBinding(state.Installations[0]))
+	}
+}
+
+// TestGroupRecoveryPostApplyVerifyChecksEveryRecoveringTargetOnce covers
+// multiple recovering targets in one group at the mechanism level.
+// Recovery is deliberately restricted to Codex (see
+// observeGroupRecoveryEligibility), and one installation has at most one
+// Codex binding, so a real RepairGroup call can never carry two recovering
+// targets in production; groupRecoveryPostApplyVerify's own loop over
+// multiple recovering entries is exercised directly instead.
+// TestGroupedRepairFailsClosedWhenAnotherInstallationsCodexDirectoryIsAlsoAbsent
+// covers the cross-installation limitation documented in
+// groupRecoveryPostApplyVerify: Codex's own registry command is global across
+// every installation's marketplace entries, not scoped to one installation.
+// If a wiped managed root leaves two installations each with their own absent
+// Codex-owned directory, repairing one restores its bytes locally but the
+// registry call still fails because of the other's missing entry, so that
+// repair rolls back too -- fail-closed, never a silent adoption, and no worse
+// than the pre-fix preflight refusal.
+func TestGroupedRepairFailsClosedWhenAnotherInstallationsCodexDirectoryIsAlsoAbsent(t *testing.T) {
+	t.Parallel()
+	service, store, _ := serviceFixture(t)
+	codexA := domain.DetectedClient{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".codex")}
+	codexB := domain.DetectedClient{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".codex")}
+	installA := addInput(t, codexA, "https://example.com/multi-install-a")
+	installB := addInput(t, codexB, "https://example.com/multi-install-b")
+	installB.InstallationID = ""
+	installB.Envelope.Manifest.Name = "demo-b"
+	if err := os.WriteFile(filepath.Join(installB.Envelope.SnapshotRoot, "plugin.json"), []byte(`{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "demo-b",
+  "version": "1.0.0",
+  "description": "Demo plugin"
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	addedA, err := service.AddGroup(context.Background(), GroupInput{Targets: []AddInput{installA}, OperationGroupID: "multi-install-add-a", Confirmed: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	addedB, err := service.AddGroup(context.Background(), GroupInput{Targets: []AddInput{installB}, OperationGroupID: "multi-install-add-b", Confirmed: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pathA, pathB := addedA.Targets[0].Plan.ActivePath, addedB.Targets[0].Plan.ActivePath
+	if err := os.RemoveAll(pathA); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(pathB); err != nil {
+		t.Fatal(err)
+	}
+
+	observer := &recoveryProbeNativeObserver{stager: service.Stager, watchPaths: []string{pathA, pathB}}
+	service.NativeObserver = observer
+
+	repairA := installA
+	repairA.InstallationID = addedA.InstallationID
+	result, err := service.RepairGroup(context.Background(), GroupInput{Targets: []AddInput{repairA}, OperationGroupID: "multi-install-repair-a", Confirmed: true, Repair: true})
+	if err == nil {
+		t.Fatal("repair succeeded despite the sibling installation's Codex directory still being absent")
+	}
+	if result.Phase != GroupPhaseManagedRolledBack {
+		t.Fatalf("phase = %s, want rolled back", result.Phase)
+	}
+	if _, statErr := os.Stat(pathA); !os.IsNotExist(statErr) {
+		t.Fatalf("failed cross-installation repair left A restored instead of rolling back: %v", statErr)
+	}
+	if _, statErr := os.Stat(pathB); !os.IsNotExist(statErr) {
+		t.Fatalf("failed cross-installation repair touched B: %v", statErr)
+	}
+	stateA, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, installation := range stateA.Installations {
+		if installation.InstallationID == addedA.InstallationID && len(onlyBinding(installation).Receipts) != 1 {
+			t.Fatalf("failed cross-installation repair changed A's receipt count: %+v", onlyBinding(installation))
+		}
+	}
+
+	// Restoring B too must let A's repair succeed on retry.
+	if err := os.MkdirAll(pathB, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pathB, "plugin.json"), []byte(`{"name":"demo"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	repaired, err := service.RepairGroup(context.Background(), GroupInput{Targets: []AddInput{repairA}, OperationGroupID: "multi-install-repair-a-retry", Confirmed: true, Repair: true})
+	if err != nil {
+		t.Fatalf("repair of A still failed once B was restored: %v", err)
+	}
+	if repaired.Phase != GroupPhaseCompleted {
+		t.Fatalf("retried repair phase = %s, want completed", repaired.Phase)
+	}
+}
+
+func TestGroupRecoveryPostApplyVerifyChecksEveryRecoveringTargetOnce(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	makeTarget := func(name string) plannedGroupTarget {
+		active := filepath.Join(root, name)
+		if err := os.MkdirAll(active, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		managed := &domain.ClientBinding{NativeObjects: []domain.NativeObjectOwnership{{Kind: "managed_package_directory", ManagedDigest: "sha256:" + name}}}
+		return plannedGroupTarget{
+			input:      AddInput{Client: domain.DetectedClient{ClientID: domain.ClientCodex}},
+			plan:       domain.DeliveryPlan{ActivePath: active},
+			managed:    managed,
+			recovering: true,
+		}
+	}
+	planned := []plannedGroupTarget{makeTarget("first"), makeTarget("second"), {noChange: true}}
+	observer := &recoveryProbeNativeObserver{stager: acceptingVerifier{}}
+	service := Service{NativeObserver: observer}
+	verify := service.groupRecoveryPostApplyVerify(planned)
+	if verify == nil {
+		t.Fatal("expected a non-nil PostApplyVerify hook")
+	}
+	if err := verify(context.Background()); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if observer.nativeCalls != 2 {
+		t.Fatalf("native identity verification calls = %d, want 2 (one per recovering target)", observer.nativeCalls)
+	}
+}
+
 func TestGroupedAddReportsCommittedActivationAndExternalPartialFailuresFromReceipts(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {

--- a/install/integrationctl/agentplugins/usecase/path_semantics_integration_test.go
+++ b/install/integrationctl/agentplugins/usecase/path_semantics_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/loader"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/specregistry"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/managedstdio"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers"
 )
 
@@ -94,6 +95,15 @@ func TestPortableDotPathsInstallAndExactRepair(t *testing.T) {
 
 func TestClaudeBundledDotPathsInstallAndRepair(t *testing.T) {
 	service, _, _ := serviceFixture(t)
+	helper := filepath.Join(t.TempDir(), "fixture-helper")
+	if err := os.WriteFile(helper, []byte("fixture helper; never executed"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	source, err := managedstdio.NewSource(helper, "fixture")
+	if err != nil {
+		t.Fatal(err)
+	}
+	service.Stager = providers.Stager{LauncherSource: source}
 	client := domain.DetectedClient{ClientID: domain.ClientClaude, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), "claude"), ExecutablePath: "/test/bin/claude"}
 	runner := &fakeClaudeLifecycleRunner{configRoot: client.ConfigRoot}
 	service.Activator = providers.Activator{Runner: runner}
@@ -133,10 +143,10 @@ func TestClaudeBundledDotPathsInstallAndRepair(t *testing.T) {
 		t.Helper()
 		runtime := filepath.Join(installed.Plan.ActivePath, ".agentplugins-runtime")
 		server := readUsecaseObject(t, filepath.Join(installed.Plan.ActivePath, ".mcp.json"))["local"].(map[string]any)
-		if server["command"] != filepath.Join(runtime, "bin/server") || server["cwd"] != filepath.Join(runtime, "work") {
+		if server["cwd"] != nil || server["args"].([]any)[3] != filepath.Join(runtime, "work") || server["args"].([]any)[6] != "./bin/../bin/server" {
 			t.Fatalf("Claude final paths: %+v", server)
 		}
-		if server["args"].([]any)[0] != filepath.Join(runtime, "config") {
+		if server["args"].([]any)[7] != filepath.Join(runtime, "config") {
 			t.Fatalf("Claude PLUGIN_ROOT expansion: %+v", server)
 		}
 		if _, err := os.Stat(filepath.Join(runtime, "bin/server")); err != nil {

--- a/install/integrationctl/agentplugins/usecase/service_test.go
+++ b/install/integrationctl/agentplugins/usecase/service_test.go
@@ -189,7 +189,7 @@ func TestOpenAIOAuthHintsDoNotOverrideGenericAuthentication(t *testing.T) {
 		service, _, _ := serviceFixture(t)
 		client := domain.DetectedClient{ClientID: clientID, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".client")}
 		input := addInput(t, client, "https://example.com/generic-auth-"+string(clientID))
-		input.Envelope.MCP = domain.MCPComponent{Present: true, Enabled: true, Servers: map[string]domain.MCPServer{"server": {Name: "server", Type: "stdio", Decoded: map[string]any{"command":"sh"}}}}
+		input.Envelope.MCP = domain.MCPComponent{Present: true, Enabled: true, Servers: map[string]domain.MCPServer{"server": {Name: "server", Type: "stdio", Decoded: map[string]any{"command": "sh"}}}}
 		input.Envelope.CatalogEvidence = &domain.CatalogEvidence{Compatibility: map[string]domain.CatalogCompatibility{string(clientID): {Package: map[bool]string{true: "projected", false: "native"}[clientID == domain.ClientCodex], Authentication: domain.AuthenticationRequirementNotRequired}}}
 		input.Hints.OpenAIMCPAuth = map[string]domain.OpenAIMCPAuthHint{"server": {OAuthResource: "https://example.com/oauth"}}
 		result, err := service.Add(context.Background(), input)
@@ -1830,6 +1830,14 @@ func TestRemoveCleansNativeCodexMarketplaceBeforeManagedArtifactDeletion(t *test
 	wantCleanup := []string{"/test/bin/codex", "plugin", "marketplace", "remove", marketplace, "--json"}
 	if got := runner.commands[len(runner.commands)-1].Argv; !reflect.DeepEqual(got, wantCleanup) {
 		t.Fatalf("last command = %#v, want cleanup %#v", got, wantCleanup)
+	}
+	// The plugin's own registration must be cleared before its marketplace
+	// source, not just the marketplace: a stale `[plugins."id"] enabled`
+	// config.toml entry left behind is what let a freshly started Codex
+	// app-server silently re-materialize an already-"removed" plugin.
+	wantPluginRemove := []string{"/test/bin/codex", "plugin", "remove", "demo@" + marketplace, "--json"}
+	if got := runner.commands[len(runner.commands)-2].Argv; !reflect.DeepEqual(got, wantPluginRemove) {
+		t.Fatalf("second-to-last command = %#v, want plugin cleanup %#v", got, wantPluginRemove)
 	}
 	config, err := os.ReadFile(filepath.Join(client.ConfigRoot, "config.toml"))
 	if err != nil {

--- a/install/integrationctl/agentplugins/usecase/skills_admission_lifecycle_test.go
+++ b/install/integrationctl/agentplugins/usecase/skills_admission_lifecycle_test.go
@@ -1,0 +1,154 @@
+package usecase
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/loader"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/specregistry"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+func skillAdmissionInput(t *testing.T, client domain.DetectedClient, extra, revision string) AddInput {
+	t.Helper()
+	input := addInput(t, client, "https://example.test/skill-admission")
+	if revision == "invalid" {
+		manifest := filepath.Join(input.Envelope.SnapshotRoot, "plugin.json")
+		body, err := os.ReadFile(manifest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(manifest, []byte(strings.Replace(string(body), `"version": "1.0.0"`, `"version": "2.0.0"`, 1)), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	root := input.Envelope.SnapshotRoot
+	for name, fields := range map[string]string{"good": "", "candidate": extra} {
+		dir := filepath.Join(root, "skills", name)
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: "+name+"\ndescription: Test skill\n"+fields+"---\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, "mcp.json"), []byte(`{"$schema":"`+domain.MCPSchemaV1+`","mcpServers":{"remote":{"type":"streamable-http","url":"https://example.test/mcp"}}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	registry, err := specregistry.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := input.Envelope.Source
+	source.ResolvedRevision = revision
+	input.Envelope, err = (loader.Loader{Registry: registry}).Load(context.Background(), domain.LoadInput{SnapshotRoot: root, Source: source, TreeDigest: "sha256:" + revision})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return input
+}
+
+func assertSkillAdmissionArtifact(t *testing.T, active string, candidate bool) {
+	t.Helper()
+	for name, present := range map[string]bool{"good": true, "candidate": candidate} {
+		_, err := os.Stat(filepath.Join(active, "skills", name, "SKILL.md"))
+		if (present && err != nil) || (!present && !os.IsNotExist(err)) {
+			t.Fatalf("skill %s present=%v: %v", name, present, err)
+		}
+	}
+	mcp := readUsecaseObject(t, filepath.Join(active, "mcp.json"))
+	if servers, ok := mcp["mcpServers"].(map[string]any); !ok || len(servers) != 1 || servers["remote"] == nil {
+		t.Fatalf("healthy MCP lost: %+v", mcp)
+	}
+}
+
+func TestSkillAdmissionInstallAndUpdate(t *testing.T) {
+	for _, extra := range []string{"metadata: {count: 5}\n", "metadata: {nested: {value: x}}\n", "compatibility: ''\n"} {
+		t.Run(extra, func(t *testing.T) {
+			service, store, client := serviceFixture(t)
+			invalid := skillAdmissionInput(t, client, extra, "invalid")
+			invalid.Confirmed = true
+			installed, err := service.Add(context.Background(), invalid)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertSkillAdmissionArtifact(t, installed.Plan.ActivePath, false)
+
+			// A separately installed valid revision can be replaced only after confirmation.
+			service, store, client = serviceFixture(t)
+			valid := skillAdmissionInput(t, client, "", "valid")
+			valid.Confirmed = true
+			installed, err = service.Add(context.Background(), valid)
+			if err != nil {
+				t.Fatal(err)
+			}
+			candidate := skillAdmissionInput(t, client, extra, "invalid")
+			candidate.InstallationID = installed.InstallationID
+			candidate.OperationID = "skill-update"
+			before, err := store.Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			preview, err := service.Update(context.Background(), candidate)
+			if err != nil || preview.Mutated || !preview.RequiresConfirmation {
+				t.Fatalf("preview=%+v err=%v", preview, err)
+			}
+			assertSkillAdmissionArtifact(t, installed.Plan.ActivePath, true)
+			after, err := store.Load()
+			if err != nil || !reflect.DeepEqual(before, after) {
+				t.Fatalf("preview changed state: %v", err)
+			}
+			candidate.Confirmed = true
+			updated, err := service.Update(context.Background(), candidate)
+			if err != nil || !updated.Mutated {
+				t.Fatalf("update=%+v err=%v", updated, err)
+			}
+			assertSkillAdmissionArtifact(t, updated.Plan.ActivePath, false)
+		})
+	}
+}
+
+func TestInvalidSkillAdmissionLifecycleHistoricalRepair(t *testing.T) {
+	service, store, client := serviceFixture(t)
+	input := skillAdmissionInput(t, client, "metadata: {count: 5}\n", "historical")
+	// Model the old loader's admission of these exact invalid bytes, then repair
+	// the same source revision using the corrected loader result.
+	current := input.Envelope
+	raw, err := os.ReadFile(filepath.Join(current.SnapshotRoot, "skills", "candidate", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	input.Envelope.Skills = map[string]domain.Skill{"good": current.Skills["good"], "candidate": {Name: "candidate", Description: "Test skill", Metadata: map[string]any{"count": 5}, RelativePath: "skills/candidate/SKILL.md", Raw: raw}}
+	input.Envelope.Inventory.InvalidSkills = nil
+	input.Envelope.Diagnostics = nil
+	input.Confirmed = true
+	installed, err := service.Add(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSkillAdmissionArtifact(t, installed.Plan.ActivePath, true)
+	before, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Damage an owned artifact so exact-revision repair must rebuild it.
+	if err := os.WriteFile(filepath.Join(installed.Plan.ActivePath, "damage"), []byte("test"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	input.Envelope = current
+	input.InstallationID = installed.InstallationID
+	input.OperationID = "historical-skill-repair"
+	repaired, err := service.Repair(context.Background(), input)
+	if err == nil || !strings.Contains(err.Error(), "resolved repair projection digest differs") || repaired.Mutated {
+		t.Fatalf("historical repair silently changed selection: %+v %v", repaired, err)
+	}
+	assertSkillAdmissionArtifact(t, installed.Plan.ActivePath, true)
+	after, loadErr := store.Load()
+	if loadErr != nil || !reflect.DeepEqual(before, after) {
+		t.Fatalf("refused repair changed state: %v", loadErr)
+	}
+}

--- a/repotests/agentplugins_claude_native_e2e_test.go
+++ b/repotests/agentplugins_claude_native_e2e_test.go
@@ -1,22 +1,7 @@
 package pluginkitairepo_test
 
-// This suite drives the real Claude Code CLI through UAP's actual install
-// route (personal <CLAUDE_CONFIG_DIR>/skills/<physical-id>/.claude-plugin,
-// declared name@skills-dir discovery). It is opt-in and uses only a disposable
-// HOME/CLAUDE_CONFIG_DIR; it never touches the invoking user's real Claude
-// Code profile, credentials, or projects. Unlike the Codex suite, this one
-// requires no container/VM: Claude Code has no known kernel-syscall
-// dependency analogous to Codex's pidfd_open requirement, so it runs directly
-// on the host OS the CLI itself supports (this suite assumes macOS/Linux;
-// CLAUDE_CONFIG_DIR isolation is the same on both).
-//
-// One isolation gap remains and is not fixable from here: the real `claude`
-// binary queries the host's OS credential store (the macOS login keychain, or
-// the platform equivalent elsewhere) for a service name derived from
-// CLAUDE_CONFIG_DIR. No real secret is read back, because the derived service
-// name differs from the real profile's, but the store itself is genuinely
-// queried rather than substituted with a disposable one -- Claude Code has no
-// flag to redirect that. Documented rather than silently claimed away.
+// This opt-in suite uses only disposable fixture paths. Native execution requires
+// an isolated Linux container; a redirected HOME cannot isolate the macOS keychain.
 
 import (
 	"context"
@@ -27,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -381,9 +367,16 @@ func TestAgentpluginsClaudeNativeLifecycle(t *testing.T) {
 	if os.Getenv("AGENTPLUGINS_CLAUDE_NATIVE_E2E") != "1" {
 		t.Skip("opt-in native client execution")
 	}
+	if runtime.GOOS != "linux" {
+		t.Fatal("native Claude requires isolated Linux runtime")
+	}
 	client := claudeNativeBinary(t, "AGENTPLUGINS_CLAUDE_BIN")
 	installer := claudeNativeBinary(t, "AGENTPLUGINS_INSTALLER_BIN")
+	if expected := os.Getenv("AGENTPLUGINS_CLAUDE_SHA256"); len(expected) != 64 || claudeSHA256(t, client) != expected {
+		t.Fatal("Claude binary pin mismatch")
+	}
 	f := newClaudeNativeFixture(t)
+	nativeProvisionScanner(t, &nativeFixture{Root: f.Root})
 	clientDir := filepath.Dir(client)
 
 	// Every expected stage is declared up front as not_evaluated, matching
@@ -422,6 +415,9 @@ func TestAgentpluginsClaudeNativeLifecycle(t *testing.T) {
 
 	// Measure the client actually under test rather than trusting an env var.
 	measuredClientVersion = claudeVersionString(t, f, client)
+	if want := os.Getenv("AGENTPLUGINS_CLAUDE_VERSION"); want == "" || measuredClientVersion != want {
+		t.Fatalf("Claude version %q does not match %q", measuredClientVersion, want)
+	}
 
 	claudeWriteFixturePackage(t, f.PackageRoot, "claude-native-proof", "1.0.0")
 

--- a/repotests/agentplugins_claude_native_e2e_test.go
+++ b/repotests/agentplugins_claude_native_e2e_test.go
@@ -1,0 +1,636 @@
+package pluginkitairepo_test
+
+// This suite drives the real Claude Code CLI through UAP's actual install
+// route (personal <CLAUDE_CONFIG_DIR>/skills/<physical-id>/.claude-plugin,
+// declared name@skills-dir discovery). It is opt-in and uses only a disposable
+// HOME/CLAUDE_CONFIG_DIR; it never touches the invoking user's real Claude
+// Code profile, credentials, or projects. Unlike the Codex suite, this one
+// requires no container/VM: Claude Code has no known kernel-syscall
+// dependency analogous to Codex's pidfd_open requirement, so it runs directly
+// on the host OS the CLI itself supports (this suite assumes macOS/Linux;
+// CLAUDE_CONFIG_DIR isolation is the same on both).
+//
+// One isolation gap remains and is not fixable from here: the real `claude`
+// binary queries the host's OS credential store (the macOS login keychain, or
+// the platform equivalent elsewhere) for a service name derived from
+// CLAUDE_CONFIG_DIR. No real secret is read back, because the derived service
+// name differs from the real profile's, but the store itself is genuinely
+// queried rather than substituted with a disposable one -- Claude Code has no
+// flag to redirect that. Documented rather than silently claimed away.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const claudeNativeCommandTimeout = 30 * time.Second
+
+type claudeNativeStage struct {
+	Status string `json:"status"`
+	Reason string `json:"reason,omitempty"`
+}
+
+type claudePluginListEntry struct {
+	ID          string `json:"id"`
+	Version     string `json:"version"`
+	Scope       string `json:"scope"`
+	Enabled     bool   `json:"enabled"`
+	InstallPath string `json:"installPath"`
+}
+
+func claudeNativeBinary(t *testing.T, key string) string {
+	t.Helper()
+	p := os.Getenv(key)
+	if !filepath.IsAbs(p) {
+		t.Fatalf("%s must name an absolute scratch binary", key)
+	}
+	st, err := os.Stat(p)
+	if err != nil || !st.Mode().IsRegular() || st.Mode()&0111 == 0 {
+		t.Fatalf("invalid %s binary", key)
+	}
+	return p
+}
+
+func claudeSHA256(t *testing.T, path string) string {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(body)
+	return hex.EncodeToString(sum[:])
+}
+
+// claudeNativeFixture isolates every path the real `claude` CLI and the
+// `agentplugins` installer touch. Nothing here is the invoking user's real
+// home, config, or data directory.
+type claudeNativeFixture struct {
+	Root, Home, ConfigDir, PackageRoot, StateHome string
+	transcriptSeq                                 int
+	transcriptSHA256                              map[string]string
+}
+
+func newClaudeNativeFixture(t *testing.T) *claudeNativeFixture {
+	t.Helper()
+	root, err := os.MkdirTemp("", "uap-claude-native-evidence-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("claude native evidence: %s", root)
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := &claudeNativeFixture{
+		Root: root, Home: filepath.Join(root, "home"), ConfigDir: filepath.Join(root, "claude-config"),
+		PackageRoot: filepath.Join(root, "fixture"), StateHome: filepath.Join(root, "installer-state"),
+		transcriptSHA256: map[string]string{},
+	}
+	for _, p := range []string{f.Home, f.ConfigDir, f.PackageRoot, f.StateHome, filepath.Join(root, "tmp"), filepath.Join(root, "xdg-config"), filepath.Join(root, "xdg-data"), filepath.Join(root, "xdg-cache")} {
+		if err := os.MkdirAll(p, 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return f
+}
+
+// env returns a bounded, isolated environment for both the `claude` CLI and
+// the `agentplugins` installer: a disposable HOME and CLAUDE_CONFIG_DIR, no
+// inherited ambient credentials beyond PATH/LANG, and updater/telemetry
+// disabled where the client honors that.
+func (f *claudeNativeFixture) env(clientDir string) []string {
+	return []string{
+		"HOME=" + f.Home,
+		"CLAUDE_CONFIG_DIR=" + f.ConfigDir,
+		"AGENTPLUGINS_HOME=" + f.StateHome,
+		"XDG_CONFIG_HOME=" + filepath.Join(f.Root, "xdg-config"),
+		"XDG_DATA_HOME=" + filepath.Join(f.Root, "xdg-data"),
+		"XDG_CACHE_HOME=" + filepath.Join(f.Root, "xdg-cache"),
+		"TMPDIR=" + filepath.Join(f.Root, "tmp"),
+		"PATH=" + clientDir + ":/usr/bin:/bin",
+		"DISABLE_AUTOUPDATER=1",
+		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1",
+		"LANG=en_US.UTF-8",
+	}
+}
+
+// record saves a command's combined stdout+stderr to its own evidence file
+// and its SHA-256 into the fixture's transcript index, mirroring the Codex
+// suite's nativeWrite/nativeSHA transcript-hashing pattern.
+func (f *claudeNativeFixture) record(t *testing.T, label string, out []byte) {
+	t.Helper()
+	f.transcriptSeq++
+	name := fmt.Sprintf("%02d-%s.log", f.transcriptSeq, label)
+	path := filepath.Join(f.Root, name)
+	if err := os.WriteFile(path, out, 0600); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(out)
+	f.transcriptSHA256[name] = hex.EncodeToString(sum[:])
+}
+
+func claudeRunInstaller(t *testing.T, f *claudeNativeFixture, installer, clientDir, label string, args ...string) map[string]any {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), claudeNativeCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, installer, append(args, "--format", "json")...)
+	cmd.Env = f.env(clientDir)
+	cmd.Dir = f.Root
+	out, err := cmd.CombinedOutput()
+	f.record(t, label, out)
+	if err != nil {
+		if _, isExit := err.(*exec.ExitError); !isExit {
+			t.Fatalf("run installer %v: %v\n%s", args, err, out)
+		}
+	}
+	line := lastJSONLine(out)
+	var decoded map[string]any
+	if line != "" {
+		if jsonErr := json.Unmarshal([]byte(line), &decoded); jsonErr != nil {
+			t.Fatalf("decode installer output for %v: %v\n%s", args, jsonErr, out)
+		}
+	}
+	return decoded
+}
+
+// claudeRunInstallerExpectError runs the installer expecting a nonzero exit
+// and returns its combined output for message inspection; it does not attempt
+// JSON decoding since these calls exercise the plain-text refusal path.
+func claudeRunInstallerExpectError(t *testing.T, f *claudeNativeFixture, installer, clientDir, label string, args ...string) (string, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), claudeNativeCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, installer, append(args, "--format", "json")...)
+	cmd.Env = f.env(clientDir)
+	cmd.Dir = f.Root
+	out, err := cmd.CombinedOutput()
+	f.record(t, label, out)
+	return string(out), err
+}
+
+func lastJSONLine(out []byte) string {
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		trimmed := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(trimmed, "{") {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func claudeVersionString(t *testing.T, f *claudeNativeFixture, client string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), claudeNativeCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, client, "--version")
+	cmd.Env = f.env(filepath.Dir(client))
+	cmd.Dir = f.Home
+	out, err := cmd.CombinedOutput()
+	f.record(t, "claude-version", out)
+	if err != nil {
+		t.Fatalf("claude --version: %v\n%s", err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func claudePluginList(t *testing.T, f *claudeNativeFixture, client, label string) []claudePluginListEntry {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), claudeNativeCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, client, "plugin", "list", "--json")
+	cmd.Env = f.env(filepath.Dir(client))
+	cmd.Dir = f.Home
+	out, err := cmd.CombinedOutput()
+	f.record(t, label, out)
+	if err != nil {
+		t.Fatalf("claude plugin list --json: %v\n%s", err, out)
+	}
+	var entries []claudePluginListEntry
+	if err := json.Unmarshal(out, &entries); err != nil {
+		t.Fatalf("decode claude plugin list output: %v\n%s", err, out)
+	}
+	return entries
+}
+
+func claudePluginDetails(t *testing.T, f *claudeNativeFixture, client, pluginID, label string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), claudeNativeCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, client, "plugin", "details", pluginID)
+	cmd.Env = f.env(filepath.Dir(client))
+	cmd.Dir = f.Home
+	out, err := cmd.CombinedOutput()
+	f.record(t, label, out)
+	if err != nil {
+		t.Fatalf("claude plugin details %s: %v\n%s", pluginID, err, out)
+	}
+	return string(out)
+}
+
+// claudeMCPList runs the real health-checked MCP listing, which is the one
+// command that reports transport-specific classification (e.g. "(HTTP)" /
+// "(SSE)") and actually attempts a connection per entry -- unlike `plugin
+// details`, which only enumerates declared .mcp.json keys without validating
+// their type. A short timeout is used deliberately: the fixture's MCP
+// endpoints point at an unroutable loopback port, so every entry is expected
+// to fail to connect quickly, not hang.
+func claudeMCPList(t *testing.T, f *claudeNativeFixture, client, label string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), claudeNativeCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, client, "mcp", "list")
+	cmd.Env = f.env(filepath.Dir(client))
+	cmd.Dir = f.Home
+	out, _ := cmd.CombinedOutput()
+	f.record(t, label, out)
+	return string(out)
+}
+
+func claudeWriteFixturePackage(t *testing.T, root, name, version string) {
+	t.Helper()
+	must := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	must(os.MkdirAll(filepath.Join(root, "skills", "demo-skill"), 0755))
+	must(os.WriteFile(filepath.Join(root, "plugin.json"), []byte(fmt.Sprintf(`{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": %q,
+  "version": %q,
+  "description": "Claude Code native lifecycle proof fixture"
+}`, name, version)), 0644))
+	must(os.WriteFile(filepath.Join(root, "skills", "demo-skill", "SKILL.md"), []byte("---\nname: demo-skill\ndescription: A demo skill for native lifecycle verification.\n---\n\n# Demo Skill\n\nSay hello when asked to demo.\n"), 0644))
+	// Loopback, unroutable addresses: real network calls against these fail
+	// fast and deterministically (connection refused), which is what lets
+	// `claude mcp list` be asserted against without depending on any external
+	// service being reachable.
+	must(os.WriteFile(filepath.Join(root, "mcp.json"), []byte(`{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "local": {"type": "stdio", "command": "sh", "args": ["-c", "cat"]},
+    "remote-http": {"type": "streamable-http", "url": "http://127.0.0.1:9/mcp"},
+    "remote-sse": {"type": "sse", "url": "http://127.0.0.1:9/sse"}
+  }
+}`), 0644))
+}
+
+func claudeReadInstalledSkill(t *testing.T, installPath string) []byte {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(installPath, ".agentplugins-runtime", "skills", "demo-skill", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+// claudeAssertMutated decodes an installer JSON result's single-target
+// mutated flag and fails the test if it does not equal want. This exists
+// because "no_change:true" alone does not prove the physical swap was
+// skipped -- mutated is the field the kernel actually sets from whether a
+// directory transaction ran.
+func claudeAssertMutated(t *testing.T, result map[string]any, want bool) {
+	t.Helper()
+	data, _ := result["data"].(map[string]any)
+	targets, _ := data["targets"].([]any)
+	if len(targets) != 1 {
+		t.Fatalf("expected exactly one target in result: %+v", result)
+	}
+	target, _ := targets[0].(map[string]any)
+	output, _ := target["output"].(map[string]any)
+	resultObj, _ := output["result"].(map[string]any)
+	mutated, _ := resultObj["mutated"].(bool)
+	if mutated != want {
+		t.Fatalf("mutated = %v, want %v: %+v", mutated, want, resultObj)
+	}
+}
+
+// claudeStateReceiptForOperation reads the persisted state-v2.json under the
+// fixture's isolated AGENTPLUGINS_HOME and returns the exact receipt whose
+// operation_group_id matches operationGroupID (the repair command's own
+// reported operation_id), for the given installation's client bindings.
+// Matching by group ID -- rather than "the last receipt of whichever client
+// binding happens to have any" -- avoids silently reading a stale receipt
+// from an earlier, unrelated operation (for example, if the targeted
+// operation turned out to be a no-op and appended no new receipt at all).
+// Exactly one client binding is required to hold a matching receipt; more or
+// fewer is a test-setup problem, not something to guess through.
+func claudeStateReceiptForOperation(t *testing.T, f *claudeNativeFixture, installationID, operationGroupID string) (beforeDigest, afterDigest string) {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(f.StateHome, "state-v2.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state struct {
+		Installations []struct {
+			InstallationID string `json:"installation_id"`
+			Clients        map[string]struct {
+				Receipts []struct {
+					OperationGroupID string `json:"operation_group_id"`
+					BeforeDigest     string `json:"before_digest"`
+					AfterDigest      string `json:"after_digest"`
+				} `json:"receipts"`
+			} `json:"clients"`
+		} `json:"installations"`
+	}
+	if err := json.Unmarshal(body, &state); err != nil {
+		t.Fatal(err)
+	}
+	matches := 0
+	for _, installation := range state.Installations {
+		if installation.InstallationID != installationID {
+			continue
+		}
+		for _, client := range installation.Clients {
+			for _, receipt := range client.Receipts {
+				if receipt.OperationGroupID != operationGroupID {
+					continue
+				}
+				matches++
+				beforeDigest, afterDigest = receipt.BeforeDigest, receipt.AfterDigest
+			}
+		}
+	}
+	if matches != 1 {
+		t.Fatalf("expected exactly one receipt for operation_group_id %s under installation %s, found %d", operationGroupID, installationID, matches)
+	}
+	return beforeDigest, afterDigest
+}
+
+// TestAgentpluginsClaudeNativeLifecycle drives the real Claude Code CLI
+// through UAP's actual skills-dir install route: install, discovery via the
+// client's own `plugin list`/`plugin details`/`mcp list`, absent-directory
+// repair, version update, same-version content update, physical idempotence,
+// and remove with foreign-content preservation plus repeat-remove refusal.
+//
+// Native tool calls through a live app-server session, actual model skill
+// use, and OAuth are NOT evaluated here; they require a distinct, separately
+// authorized route and are explicitly out of scope for this checkpoint.
+func TestAgentpluginsClaudeNativeLifecycle(t *testing.T) {
+	if os.Getenv("AGENTPLUGINS_CLAUDE_NATIVE_E2E") != "1" {
+		t.Skip("opt-in native client execution")
+	}
+	client := claudeNativeBinary(t, "AGENTPLUGINS_CLAUDE_BIN")
+	installer := claudeNativeBinary(t, "AGENTPLUGINS_INSTALLER_BIN")
+	f := newClaudeNativeFixture(t)
+	clientDir := filepath.Dir(client)
+
+	// Every expected stage is declared up front as not_evaluated, matching
+	// the Codex suite's pattern: a stage that is never reached (an early
+	// Fatal, a skipped later section) must still show up honestly in the
+	// evidence file instead of silently vanishing from an otherwise-complete-
+	// looking JSON document.
+	stages := map[string]claudeNativeStage{
+		"install":                 {Status: "not_evaluated", Reason: "not reached"},
+		"skill_discovery":         {Status: "not_evaluated", Reason: "not reached"},
+		"mcp_transport_discovery": {Status: "not_evaluated", Reason: "not reached"},
+		"version_update":          {Status: "not_evaluated", Reason: "not reached"},
+		"same_version_refresh":    {Status: "not_evaluated", Reason: "not reached"},
+		"unchanged":               {Status: "not_evaluated", Reason: "not reached"},
+		"owned_repair":            {Status: "not_evaluated", Reason: "not reached"},
+		"foreign_content_inside_managed_directory_blocked": {Status: "not_evaluated", Reason: "not reached"},
+		"remove":        {Status: "not_evaluated", Reason: "not reached"},
+		"repeat_remove": {Status: "not_evaluated", Reason: "not reached"},
+	}
+	var measuredClientVersion string
+	defer func() {
+		evidence := map[string]any{
+			"finished_utc":            time.Now().UTC().Format(time.RFC3339Nano),
+			"client_version_measured": measuredClientVersion,
+			"client_binary_sha256":    claudeSHA256(t, client),
+			"installer_binary_sha256": claudeSHA256(t, installer),
+			"installer_base_commit":   os.Getenv("AGENTPLUGINS_INSTALLER_COMMIT"),
+			"installer_tree":          os.Getenv("AGENTPLUGINS_INSTALLER_TREE"),
+			"installer_patch_sha256":  os.Getenv("AGENTPLUGINS_INSTALLER_PATCH_SHA256"),
+			"stages":                  stages,
+			"transcript_sha256":       f.transcriptSHA256,
+		}
+		body, _ := json.MarshalIndent(evidence, "", "  ")
+		_ = os.WriteFile(filepath.Join(f.Root, "evidence.json"), body, 0600)
+	}()
+
+	// Measure the client actually under test rather than trusting an env var.
+	measuredClientVersion = claudeVersionString(t, f, client)
+
+	claudeWriteFixturePackage(t, f.PackageRoot, "claude-native-proof", "1.0.0")
+
+	// install
+	result := claudeRunInstaller(t, f, installer, clientDir, "add-v1", "add", f.PackageRoot, "--target", "claude")
+	if data, _ := result["data"].(map[string]any); data == nil || data["status"] != "completed" {
+		t.Fatalf("install did not complete: %+v", result)
+	}
+	entries := claudePluginList(t, f, client, "list-after-install")
+	if len(entries) != 1 || entries[0].ID != "claude-native-proof@skills-dir" || !entries[0].Enabled || entries[0].Version != "1.0.0" {
+		t.Fatalf("claude plugin list did not report the installed plugin: %+v", entries)
+	}
+	installPath := entries[0].InstallPath
+	data, _ := result["data"].(map[string]any)
+	targetsRaw, _ := data["targets"].([]any)
+	target0, _ := targetsRaw[0].(map[string]any)
+	output0, _ := target0["output"].(map[string]any)
+	resultObj0, _ := output0["result"].(map[string]any)
+	installationID, _ := resultObj0["installation_id"].(string)
+	if installationID == "" {
+		t.Fatalf("install result did not report an installation_id: %+v", result)
+	}
+	stages["install"] = claudeNativeStage{Status: "passed"}
+
+	// skill discovery: exact plugin-attributed skill, exact bytes
+	details := claudePluginDetails(t, f, client, "claude-native-proof@skills-dir", "details-after-install")
+	if !strings.Contains(details, "demo-skill") || !strings.Contains(details, "MCP servers (3)") {
+		t.Fatalf("claude plugin details did not attribute the exact skill/MCP inventory: %s", details)
+	}
+	installedSkill := claudeReadInstalledSkill(t, installPath)
+	if !strings.Contains(string(installedSkill), "Say hello when asked to demo.") {
+		t.Fatalf("installed skill body does not match the exact fixture bytes: %q", installedSkill)
+	}
+	stages["skill_discovery"] = claudeNativeStage{Status: "passed", Reason: "exact plugin-attributed skill enumerated by the real CLI with exact body bytes verified on disk; no model use claimed"}
+
+	// MCP transport discovery: `plugin details` only enumerates declared
+	// .mcp.json keys without validating their type (a bogus type value is
+	// listed identically to a real one there); `claude mcp list` is the
+	// command that classifies by transport and attempts a real connection
+	// per entry, so it is the one asserted against for transport-specific
+	// proof. Loopback URLs make every entry fail fast and deterministically
+	// rather than depending on external network reachability.
+	mcpList := claudeMCPList(t, f, client, "mcp-list-after-install")
+	for _, want := range []string{
+		"plugin:claude-native-proof:remote-http:", "(HTTP)",
+		"plugin:claude-native-proof:remote-sse:", "(SSE)",
+		"plugin:claude-native-proof:local:",
+	} {
+		if !strings.Contains(mcpList, want) {
+			t.Fatalf("claude mcp list did not classify the declared transports as expected (missing %q): %s", want, mcpList)
+		}
+	}
+	stages["mcp_transport_discovery"] = claudeNativeStage{Status: "passed", Reason: "claude mcp list classified remote-http as (HTTP) and remote-sse as (SSE) and attempted a real (loopback-refused) connection to each, distinct from plugin details' shallow key enumeration; no live tool call or successful connection claimed"}
+
+	// version update
+	claudeWriteFixturePackage(t, f.PackageRoot, "claude-native-proof", "2.0.0")
+	result = claudeRunInstaller(t, f, installer, clientDir, "update-v2", "update", "claude-native-proof", "--target", "claude")
+	if data, _ := result["data"].(map[string]any); data == nil || data["status"] != "completed" {
+		t.Fatalf("version update did not complete: %+v", result)
+	}
+	entries = claudePluginList(t, f, client, "list-after-version-update")
+	if len(entries) != 1 || entries[0].Version != "2.0.0" {
+		t.Fatalf("claude plugin list did not reflect the updated version: %+v", entries)
+	}
+	stages["version_update"] = claudeNativeStage{Status: "passed"}
+
+	// same-version content update
+	before := claudeReadInstalledSkill(t, installPath)
+	must := func(err error) {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	must(os.WriteFile(filepath.Join(f.PackageRoot, "skills", "demo-skill", "SKILL.md"), append(append([]byte{}, before...), []byte("\nExtra content for the same-version refresh.\n")...), 0644))
+	refreshResult := claudeRunInstaller(t, f, installer, clientDir, "update-same-version", "update", "claude-native-proof", "--target", "claude")
+	if data, _ := refreshResult["data"].(map[string]any); data == nil || data["status"] != "completed" {
+		t.Fatalf("same-version content update did not complete: %+v", refreshResult)
+	}
+	claudeAssertMutated(t, refreshResult, true)
+	after := claudeReadInstalledSkill(t, installPath)
+	if !strings.Contains(string(after), "Extra content for the same-version refresh.") {
+		t.Fatalf("same-version content update did not refresh the skill body")
+	}
+	stages["same_version_refresh"] = claudeNativeStage{Status: "passed"}
+
+	// physical idempotence: re-apply the exact same content and require
+	// mutated:false plus byte-identical on-disk state, not merely a no_change
+	// field's presence. The installer JSON's own tree_digest reflects the
+	// source PACKAGE's digest (fixed at install time), not the actual managed
+	// directory -- it cannot distinguish "physically untouched" from
+	// "re-swapped with the same bytes", so the real proof is a filesystem
+	// tree digest of the managed directory plus a digest of the persisted
+	// state file, both taken before and after, matching the Codex suite's
+	// own unchanged-stage pattern (agentplugins_codex_native_e2e_test.go).
+	statePath := filepath.Join(f.StateHome, "state-v2.json")
+	beforeManagedTree, beforeStateDigest := nativeTreeDigest(t, installPath), claudeSHA256(t, statePath)
+	unchangedResult := claudeRunInstaller(t, f, installer, clientDir, "update-unchanged", "update", "claude-native-proof", "--target", "claude")
+	if data, _ := unchangedResult["data"].(map[string]any); data == nil || data["status"] != "completed" {
+		t.Fatalf("idempotent re-apply did not complete: %+v", unchangedResult)
+	}
+	claudeAssertMutated(t, unchangedResult, false)
+	if got := nativeTreeDigest(t, installPath); got != beforeManagedTree {
+		t.Fatalf("idempotent re-apply changed the managed directory's physical content: before=%q after=%q", beforeManagedTree, got)
+	}
+	if got := claudeSHA256(t, statePath); got != beforeStateDigest {
+		t.Fatalf("idempotent re-apply changed the persisted state file: before=%q after=%q", beforeStateDigest, got)
+	}
+	stages["unchanged"] = claudeNativeStage{Status: "passed", Reason: "mutated:false plus byte-identical managed-directory tree digest and state-file digest before/after a byte-identical re-apply"}
+
+	// absent-directory repair (mirrors the Codex C3 absent-repair scenario;
+	// unlike Codex's `plugin list`, Claude Code's own list command does not
+	// fail globally when a managed directory is missing, so no analogous
+	// defect was found or fixed here). Repair here re-stages from the still-
+	// present original local source directory, which must still exist and
+	// match the exact recorded revision -- it is not a reconstruction from
+	// state alone the way Codex's C3 recovery path is, since this repair
+	// route is not restricted to the Codex-only recovering gate.
+	must(os.RemoveAll(installPath))
+	repairResult := claudeRunInstaller(t, f, installer, clientDir, "repair-absent", "repair", "claude-native-proof", "--target", "claude")
+	if data, _ := repairResult["data"].(map[string]any); data == nil || data["status"] != "completed" {
+		t.Fatalf("absent-directory repair did not complete: %+v", repairResult)
+	}
+	entries = claudePluginList(t, f, client, "list-after-repair")
+	if len(entries) != 1 || entries[0].Version != "2.0.0" {
+		t.Fatalf("repair did not restore a plugin the real CLI recognizes: %+v", entries)
+	}
+	restoredSkill := claudeReadInstalledSkill(t, installPath)
+	if !strings.Contains(string(restoredSkill), "Extra content for the same-version refresh.") {
+		t.Fatalf("repair did not restore the exact latest content: %q", restoredSkill)
+	}
+	if _, err := os.Stat(filepath.Join(installPath, ".mcp.json")); err != nil {
+		t.Fatalf("repair did not restore .mcp.json: %v", err)
+	}
+	repairDetails := claudePluginDetails(t, f, client, "claude-native-proof@skills-dir", "details-after-repair")
+	if !strings.Contains(repairDetails, "MCP servers (3)") {
+		t.Fatalf("claude plugin details after repair did not attribute the restored MCP inventory: %s", repairDetails)
+	}
+	// Known, pre-existing, non-Codex-specific audit-trail gap (not
+	// introduced or fixed by this checkpoint): repair's recorded
+	// BeforeDigest describes what was last recorded as owned, not the
+	// physically-absent state this mutation actually observed, because the
+	// Codex-only C3 recovering gate (usecase/group.go's
+	// observeGroupRecoveryEligibility) is the only path that corrects this.
+	// BeforeDigest is not read by any production decision logic (confirmed
+	// separately in this session's C3 review), so this is tracked here as a
+	// documented limitation rather than silently missed or fixed out of
+	// scope. The receipt is located by the repair command's own reported
+	// operation_id (not "whichever client binding's last receipt happens to
+	// be"), so a no-op repair that appended no new receipt would fail this
+	// lookup loudly instead of silently reading a stale receipt from an
+	// earlier operation.
+	repairOperationID, _ := repairResult["data"].(map[string]any)["operation_id"].(string)
+	if repairOperationID == "" {
+		t.Fatalf("repair result did not report an operation_id: %+v", repairResult)
+	}
+	if before, after := claudeStateReceiptForOperation(t, f, installationID, repairOperationID); before == "" || before != after {
+		t.Fatalf("expected the known phantom BeforeDigest gap (before_digest == after_digest, both nonempty, since repair reconstructs byte-identical content despite physical absence at mutation time); got before=%q after=%q -- this either means the gap was fixed (update this test) or the receipt lookup is wrong", before, after)
+	}
+	stages["owned_repair"] = claudeNativeStage{Status: "passed", Reason: "managed directory re-staged from the still-present, exact-revision-matching local source after the directory was deleted; restored content bytes, .mcp.json, and claude plugin details all verified; recorded BeforeDigest confirmed to carry the known pre-existing phantom-before-state gap shared by every non-Codex client, not fixed by this checkpoint"}
+
+	// Foreign content INSIDE the managed directory must block removal
+	// (fail-closed ownership verification), not be silently deleted or
+	// overwritten.
+	foreignInsideFile := filepath.Join(installPath, "foreign-injected.txt")
+	must(os.WriteFile(foreignInsideFile, []byte("not ours, planted inside the managed directory"), 0644))
+	blockedOut, blockedErr := claudeRunInstallerExpectError(t, f, installer, clientDir, "remove-blocked-by-foreign-content", "remove", "claude-native-proof", "--target", "claude", "--purge-data")
+	if blockedErr == nil || !strings.Contains(blockedOut, "artifact digest mismatch") {
+		t.Fatalf("foreign content inside the managed directory did not block removal: err=%v out=%s", blockedErr, blockedOut)
+	}
+	if _, err := os.Stat(foreignInsideFile); err != nil {
+		t.Fatalf("blocked removal did not preserve the foreign file inside the managed directory: %v", err)
+	}
+	must(os.Remove(foreignInsideFile))
+	stages["foreign_content_inside_managed_directory_blocked"] = claudeNativeStage{Status: "passed", Reason: "exact ownership-verification refusal (\"artifact digest mismatch\") when foreign content is planted inside the plugin's own managed directory; the foreign file survived the blocked attempt and was removed only by the test before the real remove below"}
+
+	// foreign preservation: an unrelated skills-dir entry must survive remove
+	foreignSentinel := filepath.Join(f.ConfigDir, "skills", "foreign-plugin", "sentinel.txt")
+	must(os.MkdirAll(filepath.Dir(foreignSentinel), 0755))
+	must(os.MkdirAll(filepath.Join(f.ConfigDir, "skills", "foreign-plugin", ".claude-plugin"), 0755))
+	must(os.WriteFile(filepath.Join(f.ConfigDir, "skills", "foreign-plugin", ".claude-plugin", "plugin.json"), []byte(`{"name":"foreign-plugin"}`), 0644))
+	must(os.WriteFile(foreignSentinel, []byte("not ours"), 0644))
+
+	// --external-uninstalled is a no-op for Claude specifically: activator.go's
+	// Deactivate ClientClaude branch never reads request.ExternalUninstalled,
+	// unlike Codex/ChatGPT/Kiro which gate on it. Verified directly (removal
+	// succeeds identically with or without the flag); omitted here rather than
+	// copy-pasted from the Codex pattern to avoid implying it exercises real
+	// Claude-specific behavior it does not. --purge-data is real and kept.
+	result = claudeRunInstaller(t, f, installer, clientDir, "remove", "remove", "claude-native-proof", "--target", "claude", "--purge-data")
+	if data, _ := result["data"].(map[string]any); data == nil || data["status"] != "completed" {
+		t.Fatalf("remove did not complete: %+v", result)
+	}
+	if _, err := os.Stat(installPath); !os.IsNotExist(err) {
+		t.Fatalf("remove left the managed directory behind: %v", err)
+	}
+	body, err := os.ReadFile(foreignSentinel)
+	if err != nil || string(body) != "not ours" {
+		t.Fatalf("remove touched foreign content: body=%q err=%v", body, err)
+	}
+	remaining := claudePluginList(t, f, client, "list-after-remove")
+	if len(remaining) != 1 || remaining[0].ID != "foreign-plugin@skills-dir" {
+		t.Fatalf("claude plugin list after remove did not show exactly the surviving foreign plugin: %+v", remaining)
+	}
+	stages["remove"] = claudeNativeStage{Status: "passed", Reason: "managed directory removed; sibling foreign plugin's sentinel content and its sole remaining claude plugin list entry both confirmed"}
+
+	// repeat remove must be refused, not silently succeed or crash
+	repeatOut, repeatErr := claudeRunInstallerExpectError(t, f, installer, clientDir, "repeat-remove", "remove", "claude-native-proof", "--target", "claude", "--purge-data")
+	if repeatErr == nil || !strings.Contains(repeatOut, "was not found") {
+		t.Fatalf("repeated remove of an absent installation was not refused: err=%v out=%s", repeatErr, repeatOut)
+	}
+	stages["repeat_remove"] = claudeNativeStage{Status: "passed", Reason: "exact expected refusal message"}
+}

--- a/repotests/agentplugins_claude_runtime_fixture_test.go
+++ b/repotests/agentplugins_claude_runtime_fixture_test.go
@@ -1,0 +1,332 @@
+package pluginkitairepo_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Scripted provider exercises the native client's tool dispatch, not model intelligence.
+// The supported gateway seam is https://code.claude.com/docs/en/llm-gateway.
+type claudeGateway struct {
+	mu             sync.Mutex
+	requests       []json.RawMessage
+	skillRequested bool
+	skillBodySeen  bool
+	results        map[string]json.RawMessage
+	calls          map[string]string
+}
+
+func claudeRuntimeSession(t *testing.T, f *nativeFixture, cf *claudeNativeFixture, client, label, revision, operation string) string {
+	t.Helper()
+	g := &claudeGateway{results: map[string]json.RawMessage{}, calls: map[string]string{}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/messages/count_tokens" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"input_tokens":100}`)
+			return
+		}
+		if r.URL.Path != "/v1/messages" {
+			http.Error(w, "fixture endpoint only", 404)
+			return
+		}
+		b, err := io.ReadAll(io.LimitReader(r.Body, 8<<20))
+		if err != nil {
+			http.Error(w, "read", 400)
+			return
+		}
+		var req struct {
+			Tools []struct {
+				Name string `json:"name"`
+			} `json:"tools"`
+			Messages []struct {
+				Content json.RawMessage `json:"content"`
+			} `json:"messages"`
+		}
+		if json.Unmarshal(b, &req) != nil {
+			http.Error(w, "json", 400)
+			return
+		}
+		g.mu.Lock()
+		defer g.mu.Unlock()
+		g.requests = append(g.requests, append(json.RawMessage(nil), b...))
+		if strings.Contains(string(b), "UAP_SKILL_BODY_"+revision+"_"+f.Nonce) {
+			g.skillBodySeen = true
+		}
+		for _, m := range req.Messages {
+			var blocks []struct {
+				Type    string          `json:"type"`
+				ID      string          `json:"tool_use_id"`
+				Content json.RawMessage `json:"content"`
+				IsError bool            `json:"is_error"`
+			}
+			if json.Unmarshal(m.Content, &blocks) != nil {
+				continue
+			}
+			for _, block := range blocks {
+				if block.Type == "tool_result" && !block.IsError && g.calls[block.ID] != "" {
+					g.results[g.calls[block.ID]] = block.Content
+				}
+			}
+		}
+		var content []map[string]any
+		for _, tool := range req.Tools {
+			if tool.Name == "Skill" && !g.skillRequested && strings.Contains(string(b), "native-proof:native-proof") {
+				g.skillRequested = true
+				content = append(content, map[string]any{"type": "tool_use", "id": "uap_skill", "name": "Skill", "input": map[string]string{"skill": "native-proof:native-proof"}})
+			}
+		}
+		for _, tool := range req.Tools {
+			if !strings.Contains(tool.Name, "native-proof") || !strings.HasSuffix(tool.Name, "inspect_runtime") {
+				continue
+			}
+			if _, ok := g.results[tool.Name]; ok {
+				continue
+			}
+			id := fmt.Sprintf("uap_tool_%d", len(g.calls)+1)
+			g.calls[id] = tool.Name
+			content = append(content, map[string]any{"type": "tool_use", "id": id, "name": tool.Name, "input": map[string]string{"nonce": f.Nonce, "operation": operation, "marker": "persist-" + f.Nonce}})
+		}
+		stop := "tool_use"
+		if len(content) == 0 {
+			content = []map[string]any{{"type": "text", "text": "fixture complete"}}
+			stop = "end_turn"
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		emit := func(kind string, v any) {
+			data, _ := json.Marshal(v)
+			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", kind, data)
+		}
+		emit("message_start", map[string]any{"type": "message_start", "message": map[string]any{"id": "msg_uap", "type": "message", "role": "assistant", "model": "claude-sonnet-4-5", "content": []any{}, "stop_reason": nil, "stop_sequence": nil, "usage": map[string]int{"input_tokens": 100, "output_tokens": 0}}})
+		for i, c := range content {
+			var delta map[string]any
+			if c["type"] == "tool_use" {
+				input, _ := json.Marshal(c["input"])
+				c["input"] = map[string]any{}
+				delta = map[string]any{"type": "input_json_delta", "partial_json": string(input)}
+			} else {
+				delta = map[string]any{"type": "text_delta", "text": c["text"]}
+				c["text"] = ""
+			}
+			emit("content_block_start", map[string]any{"type": "content_block_start", "index": i, "content_block": c})
+			emit("content_block_delta", map[string]any{"type": "content_block_delta", "index": i, "delta": delta})
+			emit("content_block_stop", map[string]any{"type": "content_block_stop", "index": i})
+		}
+		emit("message_delta", map[string]any{"type": "message_delta", "delta": map[string]any{"stop_reason": stop, "stop_sequence": nil}, "usage": map[string]int{"output_tokens": 10}})
+		emit("message_stop", map[string]any{"type": "message_stop"})
+	}))
+	defer server.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, client, "-p", "Use the installed native-proof runtime inspection tools.", "--output-format", "stream-json", "--verbose", "--max-turns", "4", "--permission-mode", "bypassPermissions", "--model", "claude-sonnet-4-5")
+	cmd.Env = append(cf.env(filepath.Dir(client)), "ANTHROPIC_BASE_URL="+server.URL, "ANTHROPIC_AUTH_TOKEN=uap-disposable-fixture-token", "CLAUDE_CODE_DISABLE_1M_CONTEXT=1")
+	cmd.Dir = f.Project
+	out, err := cmd.CombinedOutput()
+	cf.record(t, label, out)
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	gatewayPath := filepath.Join(f.Root, label+"-gateway.json")
+	nativeJSON(t, gatewayPath, g.requests)
+	cf.transcriptSHA256[label+"-gateway.json"] = nativeSHA(t, gatewayPath)
+	if err != nil {
+		t.Fatalf("Claude runtime %s: %v\n%s", label, err, out)
+	}
+	if !g.skillBodySeen {
+		t.Fatal("installed selected skill body was not observed in outgoing provider context")
+	}
+	if len(g.results) != 3 {
+		t.Fatalf("expected installed stdio and HTTP tools returned through native client, got %d; see gateway evidence", len(g.results))
+	}
+	seen := map[string]bool{}
+	var markerPath string
+	for name, raw := range g.results {
+		var blocks []struct {
+			Text string `json:"text"`
+		}
+		if json.Unmarshal(raw, &blocks) != nil {
+			t.Fatalf("tool result content: %s", raw)
+		}
+		if len(blocks) != 1 {
+			t.Fatalf("tool result blocks: %s", raw)
+		}
+		var facts nativeFacts
+		if json.Unmarshal([]byte(blocks[0].Text), &facts) != nil {
+			t.Fatalf("tool facts: %s", raw)
+		}
+		expectedRevision := revision
+		if strings.Contains(name, "http") {
+			expectedRevision = "HTTP"
+		}
+		if facts.Nonce != f.Nonce || facts.Revision != expectedRevision || facts.Marker != "persist-"+f.Nonce || facts.Session == "" {
+			t.Fatalf("uncorrelated facts: %+v", facts)
+		}
+		nativeAssertEvent(t, f, facts)
+		for _, p := range []string{facts.Root, facts.Data, facts.CWD} {
+			nativeRequireContained(t, f.Root, p)
+		}
+		if strings.Contains(name, "http") {
+			seen["http"] = true
+			continue
+		}
+		markerPath = filepath.Join(facts.Data, "native-marker.txt")
+		expected := facts.Root
+		if strings.Contains(name, "explicit") {
+			expected = filepath.Join(expected, "skills")
+			seen["explicit"] = true
+		} else if strings.Contains(name, "default") {
+			seen["default"] = true
+		} else {
+			t.Fatalf("unexpected fixture tool: %s", name)
+		}
+		if facts.CWD != expected || facts.Literal != "literal ${UNKNOWN} $HOME" || facts.Once != facts.Root+"/${UNKNOWN}" || len(facts.Argv) != 3 || facts.Argv[1] != facts.Root+"/argument" {
+			t.Fatalf("runtime semantics: %+v", facts)
+		}
+	}
+	if !seen["default"] || !seen["explicit"] || !seen["http"] {
+		t.Fatal("missing default/explicit stdio tools")
+	}
+	return markerPath
+}
+
+func TestAgentpluginsClaudeNativeRuntimeLifecycle(t *testing.T) {
+	if os.Getenv("AGENTPLUGINS_CLAUDE_NATIVE_E2E") != "1" {
+		t.Skip("opt-in native client execution")
+	}
+	if runtime.GOOS != "linux" {
+		t.Fatal("native Claude requires isolated Linux runtime; macOS keychain is not isolated")
+	}
+	client := claudeNativeBinary(t, "AGENTPLUGINS_CLAUDE_BIN")
+	installer := claudeNativeBinary(t, "AGENTPLUGINS_INSTALLER_BIN")
+	if expected := os.Getenv("AGENTPLUGINS_CLAUDE_SHA256"); len(expected) != 64 || claudeSHA256(t, client) != expected {
+		t.Fatal("Claude binary pin mismatch")
+	}
+	f := newNativeFixture(t, true)
+	cf := &claudeNativeFixture{Root: f.Root, Home: f.Home, ConfigDir: filepath.Join(f.Root, "claude-config"), PackageRoot: f.Package, StateHome: filepath.Join(f.Root, "installer-state"), transcriptSHA256: map[string]string{}}
+	nativeWrite(t, filepath.Join(cf.ConfigDir, "settings.json"), []byte(`{"enableAllProjectMcpServers":true}`), 0600)
+	stages := map[string]string{"install": "not_evaluated", "runtime_A": "not_evaluated", "runtime_B": "not_evaluated", "same_version_refresh": "not_evaluated", "repair": "not_evaluated", "remove": "not_evaluated"}
+	identity, identityErr := nativeSourceIdentity(os.Getenv("AGENTPLUGINS_INSTALLER_COMMIT"), os.Getenv("AGENTPLUGINS_INSTALLER_TREE"), os.Getenv("AGENTPLUGINS_INSTALLER_PATCH_SHA256"))
+	if identityErr != nil {
+		t.Fatal(identityErr)
+	}
+	evidence := map[string]any{"source_identity": identity, "os": runtime.GOOS, "arch": runtime.GOARCH, "profile_root": cf.ConfigDir, "stages": stages, "provider": "scripted_loopback", "real_model": "not_evaluated", "oauth": "not_evaluated", "client_sha256": claudeSHA256(t, client), "installer_sha256": claudeSHA256(t, installer)}
+	defer func() {
+		evidence["finished_utc"] = time.Now().UTC().Format(time.RFC3339Nano)
+		evidence["transcript_sha256"] = cf.transcriptSHA256
+		nativeJSON(t, filepath.Join(f.Root, "evidence.json"), evidence)
+	}()
+	evidence["scanner"] = nativeProvisionScanner(t, f)
+	version := claudeVersionString(t, cf, client)
+	evidence["client_version"] = version
+	if want := os.Getenv("AGENTPLUGINS_CLAUDE_VERSION"); want == "" || version != want {
+		t.Fatalf("Claude version %q does not match pin %q", version, want)
+	}
+	run := func(label string, args ...string) {
+		t.Helper()
+		r := claudeRunInstaller(t, cf, installer, filepath.Dir(client), label, args...)
+		d, _ := r["data"].(map[string]any)
+		if label == "add" && nativeFindString(r, "evidence_source") != "local_scan" {
+			t.Fatal("first add did not use local scanner")
+		}
+		if label == "remove" {
+			if err := claudeRetainedRemovalResult(r); err != nil {
+				t.Fatal(err)
+			}
+			return
+		}
+		if d["status"] != "completed" {
+			t.Fatalf("%s: %+v", label, r)
+		}
+	}
+	nativeHTTP(t, f)
+	f.RedirectURL = "" // Redirect credential policy is a separate native evidence row.
+	f.writePackage(t, "A", "1.0.0")
+	stages["install"] = "failed"
+	run("add", "add", f.Package, "--target", "claude")
+	stages["install"] = "passed"
+	entries := claudePluginList(t, cf, client, "installed")
+	if len(entries) != 1 || entries[0].ID != "native-proof@skills-dir" {
+		t.Fatalf("installed attribution: %+v", entries)
+	}
+	stages["runtime_A"] = "failed"
+	claudeRuntimeSession(t, f, cf, client, "runtime-A", "A", "write")
+	stages["runtime_A"] = "passed"
+	stages["runtime_B"] = "failed"
+	f.writePackage(t, "B", "2.0.0")
+	run("update", "update", "native-proof", "--target", "claude")
+	claudeRuntimeSession(t, f, cf, client, "runtime-B", "B", "read")
+	stages["runtime_B"] = "passed"
+	stages["same_version_refresh"] = "failed"
+	f.writePackage(t, "C", "2.0.0")
+	run("same-version-update", "update", "native-proof", "--target", "claude")
+	claudeRuntimeSession(t, f, cf, client, "runtime-C", "C", "read")
+	stages["same_version_refresh"] = "passed"
+	stages["repair"] = "failed"
+	nativeRequireContained(t, f.Root, entries[0].InstallPath)
+	if err := os.RemoveAll(entries[0].InstallPath); err != nil {
+		t.Fatal(err)
+	}
+	run("repair", "repair", "native-proof", "--target", "claude")
+	markerPath := claudeRuntimeSession(t, f, cf, client, "runtime-repair", "C", "read")
+	markerDigest := nativeSHA(t, markerPath)
+	stages["repair"] = "passed"
+	stages["remove"] = "failed"
+	run("remove", "remove", "native-proof", "--target", "claude")
+	if got := claudePluginList(t, cf, client, "removed"); len(got) != 0 {
+		t.Fatalf("plugin survived removal: %+v", got)
+	}
+	if _, err := os.Stat(entries[0].InstallPath); !os.IsNotExist(err) {
+		t.Fatalf("managed artifact survived remove: %v", err)
+	}
+	if nativeSHA(t, markerPath) != markerDigest {
+		t.Fatal("safe remove changed retained marker")
+	}
+	stages["remove"] = "passed"
+}
+
+// Removal with owned data deliberately has a distinct status. Validate that exact
+// contract instead of treating arbitrary success/data_retained output as completion.
+func claudeRetainedRemovalResult(r map[string]any) error {
+	d, _ := r["data"].(map[string]any)
+	targets, _ := d["targets"].([]any)
+	if r["result"] != "success" || d["status"] != "data_retained" || d["plugin_data_preserved"] != true || d["data_retained"] != true || len(targets) != 1 {
+		return fmt.Errorf("invalid retained removal: %+v", r)
+	}
+	target, _ := targets[0].(map[string]any)
+	output, _ := target["output"].(map[string]any)
+	result, _ := output["result"].(map[string]any)
+	deactivation, _ := result["deactivation"].(map[string]any)
+	if target["target"] != "claude" || target["status"] != "external_completed" || result["mutated"] != true || result["group_phase"] != "external_completed" || deactivation["artifact_removal_allowed"] != true || deactivation["external_removal_complete"] != true {
+		return fmt.Errorf("incomplete retained removal: %+v", r)
+	}
+	return nil
+}
+
+func TestClaudeRetainedRemovalResult(t *testing.T) {
+	const fixture = `{"result":"success","data":{"status":"data_retained","plugin_data_preserved":true,"data_retained":true,"targets":[{"target":"claude","status":"external_completed","output":{"result":{"mutated":true,"group_phase":"external_completed","deactivation":{"artifact_removal_allowed":true,"external_removal_complete":true}}}}]}}`
+	var result map[string]any
+	if err := json.Unmarshal([]byte(fixture), &result); err != nil {
+		t.Fatal(err)
+	}
+	if err := claudeRetainedRemovalResult(result); err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"plugin_data_preserved", "data_retained", "mutated", "artifact_removal_allowed", "external_removal_complete"} {
+		altered := strings.Replace(fixture, `"`+field+`":true`, `"`+field+`":false`, 1)
+		var bad map[string]any
+		_ = json.Unmarshal([]byte(altered), &bad)
+		if claudeRetainedRemovalResult(bad) == nil {
+			t.Fatalf("accepted false %s", field)
+		}
+	}
+}

--- a/repotests/agentplugins_codex_native_e2e_test.go
+++ b/repotests/agentplugins_codex_native_e2e_test.go
@@ -227,6 +227,12 @@ func nativeSession(t *testing.T, f *nativeFixture, client, label, revision, oper
 			t.Fatalf("duplicate native plugin server: %s", server.Name)
 		}
 		serverNames[server.Name] = true
+		if label == "partial_failure" && server.Name == "startup-failure" {
+			if server.RuntimeStatus != "failed" || len(server.Tools) != 0 {
+				t.Fatalf("startup-failure server was not independently failed: %+v", server)
+			}
+			continue
+		}
 		if server.Name == "http" {
 			result, err := r.request("mcpServer/tool/call", map[string]any{"threadId": thread.Thread.ID, "server": server.Name, "tool": "inspect_runtime", "arguments": map[string]string{"nonce": f.Nonce}})
 			if err != nil {
@@ -276,7 +282,14 @@ func nativeSession(t *testing.T, f *nativeFixture, client, label, revision, oper
 		}
 		observed = facts
 	}
-	if len(serverNames) != 4 || !serverNames["default"] || !serverNames["explicit"] || !serverNames["http"] || !serverNames["redirect"] {
+	wantServers := 4
+	if label == "partial_failure" {
+		wantServers = 5
+		if !serverNames["startup-failure"] || serverNames["unavailable"] || serverNames["unsupported-sse"] {
+			t.Fatalf("failure isolation inventory: %v", serverNames)
+		}
+	}
+	if len(serverNames) != wantServers || !serverNames["default"] || !serverNames["explicit"] || !serverNames["http"] || !serverNames["redirect"] {
 		t.Fatalf("unexpected exact native server inventory: %v", serverNames)
 	}
 	if count != 2 {
@@ -301,6 +314,9 @@ func nativeSession(t *testing.T, f *nativeFixture, client, label, revision, oper
 	found := false
 	for _, group := range skills.Data {
 		for _, skill := range group.Skills {
+			if label == "partial_failure" && skill.PluginID == f.PluginID && strings.Contains(skill.Path, "invalid-proof") {
+				t.Fatal("invalid skill reached native discovery")
+			}
 			if nativeSkillIdentity(skill.Name, skill.PluginID, skill.Path, skill.Enabled, f.PluginID, observed.Root) {
 				body, err := os.ReadFile(skill.Path)
 				if err != nil {
@@ -318,6 +334,27 @@ func nativeSession(t *testing.T, f *nativeFixture, client, label, revision, oper
 	}
 	stages[label+"_native_tool"] = nativeStage{Status: "passed", Artifacts: []string{label + "-rpc.jsonl", "events.jsonl"}}
 	stages[label+"_skill_discovery"] = nativeStage{Status: "passed", Reason: "Exact plugin-attributed skill path and body bytes; no model use claimed"}
+	if label == "A" && f.ProviderRequests != nil {
+		nativeAttempt(stages, "skill_context", "skill-context-request.json")
+		r.must(t, "turn/start", map[string]any{"threadId": thread.Thread.ID, "input": []any{
+			map[string]any{"type": "text", "text": "Use the explicitly selected skill and reply briefly.", "text_elements": []any{}},
+			map[string]string{"type": "skill", "name": "native-proof:native-proof", "path": filepath.Join(observed.Root, "skills", "native-proof", "SKILL.md")},
+		}})
+		select {
+		case body := <-f.ProviderRequests:
+			nativeWrite(t, filepath.Join(f.Root, "skill-context-request.json"), body, 0600)
+			var request map[string]json.RawMessage
+			if err := json.Unmarshal(body, &request); err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Contains(request["input"], []byte("UAP_SKILL_BODY_A_"+f.Nonce)) {
+				t.Fatal("native turn did not inject selected installed skill body into outgoing input")
+			}
+			stages["skill_context"] = nativeStage{Status: "passed", Reason: "model_provider=scripted_loopback; real native explicit-skill turn injected BODY into outgoing Responses input; no real model skill use claimed", Artifacts: []string{"skill-context-request.json", label + "-rpc.jsonl"}}
+		case <-time.After(30 * time.Second):
+			t.Fatal("native explicit-skill turn did not reach scripted provider")
+		}
+	}
 	return observed
 }
 
@@ -336,29 +373,31 @@ func TestAgentpluginsCodexNativeLifecycle(t *testing.T) {
 	f := newNativeFixture(t, true)
 	f.ClientBinDir = filepath.Dir(client)
 	stages := map[string]nativeStage{}
-	for _, name := range []string{"install", "A_native_tool", "B_native_tool", "same_version_native_tool", "unchanged", "owned_repair", "native_cache_repair", "partial_failure", "remove", "repeat_remove", "foreign_preservation", "collision_drift", "immutable_git", "http", "redirect_headers", "skill_context", "real_model_skill_use", "oauth"} {
+	for _, name := range []string{"install", "A_native_tool", "B_native_tool", "same_version_native_tool", "unchanged", "owned_repair", "native_cache_repair", "partial_failure", "all_unsupported", "remove", "repeat_remove", "foreign_preservation", "collision_drift", "immutable_git", "immutable_git_native", "http", "redirect_headers", "skill_context", "real_model_skill_use", "oauth"} {
 		stages[name] = nativeStage{Status: "not_evaluated", Reason: "not reached"}
 	}
-	evidence := map[string]any{"started_utc": time.Now().UTC().Format(time.RFC3339Nano), "os": runtime.GOOS, "arch": runtime.GOARCH, "profile": f.Root, "client_version": "0.153.4", "client_source": "3d2ee51ca2d5db578f328aa75e20aa22c0197c9a", "client_sha256": nativeSHA(t, client), "installer_sha256": nativeSHA(t, installer), "installer_base_commit": os.Getenv("AGENTPLUGINS_INSTALLER_COMMIT"), "installer_source_state": "reviewed_uncommitted_patches", "installer_patch_sha256": strings.Split(os.Getenv("AGENTPLUGINS_INSTALLER_PATCH_SHA256"), ","), "installer_tree": os.Getenv("AGENTPLUGINS_INSTALLER_TREE"), "acquisition": "local_directory", "native_surface": "codex app-server direct thread MCP RPC", "stages": stages}
+	evidence := map[string]any{"started_utc": time.Now().UTC().Format(time.RFC3339Nano), "os": runtime.GOOS, "arch": runtime.GOARCH, "profile": f.Root, "client_version": "0.153.4", "client_source": "3d2ee51ca2d5db578f328aa75e20aa22c0197c9a", "client_sha256": nativeSHA(t, client), "installer_sha256": nativeSHA(t, installer), "acquisition": "local_directory", "native_surface": "codex app-server direct thread MCP RPC", "stages": stages}
 	defer func() {
 		evidence["finished_utc"] = time.Now().UTC().Format(time.RFC3339Nano)
 		hashes := map[string]string{}
 		entries, _ := os.ReadDir(f.Root)
 		for _, e := range entries {
-			if !e.IsDir() && (strings.HasSuffix(e.Name(), ".jsonl") || strings.HasSuffix(e.Name(), ".log") || strings.HasSuffix(e.Name(), "-installer.json")) {
+			if !e.IsDir() && (strings.HasSuffix(e.Name(), ".jsonl") || strings.HasSuffix(e.Name(), ".log") || strings.HasSuffix(e.Name(), "-installer.json") || e.Name() == "skill-context-request.json" || e.Name() == "immutable-git.json") {
 				hashes[e.Name()] = nativeSHA(t, filepath.Join(f.Root, e.Name()))
 			}
 		}
 		evidence["artifact_sha256"] = hashes
 		nativeJSON(t, filepath.Join(f.Root, "evidence.json"), evidence)
 	}()
-	if evidence["installer_base_commit"] == "" || evidence["installer_tree"] == "" {
-		t.Fatal("exact installer base commit and resulting tree required")
+	identity, err := nativeSourceIdentity(os.Getenv("AGENTPLUGINS_INSTALLER_COMMIT"), os.Getenv("AGENTPLUGINS_INSTALLER_TREE"), os.Getenv("AGENTPLUGINS_INSTALLER_PATCH_SHA256"))
+	if err != nil {
+		t.Fatal(err)
 	}
-	if os.Getenv("AGENTPLUGINS_INSTALLER_PATCH_SHA256") == "" {
-		t.Fatal("accepted installer patch digests required for reviewed uncommitted source identity")
+	for key, value := range identity {
+		evidence[key] = value
 	}
-	nativeWrite(t, filepath.Join(f.CodexHome, "config.toml"), []byte("cli_auth_credentials_store = \"file\"\nmcp_oauth_credentials_store = \"file\"\nmodel_provider = \"fixture\"\nmodel = \"fixture-model\"\n[model_providers.fixture]\nname = \"Fixture\"\nbase_url = \"http://127.0.0.1:1/v1\"\nwire_api = \"responses\"\nrequires_openai_auth = false\n[analytics]\nenabled = false\n[feedback]\nenabled = false\n"), 0600)
+	providerURL := nativeScriptedProvider(t, f)
+	nativeWrite(t, filepath.Join(f.CodexHome, "config.toml"), []byte("cli_auth_credentials_store = \"file\"\nmcp_oauth_credentials_store = \"file\"\nmodel_provider = \"fixture\"\nmodel = \"fixture-model\"\n[model_providers.fixture]\nname = \"Fixture\"\nbase_url = \""+providerURL+"\"\nwire_api = \"responses\"\nrequires_openai_auth = false\n[analytics]\nenabled = false\n[feedback]\nenabled = false\n"), 0600)
 	b, err := nativeCommand(t, f, client, "client-version", "--version")
 	if err != nil || strings.TrimSpace(string(b)) != "codex-cli 0.153.4" {
 		t.Fatalf("wrong pinned client: %s %v", b, err)
@@ -510,6 +549,33 @@ func TestAgentpluginsCodexNativeLifecycle(t *testing.T) {
 	if nativeTreeDigest(t, active) != originalDigest {
 		t.Fatal("fixture original bytes were not restored exactly")
 	}
+	// A foreign directory at the formerly owned path must not be adopted.
+	nativeAttempt(stages, "collision_drift", "foreign-collision.log")
+	collisionBackup := filepath.Join(f.Root, "collision-original-backup")
+	if err := os.Rename(active, collisionBackup); err != nil {
+		t.Fatal(err)
+	}
+	nativeWrite(t, filepath.Join(active, "foreign-sentinel"), []byte("foreign-"+f.Nonce), 0600)
+	collisionDigest := nativeTreeDigest(t, active)
+	collision, collisionErr := nativeCommand(t, f, installer, "foreign-collision", "repair", "native-proof", "--target", "codex", "--format", "json")
+	collisionStderr, err := os.ReadFile(filepath.Join(f.Root, "foreign-collision-stderr.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := nativeCollisionGuardResult(collision, collisionStderr, collisionErr); err != nil {
+		t.Fatal(err)
+	}
+	if nativeTreeDigest(t, active) != collisionDigest || nativeSHA(t, statePath) != guardState || nativeTreeDigest(t, c.Root) != cacheDigest {
+		t.Fatal("foreign collision refusal mutated protected bytes")
+	}
+	stages["collision_drift"] = nativeStage{Status: "passed", Reason: "Modified owned artifact and foreign replacement directory independently refused; state/cache/foreign bytes preserved", Artifacts: []string{"owned-guard.log", "foreign-collision.log", "foreign-collision-stderr.log"}}
+	// Explicit fixture reset of only the test-authored foreign directory.
+	if err := os.Rename(active, filepath.Join(f.Root, "foreign-collision-retained")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(collisionBackup, active); err != nil {
+		t.Fatal(err)
+	}
 	// Actual reconstruction tests an absent recorded artifact separately.
 	nativeAttempt(stages, "owned_repair", "owned-repair-installer.json")
 	backup := filepath.Join(f.Root, "owned-artifact-backup")
@@ -532,6 +598,79 @@ func TestAgentpluginsCodexNativeLifecycle(t *testing.T) {
 		nativeSession(t, f, client, "native_cache_repair", "C", "read", stages)
 		stages["native_cache_repair"] = nativeStage{Status: "passed"}
 	}
+	nativeAttempt(stages, "partial_failure", "partial-failure-installer.json")
+	var partialMCP map[string]any
+	partialBody, err := os.ReadFile(filepath.Join(f.Package, "mcp.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(partialBody, &partialMCP); err != nil {
+		t.Fatal(err)
+	}
+	partialServers := partialMCP["mcpServers"].(map[string]any)
+	partialServers["unavailable"] = map[string]any{"type": "stdio", "command": "uap-deliberately-unavailable-" + f.Nonce}
+	partialServers["startup-failure"] = map[string]any{"type": "stdio", "command": "./bin/probe", "args": []string{"--fail-startup"}, "env": map[string]string{"UAP_TEST_ROOT": f.Root, "UAP_TEST_EVENTS": f.Events, "UAP_TEST_NONCE": f.Nonce}}
+	partialServers["unsupported-sse"] = map[string]any{"type": "sse", "url": f.HTTPURL + "/unsupported-sse"}
+	nativeJSON(t, filepath.Join(f.Package, "mcp.json"), partialMCP)
+	nativeWrite(t, filepath.Join(f.Package, "skills", "invalid-proof", "SKILL.md"), []byte("No required skill frontmatter"), 0600)
+	partialOutput := nativeInstaller(t, f, installer, client, "partial-failure", "update", "native-proof")
+	if !bytes.Contains(partialOutput, []byte("declared_sse_not_supported_by_client")) || !bytes.Contains(partialOutput, []byte("stdio_runtime_unavailable")) {
+		t.Fatal("installer did not distinguish planner-unsupported SSE")
+	}
+	nativeSession(t, f, client, "partial_failure", "C", "read", stages)
+	startupEvents, err := os.ReadFile(f.Events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	startupObserved := false
+	for _, line := range bytes.Split(startupEvents, []byte{'\n'}) {
+		if len(line) == 0 {
+			continue
+		}
+		var event struct {
+			Method string `json:"method"`
+			Nonce  string `json:"nonce"`
+		}
+		if err := json.Unmarshal(line, &event); err != nil {
+			t.Fatal(err)
+		}
+		if event.Method == "startup-failed" && event.Nonce == f.Nonce {
+			startupObserved = true
+		}
+	}
+	if !startupObserved {
+		t.Fatal("native startup failure had no correlated fixture process event")
+	}
+
+	stages["partial_failure"] = nativeStage{Status: "passed", Reason: "UAP omitted unavailable runtime, unsupported SSE and invalid skill; an existing executable failed at native startup independently while healthy sibling tools and skill remained usable", Artifacts: []string{"partial-failure-installer.json", "partial_failure-rpc.jsonl"}}
+	nativeAttempt(stages, "all_unsupported", "all-unsupported.log")
+	unsupportedState, unsupportedManaged, unsupportedCache := nativeSHA(t, statePath), nativeTreeDigest(t, active), nativeTreeDigest(t, c.Root)
+	unsupportedConfig := nativeSHA(t, filepath.Join(f.CodexHome, "config.toml"))
+	skillsBackup := filepath.Join(f.Root, "unsupported-skills-backup")
+	if err := os.Rename(filepath.Join(f.Package, "skills"), skillsBackup); err != nil {
+		t.Fatal(err)
+	}
+	nativeJSON(t, filepath.Join(f.Package, "mcp.json"), map[string]any{"$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json", "mcpServers": map[string]any{"unsupported-sse": partialServers["unsupported-sse"]}})
+	unsupportedOut, unsupportedErr := nativeCommand(t, f, installer, "all-unsupported", "update", "native-proof", "--target", "codex", "--format", "json")
+	unsupportedStderr, err := os.ReadFile(filepath.Join(f.Root, "all-unsupported-stderr.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unsupportedErr == nil || !strings.Contains(string(unsupportedStderr), "target codex is unsupported; group preflight caused no mutation") {
+		t.Fatalf("expected exact all-unsupported refusal: %v %s", unsupportedErr, unsupportedStderr)
+	}
+	if err := nativeUnmutatedPreflightResult(unsupportedOut); err != nil {
+		t.Fatal(err)
+	}
+	if nativeSHA(t, statePath) != unsupportedState || nativeTreeDigest(t, active) != unsupportedManaged || nativeTreeDigest(t, c.Root) != unsupportedCache || nativeSHA(t, filepath.Join(f.CodexHome, "config.toml")) != unsupportedConfig {
+		t.Fatal("all-unsupported refusal mutated installed surfaces")
+	}
+	stages["all_unsupported"] = nativeStage{Status: "passed", Reason: "SSE-only update refused in preflight with mutated=false; state, managed/cache bytes and native config unchanged", Artifacts: []string{"all-unsupported.log", "all-unsupported-stderr.log"}}
+	// Restore only the source fixture bytes; this reset is not repair evidence.
+	if err := os.Rename(skillsBackup, filepath.Join(f.Package, "skills")); err != nil {
+		t.Fatal(err)
+	}
+	nativeJSON(t, filepath.Join(f.Package, "mcp.json"), partialMCP)
 	nativeAttempt(stages, "remove", "remove-installer.json")
 	// Codex has no supported CLI verb for UAP to silently uninstall a plugin
 	// on the user's behalf (see usecase/remove.go and remove_group.go); every
@@ -589,7 +728,12 @@ func TestAgentpluginsCodexNativeLifecycle(t *testing.T) {
 		t.Fatal("repeated removal lost native data marker")
 	}
 	stages["repeat_remove"] = nativeStage{Status: "passed", Reason: "Expected idempotent/not-found outcome; new native inventory absent and foreign/data bytes preserved"}
+	nativeAttempt(stages, "immutable_git", "immutable-git.json")
+	nativeJSON(t, filepath.Join(f.Root, "immutable-git.json"), nativeImmutableAcquisition(t, f))
+	stages["immutable_git"] = nativeStage{Status: "passed", Reason: "Exact-SHA production acquisition with synthetic local Git transport; acquisition only, not native Git E2E", Artifacts: []string{"immutable-git.json"}}
 	nativeCheckHTTP(t, f, stages)
+	stages["http"] = stages["A_http"]
+	stages["immutable_git_native"] = nativeStage{Status: "not_evaluated", Reason: "CLI admits immutable GitHub sources only and disables Git config rewrites; synthetic supported transport seam proves acquisition separately"}
 	for _, name := range []string{"real_model_skill_use", "oauth"} {
 		stages[name] = nativeStage{Status: "not_evaluated", Reason: "No authenticated provider or real model requested"}
 	}
@@ -649,7 +793,7 @@ func nativeCheckHTTP(t *testing.T, f *nativeFixture, stages map[string]nativeSta
 	if err != nil {
 		t.Fatal(err)
 	}
-	seen, redirect, leaked := false, false, false
+	seen, redirect, leaked, redirectSource := false, false, false, false
 	negotiated := ""
 	stages["generated_protocol_header_priority"] = nativeStage{Status: "not_evaluated", Reason: "No post-negotiation request with a generated protocol header observed"}
 	for _, line := range bytes.Split(b, []byte{'\n'}) {
@@ -681,6 +825,9 @@ func nativeCheckHTTP(t *testing.T, f *nativeFixture, stages map[string]nativeSta
 				stages["generated_protocol_header_priority"] = nativeStage{Status: "passed", Reason: "Post-negotiation header exactly matches negotiated " + negotiated}
 			}
 		}
+		if e.Origin == "declared-source" && e.URI == "/redirect" && e.Probe == f.Nonce {
+			redirectSource = true
+		}
 		if e.Origin == "redirect-destination" {
 			redirect = true
 			if e.Probe != "" {
@@ -699,10 +846,12 @@ func nativeCheckHTTP(t *testing.T, f *nativeFixture, stages map[string]nativeSta
 	}
 	if leaked {
 		stages["redirect_headers"] = nativeStage{Status: "failed", Reason: "Configured custom test header reached another loopback origin"}
-	} else if redirect {
+	} else if redirect && redirectSource {
 		stages["redirect_headers"] = nativeStage{Status: "passed", Reason: "Redirect destination received no configured test header"}
+	} else if redirectSource && !redirect {
+		stages["redirect_headers"] = nativeStage{Status: "passed", Reason: "Configured request reached redirect source; client did not follow to another origin during completed sessions", Artifacts: []string{"http-events.jsonl"}}
 	} else {
-		stages["redirect_headers"] = nativeStage{Status: "not_evaluated", Reason: "No redirect destination request observed; inspect source transcript"}
+		stages["redirect_headers"] = nativeStage{Status: "not_evaluated", Reason: "No correlated source/destination redirect exchange; containment not proven"}
 	}
 }
 
@@ -818,6 +967,17 @@ func nativeRepairGuardResult(stdout, stderr []byte, commandErr error) error {
 	if commandErr == nil || !strings.Contains(string(stderr), "native identity ownership is indeterminate; refusing repair") {
 		return fmt.Errorf("expected ownership guard refusal, got %v; %s", commandErr, stderr)
 	}
+	return nativeUnmutatedPreflightResult(stdout)
+}
+func nativeCollisionGuardResult(stdout, stderr []byte, commandErr error) error {
+	const expected = "agentplugins: group repair preflight failed; no target was changed: observe prepared identity for codex: native package has no recognized authoritative manifest"
+	lines := strings.Split(strings.TrimSpace(string(stderr)), "\n")
+	if commandErr == nil || lines[len(lines)-1] != expected {
+		return fmt.Errorf("expected manifest-less foreign-directory refusal, got %v; %s", commandErr, stderr)
+	}
+	return nativeUnmutatedPreflightResult(stdout)
+}
+func nativeUnmutatedPreflightResult(stdout []byte) error {
 	var result struct {
 		Result string `json:"result"`
 		Data   struct {
@@ -842,4 +1002,192 @@ func nativeRepairGuardResult(stdout, stderr []byte, commandErr error) error {
 		return fmt.Errorf("ownership refusal did not explicitly preserve targets")
 	}
 	return nil
+}
+
+// Public exact-SHA skill-only acquisition. The outer disposable-container runner
+// must disconnect the network and acknowledge the nonce before native discovery.
+func TestAgentpluginsCodexImmutableGitDiscovery(t *testing.T) {
+	if os.Getenv("AGENTPLUGINS_CODEX_GIT_E2E") != "1" {
+		t.Skip("opt-in public immutable Git native discovery")
+	}
+	if runtime.GOOS != "linux" || os.Getenv("AGENTPLUGINS_NATIVE_DISPOSABLE_LINUX") != "1" {
+		t.Fatal("requires disposable Linux boundary")
+	}
+	if _, err := os.Lstat("/etc/codex"); !os.IsNotExist(err) {
+		t.Fatal("system Codex config must be absent")
+	}
+	gate := os.Getenv("AGENTPLUGINS_GIT_GATE_DIR")
+	if !filepath.IsAbs(gate) {
+		t.Fatal("AGENTPLUGINS_GIT_GATE_DIR must be an absolute fresh outer-runner directory")
+	}
+	if info, err := os.Lstat(gate); err == nil && !info.IsDir() {
+		t.Fatal("Git gate must be a real directory")
+	}
+	if entries, err := os.ReadDir(gate); err == nil {
+		if len(entries) != 0 {
+			t.Fatal("Git gate directory must be empty")
+		}
+	} else if !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"git-acquisition-complete", "git-network-isolated"} {
+		if _, err := os.Lstat(filepath.Join(gate, name)); !os.IsNotExist(err) {
+			t.Fatal("Git gate must be fresh and absent")
+		}
+	}
+	client, installer := nativeBinary(t, "AGENTPLUGINS_CODEX_BIN"), nativeBinary(t, "AGENTPLUGINS_INSTALLER_BIN")
+	f := newNativeFixture(t, true)
+	f.ClientBinDir = filepath.Dir(client)
+	stages := map[string]nativeStage{"git_acquisition": {Status: "not_evaluated"}, "native_skill_discovery": {Status: "not_evaluated"}, "native_mcp_from_git": {Status: "not_evaluated", Reason: "Reviewed public fixture contains a skill only"}}
+	evidence, err := nativeSourceIdentity(os.Getenv("AGENTPLUGINS_INSTALLER_COMMIT"), os.Getenv("AGENTPLUGINS_INSTALLER_TREE"), os.Getenv("AGENTPLUGINS_INSTALLER_PATCH_SHA256"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stages["real_model_skill_use"] = nativeStage{Status: "not_evaluated", Reason: "Skill discovery only; no real model invocation"}
+	stages["oauth"] = nativeStage{Status: "not_evaluated", Reason: "Credential-free fixture"}
+	stages["remove"] = nativeStage{Status: "not_evaluated", Reason: "not reached"}
+	evidence["os"] = runtime.GOOS
+	evidence["arch"] = runtime.GOARCH
+	evidence["stages"] = stages
+	evidence["profile"] = f.Root
+	evidence["client_sha256"] = nativeSHA(t, client)
+	evidence["installer_sha256"] = nativeSHA(t, installer)
+	evidence["started_utc"] = time.Now().UTC().Format(time.RFC3339Nano)
+	defer func() {
+		evidence["finished_utc"] = time.Now().UTC().Format(time.RFC3339Nano)
+		hashes := map[string]string{}
+		entries, _ := os.ReadDir(f.Root)
+		for _, entry := range entries {
+			if !entry.IsDir() && (strings.HasSuffix(entry.Name(), ".log") || strings.HasSuffix(entry.Name(), ".jsonl") || strings.HasSuffix(entry.Name(), "-installer.json")) {
+				hashes[entry.Name()] = nativeSHA(t, filepath.Join(f.Root, entry.Name()))
+			}
+		}
+		evidence["artifact_sha256"] = hashes
+		nativeJSON(t, filepath.Join(f.Root, "evidence.json"), evidence)
+	}()
+	nativeWrite(t, filepath.Join(f.CodexHome, "config.toml"), []byte("cli_auth_credentials_store = \"file\"\nmcp_oauth_credentials_store = \"file\"\n[analytics]\nenabled = false\n[feedback]\nenabled = false\n"), 0600)
+	version, err := nativeCommand(t, f, client, "client-version", "--version")
+	if err != nil || strings.TrimSpace(string(version)) != "codex-cli 0.153.4" {
+		t.Fatalf("wrong client %s %v", version, err)
+	}
+	evidence["client_version"] = "0.153.4"
+	evidence["client_source"] = "3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
+	evidence["security_scanner"] = nativeProvisionScanner(t, f)
+	const revision = "4d163c6281a9b4929f482f387efe340b4dc175a1"
+	const source = "Booyaka101/agent-plugins-conformance-kit@" + revision + "//fixtures/core/AP-6.2-MISSING-LOCATION-OK/plugin"
+	evidence["source"] = source
+	nativeAttempt(stages, "git_acquisition", "git-add-installer.json")
+	output := nativeInstaller(t, f, installer, client, "git-add", "add", source)
+	var result any
+	if err := json.Unmarshal(output, &result); err != nil {
+		t.Fatal(err)
+	}
+	physical := nativeFindString(result, "physical_artifact_id")
+	if physical == "" {
+		t.Fatal("missing native physical identity")
+	}
+	f.PluginID = "demo@" + providers.ManagedMarketplaceName(physical)
+	stateBytes, err := os.ReadFile(filepath.Join(f.Root, "installer-state", "state-v2.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state any
+	if err := json.Unmarshal(stateBytes, &state); err != nil {
+		t.Fatal(err)
+	}
+	if nativeFindString(state, "resolved_revision") != revision {
+		t.Fatal("installer source is not exact pinned Git revision")
+	}
+	active := nativeFindString(state, "target_locator")
+	nativeRequireContained(t, f.Root, active)
+	const manifestSHA = "c9036920ac155cbb4d0a09deca484a98e64071677df431dfd897db855880d3ad"
+	if nativeSHA(t, filepath.Join(active, "plugin.json")) != manifestSHA {
+		t.Fatal("acquired manifest does not match reviewed pinned fixture")
+	}
+	evidence["reviewed_git_subtree"] = "ea758f6ddb033f2b3eb2db138212ab7525e1ce7c"
+	evidence["managed_manifest_sha256"] = nativeSHA(t, filepath.Join(active, "plugin.json"))
+	evidence["source_tree_digest"] = nativeFindString(result, "tree_digest")
+	evidence["source_manifest_digest"] = nativeFindString(result, "manifest_digest")
+	evidence["resolved_revision"] = revision
+	stages["git_acquisition"] = nativeStage{Status: "passed", Reason: "Actual CLI immutable public GitHub acquisition without Directory", Artifacts: []string{"git-add-installer.json"}}
+	nativeWrite(t, filepath.Join(gate, "git-acquisition-complete"), []byte(f.Nonce), 0600)
+	timer := time.NewTimer(55 * time.Second)
+	defer timer.Stop()
+	tick := time.NewTicker(100 * time.Millisecond)
+	defer tick.Stop()
+	isolated := false
+	for !isolated {
+		select {
+		case <-timer.C:
+			t.Fatal("outer runner did not acknowledge network isolation within 55s")
+		case <-tick.C:
+			path := filepath.Join(gate, "git-network-isolated")
+			info, err := os.Lstat(path)
+			if os.IsNotExist(err) {
+				continue
+			}
+			if err != nil || !info.Mode().IsRegular() {
+				t.Fatal("isolation gate must be regular file")
+			}
+			body, err := os.ReadFile(path)
+			if err != nil || string(body) != f.Nonce {
+				t.Fatal("isolation gate nonce mismatch")
+			}
+			isolated = true
+		}
+	}
+	evidence["network_boundary"] = "outer runner disconnected container network after acquisition and acknowledged per-run nonce before app-server"
+	nativeAttempt(stages, "native_skill_discovery", "git-native-rpc.jsonl")
+	r := startNativeRPC(t, f, client, "git-native")
+	defer r.close()
+	r.must(t, "initialize", map[string]any{"clientInfo": map[string]string{"name": "uap_native_fixture", "version": "1.0.0"}, "capabilities": map[string]any{"experimentalApi": true}})
+	if err := json.NewEncoder(r.in).Encode(map[string]any{"method": "initialized"}); err != nil {
+		t.Fatal(err)
+	}
+	var listing struct {
+		Data []struct {
+			Skills []struct {
+				Name     string `json:"name"`
+				Path     string `json:"path"`
+				PluginID string `json:"pluginId"`
+				Enabled  bool   `json:"enabled"`
+			} `json:"skills"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(r.must(t, "skills/list", map[string]any{"cwds": []string{f.Project}, "forceReload": true}), &listing); err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, group := range listing.Data {
+		for _, skill := range group.Skills {
+			if skill.Name != "demo:alpha" || skill.PluginID != f.PluginID || !skill.Enabled {
+				continue
+			}
+			nativeRequireContained(t, f.Root, skill.Path)
+			if !strings.Contains(skill.Path, "/plugins/cache/") || !strings.HasSuffix(skill.Path, "/skills/alpha/SKILL.md") {
+				t.Fatal("skill is not from installed native cache")
+			}
+			body, err := os.ReadFile(skill.Path)
+			if err != nil || string(body) != "---\nname: alpha\ndescription: Fixture skill alpha for the Agent Plugins conformance kit.\n---\n\nFixture body.\n" || nativeSHA(t, skill.Path) != "f77d30f91adee306136e36b0bedd535a826db3b2884b6dfbd5ba8f3d548efd3b" {
+				t.Fatal("native Git skill body mismatch")
+			}
+			evidence["native_skill_sha256"] = nativeSHA(t, skill.Path)
+			evidence["native_plugin_id"] = skill.PluginID
+			evidence["native_skill_path"] = skill.Path
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("exact Git plugin-attributed skill absent from native discovery")
+	}
+	stages["native_skill_discovery"] = nativeStage{Status: "passed", Reason: "Fresh isolated native app-server discovered exact plugin-attributed demo:alpha installed cache body; no model use or MCP execution claimed", Artifacts: []string{"git-native-rpc.jsonl"}}
+	r.close()
+	nativeAttempt(stages, "remove", "git-remove-installer.json")
+	nativeInstaller(t, f, installer, client, "git-remove", "remove", "demo", "--external-uninstalled")
+	if _, err := os.Lstat(active); !os.IsNotExist(err) {
+		t.Fatal("Git-installed managed directory remains after remove")
+	}
+	nativeAssertAbsent(t, f, client, f.PluginID, "git-removed")
+	stages["remove"] = nativeStage{Status: "passed", Reason: "Normal remove deleted managed artifact; fresh app-server excludes plugin tools/skills", Artifacts: []string{"git-remove-installer.json", "git-removed-rpc.jsonl"}}
+
 }

--- a/repotests/agentplugins_codex_native_e2e_test.go
+++ b/repotests/agentplugins_codex_native_e2e_test.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -388,6 +389,9 @@ func TestAgentpluginsCodexNativeLifecycle(t *testing.T) {
 		}
 		evidence["artifact_sha256"] = hashes
 		nativeJSON(t, filepath.Join(f.Root, "evidence.json"), evidence)
+		if err := nativeStageFailures(stages); err != nil {
+			t.Error(err)
+		}
 	}()
 	identity, err := nativeSourceIdentity(os.Getenv("AGENTPLUGINS_INSTALLER_COMMIT"), os.Getenv("AGENTPLUGINS_INSTALLER_TREE"), os.Getenv("AGENTPLUGINS_INSTALLER_PATCH_SHA256"))
 	if err != nil {
@@ -855,6 +859,22 @@ func nativeCheckHTTP(t *testing.T, f *nativeFixture, stages map[string]nativeSta
 	}
 }
 
+// Evaluate only recorded failures: unattempted and out-of-scope stages do not
+// claim success and must not make a bounded native run fail.
+func nativeStageFailures(stages map[string]nativeStage) error {
+	var failures []string
+	for name, stage := range stages {
+		if stage.Status == "failed" {
+			failures = append(failures, name+": "+stage.Reason)
+		}
+	}
+	if len(failures) == 0 {
+		return nil
+	}
+	sort.Strings(failures)
+	return fmt.Errorf("native stages failed: %s", strings.Join(failures, "; "))
+}
+
 func nativeAttempt(stages map[string]nativeStage, name, artifact string) {
 	stages[name] = nativeStage{Status: "failed", Reason: "Attempt started but did not complete its assertions; inspect the test failure and transcript", Artifacts: []string{artifact}}
 }
@@ -1064,6 +1084,9 @@ func TestAgentpluginsCodexImmutableGitDiscovery(t *testing.T) {
 		}
 		evidence["artifact_sha256"] = hashes
 		nativeJSON(t, filepath.Join(f.Root, "evidence.json"), evidence)
+		if err := nativeStageFailures(stages); err != nil {
+			t.Error(err)
+		}
 	}()
 	nativeWrite(t, filepath.Join(f.CodexHome, "config.toml"), []byte("cli_auth_credentials_store = \"file\"\nmcp_oauth_credentials_store = \"file\"\n[analytics]\nenabled = false\n[feedback]\nenabled = false\n"), 0600)
 	version, err := nativeCommand(t, f, client, "client-version", "--version")

--- a/repotests/agentplugins_codex_native_e2e_test.go
+++ b/repotests/agentplugins_codex_native_e2e_test.go
@@ -1,0 +1,845 @@
+package pluginkitairepo_test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// This suite is intentionally opt-in and uses only a freshly provisioned binary.
+// macOS release binaries read managed CFPreferences independently of HOME; this
+// runner requires a clean Linux container/VM until that boundary is isolated.
+func nativeBinary(t *testing.T, key string) string {
+	t.Helper()
+	p := os.Getenv(key)
+	if !filepath.IsAbs(p) {
+		t.Fatalf("%s must name an absolute scratch binary", key)
+	}
+	st, err := os.Stat(p)
+	if err != nil || !st.Mode().IsRegular() || st.Mode()&0111 == 0 {
+		t.Fatalf("invalid %s binary", key)
+	}
+	return p
+}
+
+type nativeRPC struct {
+	cmd      *exec.Cmd
+	in       io.WriteCloser
+	messages chan []byte
+	cancel   context.CancelFunc
+	log      *os.File
+	next     int
+}
+
+func startNativeRPC(t *testing.T, f *nativeFixture, client, label string) *nativeRPC {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	cmd := exec.CommandContext(ctx, client, "app-server")
+	cmd.Dir = f.Project
+	cmd.Env = f.env(filepath.Dir(client))
+	in, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	out, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	stderr, err := os.Create(filepath.Join(f.Root, label+"-stderr.log"))
+	if err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	cmd.Stderr = stderr
+	log, err := os.Create(filepath.Join(f.Root, label+"-rpc.jsonl"))
+	if err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		cancel()
+		stderr.Close()
+		log.Close()
+		t.Fatal(err)
+	}
+	r := &nativeRPC{cmd: cmd, in: in, cancel: cancel, log: log, messages: make(chan []byte, 128)}
+	go func() {
+		defer close(r.messages)
+		scan := bufio.NewScanner(io.LimitReader(out, 16<<20))
+		scan.Buffer(make([]byte, 4096), 2<<20)
+		for scan.Scan() {
+			b := bytes.Clone(scan.Bytes())
+			select {
+			case r.messages <- b:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	t.Cleanup(func() { r.close(); stderr.Close() })
+	return r
+}
+func (r *nativeRPC) close() {
+	if r.cancel != nil {
+		r.in.Close()
+		r.cancel()
+		_ = r.cmd.Wait()
+		r.log.Close()
+		r.cancel = nil
+	}
+}
+func (r *nativeRPC) request(method string, params any) (json.RawMessage, error) {
+	r.next++
+	id := r.next
+	request := map[string]any{"id": id, "method": method, "params": params}
+	if err := json.NewEncoder(r.log).Encode(map[string]any{"direction": "send", "message": request}); err != nil {
+		return nil, err
+	}
+	if err := json.NewEncoder(r.in).Encode(request); err != nil {
+		return nil, err
+	}
+	timer := time.NewTimer(35 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case b, ok := <-r.messages:
+			if !ok {
+				return nil, fmt.Errorf("app-server closed during %s", method)
+			}
+			var row struct {
+				ID     int             `json:"id"`
+				Result json.RawMessage `json:"result"`
+				Error  json.RawMessage `json:"error"`
+			}
+			if err := json.Unmarshal(b, &row); err != nil {
+				return nil, err
+			}
+			if err := json.NewEncoder(r.log).Encode(map[string]any{"direction": "receive", "message": json.RawMessage(b)}); err != nil {
+				return nil, err
+			}
+			if row.ID == id {
+				if len(row.Error) > 0 {
+					return nil, fmt.Errorf("%s: %s", method, row.Error)
+				}
+				return row.Result, nil
+			}
+		case <-timer.C:
+			return nil, fmt.Errorf("timeout: %s", method)
+		}
+	}
+}
+func (r *nativeRPC) must(t *testing.T, method string, params any) json.RawMessage {
+	t.Helper()
+	b, err := r.request(method, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+func nativeCommand(t *testing.T, f *nativeFixture, binary, label string, args ...string) ([]byte, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd.Env = f.env(filepath.Dir(binary))
+	cmd.Dir = f.Project
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	b, err := cmd.Output()
+	nativeWrite(t, filepath.Join(f.Root, label+"-stderr.log"), stderr.Bytes(), 0600)
+	nativeWrite(t, filepath.Join(f.Root, label+".log"), b, 0600)
+	return b, err
+}
+func nativeInstaller(t *testing.T, f *nativeFixture, installer, client, label string, args ...string) []byte {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, installer, append(args, "--target", "codex", "--format", "json")...)
+	cmd.Env = f.env(filepath.Dir(client))
+	cmd.Dir = f.Project
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	b, err := cmd.Output()
+	nativeWrite(t, filepath.Join(f.Root, label+"-installer-stderr.log"), stderr.Bytes(), 0600)
+	nativeWrite(t, filepath.Join(f.Root, label+"-installer.json"), b, 0600)
+	if err != nil {
+		t.Fatalf("%s: %v\nstdout: %s\nstderr: %s", label, err, b, stderr.Bytes())
+	}
+	if err := nativeValidateInstallerJSON(b); err != nil {
+		t.Fatalf("%s JSON contract: %v; stderr: %s", label, err, stderr.Bytes())
+	}
+	return b
+}
+func nativeSession(t *testing.T, f *nativeFixture, client, label, revision, operation string, stages map[string]nativeStage) nativeFacts {
+	t.Helper()
+	nativeAttempt(stages, label+"_native_tool", label+"-rpc.jsonl")
+	r := startNativeRPC(t, f, client, label)
+	defer r.close()
+	r.must(t, "initialize", map[string]any{"clientInfo": map[string]string{"name": "uap_native_fixture", "version": "1.0.0"}, "capabilities": map[string]any{"experimentalApi": true}})
+	if err := json.NewEncoder(r.in).Encode(map[string]any{"method": "initialized"}); err != nil {
+		t.Fatal(err)
+	}
+	var thread struct {
+		Thread struct {
+			ID string `json:"id"`
+		} `json:"thread"`
+	}
+	if err := json.Unmarshal(r.must(t, "thread/start", map[string]any{"cwd": f.Project, "ephemeral": true, "approvalPolicy": "never", "sandbox": "read-only", "model": "fixture-model", "modelProvider": "fixture"}), &thread); err != nil || thread.Thread.ID == "" {
+		t.Fatalf("thread start: %v", err)
+	}
+	var inventory struct {
+		Data []struct {
+			Name          string                     `json:"name"`
+			PluginID      string                     `json:"pluginId"`
+			RuntimeStatus string                     `json:"runtimeStatus"`
+			Tools         map[string]json.RawMessage `json:"tools"`
+		} `json:"data"`
+		NextCursor *string `json:"nextCursor"`
+	}
+	b := r.must(t, "mcpServerStatus/list", map[string]any{"threadId": thread.Thread.ID, "limit": 100})
+	if err := json.Unmarshal(b, &inventory); err != nil {
+		t.Fatal(err)
+	}
+	if inventory.NextCursor != nil {
+		t.Fatal("unexpected inventory pagination; refusing incomplete evidence")
+	}
+	var observed nativeFacts
+	count := 0
+	serverNames := map[string]bool{}
+	for _, server := range inventory.Data {
+		if server.PluginID != f.PluginID {
+			continue
+		}
+		if serverNames[server.Name] {
+			t.Fatalf("duplicate native plugin server: %s", server.Name)
+		}
+		serverNames[server.Name] = true
+		if server.Name == "http" {
+			result, err := r.request("mcpServer/tool/call", map[string]any{"threadId": thread.Thread.ID, "server": server.Name, "tool": "inspect_runtime", "arguments": map[string]string{"nonce": f.Nonce}})
+			if err != nil {
+				stages[label+"_http"] = nativeStage{Status: "failed", Reason: err.Error()}
+			} else {
+				facts := nativeDecodeFacts(t, result)
+				nativeAssertEvent(t, f, facts)
+				stages[label+"_http"] = nativeStage{Status: "passed", Reason: "Native HTTP call correlated; HTTP process roots are harness behavior", Artifacts: []string{"http-events.jsonl", label + "-rpc.jsonl"}}
+			}
+			continue
+		}
+		if server.Name != "default" && server.Name != "explicit" {
+			continue
+		}
+		count++
+		result := r.must(t, "mcpServer/tool/call", map[string]any{"threadId": thread.Thread.ID, "server": server.Name, "tool": "inspect_runtime", "arguments": map[string]string{"nonce": f.Nonce, "operation": operation, "marker": "persist-" + f.Nonce}})
+		facts := nativeDecodeFacts(t, result)
+		nativeAssertEvent(t, f, facts)
+		if facts.Revision != revision || facts.Nonce != f.Nonce || facts.Marker != "persist-"+f.Nonce {
+			t.Fatalf("runtime mismatch: %+v", facts)
+		}
+		for _, p := range []string{facts.Root, facts.Data, facts.CWD} {
+			rel, err := filepath.Rel(f.Root, p)
+			if err != nil || rel == ".." || strings.HasPrefix(rel, "../") {
+				t.Fatalf("runtime path escapes fixture: %s", p)
+			}
+		}
+		if !strings.Contains(facts.Root, string(filepath.Separator)+"plugins/cache/") {
+			t.Fatalf("not native installed cache: %s", facts.Root)
+		}
+		for _, path := range []string{"plugin.json", ".codex-plugin/plugin.json"} {
+			if _, err := os.Stat(filepath.Join(facts.Root, path)); err != nil {
+				t.Fatalf("missing root/sidecar: %v", err)
+			}
+		}
+		wantCWD := facts.Root
+		if server.Name == "explicit" {
+			wantCWD = filepath.Join(facts.Root, "skills")
+		}
+		if facts.CWD != wantCWD {
+			stages[label+"_cwd_"+server.Name] = nativeStage{Status: "failed", Reason: fmt.Sprintf("observed %s, wanted %s", facts.CWD, wantCWD)}
+		} else {
+			stages[label+"_cwd_"+server.Name] = nativeStage{Status: "passed"}
+		}
+		if facts.Literal != "literal ${UNKNOWN} $HOME" || facts.Once != facts.Root+"/${UNKNOWN}" || len(facts.Argv) != 3 || facts.Argv[0] != "argument with spaces" || facts.Argv[1] != facts.Root+"/argument" || facts.Argv[2] != "${UNKNOWN}" {
+			t.Fatalf("literal/substitution mismatch: %+v", facts)
+		}
+		observed = facts
+	}
+	if len(serverNames) != 4 || !serverNames["default"] || !serverNames["explicit"] || !serverNames["http"] || !serverNames["redirect"] {
+		t.Fatalf("unexpected exact native server inventory: %v", serverNames)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 plugin servers, got %d: %s", count, b)
+	}
+	stages[label+"_native_tool"] = nativeStage{Status: "passed", Artifacts: []string{label + "-rpc.jsonl", "events.jsonl"}}
+	nativeAttempt(stages, label+"_skill_discovery", label+"-rpc.jsonl")
+	var skills struct {
+		Data []struct {
+			Skills []struct {
+				Name     string `json:"name"`
+				Path     string `json:"path"`
+				PluginID string `json:"pluginId"`
+				Enabled  bool   `json:"enabled"`
+			} `json:"skills"`
+		} `json:"data"`
+	}
+	b = r.must(t, "skills/list", map[string]any{"cwds": []string{f.Project}, "forceReload": true})
+	if err := json.Unmarshal(b, &skills); err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, group := range skills.Data {
+		for _, skill := range group.Skills {
+			if nativeSkillIdentity(skill.Name, skill.PluginID, skill.Path, skill.Enabled, f.PluginID, observed.Root) {
+				body, err := os.ReadFile(skill.Path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Contains(body, []byte("UAP_SKILL_BODY_"+revision+"_"+f.Nonce)) {
+					t.Fatal("stale skill cache")
+				}
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("plugin skill absent: %s", b)
+	}
+	stages[label+"_native_tool"] = nativeStage{Status: "passed", Artifacts: []string{label + "-rpc.jsonl", "events.jsonl"}}
+	stages[label+"_skill_discovery"] = nativeStage{Status: "passed", Reason: "Exact plugin-attributed skill path and body bytes; no model use claimed"}
+	return observed
+}
+
+func TestAgentpluginsCodexNativeLifecycle(t *testing.T) {
+	if os.Getenv("AGENTPLUGINS_CODEX_NATIVE_E2E") != "1" {
+		t.Skip("opt-in native client execution")
+	}
+	if runtime.GOOS != "linux" || os.Getenv("AGENTPLUGINS_NATIVE_DISPOSABLE_LINUX") != "1" {
+		t.Fatal("requires a newly provisioned disposable Linux container/VM; macOS managed preferences are not isolated by HOME")
+	}
+	if _, err := os.Lstat("/etc/codex"); !os.IsNotExist(err) {
+		t.Fatal("system Codex config must be absent in disposable image")
+	}
+	client := nativeBinary(t, "AGENTPLUGINS_CODEX_BIN")
+	installer := nativeBinary(t, "AGENTPLUGINS_INSTALLER_BIN")
+	f := newNativeFixture(t, true)
+	f.ClientBinDir = filepath.Dir(client)
+	stages := map[string]nativeStage{}
+	for _, name := range []string{"install", "A_native_tool", "B_native_tool", "same_version_native_tool", "unchanged", "owned_repair", "native_cache_repair", "partial_failure", "remove", "repeat_remove", "foreign_preservation", "collision_drift", "immutable_git", "http", "redirect_headers", "skill_context", "real_model_skill_use", "oauth"} {
+		stages[name] = nativeStage{Status: "not_evaluated", Reason: "not reached"}
+	}
+	evidence := map[string]any{"started_utc": time.Now().UTC().Format(time.RFC3339Nano), "os": runtime.GOOS, "arch": runtime.GOARCH, "profile": f.Root, "client_version": "0.153.4", "client_source": "3d2ee51ca2d5db578f328aa75e20aa22c0197c9a", "client_sha256": nativeSHA(t, client), "installer_sha256": nativeSHA(t, installer), "installer_base_commit": os.Getenv("AGENTPLUGINS_INSTALLER_COMMIT"), "installer_source_state": "reviewed_uncommitted_patches", "installer_patch_sha256": strings.Split(os.Getenv("AGENTPLUGINS_INSTALLER_PATCH_SHA256"), ","), "installer_tree": os.Getenv("AGENTPLUGINS_INSTALLER_TREE"), "acquisition": "local_directory", "native_surface": "codex app-server direct thread MCP RPC", "stages": stages}
+	defer func() {
+		evidence["finished_utc"] = time.Now().UTC().Format(time.RFC3339Nano)
+		hashes := map[string]string{}
+		entries, _ := os.ReadDir(f.Root)
+		for _, e := range entries {
+			if !e.IsDir() && (strings.HasSuffix(e.Name(), ".jsonl") || strings.HasSuffix(e.Name(), ".log") || strings.HasSuffix(e.Name(), "-installer.json")) {
+				hashes[e.Name()] = nativeSHA(t, filepath.Join(f.Root, e.Name()))
+			}
+		}
+		evidence["artifact_sha256"] = hashes
+		nativeJSON(t, filepath.Join(f.Root, "evidence.json"), evidence)
+	}()
+	if evidence["installer_base_commit"] == "" || evidence["installer_tree"] == "" {
+		t.Fatal("exact installer base commit and resulting tree required")
+	}
+	if os.Getenv("AGENTPLUGINS_INSTALLER_PATCH_SHA256") == "" {
+		t.Fatal("accepted installer patch digests required for reviewed uncommitted source identity")
+	}
+	nativeWrite(t, filepath.Join(f.CodexHome, "config.toml"), []byte("cli_auth_credentials_store = \"file\"\nmcp_oauth_credentials_store = \"file\"\nmodel_provider = \"fixture\"\nmodel = \"fixture-model\"\n[model_providers.fixture]\nname = \"Fixture\"\nbase_url = \"http://127.0.0.1:1/v1\"\nwire_api = \"responses\"\nrequires_openai_auth = false\n[analytics]\nenabled = false\n[feedback]\nenabled = false\n"), 0600)
+	b, err := nativeCommand(t, f, client, "client-version", "--version")
+	if err != nil || strings.TrimSpace(string(b)) != "codex-cli 0.153.4" {
+		t.Fatalf("wrong pinned client: %s %v", b, err)
+	}
+	nativeAttempt(stages, "scanner_prerequisite", "evidence.json")
+	evidence["security_scanner"] = nativeProvisionScanner(t, f)
+	stages["scanner_prerequisite"] = nativeStage{Status: "passed", Reason: "Verified pinned official scanner prepopulated supported fresh cache"}
+	nativeHTTP(t, f)
+	f.writePackage(t, "A", "1.0.0")
+	evidence["manifest_sha256"] = nativeSHA(t, filepath.Join(f.Package, "plugin.json"))
+	nativeAttempt(stages, "install", "add-installer.json")
+	nativeAttempt(stages, "local_security_scan", "add-installer.json")
+	addOutput := nativeInstaller(t, f, installer, client, "add", "add", f.Package)
+	var securityOutput any
+	if err := json.Unmarshal(addOutput, &securityOutput); err != nil {
+		t.Fatal(err)
+	}
+	if err := nativeValidateMCPSelections(securityOutput); err != nil {
+		t.Fatal(err)
+	}
+	if nativeFindString(securityOutput, "evidence_source") != "local_scan" {
+		t.Fatal("first add did not report ordinary local_scan security assessment")
+	}
+	stages["local_security_scan"] = nativeStage{Status: "passed", Artifacts: []string{"add-installer.json"}}
+	stages["install"] = nativeStage{Status: "passed", Artifacts: []string{"add-installer.json"}}
+	var output any
+	if err := json.Unmarshal(addOutput, &output); err != nil {
+		t.Fatal(err)
+	}
+	active := nativeFindString(output, "active_path")
+	if active == "" {
+		state, err := os.ReadFile(filepath.Join(f.Root, "installer-state", "state-v2.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var doc any
+		if err := json.Unmarshal(state, &doc); err != nil {
+			t.Fatal(err)
+		}
+		active = nativeFindString(doc, "target_locator")
+	}
+	if active == "" {
+		t.Fatal("installer state omitted managed target_locator")
+	}
+	nativeRequireContained(t, f.Root, active)
+	physical := nativeFindString(securityOutput, "physical_artifact_id")
+	if physical == "" {
+		t.Fatal("installer plan omitted physical artifact identity")
+	}
+	f.PluginID = "native-proof@" + providers.ManagedMarketplaceName(physical)
+	nativeAttempt(stages, "native_inventory", "installed-inventory.log")
+	b, err = nativeCommand(t, f, client, "installed-inventory", "plugin", "list", "--json")
+	if err != nil {
+		t.Fatalf("native inventory: %v %s", err, b)
+	}
+	var inventory struct {
+		Installed []struct {
+			ID          string `json:"pluginId"`
+			Name        string `json:"name"`
+			Marketplace string `json:"marketplaceName"`
+			Source      struct {
+				Path string `json:"path"`
+			} `json:"source"`
+			Installed bool `json:"installed"`
+			Enabled   bool `json:"enabled"`
+		} `json:"installed"`
+	}
+	if err := json.Unmarshal(b, &inventory); err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, p := range inventory.Installed {
+		if p.Name == "native-proof" && p.ID == f.PluginID && p.ID == p.Name+"@"+p.Marketplace && p.Source.Path == active && p.Installed && p.Enabled {
+			found = true
+			evidence["native_plugin_id"] = p.ID
+		}
+	}
+	if !found {
+		t.Fatalf("exact native installation missing: %s", b)
+	}
+	stages["native_inventory"] = nativeStage{Status: "passed", Artifacts: []string{"installed-inventory.log"}}
+	foreign := map[string][]byte{
+		filepath.Join(f.CodexHome, "skills", "foreign-proof", "SKILL.md"):                                          []byte("---\nname: foreign-proof\ndescription: Foreign sandbox sentinel\n---\nForeign fixture body\n"),
+		filepath.Join(f.CodexHome, "plugins", "cache", "foreign-market", "foreign-plugin", "1.0.0", "plugin.json"): []byte(`{"name":"foreign-plugin","version":"1.0.0"}`),
+		filepath.Join(f.CodexHome, "plugins", "marketplaces", "foreign-market", "sentinel.txt"):                    []byte("foreign marketplace fixture"),
+	}
+	for path, body := range foreign {
+		nativeWrite(t, path, body, 0600)
+	}
+	a := nativeSession(t, f, client, "A", "A", "write", stages)
+	nativeAttempt(stages, "B_native_tool", "update-B-installer.json")
+	f.writePackage(t, "B", "1.1.0")
+	nativeInstaller(t, f, installer, client, "update-B", "update", "native-proof")
+	bFacts := nativeSession(t, f, client, "B", "B", "read", stages)
+	nativeAttempt(stages, "B_data_identity", "B-rpc.jsonl")
+	if a.Data != bFacts.Data {
+		t.Fatal("native data identity changed")
+	}
+	nativeAttempt(stages, "same_version_native_tool", "update-same-version-installer.json")
+	stages["B_data_identity"] = nativeStage{Status: "passed"}
+	f.writePackage(t, "C", "1.1.0")
+	nativeInstaller(t, f, installer, client, "update-same-version", "update", "native-proof")
+	c := nativeSession(t, f, client, "same_version", "C", "read", stages)
+	nativeAttempt(stages, "same_version_data_identity", "same_version-rpc.jsonl")
+	if c.Data != a.Data {
+		t.Fatal("same-version data identity changed")
+	}
+	stages["same_version_data_identity"] = nativeStage{Status: "passed"}
+	nativeAttempt(stages, "unchanged", "unchanged-installer.json")
+	statePath := filepath.Join(f.Root, "installer-state", "state-v2.json")
+	unchangedState, unchangedManaged, unchangedCache := nativeSHA(t, statePath), nativeTreeDigest(t, active), nativeTreeDigest(t, c.Root)
+	b = nativeInstaller(t, f, installer, client, "unchanged", "add", f.Package)
+	if err := nativeUnchangedResult(b); err != nil {
+		t.Fatal(err)
+	}
+	if nativeSHA(t, statePath) != unchangedState || nativeTreeDigest(t, active) != unchangedManaged || nativeTreeDigest(t, c.Root) != unchangedCache {
+		t.Fatal("non-mutating same-source add changed state or managed/cache content")
+	}
+	stages["unchanged"] = nativeStage{Status: "passed", Reason: "Unchanged package: explicit mutated=false and identical state/managed/cache bytes; authentication convergence not claimed"}
+	// A changed existing directory deliberately loses provable content ownership.
+	// Verify fail-closed protection, then restore only bytes this fixture saved.
+	nativeAttempt(stages, "owned_artifact_guard", "owned-guard.log")
+	skillPath := filepath.Join(active, "skills", "native-proof", "SKILL.md")
+	originalSkill, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalInfo, err := os.Stat(skillPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalDigest := nativeTreeDigest(t, active)
+	nativeWrite(t, skillPath, []byte("owned damage"), originalInfo.Mode().Perm())
+	damagedDigest, cacheDigest := nativeTreeDigest(t, active), nativeTreeDigest(t, c.Root)
+	guardState, guardMarker := nativeSHA(t, statePath), nativeSHA(t, filepath.Join(a.Data, "native-marker.txt"))
+	guard, guardErr := nativeCommand(t, f, installer, "owned-guard", "repair", "native-proof", "--target", "codex", "--format", "json")
+	guardStderr, err := os.ReadFile(filepath.Join(f.Root, "owned-guard-stderr.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := nativeRepairGuardResult(guard, guardStderr, guardErr); err != nil {
+		t.Fatal(err)
+	}
+	if nativeTreeDigest(t, active) != damagedDigest || nativeTreeDigest(t, c.Root) != cacheDigest || nativeSHA(t, statePath) != guardState || nativeSHA(t, filepath.Join(a.Data, "native-marker.txt")) != guardMarker {
+		t.Fatal("refused repair changed state, managed/cache bytes or native data")
+	}
+	stages["owned_artifact_guard"] = nativeStage{Status: "passed", Reason: "Existing modified artifact refused as indeterminate ownership; managed/cache bytes unchanged", Artifacts: []string{"owned-guard.log", "owned-guard-stderr.log"}}
+	nativeWrite(t, skillPath, originalSkill, originalInfo.Mode().Perm())
+	if nativeTreeDigest(t, active) != originalDigest {
+		t.Fatal("fixture original bytes were not restored exactly")
+	}
+	// Actual reconstruction tests an absent recorded artifact separately.
+	nativeAttempt(stages, "owned_repair", "owned-repair-installer.json")
+	backup := filepath.Join(f.Root, "owned-artifact-backup")
+	if err := os.Rename(active, backup); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(active); !os.IsNotExist(err) {
+		t.Fatal("recorded artifact is not absent after fixture backup")
+	}
+	nativeInstaller(t, f, installer, client, "owned-repair", "repair", "native-proof")
+	nativeSession(t, f, client, "owned_repair", "C", "read", stages)
+	stages["owned_repair"] = nativeStage{Status: "passed", Reason: "Absent recorded artifact reconstructed by supported repair; fresh tool/skill verified"}
+	// Native cache is a separate ownership surface; refusal is recorded independently.
+	nativeAttempt(stages, "native_cache_repair", "native-cache-repair.log")
+	nativeWrite(t, filepath.Join(c.Root, "skills", "native-proof", "SKILL.md"), []byte("native cache damage"), 0600)
+	repair, repairErr := nativeCommand(t, f, installer, "native-cache-repair", "repair", "native-proof", "--target", "codex", "--format", "json")
+	if repairErr != nil {
+		stages["native_cache_repair"] = nativeStage{Status: "failed", Reason: "Supported repair refused cache damage: " + string(repair)}
+	} else {
+		nativeSession(t, f, client, "native_cache_repair", "C", "read", stages)
+		stages["native_cache_repair"] = nativeStage{Status: "passed"}
+	}
+	nativeAttempt(stages, "remove", "remove-installer.json")
+	// Codex has no supported CLI verb for UAP to silently uninstall a plugin
+	// on the user's behalf (see usecase/remove.go and remove_group.go); every
+	// real remove against Codex must be an acknowledged external uninstall.
+	nativeInstaller(t, f, installer, client, "remove", "remove", "native-proof", "--external-uninstalled")
+	// UAP's own directory removal must be immediate and independent of
+	// whatever a later fresh app-server session reports; this isolates that
+	// claim from the app-server-level check below (nativeAssertAbsent), which
+	// caught a real regression where Codex's own config.toml retained a
+	// stale enabled-plugin entry and a fresh app-server silently
+	// re-materialized the plugin from its original source (fixed in
+	// providers/activator.go's removeCodexPlugin).
+	if _, statErr := os.Lstat(active); statErr == nil {
+		t.Fatalf("managed active path still exists immediately after remove, before any fresh app-server session: %s", active)
+	} else if !os.IsNotExist(statErr) {
+		t.Fatalf("stat active path after remove: %v", statErr)
+	}
+	b, err = nativeCommand(t, f, client, "removed-inventory", "plugin", "list", "--json")
+	if err != nil || nativeHasPluginID(t, b, fmt.Sprint(evidence["native_plugin_id"])) {
+		t.Fatalf("native remove not verified: %v %s", err, b)
+	}
+	marker, err := os.ReadFile(filepath.Join(a.Data, "native-marker.txt"))
+	if err != nil || string(marker) != "persist-"+f.Nonce {
+		t.Fatal("remove lost native data marker")
+	}
+	nativeAssertAbsent(t, f, client, fmt.Sprint(evidence["native_plugin_id"]), "removed")
+	stages["remove"] = nativeStage{Status: "passed", Reason: "New CLI/app-server inventory excludes plugin; native data retained"}
+	nativeAttempt(stages, "foreign_preservation", "removed-rpc.jsonl")
+	for path, body := range foreign {
+		got, err := os.ReadFile(path)
+		if err != nil || !bytes.Equal(got, body) {
+			t.Fatalf("foreign bytes changed: %s", path)
+		}
+	}
+	stages["foreign_preservation"] = nativeStage{Status: "passed", Reason: "Foreign skill/cache/marketplace sentinel bytes retained"}
+	nativeAttempt(stages, "repeat_remove", "repeat-remove.log")
+	repeat, repeatErr := nativeCommand(t, f, installer, "repeat-remove", "remove", "native-proof", "--external-uninstalled", "--target", "codex", "--format", "json")
+	repeatStderr, readErr := os.ReadFile(filepath.Join(f.Root, "repeat-remove-stderr.log"))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !nativeRepeatRemoveExpected(append(append([]byte{}, repeat...), repeatStderr...), repeatErr) {
+		stages["repeat_remove"] = nativeStage{Status: "failed", Reason: fmt.Sprintf("unexpected repeated removal error: %v; %s", repeatErr, repeat)}
+		t.Fatal(stages["repeat_remove"].Reason)
+	}
+	for path, body := range foreign {
+		got, err := os.ReadFile(path)
+		if err != nil || !bytes.Equal(got, body) {
+			t.Fatalf("repeat remove changed foreign bytes: %s", path)
+		}
+	}
+	nativeAssertAbsent(t, f, client, fmt.Sprint(evidence["native_plugin_id"]), "repeat-removed")
+	marker, err = os.ReadFile(filepath.Join(a.Data, "native-marker.txt"))
+	if err != nil || string(marker) != "persist-"+f.Nonce {
+		t.Fatal("repeated removal lost native data marker")
+	}
+	stages["repeat_remove"] = nativeStage{Status: "passed", Reason: "Expected idempotent/not-found outcome; new native inventory absent and foreign/data bytes preserved"}
+	nativeCheckHTTP(t, f, stages)
+	for _, name := range []string{"real_model_skill_use", "oauth"} {
+		stages[name] = nativeStage{Status: "not_evaluated", Reason: "No authenticated provider or real model requested"}
+	}
+}
+
+func nativeFindString(v any, key string) string {
+	switch value := v.(type) {
+	case map[string]any:
+		if s, ok := value[key].(string); ok && s != "" {
+			return s
+		}
+		for _, child := range value {
+			if s := nativeFindString(child, key); s != "" {
+				return s
+			}
+		}
+	case []any:
+		for _, child := range value {
+			if s := nativeFindString(child, key); s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+func nativeRequireContained(t *testing.T, root, path string) {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rel, err := filepath.Rel(root, resolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, "../") {
+		t.Fatalf("path escapes disposable fixture: %s", path)
+	}
+}
+func nativeAssertAbsent(t *testing.T, f *nativeFixture, client, pluginID, label string) {
+	t.Helper()
+	r := startNativeRPC(t, f, client, label)
+	defer r.close()
+	r.must(t, "initialize", map[string]any{"clientInfo": map[string]string{"name": "uap_native_fixture", "version": "1.0.0"}, "capabilities": map[string]any{"experimentalApi": true}})
+	if err := json.NewEncoder(r.in).Encode(map[string]any{"method": "initialized"}); err != nil {
+		t.Fatal(err)
+	}
+	result := r.must(t, "mcpServerStatus/list", map[string]any{"limit": 100})
+	if nativeHasPluginID(t, result, pluginID) {
+		t.Fatalf("removed plugin still in new app-server: %s", result)
+	}
+	skills := r.must(t, "skills/list", map[string]any{"cwds": []string{f.Project}, "forceReload": true})
+	if nativeHasPluginID(t, skills, pluginID) {
+		t.Fatal("removed plugin skill still discovered")
+	}
+}
+func nativeCheckHTTP(t *testing.T, f *nativeFixture, stages map[string]nativeStage) {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(f.Root, "http-events.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen, redirect, leaked := false, false, false
+	negotiated := ""
+	stages["generated_protocol_header_priority"] = nativeStage{Status: "not_evaluated", Reason: "No post-negotiation request with a generated protocol header observed"}
+	for _, line := range bytes.Split(b, []byte{'\n'}) {
+		if len(line) == 0 {
+			continue
+		}
+		var e struct {
+			Origin     string `json:"origin"`
+			Method     string `json:"method"`
+			URI        string `json:"uri"`
+			Probe      string `json:"probe_header"`
+			Literal    string `json:"literal_header"`
+			Protocol   string `json:"protocol"`
+			RPCMethod  string `json:"rpc_method"`
+			Negotiated string `json:"negotiated_protocol"`
+		}
+		if err := json.Unmarshal(line, &e); err != nil {
+			t.Fatal(err)
+		}
+		if e.Origin == "protocol-response" {
+			negotiated = e.Negotiated
+			continue
+		}
+		if strings.HasPrefix(e.URI, "/mcp?") && e.RPCMethod != "initialize" && e.RPCMethod != "" && negotiated != "" {
+			previous := stages["generated_protocol_header_priority"]
+			if e.Protocol != "" && e.Protocol != negotiated {
+				stages["generated_protocol_header_priority"] = nativeStage{Status: "failed", Reason: "Post-negotiation header " + e.Protocol + " differs from negotiated " + negotiated}
+			} else if e.Protocol == negotiated && previous.Status != "failed" {
+				stages["generated_protocol_header_priority"] = nativeStage{Status: "passed", Reason: "Post-negotiation header exactly matches negotiated " + negotiated}
+			}
+		}
+		if e.Origin == "redirect-destination" {
+			redirect = true
+			if e.Probe != "" {
+				leaked = true
+			}
+		}
+		if !seen && strings.HasPrefix(e.URI, "/mcp?") {
+			seen = true
+			if e.Method != "POST" || e.Probe != f.Nonce || e.Literal != "${UNKNOWN}" || e.URI != "/mcp?literal=%24%7BUNKNOWN%7D" {
+				stages["http_request_contract"] = nativeStage{Status: "failed", Reason: string(line)}
+			} else {
+				stages["http_request_contract"] = nativeStage{Status: "passed"}
+			}
+
+		}
+	}
+	if leaked {
+		stages["redirect_headers"] = nativeStage{Status: "failed", Reason: "Configured custom test header reached another loopback origin"}
+	} else if redirect {
+		stages["redirect_headers"] = nativeStage{Status: "passed", Reason: "Redirect destination received no configured test header"}
+	} else {
+		stages["redirect_headers"] = nativeStage{Status: "not_evaluated", Reason: "No redirect destination request observed; inspect source transcript"}
+	}
+}
+
+func nativeAttempt(stages map[string]nativeStage, name, artifact string) {
+	stages[name] = nativeStage{Status: "failed", Reason: "Attempt started but did not complete its assertions; inspect the test failure and transcript", Artifacts: []string{artifact}}
+}
+func nativeRepeatRemoveExpected(output []byte, err error) bool {
+	if err == nil {
+		return true
+	}
+	message := strings.TrimSpace(string(output))
+	return message == `agentplugins: installation "native-proof" was not found` || message == `agentplugins: plugin is not installed for target "codex" in user scope; no target was changed`
+}
+
+func nativeValidateInstallerJSON(b []byte) error {
+	var envelope struct {
+		Schema  int             `json:"schema_version"`
+		Command string          `json:"command"`
+		Result  string          `json:"result"`
+		Data    json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(b, &envelope); err != nil {
+		return err
+	}
+	if envelope.Schema != 1 || envelope.Command == "" || envelope.Result != "success" || len(envelope.Data) == 0 {
+		return fmt.Errorf("installer did not report a successful versioned JSON envelope: %s", b)
+	}
+	return nil
+}
+
+func nativeValidateMCPSelections(v any) error {
+	selected := map[string]bool{}
+	var visit func(any)
+	visit = func(value any) {
+		switch node := value.(type) {
+		case map[string]any:
+			if node["kind"] == "mcp_server" && (node["support"] == "projected" || node["support"] == "native") {
+				name, _ := node["name"].(string)
+				selected[name] = true
+			}
+			for _, child := range node {
+				visit(child)
+			}
+		case []any:
+			for _, child := range node {
+				visit(child)
+			}
+		}
+	}
+	visit(v)
+	if len(selected) != 4 || !selected["default"] || !selected["explicit"] || !selected["http"] || !selected["redirect"] {
+		return fmt.Errorf("installer plan did not select exact fixture MCP inventory: %v", selected)
+	}
+	return nil
+}
+
+// Pinned Codex namespace.rs qualifies skills as plugin-name:base-name. MCP
+// inventory instead preserves raw server keys; attribution is separate pluginId.
+func nativeSkillIdentity(name, pluginID, path string, enabled bool, expectedPluginID, cacheRoot string) bool {
+	return enabled && name == "native-proof:native-proof" && pluginID == expectedPluginID && path == filepath.Join(cacheRoot, "skills", "native-proof", "SKILL.md")
+}
+
+func nativeHasPluginID(t *testing.T, b []byte, id string) bool {
+	t.Helper()
+	var value any
+	if err := json.Unmarshal(b, &value); err != nil {
+		t.Fatal(err)
+	}
+	var has func(any) bool
+	has = func(v any) bool {
+		switch node := v.(type) {
+		case map[string]any:
+			if node["pluginId"] == id {
+				return true
+			}
+			for _, child := range node {
+				if has(child) {
+					return true
+				}
+			}
+		case []any:
+			for _, child := range node {
+				if has(child) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	return has(value)
+}
+
+func nativeUnchangedResult(b []byte) error {
+	if err := nativeValidateInstallerJSON(b); err != nil {
+		return err
+	}
+	var envelope struct {
+		Data struct {
+			Result struct {
+				Mutated *bool `json:"mutated"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(b, &envelope); err != nil {
+		return err
+	}
+	if envelope.Data.Result.Mutated == nil || *envelope.Data.Result.Mutated {
+		return fmt.Errorf("same-source add did not explicitly report data.result.mutated=false")
+	}
+	return nil
+}
+func nativeRepairGuardResult(stdout, stderr []byte, commandErr error) error {
+	if commandErr == nil || !strings.Contains(string(stderr), "native identity ownership is indeterminate; refusing repair") {
+		return fmt.Errorf("expected ownership guard refusal, got %v; %s", commandErr, stderr)
+	}
+	var result struct {
+		Result string `json:"result"`
+		Data   struct {
+			Status  string `json:"status"`
+			Targets []struct {
+				Output struct {
+					Result struct {
+						Mutated *bool `json:"mutated"`
+					} `json:"result"`
+				} `json:"output"`
+			} `json:"targets"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout, &result); err != nil {
+		return err
+	}
+	if result.Result != "failure" || result.Data.Status != "preflight_failed" || len(result.Data.Targets) != 1 {
+		return fmt.Errorf("unexpected ownership refusal envelope")
+	}
+	m := result.Data.Targets[0].Output.Result.Mutated
+	if m == nil || *m {
+		return fmt.Errorf("ownership refusal did not explicitly preserve targets")
+	}
+	return nil
+}

--- a/repotests/agentplugins_native_fixture_test.go
+++ b/repotests/agentplugins_native_fixture_test.go
@@ -433,6 +433,35 @@ func TestAgentpluginsNativeFixtureEvidenceOutcomes(t *testing.T) {
 	}
 }
 
+func TestAgentpluginsNativeFixtureStageFailures(t *testing.T) {
+	stages := map[string]nativeStage{
+		"tool":     {Status: "passed"},
+		"oauth":    {Status: "not_evaluated"},
+		"data":     {Status: "not_applicable"},
+		"optional": {Status: "skipped"},
+	}
+	if err := nativeStageFailures(stages); err != nil {
+		t.Fatalf("bounded successful evidence rejected: %v", err)
+	}
+	nativeAttempt(stages, "install", "add-installer.json")
+	if err := nativeStageFailures(stages); err == nil || !strings.Contains(err.Error(), "install:") {
+		t.Fatalf("unfinished attempted stage accepted: %v", err)
+	}
+	stages["install"] = nativeStage{Status: "passed"}
+	for _, name := range []string{"A_http", "A_cwd_default", "native_cache_repair", "generated_protocol_header_priority", "redirect_headers"} {
+		stages[name] = nativeStage{Status: "failed", Reason: "fixture mismatch"}
+		if err := nativeStageFailures(stages); err == nil || !strings.Contains(err.Error(), name+": fixture mismatch") {
+			t.Fatalf("%s failure accepted or omitted: %v", name, err)
+		}
+		delete(stages, name)
+	}
+	stages["z"] = nativeStage{Status: "failed", Reason: "last"}
+	stages["a"] = nativeStage{Status: "failed", Reason: "first"}
+	if err := nativeStageFailures(stages); err == nil || err.Error() != "native stages failed: a: first; z: last" {
+		t.Fatalf("failure reporting is incomplete or nondeterministic: %v", err)
+	}
+}
+
 // ReleaseScanner.resolve supports a prepopulated cache. The runtime still runs
 // the normal scan-agent-plugin command and validates its pinned report/policy.
 func nativeProvisionScanner(t *testing.T, f *nativeFixture) map[string]string {

--- a/repotests/agentplugins_native_fixture_test.go
+++ b/repotests/agentplugins_native_fixture_test.go
@@ -10,6 +10,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/loader"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/packagedigest"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/sourceacquisition"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/specregistry"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/planner"
@@ -29,6 +31,7 @@ import (
 type nativeFixture struct {
 	Root, Project, Home, CodexHome, Package, Probe, Events, Nonce string
 	PluginID, ClientBinDir, HTTPURL, RedirectURL                  string
+	ProviderRequests                                              chan []byte
 }
 type nativeStage struct {
 	Status    string   `json:"status"`
@@ -644,5 +647,172 @@ func TestAgentpluginsNativeFixtureLifecycleResults(t *testing.T) {
 	nativeWrite(t, path, []byte("original"), 0600)
 	if nativeTreeDigest(t, root) != before {
 		t.Fatal("exact restore not reproducible")
+	}
+}
+
+// Identity metadata describes the build input, never a made-up patch for a clean commit.
+// The orchestrator verifies these values against the build checkout and hashes the binary.
+func nativeSourceIdentity(commit, tree, patches string) (map[string]any, error) {
+	valid := func(value string, n int) bool {
+		b, err := hex.DecodeString(value)
+		return err == nil && len(b) == n && value == strings.ToLower(value)
+	}
+	if !valid(commit, 20) || !valid(tree, 20) {
+		return nil, fmt.Errorf("exact 40-character installer commit and tree required")
+	}
+	state := "committed"
+	hashes := []string{}
+	if patches != "" {
+		state = "reviewed_uncommitted_patches"
+		for _, h := range strings.Split(patches, ",") {
+			if !valid(h, 32) {
+				return nil, fmt.Errorf("installer patch must be an exact SHA256 digest")
+			}
+			hashes = append(hashes, h)
+		}
+	}
+	return map[string]any{"installer_base_commit": commit, "installer_tree": tree, "installer_source_state": state, "installer_patch_sha256": hashes}, nil
+}
+func TestAgentpluginsNativeFixtureSourceIdentity(t *testing.T) {
+	commit, tree := strings.Repeat("a", 40), strings.Repeat("b", 40)
+	identity, err := nativeSourceIdentity(commit, tree, "")
+	if err != nil || identity["installer_source_state"] != "committed" {
+		t.Fatalf("clean source: %v %v", identity, err)
+	}
+	identity, err = nativeSourceIdentity(commit, tree, strings.Repeat("c", 64))
+	if err != nil || identity["installer_source_state"] != "reviewed_uncommitted_patches" {
+		t.Fatal("patch source identity lost")
+	}
+	for _, bad := range []string{"unknown", strings.Repeat("c", 63), strings.Repeat("c", 64) + ","} {
+		if _, err := nativeSourceIdentity(commit, tree, bad); err == nil {
+			t.Fatalf("invalid patch accepted: %q", bad)
+		}
+	}
+	if _, err := nativeSourceIdentity("HEAD", tree, ""); err == nil {
+		t.Fatal("symbolic commit accepted")
+	}
+}
+
+// Uses the production exact-SHA acquirer with its supported transport injection.
+// The CLI only admits GitHub identities, so this is acquisition evidence, not
+// a claim that the CLI accepted a local Git URL or native Git registration.
+func nativeImmutableAcquisition(t *testing.T, f *nativeFixture) map[string]any {
+	t.Helper()
+	git, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := func(args ...string) string {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, git, args...)
+		cmd.Dir = f.Package
+		cmd.Env = append(f.env(filepath.Dir(git)), "GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL="+os.DevNull, "GIT_TERMINAL_PROMPT=0", "GIT_AUTHOR_NAME=Fixture", "GIT_AUTHOR_EMAIL=fixture@example.invalid", "GIT_COMMITTER_NAME=Fixture", "GIT_COMMITTER_EMAIL=fixture@example.invalid")
+		b, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("synthetic git: %v %s", err, b)
+		}
+		return strings.TrimSpace(string(b))
+	}
+	run("init", "--quiet")
+	run("add", ".")
+	run("commit", "--quiet", "-m", "test: immutable fixture")
+	revision := run("rev-parse", "HEAD")
+	original := nativeSHA(t, filepath.Join(f.Package, "plugin.json"))
+	nativeWrite(t, filepath.Join(f.Package, "uncommitted-sentinel"), []byte("must not enter snapshot"), 0600)
+	acquirer := sourceacquisition.Acquirer{TempRoot: filepath.Join(f.Root, "tmp"), URLForRepo: func(string) string { return f.Package }}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	snapshot, err := acquirer.AcquireGitHub(ctx, "fixture/native-proof", revision, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer packagedigest.Remove(snapshot)
+	if snapshot.Source.ResolvedRevision != revision || nativeSHA(t, filepath.Join(snapshot.Root, "plugin.json")) != original {
+		t.Fatal("immutable acquisition identity mismatch")
+	}
+	if _, err := os.Lstat(filepath.Join(snapshot.Root, "uncommitted-sentinel")); !os.IsNotExist(err) {
+		t.Fatal("uncommitted bytes entered immutable acquisition")
+	}
+	if _, err := os.Lstat(filepath.Join(snapshot.Root, ".git")); !os.IsNotExist(err) {
+		t.Fatal("Git metadata entered package")
+	}
+	return map[string]any{"revision": revision, "tree": run("rev-parse", "HEAD^{tree}"), "manifest_sha256": original, "source": snapshot.Source, "evidence_scope": "production acquirer with synthetic local Git transport; acquisition only"}
+}
+func TestAgentpluginsNativeFixtureImmutableAcquisition(t *testing.T) {
+	f := newNativeFixture(t, false)
+	f.writePackage(t, "A", "1.0.0")
+	nativeImmutableAcquisition(t, f)
+}
+
+// Minimal Responses events match pinned codex-api/tests/sse_end_to_end.rs.
+func nativeScriptedProvider(t *testing.T, f *nativeFixture) string {
+	t.Helper()
+	f.ProviderRequests = make(chan []byte, 8)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" || r.URL.Path != "/v1/responses" {
+			http.NotFound(w, r)
+			return
+		}
+		body, err := io.ReadAll(io.LimitReader(r.Body, (2<<20)+1))
+		if err != nil || len(body) > 2<<20 {
+			http.Error(w, "bounded fixture request", 400)
+			return
+		}
+		select {
+		case f.ProviderRequests <- body:
+		default:
+			http.Error(w, "fixture request limit", 429)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		events := []map[string]any{
+			{"type": "response.output_item.done", "item": map[string]any{"type": "message", "id": "fixture-message", "role": "assistant", "content": []any{map[string]string{"type": "output_text", "text": "Fixture response."}}}},
+			{"type": "response.completed", "response": map[string]any{"id": "fixture-response", "usage": map[string]int{"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}}},
+		}
+		for _, event := range events {
+			b, _ := json.Marshal(event)
+			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event["type"], b)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server.URL + "/v1"
+}
+
+func TestAgentpluginsNativeFixtureForeignCollisionClassification(t *testing.T) {
+	good := []byte(`{"result":"failure","data":{"status":"preflight_failed","targets":[{"output":{"result":{"mutated":false}}}]}}`)
+	stderr := []byte("Resolving and validating each unique exact installed package revision once...\nagentplugins: group repair preflight failed; no target was changed: observe prepared identity for codex: native package has no recognized authoritative manifest\n")
+	if err := nativeCollisionGuardResult(good, stderr, fmt.Errorf("exit 1")); err != nil {
+		t.Fatal(err)
+	}
+	for _, bad := range []string{"network timeout", "agentplugins: unrelated preflight failure"} {
+		if nativeCollisionGuardResult(good, []byte(bad), fmt.Errorf("exit 1")) == nil {
+			t.Fatal("unrelated failure accepted")
+		}
+	}
+	mutated := bytes.ReplaceAll(good, []byte("false"), []byte("true"))
+	if nativeCollisionGuardResult(mutated, stderr, fmt.Errorf("exit 1")) == nil {
+		t.Fatal("mutating collision accepted")
+	}
+	if nativeCollisionGuardResult(good, stderr, nil) == nil {
+		t.Fatal("successful collision accepted")
+	}
+}
+
+func TestAgentpluginsNativeFixtureStartupFailure(t *testing.T) {
+	f := newNativeFixture(t, false)
+	cmd := exec.Command(f.Probe, "--fail-startup")
+	cmd.Dir = f.Project
+	cmd.Env = append(f.env(filepath.Dir(f.Probe)), "UAP_TEST_ROOT="+f.Root, "UAP_TEST_EVENTS="+f.Events, "UAP_TEST_NONCE="+f.Nonce)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	output, err := cmd.Output()
+	exit, ok := err.(*exec.ExitError)
+	if !ok || exit.ExitCode() != 42 || len(output) != 0 || !strings.Contains(stderr.String(), "intentional fixture startup failure") {
+		t.Fatalf("startup failure contract: %v %s %s", err, output, stderr.String())
+	}
+	events, err := os.ReadFile(f.Events)
+	if err != nil || !bytes.Contains(events, []byte(`"method":"startup-failed"`)) {
+		t.Fatalf("startup failure not recorded: %v %s", err, events)
 	}
 }

--- a/repotests/agentplugins_native_fixture_test.go
+++ b/repotests/agentplugins_native_fixture_test.go
@@ -1,0 +1,648 @@
+package pluginkitairepo_test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/loader"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/specregistry"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/planner"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type nativeFixture struct {
+	Root, Project, Home, CodexHome, Package, Probe, Events, Nonce string
+	PluginID, ClientBinDir, HTTPURL, RedirectURL                  string
+}
+type nativeStage struct {
+	Status    string   `json:"status"`
+	Reason    string   `json:"reason,omitempty"`
+	Artifacts []string `json:"artifacts,omitempty"`
+}
+type nativeFacts struct {
+	Nonce    string   `json:"nonce"`
+	Revision string   `json:"revision"`
+	CWD      string   `json:"cwd"`
+	Argv     []string `json:"argv"`
+	Root     string   `json:"plugin_root"`
+	Data     string   `json:"plugin_data"`
+	Literal  string   `json:"literal"`
+	Once     string   `json:"once"`
+	Marker   string   `json:"marker"`
+	PID      int      `json:"pid"`
+	Session  string   `json:"session"`
+}
+
+func nativeWrite(t *testing.T, path string, b []byte, mode os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, b, mode); err != nil {
+		t.Fatal(err)
+	}
+}
+func nativeJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	nativeWrite(t, path, append(b, '\n'), 0600)
+}
+func nativeSHA(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}
+func newNativeFixture(t *testing.T, preserve bool) *nativeFixture {
+	t.Helper()
+	root := t.TempDir()
+	if preserve {
+		var err error
+		root, err = os.MkdirTemp("", "uap-native-evidence-")
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("native evidence: %s", root)
+	}
+	root, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var nonce [16]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		t.Fatal(err)
+	}
+	f := &nativeFixture{Root: root, Project: filepath.Join(root, "project"), Home: filepath.Join(root, "home"), CodexHome: filepath.Join(root, "home", ".codex"), Package: filepath.Join(root, "package"), Probe: filepath.Join(root, "native-probe"), Events: filepath.Join(root, "events.jsonl"), Nonce: hex.EncodeToString(nonce[:])}
+	for _, p := range []string{f.Project, f.Home, f.CodexHome, filepath.Join(root, "tmp"), filepath.Join(root, "xdg-config"), filepath.Join(root, "xdg-data"), filepath.Join(root, "xdg-cache"), filepath.Join(root, "xdg-state")} {
+		if err := os.MkdirAll(p, 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if supplied := os.Getenv("AGENTPLUGINS_NATIVE_PROBE_BIN"); supplied != "" {
+		supplied = nativeBinary(t, "AGENTPLUGINS_NATIVE_PROBE_BIN")
+		b, err := os.ReadFile(supplied)
+		if err != nil {
+			t.Fatal(err)
+		}
+		nativeWrite(t, f.Probe, b, 0700)
+		return f
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", "build", "-o", f.Probe, "./testdata/agentplugins_native_probe")
+	if b, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build fixture: %v\n%s", err, b)
+	}
+	return f
+}
+
+// Environment is assembled explicitly. Never inherit auth, proxy, shell, HOME or PATH.
+func (f *nativeFixture) env(binDir string) []string {
+	clientDir := f.ClientBinDir
+	if clientDir == "" {
+		clientDir = binDir
+	}
+	return []string{"HOME=" + f.Home, "AGENTPLUGINS_HOME=" + filepath.Join(f.Root, "installer-state"), "CODEX_HOME=" + f.CodexHome, "XDG_CONFIG_HOME=" + filepath.Join(f.Root, "xdg-config"), "XDG_DATA_HOME=" + filepath.Join(f.Root, "xdg-data"), "XDG_CACHE_HOME=" + filepath.Join(f.Root, "xdg-cache"), "XDG_STATE_HOME=" + filepath.Join(f.Root, "xdg-state"), "TMPDIR=" + filepath.Join(f.Root, "tmp"), "PATH=" + binDir + ":" + clientDir + ":/usr/bin:/bin", "LANG=en_US.UTF-8", "TERM=dumb"}
+}
+func (f *nativeFixture) writePackage(t *testing.T, revision, version string) {
+	t.Helper()
+	nativeJSON(t, filepath.Join(f.Package, "plugin.json"), map[string]any{"$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json", "name": "native-proof", "version": version, "description": "Disposable native lifecycle fixture"})
+	nativeWrite(t, filepath.Join(f.Package, "skills", "native-proof", "SKILL.md"), []byte("---\nname: native-proof\ndescription: Disposable native lifecycle fixture\n---\n\nUAP_SKILL_BODY_"+revision+"_"+f.Nonce+"\n"), 0600)
+	b, err := os.ReadFile(f.Probe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nativeWrite(t, filepath.Join(f.Package, "bin", "probe"), b, 0700)
+	env := map[string]string{"UAP_TEST_ROOT": f.Root, "UAP_TEST_EVENTS": f.Events, "UAP_TEST_NONCE": f.Nonce, "UAP_TEST_REVISION": revision, "UAP_TEST_LITERAL": "literal ${UNKNOWN} $HOME", "UAP_TEST_ONCE": "${PLUGIN_ROOT}/${UNKNOWN}"}
+	server := func(cwd string) map[string]any {
+		m := map[string]any{"type": "stdio", "command": "./bin/../bin/probe", "args": []string{"argument with spaces", "${PLUGIN_ROOT}/argument", "${UNKNOWN}"}, "env": env}
+		if cwd != "" {
+			m["cwd"] = cwd
+		}
+		return m
+	}
+	servers := map[string]any{"default": server(""), "explicit": server("./skills")}
+	if f.HTTPURL != "" {
+		servers["http"] = map[string]any{"type": "streamable-http", "url": f.HTTPURL + "/mcp?literal=%24%7BUNKNOWN%7D", "headers": map[string]string{"X-UAP-Probe": f.Nonce, "X-UAP-Literal": "${UNKNOWN}", "MCP-Protocol-Version": "harmless-fixture-priority"}}
+	}
+	if f.RedirectURL != "" {
+		servers["redirect"] = map[string]any{"type": "streamable-http", "url": f.RedirectURL, "headers": map[string]string{"X-UAP-Probe": f.Nonce}}
+	}
+	nativeJSON(t, filepath.Join(f.Package, "mcp.json"), map[string]any{"$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json", "mcpServers": servers})
+}
+func nativeDecodeFacts(t *testing.T, result json.RawMessage) nativeFacts {
+	t.Helper()
+	var r struct {
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+		IsError bool `json:"isError"`
+	}
+	if err := json.Unmarshal(result, &r); err != nil || r.IsError || len(r.Content) != 1 {
+		t.Fatalf("invalid tool result: %s", result)
+	}
+	var f nativeFacts
+	if err := json.Unmarshal([]byte(r.Content[0].Text), &f); err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+func nativeAssertEvent(t *testing.T, f *nativeFixture, facts nativeFacts) {
+	t.Helper()
+	b, err := os.ReadFile(f.Events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	methods := map[string]bool{}
+	for _, line := range bytes.Split(b, []byte{'\n'}) {
+		if len(line) == 0 {
+			continue
+		}
+		var e struct {
+			Method  string      `json:"method"`
+			Session string      `json:"session"`
+			Nonce   string      `json:"nonce"`
+			Facts   nativeFacts `json:"facts"`
+		}
+		if err := json.Unmarshal(line, &e); err != nil {
+			t.Fatal(err)
+		}
+		if e.Session == facts.Session && e.Nonce == facts.Nonce {
+			methods[e.Method] = true
+			if e.Method == "tools/call" && e.Facts.Revision != facts.Revision {
+				t.Fatal("event/result revision mismatch")
+			}
+		}
+	}
+	for _, m := range []string{"initialize", "tools/list", "tools/call"} {
+		if !methods[m] {
+			t.Fatalf("no correlated %s event", m)
+		}
+	}
+}
+func TestAgentpluginsNativeFixtureProtocol(t *testing.T) {
+	f := newNativeFixture(t, false)
+	f.writePackage(t, "A", "1.0.0")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, f.Probe, "fixture arg")
+	cmd.Dir = f.Project
+	cmd.Env = append(f.env(filepath.Dir(f.Probe)), "UAP_TEST_ROOT="+f.Root, "UAP_TEST_EVENTS="+f.Events, "UAP_TEST_NONCE="+f.Nonce, "UAP_TEST_REVISION=A", "PLUGIN_ROOT="+f.Package, "PLUGIN_DATA="+filepath.Join(f.Root, "data"))
+	requests := []map[string]any{{"jsonrpc": "2.0", "id": "init-string", "method": "initialize", "params": map[string]any{"protocolVersion": "2025-06-18"}}, {"jsonrpc": "2.0", "method": "notifications/initialized"}, {"jsonrpc": "2.0", "id": 2, "method": "tools/list"}, {"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": map[string]any{"name": "inspect_runtime", "arguments": map[string]string{"nonce": f.Nonce, "operation": "write", "marker": "retained"}}}, {"jsonrpc": "2.0", "id": 4, "method": "tools/call", "params": map[string]any{"name": "inspect_runtime", "arguments": map[string]string{"nonce": "wrong"}}}}
+	var input bytes.Buffer
+	for _, r := range requests {
+		if err := json.NewEncoder(&input).Encode(r); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cmd.Stdin = &input
+	b, err := cmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	scan := bufio.NewScanner(bytes.NewReader(b))
+	var rows []struct {
+		ID     json.RawMessage `json:"id"`
+		Result json.RawMessage `json:"result"`
+		Error  json.RawMessage `json:"error"`
+	}
+	for scan.Scan() {
+		var row struct {
+			ID     json.RawMessage `json:"id"`
+			Result json.RawMessage `json:"result"`
+			Error  json.RawMessage `json:"error"`
+		}
+		if err := json.Unmarshal(scan.Bytes(), &row); err != nil {
+			t.Fatal(err)
+		}
+		rows = append(rows, row)
+	}
+	if len(rows) != 4 || string(rows[0].ID) != `"init-string"` || !bytes.Contains(rows[0].Result, []byte("2025-06-18")) || len(rows[3].Error) == 0 {
+		t.Fatalf("protocol rows: %s", b)
+	}
+	facts := nativeDecodeFacts(t, rows[2].Result)
+	if facts.Marker != "retained" || facts.Nonce != f.Nonce || facts.CWD != f.Project {
+		t.Fatalf("facts: %+v", facts)
+	}
+	nativeAssertEvent(t, f, facts)
+}
+func TestAgentpluginsNativeFixtureRejectsEscapedData(t *testing.T) {
+	f := newNativeFixture(t, false)
+	outside := t.TempDir()
+	link := filepath.Join(f.Root, "escape")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, f.Probe)
+	cmd.Dir = f.Project
+	cmd.Env = append(f.env(filepath.Dir(f.Probe)), "UAP_TEST_ROOT="+f.Root, "UAP_TEST_EVENTS="+f.Events, "UAP_TEST_NONCE="+f.Nonce, "PLUGIN_DATA="+link)
+	cmd.Stdin = strings.NewReader(fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"inspect_runtime","arguments":{"nonce":%q,"operation":"write","marker":"unsafe"}}}`+"\n", f.Nonce))
+	b, err := cmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(b, []byte("escapes test root")) {
+		t.Fatalf("escape accepted: %s", b)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "native-marker.txt")); !os.IsNotExist(err) {
+		t.Fatal("wrote outside test root")
+	}
+}
+
+// The HTTP endpoint forwards to our own probe process. Its cwd/env are explicitly
+// harness behavior, never evidence of the client's stdio runtime roots.
+func nativeHTTP(t *testing.T, f *nativeFixture) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
+	cmd := exec.CommandContext(ctx, f.Probe)
+	cmd.Dir = f.Project
+	cmd.Env = append(f.env(filepath.Dir(f.Probe)), "UAP_TEST_ROOT="+f.Root, "UAP_TEST_EVENTS="+f.Events, "UAP_TEST_NONCE="+f.Nonce, "UAP_TEST_REVISION=HTTP", "PLUGIN_ROOT="+f.Package, "PLUGIN_DATA="+filepath.Join(f.Root, "http-data"))
+	in, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	out, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	reader := bufio.NewReader(out)
+	var mu sync.Mutex
+	log, err := os.Create(filepath.Join(f.Root, "http-events.jsonl"))
+	if err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	record := func(r *http.Request, origin, rpcMethod string) {
+		_ = json.NewEncoder(log).Encode(map[string]any{"timestamp": time.Now().UTC().Format(time.RFC3339Nano), "origin": origin, "rpc_method": rpcMethod, "method": r.Method, "uri": r.URL.RequestURI(), "protocol": r.Header.Get("MCP-Protocol-Version"), "probe_header": r.Header.Get("X-UAP-Probe"), "literal_header": r.Header.Get("X-UAP-Literal")})
+	}
+	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		record(r, "redirect-destination", "")
+		http.Error(w, "test destination", http.StatusNotFound)
+	}))
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		if r.URL.Path == "/redirect" {
+			record(r, "declared-source", "")
+			http.Redirect(w, r, destination.URL+"/cross-origin", http.StatusTemporaryRedirect)
+			return
+		}
+		if r.Method != "POST" {
+			record(r, "declared-source", "")
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		if err != nil {
+			http.Error(w, "read", 400)
+			return
+		}
+		var request map[string]json.RawMessage
+		if json.Unmarshal(body, &request) != nil {
+			http.Error(w, "JSON", 400)
+			return
+		}
+		var rpcMethod string
+		_ = json.Unmarshal(request["method"], &rpcMethod)
+		record(r, "declared-source", rpcMethod)
+		if _, ok := request["id"]; !ok {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		if _, err := in.Write(append(body, '\n')); err != nil {
+			http.Error(w, "fixture pipe", 500)
+			return
+		}
+		response, err := reader.ReadBytes('\n')
+		if err != nil {
+			http.Error(w, "fixture response", 500)
+			return
+		}
+		if rpcMethod == "initialize" {
+			var result struct {
+				Result struct {
+					Protocol string `json:"protocolVersion"`
+				} `json:"result"`
+			}
+			_ = json.Unmarshal(response, &result)
+			_ = json.NewEncoder(log).Encode(map[string]string{"origin": "protocol-response", "negotiated_protocol": result.Result.Protocol})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(response)
+	}))
+	f.HTTPURL = source.URL
+	f.RedirectURL = source.URL + "/redirect"
+	t.Cleanup(func() {
+		cancel()
+		in.Close()
+		_ = cmd.Wait()
+		source.Close()
+		destination.Close()
+		log.Close()
+	})
+}
+
+func TestAgentpluginsNativeFixtureHTTP(t *testing.T) {
+	f := newNativeFixture(t, false)
+	nativeHTTP(t, f)
+	body := strings.NewReader(`{"jsonrpc":"2.0","id":"http","method":"initialize","params":{"protocolVersion":"2025-03-26"}}`)
+	req, err := http.NewRequest("POST", f.HTTPURL+"/mcp", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-UAP-Probe", f.Nonce)
+	client := &http.Client{Timeout: 5 * time.Second}
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	b, err := io.ReadAll(res.Body)
+	if err != nil || res.StatusCode != 200 || !bytes.Contains(b, []byte(`"id":"http"`)) {
+		t.Fatalf("HTTP fixture: %s %v", b, err)
+	}
+}
+
+func TestAgentpluginsNativeFixtureEvidenceOutcomes(t *testing.T) {
+	for _, tc := range []struct{ name, requestHeader, negotiated, want string }{
+		{"missing", "", "2025-06-18", "not_evaluated"},
+		{"matching", "2025-06-18", "2025-06-18", "passed"},
+		{"authored-sentinel", "harmless-fixture-priority", "2025-06-18", "failed"},
+		{"unnegotiated", "2025-06-18", "", "not_evaluated"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &nativeFixture{Root: t.TempDir(), Nonce: "nonce"}
+			var b bytes.Buffer
+			enc := json.NewEncoder(&b)
+			_ = enc.Encode(map[string]string{"origin": "declared-source", "method": "POST", "uri": "/mcp?literal=%24%7BUNKNOWN%7D", "rpc_method": "initialize", "probe_header": "nonce", "literal_header": "${UNKNOWN}"})
+			_ = enc.Encode(map[string]string{"origin": "protocol-response", "negotiated_protocol": tc.negotiated})
+			_ = enc.Encode(map[string]string{"origin": "declared-source", "method": "POST", "uri": "/mcp?literal=%24%7BUNKNOWN%7D", "rpc_method": "tools/list", "protocol": tc.requestHeader})
+			nativeWrite(t, filepath.Join(f.Root, "http-events.jsonl"), b.Bytes(), 0600)
+			stages := map[string]nativeStage{}
+			nativeCheckHTTP(t, f, stages)
+			if got := stages["generated_protocol_header_priority"].Status; got != tc.want {
+				t.Fatalf("header evidence=%s, want %s", got, tc.want)
+			}
+		})
+	}
+	stages := map[string]nativeStage{"unattempted": {Status: "not_evaluated"}}
+	nativeAttempt(stages, "install", "add-installer.json")
+	if stages["install"].Status != "failed" || stages["unattempted"].Status != "not_evaluated" {
+		t.Fatal("attempt/unattempted evidence conflated")
+	}
+	if nativeRepeatRemoveExpected([]byte("network timeout"), fmt.Errorf("exit 1")) {
+		t.Fatal("arbitrary repeat-remove error accepted")
+	}
+	if !nativeRepeatRemoveExpected([]byte(`agentplugins: installation "native-proof" was not found`), fmt.Errorf("exit 1")) {
+		t.Fatal("expected absent installation rejected")
+	}
+}
+
+// ReleaseScanner.resolve supports a prepopulated cache. The runtime still runs
+// the normal scan-agent-plugin command and validates its pinned report/policy.
+func nativeProvisionScanner(t *testing.T, f *nativeFixture) map[string]string {
+	t.Helper()
+	binary := nativeBinary(t, "AGENTPLUGINS_LINTAI_BIN")
+	digest := nativeSHA(t, binary)
+	if expected := os.Getenv("AGENTPLUGINS_LINTAI_SHA256"); len(expected) != 64 || digest != expected {
+		t.Fatal("provisioned lintai binary digest mismatch")
+	}
+	// Platform/digest pins mirror agentplugins/adapters/securityscan/release.go's
+	// releaseAssets table exactly, so this cache prepopulation stays consistent
+	// with what the real ReleaseScanner would resolve to on the same host.
+	var platform, archive string
+	switch runtime.GOARCH {
+	case "arm64":
+		platform = "linux-arm64"
+		archive = "132a37610575bd251ecaf0be4c6090dad144dd1397c99aad989a3944c63c3d4a"
+	case "amd64":
+		platform = "linux-amd64"
+		archive = "2b3d176db752433b904a4b42375543ff398f4841d22e48f7d4f23ded925b72da"
+		for _, path := range []string{"/lib/ld-musl-x86_64.so.1", "/lib64/ld-musl-x86_64.so.1"} {
+			if _, err := os.Stat(path); err == nil {
+				platform = "linux-amd64-musl"
+				archive = "3da60f749c61e2caca029a44a9ce422d570aef8c57f82ce51c411c8cec12f61b"
+				break
+			}
+		}
+	default:
+		t.Fatalf("lintai security scanner has no pinned platform asset for linux/%s", runtime.GOARCH)
+	}
+	if os.Getenv("AGENTPLUGINS_LINTAI_ARCHIVE_SHA256") != archive {
+		t.Fatal("lintai archive provenance does not match pinned platform asset")
+	}
+	destination := filepath.Join(f.Root, "installer-state", "security", "lintai", "0.1.3", platform, "lintai")
+	b, err := os.ReadFile(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nativeWrite(t, destination, b, 0700)
+	if nativeSHA(t, destination) != digest {
+		t.Fatal("cached lintai digest mismatch")
+	}
+	return map[string]string{"version": "0.1.3", "source_tag": "v0.1.3", "binary_sha256": digest, "archive_sha256": archive, "platform": platform, "route": "prepopulated supported scanner cache; ordinary CLI security assessment"}
+}
+
+func TestAgentpluginsNativeFixtureAdmission(t *testing.T) {
+	f := newNativeFixture(t, false)
+	f.HTTPURL = "http://127.0.0.1:12345"
+	f.RedirectURL = f.HTTPURL + "/redirect"
+	f.writePackage(t, "A", "1.0.0")
+	registry, err := specregistry.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	load := func() domain.PackageEnvelope {
+		envelope, err := (loader.Loader{Registry: registry}).Load(context.Background(), domain.LoadInput{SnapshotRoot: f.Package, ExecutableFiles: []string{"bin/probe"}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return envelope
+	}
+	envelope := load()
+	if !envelope.MCP.Enabled || len(envelope.MCP.Servers) != 4 || len(envelope.Skills) != 1 {
+		t.Fatalf("fixture components disabled or missing: %+v; diagnostics:%+v", envelope.Inventory, envelope.Diagnostics)
+	}
+	for name, kind := range map[string]string{"default": "stdio", "explicit": "stdio", "http": "streamable-http", "redirect": "streamable-http"} {
+		if envelope.MCP.Servers[name].Type != kind {
+			t.Fatalf("wrong %s fixture type", name)
+		}
+	}
+	for _, d := range envelope.Diagnostics {
+		if d.Severity == domain.SeverityError {
+			t.Fatalf("fixture admission: %+v", d)
+		}
+	}
+	plan, err := (planner.Planner{ManagedRoot: filepath.Join(f.Root, "managed")}).Plan(context.Background(), envelope, domain.DetectedClient{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: f.CodexHome}, domain.ScopeUser, "native-proof-0123456789ab")
+	if err != nil {
+		t.Fatal(err)
+	}
+	selected := map[string]bool{}
+	for _, component := range plan.Components {
+		if component.Kind == domain.ComponentMCPServer && component.Support == domain.SupportProjected {
+			selected[component.Name] = true
+		}
+	}
+	if len(selected) != 4 {
+		t.Fatalf("fixture MCP plan not selected: %+v", plan)
+	}
+	planJSON, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var planObject any
+	if err := json.Unmarshal(planJSON, &planObject); err != nil {
+		t.Fatal(err)
+	}
+	if err := nativeValidateMCPSelections(planObject); err != nil {
+		t.Fatal(err)
+	}
+	// Nil loader error alone is insufficient: malformed optional MCP is skipped.
+	path := filepath.Join(f.Package, "mcp.json")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(body, &doc); err != nil {
+		t.Fatal(err)
+	}
+	delete(doc, "$schema")
+	nativeJSON(t, path, doc)
+	invalid := load()
+	if invalid.MCP.Enabled || len(invalid.MCP.Servers) != 0 {
+		t.Fatal("missing MCP schema did not disable MCP")
+	}
+}
+func TestAgentpluginsNativeFixtureInstallerJSON(t *testing.T) {
+	good := []byte(`{"schema_version":1,"command":"add","result":"success","data":{"security":{"evidence_source":"local_scan"}}}`)
+	if err := nativeValidateInstallerJSON(good); err != nil {
+		t.Fatal(err)
+	}
+	for _, bad := range [][]byte{append([]byte("Resolving...\n"), good...), []byte(`{"schema_version":1,"command":"add","result":"failure","data":{}}`), append(append([]byte{}, good...), good...)} {
+		if nativeValidateInstallerJSON(bad) == nil {
+			t.Fatalf("invalid/failing CLI output accepted: %s", bad)
+		}
+	}
+}
+
+func TestAgentpluginsNativeFixtureCodexSkillIdentity(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "cache")
+	path := filepath.Join(root, "skills", "native-proof", "SKILL.md")
+	id := "native-proof@agentplugins-test"
+	if !nativeSkillIdentity("native-proof:native-proof", id, path, true, id, root) {
+		t.Fatal("pinned namespaced identity rejected")
+	}
+	for _, tc := range []struct {
+		name, id, path string
+		enabled        bool
+	}{{"native-proof", id, path, true}, {"native-proof:native-proof", id + "-foreign", path, true}, {"native-proof:native-proof", id, path, false}, {"native-proof:native-proof", id, filepath.Join(root, "foreign", "SKILL.md"), true}} {
+		if nativeSkillIdentity(tc.name, tc.id, tc.path, tc.enabled, id, root) {
+			t.Fatalf("inexact native identity accepted: %+v", tc)
+		}
+	}
+	if nativeHasPluginID(t, []byte(`{"data":[{"pluginId":"native-proof@agentplugins-test-foreign"}]}`), id) {
+		t.Fatal("substring plugin identity accepted")
+	}
+}
+
+func nativeTreeDigest(t *testing.T, root string) string {
+	t.Helper()
+	h := sha256.New()
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(h, "%s\x00%o\x00", filepath.ToSlash(relative), info.Mode())
+		if info.Mode().IsRegular() {
+			body, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			digest := sha256.Sum256(body)
+			h.Write(digest[:])
+		} else if info.Mode()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			h.Write([]byte(target))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+func TestAgentpluginsNativeFixtureLifecycleResults(t *testing.T) {
+	good := []byte(`{"schema_version":1,"command":"add","result":"success","data":{"result":{"mutated":false}}}`)
+	if err := nativeUnchangedResult(good); err != nil {
+		t.Fatal(err)
+	}
+	for _, b := range [][]byte{[]byte(`{"schema_version":1,"command":"add","result":"success","data":{"result":{}}}`), []byte(`{"schema_version":1,"command":"add","result":"success","data":{"result":{"mutated":true}}}`)} {
+		if nativeUnchangedResult(b) == nil {
+			t.Fatal("unknown/mutated add accepted as unchanged")
+		}
+	}
+	guard := []byte(`{"result":"failure","data":{"status":"preflight_failed","targets":[{"output":{"result":{"mutated":false}}}]}}`)
+	stderr := []byte("native identity ownership is indeterminate; refusing repair")
+	if err := nativeRepairGuardResult(guard, stderr, fmt.Errorf("exit 1")); err != nil {
+		t.Fatal(err)
+	}
+	if nativeRepairGuardResult(guard, []byte("network failure"), fmt.Errorf("exit 1")) == nil {
+		t.Fatal("arbitrary refusal accepted as ownership guard")
+	}
+	root := t.TempDir()
+	path := filepath.Join(root, "file")
+	nativeWrite(t, path, []byte("original"), 0600)
+	before := nativeTreeDigest(t, root)
+	nativeWrite(t, path, []byte("damage"), 0600)
+	if nativeTreeDigest(t, root) == before {
+		t.Fatal("changed artifact digest unchanged")
+	}
+	nativeWrite(t, path, []byte("original"), 0600)
+	if nativeTreeDigest(t, root) != before {
+		t.Fatal("exact restore not reproducible")
+	}
+}

--- a/repotests/agentplugins_opencode_collision_native_test.go
+++ b/repotests/agentplugins_opencode_collision_native_test.go
@@ -1,0 +1,289 @@
+package pluginkitairepo_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// This scripted loopback provider supplies protocol responses, not a real model.
+// Its captured request proves the actual native session's tool namespace. MCP
+// calls and their returned nonce prove dispatch independently of config/status.
+func TestAgentpluginsOpenCodeNativeToolCollision(t *testing.T) {
+	if os.Getenv("AGENTPLUGINS_OPENCODE_NATIVE_E2E") != "1" {
+		t.Skip("opt-in native client execution")
+	}
+	for _, names := range [][]string{{"api/server"}, {"api server"}, {"api/server", "api server"}} {
+		t.Run(strings.Join(names, "+"), func(t *testing.T) {
+			f := newOpenCodeNativeFixture(t)
+			client := openCodeNativeBinary(t, "AGENTPLUGINS_OPENCODE_BIN")
+			installer := openCodeNativeBinary(t, "AGENTPLUGINS_INSTALLER_BIN")
+			scanner := openCodePrepareNative(t, f, client)
+			started := time.Now().UTC().Format(time.RFC3339Nano)
+			identity, err := nativeSourceIdentity(os.Getenv("AGENTPLUGINS_INSTALLER_COMMIT"), os.Getenv("AGENTPLUGINS_INSTALLER_TREE"), os.Getenv("AGENTPLUGINS_INSTALLER_PATCH_SHA256"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			measured := openCodeVersionString(t, f, client)
+			if measured != "1.18.29" {
+				t.Fatalf("collision contract pinned to 1.18.29, got %s", measured)
+			}
+			nonce := filepath.Base(f.Root)
+			var mu sync.Mutex
+			methods := map[string][]string{}
+			var calls, offered []string
+			var requests []json.RawMessage
+			var resultSeen bool
+			mcp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "POST" {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+				var req struct {
+					ID     json.RawMessage `json:"id"`
+					Method string          `json:"method"`
+					Params struct {
+						Name      string            `json:"name"`
+						Arguments map[string]string `json:"arguments"`
+					} `json:"params"`
+				}
+				if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+					http.Error(w, "json", 400)
+					return
+				}
+				name := strings.TrimPrefix(r.URL.Path, "/")
+				mu.Lock()
+				methods[name] = append(methods[name], req.Method)
+				mu.Unlock()
+				if len(req.ID) == 0 {
+					w.WriteHeader(http.StatusAccepted)
+					return
+				}
+				var result any
+				switch req.Method {
+				case "initialize":
+					result = map[string]any{"protocolVersion": "2025-03-26", "capabilities": map[string]any{"tools": map[string]any{}}, "serverInfo": map[string]any{"name": name, "version": "1.0.0"}}
+				case "tools/list":
+					result = map[string]any{"tools": []any{map[string]any{"name": "inspect_runtime", "description": "Return disposable test identity", "inputSchema": map[string]any{"type": "object", "properties": map[string]any{"nonce": map[string]any{"type": "string"}}, "required": []string{"nonce"}}}}}
+				case "tools/call":
+					if req.Params.Name != "inspect_runtime" || req.Params.Arguments["nonce"] != nonce {
+						http.Error(w, "invalid fixture call", 400)
+						return
+					}
+					mu.Lock()
+					calls = append(calls, name)
+					mu.Unlock()
+					result = map[string]any{"content": []any{map[string]any{"type": "text", "text": fmt.Sprintf("native-dispatch:%s:%s", name, nonce)}}}
+				default:
+					result = map[string]any{}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": result})
+			}))
+			defer mcp.Close()
+			provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(io.LimitReader(r.Body, 4<<20))
+				if err != nil {
+					http.Error(w, "read", 400)
+					return
+				}
+				var req struct {
+					Tools []struct {
+						Function struct {
+							Name string `json:"name"`
+						} `json:"function"`
+					} `json:"tools"`
+					Messages []struct {
+						Role    string          `json:"role"`
+						Content json.RawMessage `json:"content"`
+					} `json:"messages"`
+				}
+				if json.Unmarshal(body, &req) != nil {
+					http.Error(w, "json", 400)
+					return
+				}
+				mu.Lock()
+				defer mu.Unlock()
+				requests = append(requests, append(json.RawMessage(nil), body...))
+				var nativeNames []string
+				for _, tool := range req.Tools {
+					if strings.HasPrefix(tool.Function.Name, "api_server_") {
+						nativeNames = append(nativeNames, tool.Function.Name)
+					}
+				}
+				if len(nativeNames) > 0 {
+					offered = append([]string(nil), nativeNames...)
+				}
+				done := false
+				for _, msg := range req.Messages {
+					if msg.Role == "tool" && len(calls) == 1 && strings.Contains(string(msg.Content), "native-dispatch:"+calls[0]+":"+nonce) {
+						done = true
+						resultSeen = true
+					}
+				}
+				w.Header().Set("Content-Type", "text/event-stream")
+				emit := func(delta any, finish any) {
+					b, _ := json.Marshal(map[string]any{"id": "uap-scripted", "object": "chat.completion.chunk", "created": 1, "model": "fixture", "choices": []any{map[string]any{"index": 0, "delta": delta, "finish_reason": finish}}})
+					fmt.Fprintf(w, "data: %s\n\n", b)
+				}
+				if !done && len(nativeNames) == 1 {
+					arguments, _ := json.Marshal(map[string]string{"nonce": nonce})
+					emit(map[string]any{"role": "assistant", "tool_calls": []any{map[string]any{"index": 0, "id": "uap-call", "type": "function", "function": map[string]any{"name": nativeNames[0], "arguments": string(arguments)}}}}, nil)
+					emit(map[string]any{}, "tool_calls")
+				} else {
+					emit(map[string]any{"role": "assistant", "content": "Disposable scripted provider complete."}, nil)
+					emit(map[string]any{}, "stop")
+				}
+				fmt.Fprint(w, "data: [DONE]\n\n")
+			}))
+			defer provider.Close()
+			config := map[string]any{"provider": map[string]any{"uap-fixture": map[string]any{"name": "Disposable fixture", "npm": "@ai-sdk/openai-compatible", "env": []string{}, "models": map[string]any{"fixture": map[string]any{"name": "Fixture", "tool_call": true, "limit": map[string]any{"context": 32000, "output": 1024}}}, "options": map[string]any{"apiKey": "disposable-not-a-secret", "baseURL": provider.URL + "/v1"}}}, "model": "uap-fixture/fixture", "small_model": "uap-fixture/fixture", "permission": "allow"}
+			nativeJSON(t, filepath.Join(f.XDGConfig, "opencode", "opencode.json"), config)
+			openCodeWriteFixturePackage(t, f.PackageRoot, "opencode-native-proof", "1.0.0")
+			servers := map[string]any{}
+			for i, name := range names {
+				servers[name] = map[string]any{"type": "streamable-http", "url": fmt.Sprintf("%s/server-%d", mcp.URL, i)}
+			}
+			nativeJSON(t, filepath.Join(f.PackageRoot, "mcp.json"), map[string]any{"$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json", "mcpServers": servers})
+			added := openCodeRunInstaller(t, f, installer, filepath.Dir(client), "add-tool-fixture", "add", f.PackageRoot, "--target", "opencode")
+			openCodeAssertCompleted(t, "tool fixture install", added)
+			installed := openCodeConfigMCP(t, openCodeDebugConfig(t, f, client, "tool-fixture-effective-config"))
+			if len(installed) != len(names) {
+				t.Fatalf("installed MCP count %d, want %d", len(installed), len(names))
+			}
+			for _, name := range names {
+				if _, ok := installed[name]; !ok {
+					t.Fatalf("installed MCP missing %q", name)
+				}
+			}
+			stages := map[string]any{}
+			evidence := map[string]any{"status": "failed", "source_identity": identity, "scanner": scanner, "os": runtime.GOOS, "arch": runtime.GOARCH, "started_utc": started, "nonce": nonce, "config_route": "opencode.json", "transcript_sha256": f.transcriptSHA256, "scenario": map[bool]string{true: "observed_client_tool_id_collision", false: "single_key_native_dispatch"}[len(names) == 2], "client_version": measured, "client_sha256": openCodeSHA256(t, client), "installer_sha256": openCodeSHA256(t, installer), "logical_servers": names, "stages": stages, "model": "scripted_loopback_no_real_model", "oauth": "not_evaluated"}
+			defer func() {
+				evidence["finished_utc"] = time.Now().UTC().Format(time.RFC3339Nano)
+				nativeJSON(t, filepath.Join(f.Root, "tool-collision-evidence.json"), evidence)
+			}()
+			runSession := func(label, revision string, removed bool) {
+				t.Helper()
+				mu.Lock()
+				methods = map[string][]string{}
+				calls = nil
+				offered = nil
+				requests = nil
+				resultSeen = false
+				mu.Unlock()
+				ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+				defer cancel()
+				cmd := exec.CommandContext(ctx, client, "run", "--model", "uap-fixture/fixture", "--format", "json", "Call the fixture inspect_runtime tool once if available, then finish.")
+				cmd.Dir = f.Project
+				cmd.Env = f.env(filepath.Dir(client))
+				out, err := cmd.CombinedOutput()
+				f.record(t, "native-"+label, out)
+				mu.Lock()
+				defer mu.Unlock()
+				stage := map[string]any{"status": "failed", "native_tool_names": offered, "mcp_methods": methods, "dispatch_servers": calls, "tool_result_returned_to_provider": resultSeen, "provider_requests": requests, "expected_revision": revision}
+				stages[label] = stage
+				if err != nil {
+					t.Fatalf("native %s: %v\n%s", label, err, out)
+				}
+				if len(requests) == 0 {
+					t.Fatal("native session never contacted scripted provider")
+				}
+				if removed {
+					if len(offered) != 0 || len(calls) != 0 || len(methods) != 0 {
+						t.Fatalf("removed tool still active: offered=%v calls=%v methods=%v", offered, calls, methods)
+					}
+				} else {
+					if len(offered) != 1 || offered[0] != "api_server_inspect_runtime" {
+						t.Fatalf("unexpected native namespace: %v", offered)
+					}
+					if len(calls) != 1 || !resultSeen {
+						t.Fatalf("dispatch missing: calls=%v returned=%v\n%s", calls, resultSeen, out)
+					}
+					if len(names) == 1 && calls[0] != "server-0"+revision {
+						t.Fatalf("stale dispatch: %q, want %q", calls[0], "server-0"+revision)
+					}
+					for i := range names {
+						for _, method := range []string{"initialize", "tools/list"} {
+							if !strings.Contains(strings.Join(methods[fmt.Sprintf("server-%d%s", i, revision)], ","), method) {
+								t.Fatalf("server %d missing %s", i, method)
+							}
+						}
+					}
+				}
+				stage["status"] = "passed"
+			}
+			runSession("install", "", false)
+			if len(names) == 1 && names[0] == "api/server" {
+				// Runtime revision lives in the installed URL, not mutable server
+				// state: a stale native config necessarily returns the old marker.
+				for _, update := range []struct{ version, revision, label string }{{"2.0.0", "/B", "version-update"}, {"2.0.0", "/C", "same-version-refresh"}} {
+					openCodeWriteFixturePackage(t, f.PackageRoot, "opencode-native-proof", update.version)
+					servers[names[0]] = map[string]any{"type": "streamable-http", "url": mcp.URL + "/server-0" + update.revision}
+					nativeJSON(t, filepath.Join(f.PackageRoot, "mcp.json"), map[string]any{"$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json", "mcpServers": servers})
+					changed := openCodeRunInstaller(t, f, installer, filepath.Dir(client), update.label, "update", f.PackageRoot, "--target", "opencode")
+					openCodeAssertCompleted(t, update.label, changed)
+					openCodeAssertMutated(t, changed, true)
+					runSession(update.label, update.revision, false)
+				}
+				configPath := filepath.Join(f.XDGConfig, "opencode", "opencode.json")
+				body, err := os.ReadFile(configPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var doc map[string]any
+				openCodeReadConfigDocument(t, body, &doc)
+				foreign := map[string]any{"type": "local", "command": []string{"sh", "-c", "cat"}, "enabled": false}
+				doc["mcp"].(map[string]any)["foreign-untouched"] = foreign
+				nativeJSON(t, configPath, doc)
+				// packageNeedsPluginData allocates only for selected stdio MCP.
+				// This package uses HTTP exclusively; do not fabricate a receipt.
+				if _, err := os.Stat(filepath.Join(f.StateHome, "plugin-data")); !os.IsNotExist(err) {
+					t.Fatalf("HTTP-only fixture unexpectedly has plugin-data: %v", err)
+				}
+				stages["plugin_data_retention"] = map[string]any{"status": "not_applicable", "reason": "HTTP-only MCP package has no allocated PLUGIN_DATA receipt; native stdio data semantics are not tested"}
+				managedDir := filepath.Join(f.StateHome, "managed", "clients", "opencode", openCodePhysicalArtifactID(t, added))
+				if _, err := os.Stat(filepath.Join(managedDir, "plugin.json")); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.RemoveAll(managedDir); err != nil {
+					t.Fatal(err)
+				}
+				repaired := openCodeRunInstaller(t, f, installer, filepath.Dir(client), "runtime-repair", "repair", "opencode-native-proof", "--target", "opencode")
+				openCodeAssertCompleted(t, "runtime repair", repaired)
+				runSession("repair", "/C", false)
+				removed := openCodeRunInstaller(t, f, installer, filepath.Dir(client), "runtime-remove", "remove", "opencode-native-proof", "--target", "opencode")
+				data, _ := removed["data"].(map[string]any)
+				if removed["result"] != "success" || data["status"] != "data_retained" {
+					t.Fatalf("remove: %+v", removed)
+				}
+				runSession("remove", "", true)
+				post := openCodeConfigMCP(t, openCodeDebugConfig(t, f, client, "runtime-post-remove-config"))
+				got, _ := json.Marshal(post["foreign-untouched"])
+				want, _ := json.Marshal(foreign)
+				if string(got) != string(want) {
+					t.Fatalf("foreign config changed: %s != %s", got, want)
+				}
+				stages["foreign_config_preservation"] = map[string]any{"status": "passed"}
+			}
+			evidence["status"] = "passed"
+
+			// With two logical servers, one offered tool and one dispatch establishes
+			// native tool-ID collision; this is an upstream limitation, not success
+			// evidence for separately addressable tools.
+			if len(names) == 2 {
+				t.Log("native collision observed: two MCP catalogs become one callable tool ID")
+			}
+		})
+	}
+}

--- a/repotests/agentplugins_opencode_native_e2e_test.go
+++ b/repotests/agentplugins_opencode_native_e2e_test.go
@@ -1,0 +1,699 @@
+package pluginkitairepo_test
+
+// This suite drives the real OpenCode CLI through UAP's actual install route
+// (global opencode.json under <XDG_CONFIG_HOME>/opencode, plus global
+// skills). UAP also supports opencode.jsonc for this same route, but this
+// checkpoint only exercises the .json path -- that is a real, currently
+// unproven gap, not a claim that both are covered. It is opt-in and uses
+// only disposable HOME/XDG roots and a fresh project directory; it never
+// touches the invoking user's real OpenCode config. `opencode debug config`
+// proves effective config, not a handshake or tool call -- that distinction
+// is preserved in the recorded evidence, per the O2 contract.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+const openCodeNativeCommandTimeout = 30 * time.Second
+
+type openCodeNativeStage struct {
+	Status string `json:"status"`
+	Reason string `json:"reason,omitempty"`
+}
+
+type openCodeNativeFixture struct {
+	Root, Home, XDGConfig, XDGData, XDGCache, XDGState, Project, PackageRoot, StateHome string
+	transcriptSeq                                                                       int
+	transcriptSHA256                                                                    map[string]string
+}
+
+func newOpenCodeNativeFixture(t *testing.T) *openCodeNativeFixture {
+	t.Helper()
+	root, err := os.MkdirTemp("", "uap-opencode-native-evidence-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("opencode native evidence: %s", root)
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := &openCodeNativeFixture{
+		Root: root, Home: filepath.Join(root, "home"), XDGConfig: filepath.Join(root, "xdg-config"),
+		XDGData: filepath.Join(root, "xdg-data"), XDGCache: filepath.Join(root, "xdg-cache"), XDGState: filepath.Join(root, "xdg-state"),
+		Project: filepath.Join(root, "project"), PackageRoot: filepath.Join(root, "fixture"), StateHome: filepath.Join(root, "installer-state"),
+		transcriptSHA256: map[string]string{},
+	}
+	for _, p := range []string{f.Home, f.XDGConfig, f.XDGData, f.XDGCache, f.XDGState, f.Project, f.PackageRoot, f.StateHome, filepath.Join(root, "tmp")} {
+		if err := os.MkdirAll(p, 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return f
+}
+
+// env returns a bounded, isolated environment for both the `opencode` CLI and
+// the `agentplugins` installer: disposable HOME/XDG roots, no inherited
+// ambient config, OPENCODE_PURE disables any implicit project/global merge
+// that could hide the owned entry.
+func (f *openCodeNativeFixture) env(clientDir string) []string {
+	return []string{
+		"HOME=" + f.Home,
+		"XDG_CONFIG_HOME=" + f.XDGConfig,
+		"XDG_DATA_HOME=" + f.XDGData,
+		"XDG_CACHE_HOME=" + f.XDGCache,
+		"XDG_STATE_HOME=" + f.XDGState,
+		"AGENTPLUGINS_HOME=" + f.StateHome,
+		"TMPDIR=" + filepath.Join(f.Root, "tmp"),
+		"OPENCODE_PURE=1",
+		"PATH=" + clientDir + ":/usr/bin:/bin",
+		"LANG=en_US.UTF-8",
+	}
+}
+
+func (f *openCodeNativeFixture) record(t *testing.T, label string, out []byte) {
+	t.Helper()
+	f.transcriptSeq++
+	name := fmt.Sprintf("%02d-%s.log", f.transcriptSeq, label)
+	path := filepath.Join(f.Root, name)
+	if err := os.WriteFile(path, out, 0600); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(out)
+	f.transcriptSHA256[name] = hex.EncodeToString(sum[:])
+}
+
+func openCodeSHA256(t *testing.T, path string) string {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(body)
+	return hex.EncodeToString(sum[:])
+}
+
+func openCodeRunInstaller(t *testing.T, f *openCodeNativeFixture, installer, clientDir, label string, args ...string) map[string]any {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), openCodeNativeCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, installer, append(args, "--format", "json")...)
+	cmd.Env = f.env(clientDir)
+	cmd.Dir = f.Root
+	out, err := cmd.CombinedOutput()
+	f.record(t, label, out)
+	if ctx.Err() != nil {
+		t.Fatalf("installer %v timed out after %s:\n%s", args, openCodeNativeCommandTimeout, out)
+	}
+	if err != nil {
+		if _, isExit := err.(*exec.ExitError); !isExit {
+			t.Fatalf("run installer %v: %v\n%s", args, err, out)
+		}
+	}
+	line := openCodeLastJSONLine(out)
+	var decoded map[string]any
+	if line != "" {
+		if jsonErr := json.Unmarshal([]byte(line), &decoded); jsonErr != nil {
+			t.Fatalf("decode installer output for %v: %v\n%s", args, jsonErr, out)
+		}
+	}
+	return decoded
+}
+
+func openCodeRunInstallerExpectError(t *testing.T, f *openCodeNativeFixture, installer, clientDir, label string, args ...string) (string, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), openCodeNativeCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, installer, append(args, "--format", "json")...)
+	cmd.Env = f.env(clientDir)
+	cmd.Dir = f.Root
+	out, err := cmd.CombinedOutput()
+	f.record(t, label, out)
+	if ctx.Err() != nil {
+		t.Fatalf("installer %v timed out after %s (expected a clean refusal, not a hang):\n%s", args, openCodeNativeCommandTimeout, out)
+	}
+	return string(out), err
+}
+
+func openCodeLastJSONLine(out []byte) string {
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		trimmed := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(trimmed, "{") {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+// openCodeAssertMutated decodes an installer JSON result's single-target
+// mutated flag. A no_change field alone does not prove the physical write
+// was skipped; mutated is the field the kernel actually sets.
+func openCodeAssertMutated(t *testing.T, result map[string]any, want bool) {
+	t.Helper()
+	data, _ := result["data"].(map[string]any)
+	targets, _ := data["targets"].([]any)
+	if len(targets) != 1 {
+		t.Fatalf("expected exactly one target in result: %+v", result)
+	}
+	target, _ := targets[0].(map[string]any)
+	output, _ := target["output"].(map[string]any)
+	resultObj, ok := output["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("result object missing from installer output: %+v", output)
+	}
+	mutated, ok := resultObj["mutated"].(bool)
+	if !ok {
+		t.Fatalf("mutated field missing from result: %+v", resultObj)
+	}
+	if mutated != want {
+		t.Fatalf("mutated = %v, want %v: %+v", mutated, want, resultObj)
+	}
+}
+
+// openCodeAssertComponentUnsupported reads the installer's own plan output
+// and requires the named component to be explicitly marked unsupported,
+// rather than inferring non-support only from its absence in the effective
+// config (which could also mean it silently failed to project for an
+// unrelated reason).
+func openCodeAssertComponentUnsupported(t *testing.T, result map[string]any, componentName, wantReason string) {
+	t.Helper()
+	data, _ := result["data"].(map[string]any)
+	targets, _ := data["targets"].([]any)
+	if len(targets) != 1 {
+		t.Fatalf("expected exactly one target in result: %+v", result)
+	}
+	target, _ := targets[0].(map[string]any)
+	output, _ := target["output"].(map[string]any)
+	resultObj, _ := output["result"].(map[string]any)
+	plan, _ := resultObj["plan"].(map[string]any)
+	components, _ := plan["components"].([]any)
+	for _, raw := range components {
+		component, _ := raw.(map[string]any)
+		if component["name"] != componentName {
+			continue
+		}
+		if component["support"] != "unsupported" {
+			t.Fatalf("component %q support = %v, want unsupported: %+v", componentName, component["support"], component)
+		}
+		// The specific reason distinguishes "declared SSE, this client
+		// doesn't support SSE" from a generic not-supported-at-all reason;
+		// checking only "support" cannot tell those apart.
+		if component["reason"] != wantReason {
+			t.Fatalf("component %q reason = %v, want %q: %+v", componentName, component["reason"], wantReason, component)
+		}
+		return
+	}
+	t.Fatalf("component %q not present in installer's own plan output: %+v", componentName, components)
+}
+
+// openCodeAssertCompleted requires both the top-level result marker and the
+// nested data.status to indicate genuine success. data.status can carry
+// error-path values (for example "managed_committed_activation_failed" or a
+// bare "managed_committed" set together with a non-nil error) that must not
+// be mistaken for success.
+func openCodeAssertCompleted(t *testing.T, label string, result map[string]any) map[string]any {
+	t.Helper()
+	if result == nil {
+		t.Fatalf("%s: no decoded installer result", label)
+	}
+	if result["result"] != "success" {
+		t.Fatalf("%s: top-level result = %v, want success: %+v", label, result["result"], result)
+	}
+	data, _ := result["data"].(map[string]any)
+	if data == nil || data["status"] != "completed" {
+		t.Fatalf("%s did not complete: %+v", label, result)
+	}
+	return data
+}
+
+// openCodePhysicalArtifactID extracts the physical_artifact_id from an
+// installer JSON result, which names the managed package directory under
+// <AGENTPLUGINS_HOME>/managed/clients/opencode/.
+// openCodeAssertJSONDataStatus parses the last JSON line of a raw CLI
+// transcript (as produced by openCodeRunInstallerExpectError, which returns
+// unparsed text since it may not be valid JSON on some failure paths) and
+// requires data.status to equal want exactly.
+func openCodeAssertJSONDataStatus(t *testing.T, rawOutput, want string) {
+	t.Helper()
+	line := openCodeLastJSONLine([]byte(rawOutput))
+	if line == "" {
+		t.Fatalf("no JSON line found in output:\n%s", rawOutput)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(line), &decoded); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, rawOutput)
+	}
+	data, _ := decoded["data"].(map[string]any)
+	if data == nil || data["status"] != want {
+		t.Fatalf("data.status = %v, want %q: %+v", data["status"], want, decoded)
+	}
+}
+
+func openCodePhysicalArtifactID(t *testing.T, result map[string]any) string {
+	t.Helper()
+	data, _ := result["data"].(map[string]any)
+	targets, _ := data["targets"].([]any)
+	if len(targets) != 1 {
+		t.Fatalf("expected exactly one target in result: %+v", result)
+	}
+	target, _ := targets[0].(map[string]any)
+	output, _ := target["output"].(map[string]any)
+	resultObj, _ := output["result"].(map[string]any)
+	plan, _ := resultObj["plan"].(map[string]any)
+	id, _ := plan["physical_artifact_id"].(string)
+	if id == "" {
+		t.Fatalf("physical_artifact_id missing from result: %+v", result)
+	}
+	return id
+}
+
+func openCodeVersionString(t *testing.T, f *openCodeNativeFixture, client string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), openCodeNativeCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, client, "--version")
+	cmd.Env = f.env(filepath.Dir(client))
+	cmd.Dir = f.Home
+	out, err := cmd.CombinedOutput()
+	f.record(t, "opencode-version", out)
+	if err != nil {
+		t.Fatalf("opencode --version: %v\n%s", err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// openCodeDebugConfig runs the real client's `debug config` and parses it as
+// exact JSON (never substring matching, per the O2 contract).
+func openCodeDebugConfig(t *testing.T, f *openCodeNativeFixture, client, label string) map[string]any {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), openCodeNativeCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, client, "debug", "config")
+	cmd.Env = f.env(filepath.Dir(client))
+	cmd.Dir = f.Project
+	out, err := cmd.CombinedOutput()
+	f.record(t, label, out)
+	if ctx.Err() != nil {
+		t.Fatalf("opencode debug config timed out after %s:\n%s", openCodeNativeCommandTimeout, out)
+	}
+	if err != nil {
+		t.Fatalf("opencode debug config: %v\n%s", err, out)
+	}
+	var decoded map[string]any
+	if jsonErr := json.Unmarshal(out, &decoded); jsonErr != nil {
+		t.Fatalf("decode opencode debug config: %v\n%s", jsonErr, out)
+	}
+	return decoded
+}
+
+var openCodeANSIEscape = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+// openCodeMCPList runs the real client's `mcp list`, which makes it actually
+// spawn and attempt a live handshake with every configured server, and
+// returns the ANSI-stripped output for per-server assertions. This is
+// stronger evidence than config readback: it proves the runtime enumerated
+// and attempted each entry as a separate connection.
+func openCodeMCPList(t *testing.T, f *openCodeNativeFixture, client, label string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), openCodeNativeCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, client, "mcp", "list")
+	cmd.Env = f.env(filepath.Dir(client))
+	cmd.Dir = f.Project
+	out, err := cmd.CombinedOutput()
+	f.record(t, label, out)
+	if ctx.Err() != nil {
+		t.Fatalf("opencode mcp list timed out after %s:\n%s", openCodeNativeCommandTimeout, out)
+	}
+	if err != nil {
+		t.Fatalf("opencode mcp list: %v\n%s", err, out)
+	}
+	return openCodeANSIEscape.ReplaceAllString(string(out), "")
+}
+
+// openCodeAssertMCPListAttempted requires the exact logical server name to
+// appear as its own attempted-connection line in `mcp list` output (not just
+// anywhere in the text), anchored on the status marker every entry line
+// carries.
+func openCodeAssertMCPListAttempted(t *testing.T, output, serverName string) {
+	t.Helper()
+	pattern := regexp.MustCompile(`(?m)^.*[✗✓].*` + regexp.QuoteMeta(serverName) + `\s*(failed|connected)`)
+	if !pattern.MatchString(output) {
+		t.Fatalf("opencode mcp list did not show a real attempted connection for %q:\n%s", serverName, output)
+	}
+}
+
+func openCodeConfigMCP(t *testing.T, config map[string]any) map[string]any {
+	t.Helper()
+	mcp, ok := config["mcp"].(map[string]any)
+	if !ok {
+		t.Fatalf("effective config has no top-level mcp object: %+v", config)
+	}
+	return mcp
+}
+
+func openCodeWriteFixturePackage(t *testing.T, root, name, version string) {
+	t.Helper()
+	must := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	must(os.MkdirAll(filepath.Join(root, "skills", "demo-skill"), 0755))
+	must(os.WriteFile(filepath.Join(root, "plugin.json"), []byte(fmt.Sprintf(`{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": %q,
+  "version": %q,
+  "description": "OpenCode native lifecycle proof fixture"
+}`, name, version)), 0644))
+	must(os.WriteFile(filepath.Join(root, "skills", "demo-skill", "SKILL.md"), []byte("---\nname: demo-skill\ndescription: A demo skill for native lifecycle verification.\n---\n\n# Demo Skill\n\nSay hello when asked to demo.\n"), 0644))
+	// "api/server" and "api server" are the exact logical MCP keys O1 fixed:
+	// they were previously rejected as invalid physical filesystem leaf names.
+	// sse-server exercises OpenCode's own unsupported-transport handling
+	// alongside two healthy stdio siblings, to observe (not assume) whether
+	// an unsupported component is isolated or blocks the whole package.
+	must(os.WriteFile(filepath.Join(root, "mcp.json"), []byte(`{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "api/server": {"type": "stdio", "command": "sh", "args": ["-c", "cat"]},
+    "api server": {"type": "stdio", "command": "sh", "args": ["-c", "cat"]},
+    "sse-server": {"type": "sse", "url": "http://127.0.0.1:9/sse"}
+  }
+}`), 0644))
+}
+
+func TestAgentpluginsOpenCodeNativeLifecycle(t *testing.T) {
+	if os.Getenv("AGENTPLUGINS_OPENCODE_NATIVE_E2E") != "1" {
+		t.Skip("opt-in native client execution")
+	}
+	client := openCodeNativeBinary(t, "AGENTPLUGINS_OPENCODE_BIN")
+	installer := openCodeNativeBinary(t, "AGENTPLUGINS_INSTALLER_BIN")
+	f := newOpenCodeNativeFixture(t)
+	clientDir := filepath.Dir(client)
+
+	stages := map[string]openCodeNativeStage{}
+	for _, name := range []string{
+		"install", "logical_key_collision_survey", "sse_unsupported", "version_update", "same_version_refresh",
+		"unchanged", "owned_repair", "foreign_config_preservation", "foreign_key_collision", "remove", "repeat_remove",
+		"native_tool_call", "actual_model_skill_use", "oauth",
+	} {
+		stages[name] = openCodeNativeStage{Status: "not_evaluated", Reason: "not reached"}
+	}
+	measuredVersion := openCodeVersionString(t, f, client)
+	evidence := map[string]any{
+		"started_utc": time.Now().UTC().Format(time.RFC3339Nano), "client_version_pinned": os.Getenv("AGENTPLUGINS_OPENCODE_VERSION"),
+		"client_version_measured": measuredVersion, "client_sha256": openCodeSHA256(t, client), "installer_sha256": openCodeSHA256(t, installer),
+		"installer_base_commit": os.Getenv("AGENTPLUGINS_INSTALLER_COMMIT"), "installer_tree": os.Getenv("AGENTPLUGINS_INSTALLER_TREE"),
+		"installer_patch_sha256": os.Getenv("AGENTPLUGINS_INSTALLER_PATCH_SHA256"), "acquisition": "local_directory",
+		"native_surface":         "opencode debug config (effective config proof; not a handshake or tool call) plus opencode mcp list (real per-server connection attempts, still not a handshake or tool call)",
+		"config_route_exercised": "opencode.json only; opencode.jsonc is not exercised by this checkpoint despite the client accepting either",
+		"network_dependency":     "the installer's security scan (lintai) is fetched from GitHub on first use during add if not already cached; this run is not fully offline despite local_directory acquisition",
+		"stages":                 stages,
+	}
+	defer func() {
+		evidence["finished_utc"] = time.Now().UTC().Format(time.RFC3339Nano)
+		evidence["transcript_sha256"] = f.transcriptSHA256
+		body, err := json.MarshalIndent(evidence, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(f.Root, "evidence.json"), body, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	if evidence["installer_base_commit"] == "" || evidence["installer_tree"] == "" {
+		t.Fatal("exact installer base commit and resulting tree required")
+	}
+	if os.Getenv("AGENTPLUGINS_INSTALLER_PATCH_SHA256") == "" {
+		t.Fatal("accepted installer patch digests required for reviewed uncommitted source identity")
+	}
+	if pinned := os.Getenv("AGENTPLUGINS_OPENCODE_VERSION"); pinned != "" && pinned != measuredVersion {
+		t.Fatalf("measured opencode version %q does not match pinned %q", measuredVersion, pinned)
+	}
+
+	openCodeWriteFixturePackage(t, f.PackageRoot, "opencode-native-proof", "1.0.0")
+	added := openCodeRunInstaller(t, f, installer, clientDir, "add-v1", "add", f.PackageRoot, "--target", "opencode")
+	openCodeAssertCompleted(t, "install", added)
+	stages["install"] = openCodeNativeStage{Status: "passed"}
+
+	config := openCodeDebugConfig(t, f, client, "debug-config-v1")
+	mcp := openCodeConfigMCP(t, config)
+	if _, slashOK := mcp["api/server"].(map[string]any); !slashOK {
+		t.Fatalf("O1's exact logical key \"api/server\" was not present: mcp=%+v", mcp)
+	}
+	if _, spaceOK := mcp["api server"].(map[string]any); !spaceOK {
+		t.Fatalf("O1's exact logical key \"api server\" was not present: mcp=%+v", mcp)
+	}
+	// Config readback alone cannot prove the runtime treats the two keys as
+	// distinct connections (O2 explicitly forbids declaring the colliding
+	// case passed from config readback alone). Run `opencode mcp list`, which
+	// makes the real client spawn and attempt a live stdio handshake with
+	// each configured server, and require each exact key to appear as its
+	// own attempted connection. This is ONE mcp list call against the
+	// simultaneous-collision fixture (both keys installed together), parsed
+	// into two per-key assertions -- real evidence of two independent
+	// process spawns and JSON-RPC round-trips, but not the two genuinely
+	// separate single-key installs O2's "separate api/server and api server
+	// runs" wording asks for. That stronger form was not performed this
+	// checkpoint; say so plainly rather than implying it was.
+	mcpList := openCodeMCPList(t, f, client, "mcp-list-v1")
+	openCodeAssertMCPListAttempted(t, mcpList, "api/server")
+	openCodeAssertMCPListAttempted(t, mcpList, "api server")
+	// What is NOT proven here, per O2's own required framing: whether the two
+	// servers' *tools* collide at the runtime tool-ID level. OpenCode 1.18.29
+	// sanitizes tool IDs as sanitize(server)+"_"+sanitize(tool)` with
+	// non-name characters replaced by "_", so "api/server" and "api server"
+	// both sanitize to the same "api_server" prefix -- a same-named tool on
+	// both servers is plausible to collide at that layer. Observing that
+	// requires a live model session actually selecting a tool, which this
+	// checkpoint does not have a safe no-auth route to. Recorded honestly as
+	// not proven rather than forced closed, per O2's explicit instruction.
+	stages["logical_key_collision_survey"] = openCodeNativeStage{Status: "not_proven", Reason: "verified beyond config readback: one opencode mcp list run over the simultaneous-collision fixture independently attempted a live connection to \"api/server\" and to \"api server\" as two distinct entries (two assertions against one run, not two genuinely separate single-key installs -- O2's stronger \"separate runs\" wording was not performed). Not proven: runtime tool-ID-level collision between the two servers' tools, which OpenCode's own sanitizer (replacing non-name characters with \"_\") makes plausible for same-named tools; observing that needs a live model session, which is out of scope here -- O2 requires this exact honesty rather than declaring the colliding case passed from config alone"}
+
+	if _, sseInstalled := mcp["sse-server"]; sseInstalled {
+		stages["sse_unsupported"] = openCodeNativeStage{Status: "failed", Reason: "sse-typed component was installed despite OpenCode SSE being unsupported"}
+		t.Fatalf("sse-server should not have been installed: %+v", mcp)
+	}
+	openCodeAssertComponentUnsupported(t, added, "sse-server", "declared_sse_not_supported_by_client")
+	stages["sse_unsupported"] = openCodeNativeStage{Status: "passed", Reason: "installer's own plan marks sse-server unsupported and absent from effective config; healthy stdio siblings installed"}
+
+	openCodeWriteFixturePackage(t, f.PackageRoot, "opencode-native-proof", "2.0.0")
+	updated := openCodeRunInstaller(t, f, installer, clientDir, "update-v2", "update", f.PackageRoot, "--target", "opencode")
+	openCodeAssertCompleted(t, "version update", updated)
+	stages["version_update"] = openCodeNativeStage{Status: "passed"}
+
+	before := openCodeSHA256(t, filepath.Join(f.XDGConfig, "opencode", "skills", "demo-skill", "SKILL.md"))
+	must := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	skillBody, err := os.ReadFile(filepath.Join(f.PackageRoot, "skills", "demo-skill", "SKILL.md"))
+	must(err)
+	must(os.WriteFile(filepath.Join(f.PackageRoot, "skills", "demo-skill", "SKILL.md"), append(append([]byte{}, skillBody...), []byte("\nExtra content for the same-version refresh.\n")...), 0644))
+	refreshed := openCodeRunInstaller(t, f, installer, clientDir, "same-version-refresh", "update", f.PackageRoot, "--target", "opencode")
+	openCodeAssertCompleted(t, "same-version content refresh", refreshed)
+	openCodeAssertMutated(t, refreshed, true)
+	after := openCodeSHA256(t, filepath.Join(f.XDGConfig, "opencode", "skills", "demo-skill", "SKILL.md"))
+	if before == after {
+		t.Fatalf("same-version content refresh did not change the installed skill file digest")
+	}
+	stages["same_version_refresh"] = openCodeNativeStage{Status: "passed", Reason: "mutated:true and installed skill file digest changed on identical version, changed content"}
+
+	beforeUnchanged := openCodeSHA256(t, filepath.Join(f.XDGConfig, "opencode", "opencode.json"))
+	unchanged := openCodeRunInstaller(t, f, installer, clientDir, "unchanged-reapply", "update", f.PackageRoot, "--target", "opencode")
+	openCodeAssertCompleted(t, "unchanged re-apply", unchanged)
+	openCodeAssertMutated(t, unchanged, false)
+	afterUnchanged := openCodeSHA256(t, filepath.Join(f.XDGConfig, "opencode", "opencode.json"))
+	if beforeUnchanged != afterUnchanged {
+		t.Fatalf("physically-unchanged re-apply changed the config file digest: %s -> %s", beforeUnchanged, afterUnchanged)
+	}
+	stages["unchanged"] = openCodeNativeStage{Status: "passed", Reason: "mutated:false and byte-identical config file digest on an identical re-apply"}
+
+	// Plant an unrelated foreign top-level config key before any destructive
+	// operation, and carry it through repair/remove to prove it survives.
+	rawConfig, err := os.ReadFile(filepath.Join(f.XDGConfig, "opencode", "opencode.json"))
+	must(err)
+	var rawDoc map[string]any
+	must(json.Unmarshal(rawConfig, &rawDoc))
+	rawMCP, _ := rawDoc["mcp"].(map[string]any)
+	if rawMCP == nil {
+		rawMCP = map[string]any{}
+		rawDoc["mcp"] = rawMCP
+	}
+	rawMCP["foreign-untouched"] = map[string]any{"type": "local", "command": []any{"sh", "-c", "cat"}}
+	foreignBody, err := json.MarshalIndent(rawDoc, "", "  ")
+	must(err)
+	must(os.WriteFile(filepath.Join(f.XDGConfig, "opencode", "opencode.json"), foreignBody, 0644))
+
+	// Genuine absent-directory repair: delete the whole managed package
+	// directory UAP owns (the closest OpenCode analog to the Codex C3 /
+	// Claude CL1 absent-repair scenario), not merely re-apply unchanged
+	// content. The config entries and installed skill file are untouched by
+	// this deletion -- only the staged source UAP would re-project from is
+	// gone, so repair must genuinely reconstruct it.
+	physicalArtifactID := openCodePhysicalArtifactID(t, updated)
+	managedDir := filepath.Join(f.StateHome, "managed", "clients", "opencode", physicalArtifactID)
+	if _, statErr := os.Stat(managedDir); statErr != nil {
+		t.Fatalf("managed package directory not found before deleting it: %v", statErr)
+	}
+	installedSkillBefore := openCodeSHA256(t, filepath.Join(f.XDGConfig, "opencode", "skills", "demo-skill", "SKILL.md"))
+	must(os.RemoveAll(managedDir))
+	if _, statErr := os.Stat(managedDir); !os.IsNotExist(statErr) {
+		t.Fatalf("managed package directory still exists after deletion: %v", statErr)
+	}
+
+	repaired := openCodeRunInstaller(t, f, installer, clientDir, "repair", "repair", "opencode-native-proof", "--target", "opencode")
+	openCodeAssertCompleted(t, "repair", repaired)
+	if _, statErr := os.Stat(filepath.Join(managedDir, "plugin.json")); statErr != nil {
+		t.Fatalf("repair did not reconstruct the deleted managed package directory: %v", statErr)
+	}
+	installedSkillAfter := openCodeSHA256(t, filepath.Join(f.XDGConfig, "opencode", "skills", "demo-skill", "SKILL.md"))
+	if installedSkillBefore != installedSkillAfter {
+		t.Fatalf("repair changed the installed skill file's digest: %s -> %s", installedSkillBefore, installedSkillAfter)
+	}
+	postRepair := openCodeDebugConfig(t, f, client, "debug-config-post-repair")
+	postRepairMCP := openCodeConfigMCP(t, postRepair)
+	if _, ok := postRepairMCP["foreign-untouched"]; !ok {
+		t.Fatalf("repair removed a foreign, unrelated config entry: %+v", postRepairMCP)
+	}
+	if _, ok := postRepairMCP["api/server"]; !ok {
+		t.Fatalf("repair lost the managed api/server entry: %+v", postRepairMCP)
+	}
+	stages["owned_repair"] = openCodeNativeStage{Status: "passed", Reason: "the whole managed package directory was deleted and repair genuinely reconstructed it; installed skill file digest unchanged, config entries intact"}
+	stages["foreign_config_preservation"] = openCodeNativeStage{Status: "passed", Reason: "foreign-untouched entry present in effective config after a genuine absent-directory repair"}
+
+	// Foreign key collision: a raw config entry claims the exact logical key
+	// our package also declares. O2 requires this be observed, not silently
+	// resolved -- record actual behavior rather than assuming refusal. Bump
+	// content first so the subsequent update attempt actually goes through
+	// the real write path (openCodeMCPRequests), not the no-change/VerifyOnly
+	// branch a same-content re-apply would take.
+	openCodeWriteFixturePackage(t, f.PackageRoot, "opencode-native-proof", "3.0.0")
+	preCollisionBytes, err := os.ReadFile(filepath.Join(f.XDGConfig, "opencode", "opencode.json"))
+	must(err)
+	collisionDoc := map[string]any{}
+	must(json.Unmarshal(preCollisionBytes, &collisionDoc))
+	collisionMCP, _ := collisionDoc["mcp"].(map[string]any)
+	delete(collisionMCP, "api/server")
+	collisionMCP["api/server"] = map[string]any{"type": "local", "command": []any{"sh", "-c", "echo foreign-owns-this-key"}}
+	collisionBody, err := json.MarshalIndent(collisionDoc, "", "  ")
+	must(err)
+	must(os.WriteFile(filepath.Join(f.XDGConfig, "opencode", "opencode.json"), collisionBody, 0644))
+	postCollisionPlantBytes, err := os.ReadFile(filepath.Join(f.XDGConfig, "opencode", "opencode.json"))
+	must(err)
+	beforeCollisionSkillDigest := openCodeSHA256(t, filepath.Join(f.XDGConfig, "opencode", "skills", "demo-skill", "SKILL.md"))
+
+	collisionUpdateOut, collisionUpdateErr := openCodeRunInstallerExpectError(t, f, installer, clientDir, "foreign-key-collision-update", "update", f.PackageRoot, "--target", "opencode")
+	if collisionUpdateErr == nil {
+		stages["foreign_key_collision"] = openCodeNativeStage{Status: "failed", Reason: "update silently overwrote a foreign entry claiming a managed logical key instead of refusing"}
+		t.Fatalf("expected refusal when a foreign entry occupies a managed logical key, got success:\n%s", collisionUpdateOut)
+	}
+	if !strings.Contains(collisionUpdateOut, "native MCP entry is not exactly owned") || !strings.Contains(collisionUpdateOut, "api/server") {
+		t.Fatalf("update refusal did not contain the exact expected ownership message for api/server:\n%s", collisionUpdateOut)
+	}
+	// The overall operation is not a clean no-op: UAP's own bookkeeping (the
+	// managed package directory and internal state) commits the new version
+	// before external activation is attempted per key, so this specific
+	// failure mode is the documented managed_committed_activation_failed
+	// state, not a full rollback. Assert that precisely instead of only
+	// checking that an error occurred.
+	openCodeAssertJSONDataStatus(t, collisionUpdateOut, "managed_committed_activation_failed")
+	afterCollisionUpdateBytes, err := os.ReadFile(filepath.Join(f.XDGConfig, "opencode", "opencode.json"))
+	must(err)
+	if string(afterCollisionUpdateBytes) != string(postCollisionPlantBytes) {
+		t.Fatalf("config file changed despite a refused update:\nbefore=%s\nafter=%s", postCollisionPlantBytes, afterCollisionUpdateBytes)
+	}
+	afterCollisionUpdateSkillDigest := openCodeSHA256(t, filepath.Join(f.XDGConfig, "opencode", "skills", "demo-skill", "SKILL.md"))
+	if afterCollisionUpdateSkillDigest != beforeCollisionSkillDigest {
+		t.Fatalf("installed skill file changed despite the refused MCP entry write: %s -> %s", beforeCollisionSkillDigest, afterCollisionUpdateSkillDigest)
+	}
+
+	// The managed key is still foreign-occupied: repair must refuse this too
+	// (it only reconstructs absent managed objects, never adopts a foreign
+	// one -- same ownership discipline as C3), verified with a real repair
+	// call and its exact refusal message, not merely asserted in a comment.
+	collisionRepairOut, collisionRepairErr := openCodeRunInstallerExpectError(t, f, installer, clientDir, "foreign-key-collision-repair", "repair", "opencode-native-proof", "--target", "opencode")
+	if collisionRepairErr == nil {
+		stages["foreign_key_collision"] = openCodeNativeStage{Status: "failed", Reason: "repair silently adopted a foreign entry claiming a managed logical key instead of refusing"}
+		t.Fatalf("expected repair to refuse when a foreign entry occupies a managed logical key, got success:\n%s", collisionRepairOut)
+	}
+	if !strings.Contains(collisionRepairOut, "native MCP entry is not exactly owned") || !strings.Contains(collisionRepairOut, "api/server") {
+		t.Fatalf("repair refusal did not contain the exact expected ownership message for api/server:\n%s", collisionRepairOut)
+	}
+	openCodeAssertJSONDataStatus(t, collisionRepairOut, "managed_committed_activation_failed")
+	afterCollisionRepairBytes, err := os.ReadFile(filepath.Join(f.XDGConfig, "opencode", "opencode.json"))
+	must(err)
+	if string(afterCollisionRepairBytes) != string(postCollisionPlantBytes) {
+		t.Fatalf("config file changed despite a refused repair:\nbefore=%s\nafter=%s", postCollisionPlantBytes, afterCollisionRepairBytes)
+	}
+	afterCollisionRepairSkillDigest := openCodeSHA256(t, filepath.Join(f.XDGConfig, "opencode", "skills", "demo-skill", "SKILL.md"))
+	if afterCollisionRepairSkillDigest != beforeCollisionSkillDigest {
+		t.Fatalf("installed skill file changed despite the refused repair: %s -> %s", beforeCollisionSkillDigest, afterCollisionRepairSkillDigest)
+	}
+	stages["foreign_key_collision"] = openCodeNativeStage{Status: "passed", Reason: "both update and repair independently refused external activation with the exact ownership message naming the occupied key (data.status:managed_committed_activation_failed -- UAP's own managed bookkeeping commits the new version, but the client-facing config write for the occupied key is refused), while the package had genuinely changed content (not a no-change/VerifyOnly re-apply); config file bytes and installed skill file digest verified unchanged after each refusal"}
+	// Restore the exact pre-collision bytes directly, simulating the foreign
+	// writer reverting its own change, so remove below observes the actual
+	// managed state.
+	must(os.WriteFile(filepath.Join(f.XDGConfig, "opencode", "opencode.json"), preCollisionBytes, 0644))
+
+	removed := openCodeRunInstaller(t, f, installer, clientDir, "remove", "remove", "opencode-native-proof", "--target", "opencode")
+	if removed == nil || removed["result"] != "success" {
+		t.Fatalf("remove did not report success: %+v", removed)
+	}
+	if data, _ := removed["data"].(map[string]any); data == nil || data["status"] != "data_retained" {
+		t.Fatalf("remove data.status = %v, want data_retained: %+v", removed["data"], removed)
+	}
+	postRemove := openCodeDebugConfig(t, f, client, "debug-config-post-remove")
+	postRemoveMCP := openCodeConfigMCP(t, postRemove)
+	if _, ok := postRemoveMCP["api/server"]; ok {
+		t.Fatalf("remove left the managed api/server entry behind: %+v", postRemoveMCP)
+	}
+	if _, ok := postRemoveMCP["api server"]; ok {
+		t.Fatalf("remove left the managed \"api server\" entry behind: %+v", postRemoveMCP)
+	}
+	if _, ok := postRemoveMCP["foreign-untouched"]; !ok {
+		t.Fatalf("remove deleted the unrelated foreign entry: %+v", postRemoveMCP)
+	}
+	// debug config only proves the MCP entries are gone from the client's
+	// view; independently confirm the installed skill directory itself was
+	// actually deleted from disk, not merely unreferenced.
+	if _, statErr := os.Stat(filepath.Join(f.XDGConfig, "opencode", "skills", "demo-skill")); !os.IsNotExist(statErr) {
+		t.Fatalf("remove did not delete the installed skill directory from disk: %v", statErr)
+	}
+	stages["remove"] = openCodeNativeStage{Status: "passed", Reason: "result:success and data.status:data_retained; managed MCP entries removed from effective config; installed skill directory actually deleted from disk (not just absent from debug config); foreign sibling config entry preserved"}
+
+	repeatOut, repeatErr := openCodeRunInstallerExpectError(t, f, installer, clientDir, "repeat-remove", "remove", "opencode-native-proof", "--target", "opencode")
+	if repeatErr == nil {
+		stages["repeat_remove"] = openCodeNativeStage{Status: "failed", Reason: "repeated remove of an already-removed installation was silently accepted"}
+		t.Fatalf("expected refusal for repeat remove, got success:\n%s", repeatOut)
+	}
+	stages["repeat_remove"] = openCodeNativeStage{Status: "passed", Reason: "repeated remove correctly refused"}
+}
+
+func openCodeNativeBinary(t *testing.T, key string) string {
+	t.Helper()
+	p := os.Getenv(key)
+	if !filepath.IsAbs(p) {
+		t.Fatalf("%s must name an absolute scratch binary", key)
+	}
+	st, err := os.Stat(p)
+	if err != nil || !st.Mode().IsRegular() || st.Mode()&0111 == 0 {
+		t.Fatalf("invalid %s binary", key)
+	}
+	return p
+}

--- a/repotests/agentplugins_opencode_native_e2e_test.go
+++ b/repotests/agentplugins_opencode_native_e2e_test.go
@@ -2,9 +2,7 @@ package pluginkitairepo_test
 
 // This suite drives the real OpenCode CLI through UAP's actual install route
 // (global opencode.json under <XDG_CONFIG_HOME>/opencode, plus global
-// skills). UAP also supports opencode.jsonc for this same route, but this
-// checkpoint only exercises the .json path -- that is a real, currently
-// unproven gap, not a claim that both are covered. It is opt-in and uses
+// skills). Both .json and .jsonc run the complete lifecycle. It is opt-in and uses
 // only disposable HOME/XDG roots and a fresh project directory; it never
 // touches the invoking user's real OpenCode config. `opencode debug config`
 // proves effective config, not a handshake or tool call -- that distinction
@@ -20,6 +18,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -396,13 +395,70 @@ func openCodeWriteFixturePackage(t *testing.T, root, name, version string) {
 }
 
 func TestAgentpluginsOpenCodeNativeLifecycle(t *testing.T) {
+	for _, route := range []string{"opencode.json", "opencode.jsonc"} {
+		t.Run(route, func(t *testing.T) { openCodeNativeLifecycle(t, route) })
+	}
+}
+
+const openCodeJSONCComment = "// UAP disposable JSONC lifecycle sentinel\n"
+
+func openCodeReadConfigDocument(t *testing.T, body []byte, doc *map[string]any) {
+	t.Helper()
+	// The only comment authored by this fixture is this exact sentinel.
+	// Do not strip arbitrary comment syntax, which could corrupt URL strings.
+	body = []byte(strings.ReplaceAll(string(body), openCodeJSONCComment, ""))
+	if err := json.Unmarshal(body, doc); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func openCodePrepareNative(t *testing.T, f *openCodeNativeFixture, client string) map[string]string {
+	t.Helper()
+	if runtime.GOOS != "linux" || os.Getenv("AGENTPLUGINS_NATIVE_DISPOSABLE_LINUX") != "1" {
+		t.Fatal("native OpenCode execution requires the approved disposable Linux container")
+	}
+	if expected := os.Getenv("AGENTPLUGINS_OPENCODE_SHA256"); len(expected) != 64 || openCodeSHA256(t, client) != expected {
+		t.Fatal("OpenCode binary SHA256 mismatch or missing pin")
+	}
+	if os.Getenv("AGENTPLUGINS_OPENCODE_VERSION") != "1.18.29" {
+		t.Fatal("OpenCode requires version pin 1.18.29")
+	}
+	return nativeProvisionScanner(t, &nativeFixture{Root: f.Root})
+}
+
+func openCodeNativeLifecycle(t *testing.T, route string) {
 	if os.Getenv("AGENTPLUGINS_OPENCODE_NATIVE_E2E") != "1" {
 		t.Skip("opt-in native client execution")
 	}
 	client := openCodeNativeBinary(t, "AGENTPLUGINS_OPENCODE_BIN")
 	installer := openCodeNativeBinary(t, "AGENTPLUGINS_INSTALLER_BIN")
 	f := newOpenCodeNativeFixture(t)
+	scanner := openCodePrepareNative(t, f, client)
 	clientDir := filepath.Dir(client)
+	configPath := filepath.Join(f.XDGConfig, "opencode", route)
+	if route == "opencode.jsonc" {
+		if err := os.MkdirAll(filepath.Dir(configPath), 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(configPath, []byte(openCodeJSONCComment+"{\n  \"mcp\": {}\n}\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	assertConfigRoute := func() {
+		t.Helper()
+		body, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if route == "opencode.jsonc" {
+			if !strings.Contains(string(body), openCodeJSONCComment) {
+				t.Fatal("JSONC comment was lost")
+			}
+			if _, err := os.Stat(filepath.Join(f.XDGConfig, "opencode", "opencode.json")); !os.IsNotExist(err) {
+				t.Fatalf("JSONC lifecycle unexpectedly created opencode.json: %v", err)
+			}
+		}
+	}
 
 	stages := map[string]openCodeNativeStage{}
 	for _, name := range []string{
@@ -419,8 +475,9 @@ func TestAgentpluginsOpenCodeNativeLifecycle(t *testing.T) {
 		"installer_base_commit": os.Getenv("AGENTPLUGINS_INSTALLER_COMMIT"), "installer_tree": os.Getenv("AGENTPLUGINS_INSTALLER_TREE"),
 		"installer_patch_sha256": os.Getenv("AGENTPLUGINS_INSTALLER_PATCH_SHA256"), "acquisition": "local_directory",
 		"native_surface":         "opencode debug config (effective config proof; not a handshake or tool call) plus opencode mcp list (real per-server connection attempts, still not a handshake or tool call)",
-		"config_route_exercised": "opencode.json only; opencode.jsonc is not exercised by this checkpoint despite the client accepting either",
-		"network_dependency":     "the installer's security scan (lintai) is fetched from GitHub on first use during add if not already cached; this run is not fully offline despite local_directory acquisition",
+		"config_route_exercised": route,
+		"network_dependency":     "none; pinned scanner preprovisioned; disposable container denies external network",
+		"scanner":                scanner,
 		"stages":                 stages,
 	}
 	defer func() {
@@ -434,11 +491,12 @@ func TestAgentpluginsOpenCodeNativeLifecycle(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
-	if evidence["installer_base_commit"] == "" || evidence["installer_tree"] == "" {
-		t.Fatal("exact installer base commit and resulting tree required")
+	identity, err := nativeSourceIdentity(os.Getenv("AGENTPLUGINS_INSTALLER_COMMIT"), os.Getenv("AGENTPLUGINS_INSTALLER_TREE"), os.Getenv("AGENTPLUGINS_INSTALLER_PATCH_SHA256"))
+	if err != nil {
+		t.Fatal(err)
 	}
-	if os.Getenv("AGENTPLUGINS_INSTALLER_PATCH_SHA256") == "" {
-		t.Fatal("accepted installer patch digests required for reviewed uncommitted source identity")
+	for key, value := range identity {
+		evidence[key] = value
 	}
 	if pinned := os.Getenv("AGENTPLUGINS_OPENCODE_VERSION"); pinned != "" && pinned != measuredVersion {
 		t.Fatalf("measured opencode version %q does not match pinned %q", measuredVersion, pinned)
@@ -447,6 +505,7 @@ func TestAgentpluginsOpenCodeNativeLifecycle(t *testing.T) {
 	openCodeWriteFixturePackage(t, f.PackageRoot, "opencode-native-proof", "1.0.0")
 	added := openCodeRunInstaller(t, f, installer, clientDir, "add-v1", "add", f.PackageRoot, "--target", "opencode")
 	openCodeAssertCompleted(t, "install", added)
+	assertConfigRoute()
 	stages["install"] = openCodeNativeStage{Status: "passed"}
 
 	config := openCodeDebugConfig(t, f, client, "debug-config-v1")
@@ -493,6 +552,7 @@ func TestAgentpluginsOpenCodeNativeLifecycle(t *testing.T) {
 	openCodeWriteFixturePackage(t, f.PackageRoot, "opencode-native-proof", "2.0.0")
 	updated := openCodeRunInstaller(t, f, installer, clientDir, "update-v2", "update", f.PackageRoot, "--target", "opencode")
 	openCodeAssertCompleted(t, "version update", updated)
+	assertConfigRoute()
 	stages["version_update"] = openCodeNativeStage{Status: "passed"}
 
 	before := openCodeSHA256(t, filepath.Join(f.XDGConfig, "opencode", "skills", "demo-skill", "SKILL.md"))
@@ -514,22 +574,23 @@ func TestAgentpluginsOpenCodeNativeLifecycle(t *testing.T) {
 	}
 	stages["same_version_refresh"] = openCodeNativeStage{Status: "passed", Reason: "mutated:true and installed skill file digest changed on identical version, changed content"}
 
-	beforeUnchanged := openCodeSHA256(t, filepath.Join(f.XDGConfig, "opencode", "opencode.json"))
+	beforeUnchanged := openCodeSHA256(t, configPath)
 	unchanged := openCodeRunInstaller(t, f, installer, clientDir, "unchanged-reapply", "update", f.PackageRoot, "--target", "opencode")
 	openCodeAssertCompleted(t, "unchanged re-apply", unchanged)
 	openCodeAssertMutated(t, unchanged, false)
-	afterUnchanged := openCodeSHA256(t, filepath.Join(f.XDGConfig, "opencode", "opencode.json"))
+	afterUnchanged := openCodeSHA256(t, configPath)
 	if beforeUnchanged != afterUnchanged {
 		t.Fatalf("physically-unchanged re-apply changed the config file digest: %s -> %s", beforeUnchanged, afterUnchanged)
 	}
+	assertConfigRoute()
 	stages["unchanged"] = openCodeNativeStage{Status: "passed", Reason: "mutated:false and byte-identical config file digest on an identical re-apply"}
 
 	// Plant an unrelated foreign top-level config key before any destructive
 	// operation, and carry it through repair/remove to prove it survives.
-	rawConfig, err := os.ReadFile(filepath.Join(f.XDGConfig, "opencode", "opencode.json"))
+	rawConfig, err := os.ReadFile(configPath)
 	must(err)
 	var rawDoc map[string]any
-	must(json.Unmarshal(rawConfig, &rawDoc))
+	openCodeReadConfigDocument(t, rawConfig, &rawDoc)
 	rawMCP, _ := rawDoc["mcp"].(map[string]any)
 	if rawMCP == nil {
 		rawMCP = map[string]any{}
@@ -538,7 +599,10 @@ func TestAgentpluginsOpenCodeNativeLifecycle(t *testing.T) {
 	rawMCP["foreign-untouched"] = map[string]any{"type": "local", "command": []any{"sh", "-c", "cat"}}
 	foreignBody, err := json.MarshalIndent(rawDoc, "", "  ")
 	must(err)
-	must(os.WriteFile(filepath.Join(f.XDGConfig, "opencode", "opencode.json"), foreignBody, 0644))
+	if route == "opencode.jsonc" {
+		foreignBody = append([]byte(openCodeJSONCComment), foreignBody...)
+	}
+	must(os.WriteFile(configPath, foreignBody, 0644))
 
 	// Genuine absent-directory repair: delete the whole managed package
 	// directory UAP owns (the closest OpenCode analog to the Codex C3 /
@@ -574,6 +638,7 @@ func TestAgentpluginsOpenCodeNativeLifecycle(t *testing.T) {
 	if _, ok := postRepairMCP["api/server"]; !ok {
 		t.Fatalf("repair lost the managed api/server entry: %+v", postRepairMCP)
 	}
+	assertConfigRoute()
 	stages["owned_repair"] = openCodeNativeStage{Status: "passed", Reason: "the whole managed package directory was deleted and repair genuinely reconstructed it; installed skill file digest unchanged, config entries intact"}
 	stages["foreign_config_preservation"] = openCodeNativeStage{Status: "passed", Reason: "foreign-untouched entry present in effective config after a genuine absent-directory repair"}
 
@@ -584,17 +649,20 @@ func TestAgentpluginsOpenCodeNativeLifecycle(t *testing.T) {
 	// the real write path (openCodeMCPRequests), not the no-change/VerifyOnly
 	// branch a same-content re-apply would take.
 	openCodeWriteFixturePackage(t, f.PackageRoot, "opencode-native-proof", "3.0.0")
-	preCollisionBytes, err := os.ReadFile(filepath.Join(f.XDGConfig, "opencode", "opencode.json"))
+	preCollisionBytes, err := os.ReadFile(configPath)
 	must(err)
 	collisionDoc := map[string]any{}
-	must(json.Unmarshal(preCollisionBytes, &collisionDoc))
+	openCodeReadConfigDocument(t, preCollisionBytes, &collisionDoc)
 	collisionMCP, _ := collisionDoc["mcp"].(map[string]any)
 	delete(collisionMCP, "api/server")
 	collisionMCP["api/server"] = map[string]any{"type": "local", "command": []any{"sh", "-c", "echo foreign-owns-this-key"}}
 	collisionBody, err := json.MarshalIndent(collisionDoc, "", "  ")
 	must(err)
-	must(os.WriteFile(filepath.Join(f.XDGConfig, "opencode", "opencode.json"), collisionBody, 0644))
-	postCollisionPlantBytes, err := os.ReadFile(filepath.Join(f.XDGConfig, "opencode", "opencode.json"))
+	if route == "opencode.jsonc" {
+		collisionBody = append([]byte(openCodeJSONCComment), collisionBody...)
+	}
+	must(os.WriteFile(configPath, collisionBody, 0644))
+	postCollisionPlantBytes, err := os.ReadFile(configPath)
 	must(err)
 	beforeCollisionSkillDigest := openCodeSHA256(t, filepath.Join(f.XDGConfig, "opencode", "skills", "demo-skill", "SKILL.md"))
 
@@ -613,7 +681,7 @@ func TestAgentpluginsOpenCodeNativeLifecycle(t *testing.T) {
 	// state, not a full rollback. Assert that precisely instead of only
 	// checking that an error occurred.
 	openCodeAssertJSONDataStatus(t, collisionUpdateOut, "managed_committed_activation_failed")
-	afterCollisionUpdateBytes, err := os.ReadFile(filepath.Join(f.XDGConfig, "opencode", "opencode.json"))
+	afterCollisionUpdateBytes, err := os.ReadFile(configPath)
 	must(err)
 	if string(afterCollisionUpdateBytes) != string(postCollisionPlantBytes) {
 		t.Fatalf("config file changed despite a refused update:\nbefore=%s\nafter=%s", postCollisionPlantBytes, afterCollisionUpdateBytes)
@@ -636,7 +704,7 @@ func TestAgentpluginsOpenCodeNativeLifecycle(t *testing.T) {
 		t.Fatalf("repair refusal did not contain the exact expected ownership message for api/server:\n%s", collisionRepairOut)
 	}
 	openCodeAssertJSONDataStatus(t, collisionRepairOut, "managed_committed_activation_failed")
-	afterCollisionRepairBytes, err := os.ReadFile(filepath.Join(f.XDGConfig, "opencode", "opencode.json"))
+	afterCollisionRepairBytes, err := os.ReadFile(configPath)
 	must(err)
 	if string(afterCollisionRepairBytes) != string(postCollisionPlantBytes) {
 		t.Fatalf("config file changed despite a refused repair:\nbefore=%s\nafter=%s", postCollisionPlantBytes, afterCollisionRepairBytes)
@@ -649,7 +717,7 @@ func TestAgentpluginsOpenCodeNativeLifecycle(t *testing.T) {
 	// Restore the exact pre-collision bytes directly, simulating the foreign
 	// writer reverting its own change, so remove below observes the actual
 	// managed state.
-	must(os.WriteFile(filepath.Join(f.XDGConfig, "opencode", "opencode.json"), preCollisionBytes, 0644))
+	must(os.WriteFile(configPath, preCollisionBytes, 0644))
 
 	removed := openCodeRunInstaller(t, f, installer, clientDir, "remove", "remove", "opencode-native-proof", "--target", "opencode")
 	if removed == nil || removed["result"] != "success" {
@@ -675,6 +743,7 @@ func TestAgentpluginsOpenCodeNativeLifecycle(t *testing.T) {
 	if _, statErr := os.Stat(filepath.Join(f.XDGConfig, "opencode", "skills", "demo-skill")); !os.IsNotExist(statErr) {
 		t.Fatalf("remove did not delete the installed skill directory from disk: %v", statErr)
 	}
+	assertConfigRoute()
 	stages["remove"] = openCodeNativeStage{Status: "passed", Reason: "result:success and data.status:data_retained; managed MCP entries removed from effective config; installed skill directory actually deleted from disk (not just absent from debug config); foreign sibling config entry preserved"}
 
 	repeatOut, repeatErr := openCodeRunInstallerExpectError(t, f, installer, clientDir, "repeat-remove", "remove", "opencode-native-proof", "--target", "opencode")

--- a/repotests/testdata/agentplugins_native_probe/main.go
+++ b/repotests/testdata/agentplugins_native_probe/main.go
@@ -1,0 +1,207 @@
+// agentplugins_native_probe is a credential-free MCP fixture, never a product server.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type request struct {
+	ID     json.RawMessage `json:"id"`
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params"`
+}
+type facts struct {
+	Nonce    string   `json:"nonce"`
+	Revision string   `json:"revision"`
+	CWD      string   `json:"cwd"`
+	Argv     []string `json:"argv"`
+	Root     string   `json:"plugin_root"`
+	Data     string   `json:"plugin_data"`
+	Literal  string   `json:"literal"`
+	Once     string   `json:"once"`
+	Marker   string   `json:"marker,omitempty"`
+	PID      int      `json:"pid"`
+	Session  string   `json:"session"`
+}
+
+var session = fmt.Sprintf("%d-%d", os.Getpid(), time.Now().UnixNano())
+
+func contained(path string) (string, error) {
+	root, err := filepath.EvalSymlinks(os.Getenv("UAP_TEST_ROOT"))
+	if err != nil {
+		return "", err
+	}
+	if !filepath.IsAbs(path) {
+		return "", errors.New("fixture path must be absolute")
+	}
+	// Resolve existing ancestors before creating anything. Reject symlinks escaping root.
+	parent := filepath.Clean(path)
+	var suffix []string
+	for {
+		_, err = os.Lstat(parent)
+		if err == nil {
+			break
+		}
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+		suffix = append(suffix, filepath.Base(parent))
+		next := filepath.Dir(parent)
+		if next == parent {
+			return "", errors.New("no existing ancestor")
+		}
+		parent = next
+	}
+	parent, err = filepath.EvalSymlinks(parent)
+	if err != nil {
+		return "", err
+	}
+	for i := len(suffix) - 1; i >= 0; i-- {
+		parent = filepath.Join(parent, suffix[i])
+	}
+	rel, err := filepath.Rel(root, parent)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", errors.New("fixture path escapes test root")
+	}
+	return parent, nil
+}
+func event(method string, f *facts) error {
+	path, err := contained(os.Getenv("UAP_TEST_EVENTS"))
+	if err != nil {
+		return err
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	stat, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if stat.Size() > 2<<20 {
+		return errors.New("fixture event limit")
+	}
+	return json.NewEncoder(file).Encode(map[string]any{"method": method, "pid": os.Getpid(), "session": session, "nonce": os.Getenv("UAP_TEST_NONCE"), "timestamp": time.Now().UTC().Format(time.RFC3339Nano), "facts": f})
+}
+func inspect(params json.RawMessage) (any, error) {
+	var p struct {
+		Name      string `json:"name"`
+		Arguments struct {
+			Nonce     string `json:"nonce"`
+			Operation string `json:"operation"`
+			Marker    string `json:"marker"`
+		} `json:"arguments"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, err
+	}
+	if p.Name != "inspect_runtime" || p.Arguments.Nonce == "" || p.Arguments.Nonce != os.Getenv("UAP_TEST_NONCE") {
+		return nil, errors.New("unknown tool or nonce mismatch")
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	f := facts{Nonce: p.Arguments.Nonce, Revision: os.Getenv("UAP_TEST_REVISION"), CWD: cwd, Argv: os.Args[1:], Root: os.Getenv("PLUGIN_ROOT"), Data: os.Getenv("PLUGIN_DATA"), Literal: os.Getenv("UAP_TEST_LITERAL"), Once: os.Getenv("UAP_TEST_ONCE"), PID: os.Getpid(), Session: session}
+	if p.Arguments.Operation != "" {
+		if p.Arguments.Operation != "write" && p.Arguments.Operation != "read" {
+			return nil, errors.New("unknown marker operation")
+		}
+		path, err := contained(filepath.Join(f.Data, "native-marker.txt"))
+		if err != nil {
+			return nil, err
+		}
+		if p.Arguments.Operation == "write" {
+			if len(p.Arguments.Marker) > 256 {
+				return nil, errors.New("marker too long")
+			}
+			if err = os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+				return nil, err
+			}
+			if err = os.WriteFile(path, []byte(p.Arguments.Marker), 0600); err != nil {
+				return nil, err
+			}
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		if len(b) > 256 {
+			return nil, errors.New("marker too long")
+		}
+		f.Marker = string(b)
+	}
+	if err := event("tools/call", &f); err != nil {
+		return nil, err
+	}
+	b, _ := json.Marshal(f)
+	return map[string]any{"content": []any{map[string]any{"type": "text", "text": string(b)}}, "isError": false}, nil
+}
+func handle(r request) (any, error) {
+	switch r.Method {
+	case "initialize":
+		var p struct {
+			Version string `json:"protocolVersion"`
+		}
+		if err := json.Unmarshal(r.Params, &p); err != nil {
+			return nil, err
+		}
+		switch p.Version {
+		case "2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25":
+		default:
+			p.Version = "2025-11-25"
+		}
+		if err := event(r.Method, nil); err != nil {
+			return nil, err
+		}
+		return map[string]any{"protocolVersion": p.Version, "capabilities": map[string]any{"tools": map[string]any{}}, "serverInfo": map[string]any{"name": "agentplugins-native-probe", "version": "1.0.0"}}, nil
+	case "tools/list":
+		if err := event(r.Method, nil); err != nil {
+			return nil, err
+		}
+		return map[string]any{"tools": []any{map[string]any{"name": "inspect_runtime", "description": "Inspect only disposable fixture runtime facts.", "inputSchema": map[string]any{"type": "object", "properties": map[string]any{"nonce": map[string]string{"type": "string"}, "operation": map[string]string{"type": "string"}, "marker": map[string]string{"type": "string"}}, "required": []string{"nonce"}, "additionalProperties": false}}}}, nil
+	case "tools/call":
+		return inspect(r.Params)
+	case "ping":
+		return map[string]any{}, nil
+	default:
+		return nil, errors.New("method not found")
+	}
+}
+func main() {
+	scan := bufio.NewScanner(io.LimitReader(os.Stdin, 8<<20))
+	scan.Buffer(make([]byte, 4096), 1<<20)
+	out := json.NewEncoder(os.Stdout)
+	for scan.Scan() {
+		var r request
+		if err := json.Unmarshal(scan.Bytes(), &r); err != nil {
+			_ = out.Encode(map[string]any{"jsonrpc": "2.0", "id": nil, "error": map[string]any{"code": -32700, "message": "invalid JSON"}})
+			continue
+		}
+		if len(r.ID) == 0 {
+			continue
+		}
+		result, err := handle(r)
+		response := map[string]any{"jsonrpc": "2.0", "id": r.ID}
+		if err != nil {
+			response["error"] = map[string]any{"code": -32602, "message": err.Error()}
+		} else {
+			response["result"] = result
+		}
+		if out.Encode(response) != nil {
+			return
+		}
+	}
+	if scan.Err() != nil {
+		fmt.Fprintln(os.Stderr, "fixture input limit or read error")
+	}
+}

--- a/repotests/testdata/agentplugins_native_probe/main.go
+++ b/repotests/testdata/agentplugins_native_probe/main.go
@@ -178,6 +178,15 @@ func handle(r request) (any, error) {
 	}
 }
 func main() {
+	if len(os.Args) == 2 && os.Args[1] == "--fail-startup" {
+		if err := event("startup-failed", nil); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(43)
+		}
+		fmt.Fprintln(os.Stderr, "intentional fixture startup failure")
+		os.Exit(42)
+	}
+
 	scan := bufio.NewScanner(io.LimitReader(os.Stdin, 8<<20))
 	scan.Buffer(make([]byte, 4096), 1<<20)
 	out := json.NewEncoder(os.Stdout)


### PR DESCRIPTION
Fix native plugin recovery and removal, preserve foreign files during rollback, and make Claude stdio honor the declared working directory.

Codex repair now reconstructs an absent recorded package before native identity verification. Removal clears stale plugin registration that could otherwise recreate an uninstalled plugin. Absent-directory publication and recovery use exclusive publication and durable ownership checks; unknown or changed foreign content is preserved. Claude stdio reuses the existing managed launcher for cwd, arguments and environment. The change also aligns Skills metadata admission and preserves OpenCode logical MCP names.

This PR carries the already prepared repair checkpoint and its independently reviewed follow-up. It is larger than the usual review target because it includes the complete disposable native test harness and regression coverage; the existing branch and checkpoint history are retained.

Validation:
- Required Go module suites, npm tests/pack, generated checks, vet and manifest workflow passed locally against source tree b8bb4aaccc6e5b6221ad9d327707831058f10c16, exactly matching the initial PR head tree.
- Real Linux ARM64 Codex 0.153.4, Claude Code 2.1.263 and OpenCode 1.18.29 runs passed through UAP installation routes. Coverage includes update/repair/remove, stdio and HTTP calls, skill context where supported, JSON/JSONC and foreign-state preservation.
- A pinned public conformance fixture passed actual immutable-Git installation, Codex skill discovery and removal; network isolation was verified before native discovery.
- Independent pre-PR source review passed. Two fresh independent PR reviews approved the transaction and client scopes. The review finding that native suites could return success with failed evidence stages was fixed with a deterministic final-stage gate and regression tests. All GitHub CI checks passed on 41df5d572561c92e611b9fa0fa622dc4f8b10e5d, including Windows/Linux authoring, polyglot smoke and the pinned corpus (133 pass, 0 failures/errors/skips/warnings).

Evidence boundaries: scripted providers are not real-model/OAuth proof. OpenCode simultaneously exposes api/server and api server under one tool ID; that upstream limitation remains explicit. OpenCode stdio/context and Git MCP/update are not covered by these native fixtures. No release or official compatibility claim is made.

Review scope: 715 added / 45 removed production lines in the initial PR; most of the total diff is dedicated regression and native E2E test coverage. The follow-up changes only the test failure gate and stale comments.
