### PR TITLE
fix(agentplugins): harden Windows lifecycle and native runtime evidence

### DIFF
--- a/.github/workflows/agentplugins-native-clients.yml
+++ b/.github/workflows/agentplugins-native-clients.yml
@@ -1,0 +1,64 @@
+name: Native Client Runtime
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'repotests/agentplugins_*native*'
+      - 'repotests/agentplugins_*runtime*'
+      - 'repotests/testdata/agentplugins_native_probe/**'
+      - 'install/integrationctl/agentplugins/**'
+      - 'scripts/run-native-client-matrix.py'
+      - 'scripts/test_native_client_matrix.py'
+      - '.github/workflows/agentplugins-native-clients.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: native-clients-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  native-client:
+    name: ${{ matrix.client }} runtime (${{ matrix.platform.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        client: [codex, claude, opencode]
+        platform:
+          - target: darwin-arm64
+            runner: macos-15
+          - target: windows-amd64
+            runner: windows-2025
+    runs-on: ${{ matrix.platform.runner }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25.13'
+          cache: false
+      - name: Build exact source and execute pinned native client in disposable fixture
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+          AGENTPLUGINS_NATIVE_DISPOSABLE_HOSTED: '1'
+        shell: bash
+        run: |
+          python scripts/run-native-client-matrix.py \
+            --client '${{ matrix.client }}' \
+            --target '${{ matrix.platform.target }}' \
+            --output '${{ runner.temp }}/native-client-proof'
+      - name: Upload native evidence including failed stages
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: native-client-${{ matrix.client }}-${{ matrix.platform.target }}
+          path: ${{ runner.temp }}/native-client-proof/
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/agentplugins-native-clients.yml
+++ b/.github/workflows/agentplugins-native-clients.yml
@@ -48,6 +48,8 @@ jobs:
         with:
           go-version: '1.25.13'
           cache: false
+      - name: Verify native matrix safety and evidence gates
+        run: python scripts/test_native_client_matrix.py
       - name: Build exact source and execute pinned native client in disposable fixture
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/agentplugins-native-clients.yml
+++ b/.github/workflows/agentplugins-native-clients.yml
@@ -36,6 +36,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        # Preserve exact Git bytes for pinned embedded schema digests.
+        env:
+          GIT_CONFIG_COUNT: '1'
+          GIT_CONFIG_KEY_0: core.autocrlf
+          GIT_CONFIG_VALUE_0: 'false'
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -453,6 +453,7 @@ func readInputLine(reader io.Reader) (string, error) {
 }
 
 func renderHumanPlan(writer io.Writer, envelope domain.PackageEnvelope, result usecase.AddResult) error {
+	result = withOpenCodeRuntimeNotice(result)
 	_, _ = fmt.Fprintf(writer, "Plugin: %s %s\n", envelope.Manifest.Name, envelope.Manifest.Version)
 	_, _ = fmt.Fprintf(writer, "Target: %s\n", result.Plan.ClientID)
 	_, _ = fmt.Fprintf(writer, "Package: %s\n", result.Plan.PackageMode)
@@ -509,6 +510,9 @@ func renderAddResultErrorWithSecurity(writer io.Writer, format string, envelope 
 	if dryRun {
 		return renderHumanPlan(writer, envelope, result)
 	}
+	if err := renderOpenCodeRuntimeNotice(writer, result); err != nil {
+		return err
+	}
 	if result.NoChange {
 		_, _ = fmt.Fprintln(writer, "Already installed and lifecycle verification is complete. No changes made.")
 		return nil
@@ -517,7 +521,11 @@ func renderAddResultErrorWithSecurity(writer io.Writer, format string, envelope 
 		if result.Activation.ActivationAttested || result.Activation.AuthenticationAttested {
 			_, _ = fmt.Fprintln(writer, "Lifecycle is user-attested for the explicitly confirmed phase; it was not observed from the client.")
 		} else {
-			_, _ = fmt.Fprintln(writer, "Installed and verified for the selected client.")
+			if result.Plan.ClientID == domain.ClientOpenCode && len(domain.SelectedMCPNames(result.Plan)) > 0 {
+				_, _ = fmt.Fprintln(writer, "OpenCode MCP configuration installed and verified.")
+			} else {
+				_, _ = fmt.Fprintln(writer, "Installed and verified for the selected client.")
+			}
 		}
 		return nil
 	}
@@ -592,6 +600,7 @@ func addFailureStatus(result usecase.AddResult, commandErr error) string {
 }
 
 func newAddResultData(envelope domain.PackageEnvelope, result usecase.AddResult, dryRun bool) addResultData {
+	result = withOpenCodeRuntimeNotice(result)
 	return addResultData{
 		OperationID: result.Receipt.OperationID, Plugin: envelope.Manifest.Name,
 		Version: envelope.Manifest.Version, Source: publicPackageSource(envelope.Source),

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
@@ -350,6 +350,9 @@ func renderAddMultiResult(cmd *cobra.Command, opts *options, result addMultiResu
 		return err
 	}
 	for _, target := range result.Targets {
+		if err := renderOpenCodeRuntimeNotice(cmd.OutOrStdout(), target.Output.Result); err != nil {
+			return err
+		}
 		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  %s: %s\n", target.Target, target.Status); err != nil {
 			return err
 		}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
@@ -177,6 +177,9 @@ func renderRepairResult(writer io.Writer, format string, installation domain.Ins
 	if format == "json" {
 		return writeJSONOutput(writer, "repair", data)
 	}
+	if err := renderOpenCodeRuntimeNotice(writer, result); err != nil {
+		return err
+	}
 	if result.NoChange {
 		_, err := fmt.Fprintln(writer, "Managed package digest is valid. No repair was needed.")
 		return err
@@ -210,6 +213,7 @@ type repairResultData struct {
 }
 
 func newRepairResultData(installation domain.Installation, result usecase.AddResult, dryRun bool) repairResultData {
+	result = withOpenCodeRuntimeNotice(result)
 	return repairResultData{
 		OperationID: result.Receipt.OperationID, Plugin: installation.DeclaredName,
 		Version: installation.Package.Version, Source: publicSource(installation.Source),
@@ -768,12 +772,19 @@ func renderUpdateResult(writer io.Writer, format string, envelope domain.Package
 	if dryRun {
 		return renderHumanPlan(writer, envelope, result)
 	}
+	if err := renderOpenCodeRuntimeNotice(writer, result); err != nil {
+		return err
+	}
 	if result.NoChange {
 		_, _ = fmt.Fprintln(writer, "Already up to date. No changes made.")
 		return nil
 	}
 	if result.Mutated && fullyInstalled(result.Activation) {
-		_, _ = fmt.Fprintln(writer, "Updated and verified for the selected client.")
+		if result.Plan.ClientID == domain.ClientOpenCode && len(domain.SelectedMCPNames(result.Plan)) > 0 {
+			_, _ = fmt.Fprintln(writer, "OpenCode MCP configuration updated and verified.")
+		} else {
+			_, _ = fmt.Fprintln(writer, "Updated and verified for the selected client.")
+		}
 		return nil
 	}
 	if result.Mutated {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/opencode_runtime_notice.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/opencode_runtime_notice.go
@@ -1,0 +1,39 @@
+package agentpluginscli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/usecase"
+)
+
+const openCodeNamespaceNotice = "opencode_tool_namespace_not_evaluated"
+
+// This is output evidence, not a portable validation or component selection rule.
+func withOpenCodeRuntimeNotice(result usecase.AddResult) usecase.AddResult {
+	if result.Plan.ClientID != domain.ClientOpenCode || len(domain.SelectedMCPNames(result.Plan)) == 0 {
+		return result
+	}
+	for _, diagnostic := range result.Plan.Diagnostics {
+		if diagnostic.Code == openCodeNamespaceNotice {
+			return result
+		}
+	}
+	result.Plan.Diagnostics = append(append([]domain.Diagnostic(nil), result.Plan.Diagnostics...), domain.Diagnostic{
+		Severity: domain.SeverityWarning, Boundary: domain.BoundaryMCPServer,
+		Code:    openCodeNamespaceNotice,
+		Message: "OpenCode MCP delivery verification covers configuration only; callable tool-ID uniqueness is not evaluated. OpenCode can map different server/tool names to the same callable ID. Observed colliding tools are an unsupported runtime combination and are not separately addressable. Verify the tools in the intended OpenCode session before relying on both.",
+	})
+	return result
+}
+
+func renderOpenCodeRuntimeNotice(writer io.Writer, result usecase.AddResult) error {
+	for _, diagnostic := range withOpenCodeRuntimeNotice(result).Plan.Diagnostics {
+		if diagnostic.Code == openCodeNamespaceNotice {
+			_, err := fmt.Fprintf(writer, "  Warning: %s: %s\n", diagnostic.Code, diagnostic.Message)
+			return err
+		}
+	}
+	return nil
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/opencode_runtime_notice_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/opencode_runtime_notice_test.go
@@ -1,0 +1,108 @@
+package agentpluginscli
+
+import (
+	"bytes"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/usecase"
+	"github.com/spf13/cobra"
+	"strings"
+	"testing"
+)
+
+func TestOpenCodeRuntimeNoticeLifecycleOutputs(t *testing.T) {
+	for _, format := range []string{"human", "json"} {
+		for _, state := range []string{"success", "nochange", "dryrun"} {
+			for _, operation := range []string{"add", "update", "repair"} {
+				t.Run(operation+"/"+format+"/"+state, func(t *testing.T) {
+					result := usecase.AddResult{Plan: domain.DeliveryPlan{ClientID: domain.ClientOpenCode, Components: []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "api/server", Support: domain.SupportPrepared}}}, Mutated: state == "success", NoChange: state == "nochange"}
+					result.Activation = domain.ActivationOutcome{Activation: domain.ActivationActive, Verification: domain.VerificationInstalled, Authentication: domain.AuthenticationNotRequired}
+					var output bytes.Buffer
+					var err error
+					switch operation {
+					case "add":
+						err = renderAddResult(&output, format, domain.PackageEnvelope{}, result, state == "dryrun")
+					case "update":
+						err = renderUpdateResult(&output, format, domain.PackageEnvelope{}, result, state == "dryrun")
+					case "repair":
+						err = renderRepairResult(&output, format, domain.Installation{}, result, state == "dryrun")
+					}
+					if err != nil {
+						t.Fatal(err)
+					}
+					if state == "success" && format == "human" && operation != "repair" && !strings.Contains(output.String(), "OpenCode MCP configuration") {
+						t.Fatal(output.String())
+					}
+					if strings.Count(output.String(), openCodeNamespaceNotice) != 1 {
+						t.Fatalf("notice missing or duplicated: %s", output.String())
+					}
+					if !strings.Contains(output.String(), "callable tool-ID uniqueness is not evaluated") {
+						t.Fatal(output.String())
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestOpenCodeRuntimeNoticeScopeAndPurity(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		client     domain.ClientID
+		components []domain.ComponentDecision
+		want       bool
+	}{
+		{"other client", domain.ClientCodex, []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "x", Support: domain.SupportPrepared}}, false},
+		{"skills only", domain.ClientOpenCode, []domain.ComponentDecision{{Kind: domain.ComponentSkill, Name: "x", Support: domain.SupportPrepared}}, false},
+		{"unsupported MCP", domain.ClientOpenCode, []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "x", Support: domain.SupportUnsupported}}, false},
+		{"singleton special key", domain.ClientOpenCode, []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "api/server", Support: domain.SupportPrepared}}, true},
+		{"equal prefixes accepted", domain.ClientOpenCode, []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "api/server", Support: domain.SupportPrepared}, {Kind: domain.ComponentMCPServer, Name: "api server", Support: domain.SupportPrepared}}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := usecase.AddResult{Plan: domain.DeliveryPlan{ClientID: tc.client, Components: tc.components}}
+			got := withOpenCodeRuntimeNotice(withOpenCodeRuntimeNotice(result))
+			expected := 0
+			if tc.want {
+				expected = 1
+			}
+			if len(got.Plan.Diagnostics) != expected || len(result.Plan.Diagnostics) != 0 {
+				t.Fatalf("unexpected diagnostics: %+v", got.Plan.Diagnostics)
+			}
+			if len(domain.SelectedMCPNames(result.Plan)) != len(domain.SelectedMCPNames(got.Plan)) {
+				t.Fatal("notice changed selection")
+			}
+		})
+	}
+}
+
+func TestOpenCodeRuntimeNoticeGroupedOutputs(t *testing.T) {
+	result := usecase.AddResult{Plan: domain.DeliveryPlan{ClientID: domain.ClientOpenCode, Components: []domain.ComponentDecision{{Kind: domain.ComponentMCPServer, Name: "x", Support: domain.SupportPrepared}}}, NoChange: true}
+	output := newAddResultData(domain.PackageEnvelope{}, result, false)
+	update := updateMultiResult{Targets: []updateTargetResult{{Target: "opencode", Output: output}}}
+	for _, format := range []string{"human", "json"} {
+		for _, operation := range []string{"add", "update", "repair", "update-all"} {
+			t.Run(operation+"/"+format, func(t *testing.T) {
+				var buf bytes.Buffer
+				cmd := &cobra.Command{}
+				cmd.SetOut(&buf)
+				opts := &options{format: format}
+				var err error
+				switch operation {
+				case "add":
+					err = renderAddMultiResult(cmd, opts, addMultiResult{Targets: []addTargetResult{{Target: "opencode", Output: output}, {Target: "codex"}}}, domain.PackageEnvelope{})
+				case "update":
+					err = renderUpdateMultiResult(cmd, opts, update)
+				case "repair":
+					err = renderRepairMultiResult(cmd, opts, repairMultiResult{Targets: []repairTargetResult{{Target: "opencode", Output: newRepairResultData(domain.Installation{}, result, false)}}})
+				case "update-all":
+					err = renderUpdateAll(cmd, opts, updateAllResult{Installations: []updateAllInstallation{{Name: "test", Plan: &update}}})
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				if strings.Count(buf.String(), openCodeNamespaceNotice) != 1 {
+					t.Fatalf("notice missing or duplicated: %s", buf.String())
+				}
+			})
+		}
+	}
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/repair_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/repair_multi.go
@@ -208,6 +208,9 @@ func renderRepairMultiResult(cmd *cobra.Command, opts *options, result repairMul
 		return err
 	}
 	for _, target := range result.Targets {
+		if err := renderOpenCodeRuntimeNotice(cmd.OutOrStdout(), target.Output.Result); err != nil {
+			return err
+		}
 		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  %s: %s\n", target.Target, target.Status); err != nil {
 			return err
 		}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/update_all.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/update_all.go
@@ -196,6 +196,13 @@ func renderUpdateAll(cmd *cobra.Command, opts *options, result updateAllResult) 
 
 func renderUpdateAllHuman(writer io.Writer, result updateAllResult) error {
 	for _, installation := range result.Installations {
+		if installation.Plan != nil {
+			for _, target := range installation.Plan.Targets {
+				if err := renderOpenCodeRuntimeNotice(writer, target.Output.Result); err != nil {
+					return err
+				}
+			}
+		}
 		if _, err := fmt.Fprintf(writer, "%s: %s", installation.Name, installation.Status); err != nil {
 			return err
 		}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/update_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/update_multi.go
@@ -349,6 +349,9 @@ func renderUpdateMultiResult(cmd *cobra.Command, opts *options, result updateMul
 	}
 	values := make([]string, len(result.Targets))
 	for index, target := range result.Targets {
+		if err := renderOpenCodeRuntimeNotice(cmd.OutOrStdout(), target.Output.Result); err != nil {
+			return err
+		}
 		values[index] = target.Target
 		rollout := "preflight only"
 		if target.Selected {

--- a/cli/plugin-kit-ai/internal/authoring/commands/concurrent_apply_windows_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/concurrent_apply_windows_test.go
@@ -1,0 +1,103 @@
+//go:build windows && amd64
+
+package commands_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/project"
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/report"
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoring/scaffold"
+)
+
+// Keep raw errors in test diagnostics: the command's public failure report
+// intentionally hides the filesystem primitive that refused publication.
+func TestConcurrentApplyWithSharedProjectService(t *testing.T) {
+	parent, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	scratch, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(parent, "demo")
+	service := project.Service{Scratch: scratch}
+	plan, err := scaffold.BuildPlan(scaffold.Options{Template: scaffold.Skill, Name: "demo", Description: "A fixture."})
+	if err != nil {
+		t.Fatal(err)
+	}
+	type outcome struct {
+		result    scaffold.Result
+		err       error
+		validated bool
+	}
+	ready := make(chan struct{}, 2)
+	release := make(chan struct{})
+	results := make(chan outcome, 2)
+	for range 2 {
+		go func() {
+			validated := false
+			// Also arrive on early errors so a failing validator cannot strand
+			// its peer at the barrier and hide the original diagnostic.
+			defer func() {
+				if !validated {
+					ready <- struct{}{}
+				}
+			}()
+			result, err := scaffold.Apply(context.Background(), plan, scaffold.ApplyOptions{
+				Destination: dest,
+				Validate: func(ctx context.Context, stage string) error {
+					p, err := service.Read(ctx, stage)
+					if err != nil {
+						return err
+					}
+					if !report.Build("validate", baseline, p, false).Successful() {
+						return fmt.Errorf("generated package validation failed")
+					}
+					// Read has returned and closed its leases before either
+					// contender is permitted to attempt publication.
+					validated = true
+					ready <- struct{}{}
+					<-release
+					return nil
+				},
+			})
+			results <- outcome{result, err, validated}
+		}()
+	}
+	<-ready
+	<-ready
+	close(release)
+	winners := 0
+	for range 2 {
+		got := <-results
+		t.Logf("shared-service Apply: validated=%t result=%+v raw_error=%T %v", got.validated, got.result, got.err, got.err)
+		if !got.validated {
+			t.Errorf("Apply did not complete shared validation: %v", got.err)
+		}
+		if got.err == nil && got.result.Committed {
+			winners++
+		} else if got.result.Committed || !errors.Is(got.err, os.ErrExist) {
+			t.Errorf("loser must report destination existence: result=%+v raw_error=%T %v", got.result, got.err, got.err)
+		}
+	}
+	if winners != 1 {
+		t.Fatalf("exclusive shared-service Apply winners: %d", winners)
+	}
+	p, err := service.Read(context.Background(), dest)
+	if err != nil || !report.Build("validate", baseline, p, false).Successful() {
+		t.Fatalf("winning tree invalid: %v", err)
+	}
+	if entries, err := os.ReadDir(parent); err != nil || len(entries) != 1 || entries[0].Name() != "demo" {
+		t.Errorf("publication staging remains: %v %v", entries, err)
+	}
+	if entries, err := os.ReadDir(scratch); err != nil || len(entries) != 0 {
+		t.Errorf("shared validation scratch remains: %v %v", entries, err)
+	}
+}

--- a/cli/plugin-kit-ai/internal/authoring/commands/slice_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/slice_test.go
@@ -78,8 +78,9 @@ func execute(t *testing.T, a commands.App, args []string, mount bool) (report.Re
 
 // Workers capture bytes and errors; only the parent may decode or fail a test.
 type rawExecution struct {
-	out, errout []byte
-	err         error
+	out, errout  []byte
+	err          error
+	operationErr error
 }
 
 func executeRaw(a commands.App, args []string, mount bool) rawExecution {
@@ -89,8 +90,32 @@ func executeRaw(a commands.App, args []string, mount bool) rawExecution {
 		builder = mounted
 		args = append([]string{"author"}, args...)
 	}
-	e := a.Execute(context.Background(), args, authoringcli.Streams{Out: &out, Err: &errout}, builder)
-	return rawExecution{out.Bytes(), errout.Bytes(), e}
+	// Each fresh command tree and captured error belong to this invocation.
+	// Capture before App.Execute replaces private causes with its public error.
+	var operationErr error
+	capture := func(factories ...authoringcli.Factory) (*cobra.Command, error) {
+		root, err := builder(factories...)
+		if err != nil {
+			return nil, err
+		}
+		var visit func(*cobra.Command)
+		visit = func(cmd *cobra.Command) {
+			if cmd.Name() == "init" && cmd.RunE != nil {
+				run := cmd.RunE
+				cmd.RunE = func(cmd *cobra.Command, args []string) error {
+					operationErr = run(cmd, args)
+					return operationErr
+				}
+			}
+			for _, child := range cmd.Commands() {
+				visit(child)
+			}
+		}
+		visit(root)
+		return root, nil
+	}
+	e := a.Execute(context.Background(), args, authoringcli.Streams{Out: &out, Err: &errout}, capture)
+	return rawExecution{out: out.Bytes(), errout: errout.Bytes(), err: e, operationErr: operationErr}
 }
 
 func decodeExecution(t *testing.T, result rawExecution) (report.Report, int, []byte) {
@@ -419,7 +444,7 @@ func TestConcurrentInitAndCanceledInvocation(t *testing.T) {
 		if r.Committed {
 			wins++
 		} else if r.Error == nil || r.Error.Code != "destination_exists" {
-			t.Fatalf("unexpected race failure: %+v", r)
+			t.Fatalf("unexpected race failure: %+v; operation_error=%T %v", r, result.operationErr, result.operationErr)
 		}
 	}
 	if wins != 1 {

--- a/cli/plugin-kit-ai/internal/authoring/scaffold/scaffold_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/scaffold/scaffold_test.go
@@ -520,21 +520,32 @@ func TestConcurrentApplyExactlyOneWinner(t *testing.T) {
 	validate := realValidation(t)
 	ready := make(chan struct{}, 2)
 	release := make(chan struct{})
-	results := make(chan bool, 2)
+	type outcome struct {
+		result Result
+		err    error
+	}
+	results := make(chan outcome, 2)
 	var wg sync.WaitGroup
 	for range 2 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			arrived := false
+			defer func() {
+				if !arrived {
+					ready <- struct{}{}
+				}
+			}()
 			r, err := Apply(context.Background(), p, ApplyOptions{Destination: dest, Validate: func(ctx context.Context, s string) error {
 				if err := validate(ctx, s); err != nil {
 					return err
 				}
+				arrived = true
 				ready <- struct{}{}
 				<-release
 				return nil
 			}})
-			results <- err == nil && r.Committed
+			results <- outcome{r, err}
 		}()
 	}
 	<-ready
@@ -543,9 +554,12 @@ func TestConcurrentApplyExactlyOneWinner(t *testing.T) {
 	wg.Wait()
 	close(results)
 	winners := 0
-	for ok := range results {
-		if ok {
+	for got := range results {
+		t.Logf("concurrent Apply: result=%+v raw_error=%T %v", got.result, got.err, got.err)
+		if got.err == nil && got.result.Committed {
 			winners++
+		} else if got.result.Committed || !errors.Is(got.err, os.ErrExist) {
+			t.Errorf("loser must report destination existence: result=%+v raw_error=%T %v", got.result, got.err, got.err)
 		}
 	}
 	if winners != 1 {

--- a/cli/plugin-kit-ai/internal/authoring/scaffold/template_quoting_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/scaffold/template_quoting_test.go
@@ -100,7 +100,11 @@ func checkTemplateJavaScriptSyntax(t *testing.T, source []byte) {
 	if err := os.WriteFile(path, source, 0600); err != nil {
 		t.Fatal(err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	timeout := 10 * time.Second
+	if runtime.GOOS == "windows" {
+		timeout = 30 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	// Parse only a newly generated temporary fixture. Do not import or execute
 	// the module, load the SDK, install dependencies, or inherit Node preload flags.
@@ -111,7 +115,8 @@ func checkTemplateJavaScriptSyntax(t *testing.T, source []byte) {
 		volume := filepath.VolumeName(dir)
 		cmd.Env = append(cmd.Env, "SystemRoot="+os.Getenv("SystemRoot"), "HOMEDRIVE="+volume, "HOMEPATH="+strings.TrimPrefix(dir, volume))
 	}
+	started := time.Now()
 	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("node --check: %v\n%s", err, out)
+		t.Fatalf("node --check: %v; context=%v elapsed=%s process=%v\n%s", err, ctx.Err(), time.Since(started), cmd.ProcessState, out)
 	}
 }

--- a/install/integrationctl/agentplugins/adapters/packageview/acquisition_metadata_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/acquisition_metadata_windows_test.go
@@ -1,0 +1,142 @@
+//go:build windows && amd64
+
+package packageview
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// These diagnostics exercise the actual acquisition comparison on fresh NTFS
+// fixtures. A passing test proves the current rejection, not a corrected policy.
+func TestWindowsAcquisitionMutableMetadataDiagnostic(t *testing.T) {
+	for _, directory := range []bool{true, false} {
+		label := "regular-file-control"
+		if directory {
+			label = "directory-child-create"
+		}
+		t.Run(label, func(t *testing.T) {
+			root := t.TempDir()
+			name := filepath.Join(root, "subject")
+			if directory {
+				if err := os.Mkdir(name, 0700); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := os.WriteFile(name, []byte("before"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			// Give the directory a clearly distinct starting timestamp without a sleep.
+			// Mutation during remember is still an actual child create and close.
+			acquisitionDiagnosticOldWrite(t, name)
+			f, err := winOpen(0, `\??\`+name, directory)
+			if err != nil {
+				t.Fatalf("direct fixture open: %v", err)
+			}
+			defer f.Close()
+			meta, err := winMeta(f)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var fs [32]uint16
+			if err := windows.GetVolumeInformationByHandle(windows.Handle(f.Fd()), nil, 0, nil, nil, nil, &fs[0], uint32(len(fs))); err != nil {
+				t.Fatal(err)
+			}
+			if windows.UTF16ToString(fs[:]) != "NTFS" {
+				t.Fatal("diagnostic requires NTFS")
+			}
+			drive, err := windows.UTF16PtrFromString(filepath.VolumeName(name) + `\`)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if windows.GetDriveType(drive) != windows.DRIVE_FIXED {
+				t.Fatal("diagnostic requires local fixed drive")
+			}
+			s := &source{volume: meta.Volume, records: make(map[winSnapshot]*winObservation)}
+			defer s.close()
+			mutated, observed := false, false
+			var before, after winSnapshot
+			s.acquisitionHook = func(stage string, initial, current winSnapshot, queryErr error) {
+				switch stage {
+				case "before-after-stat":
+					if mutated {
+						t.Fatal("mutation hook invoked more than once")
+					}
+					mutated = true
+					target := name
+					if directory {
+						target = filepath.Join(name, "new-child")
+					}
+					if err := os.WriteFile(target, []byte("actual fixture mutation, larger than before"), 0600); err != nil {
+						t.Fatal(err)
+					}
+				case "after-stat":
+					observed = true
+					before, after = initial, current
+					t.Logf("stage=%s before=%+v after=%+v query_error=%v", stage, before, after, queryErr)
+					if queryErr != nil {
+						t.Fatalf("metadata query failed instead of comparison: %v", queryErr)
+					}
+				default:
+					t.Fatalf("unexpected acquisition stage %q", stage)
+				}
+			}
+			pin, err := s.remember(f)
+			if pin != nil {
+				pin.file.Close()
+				t.Fatal("mutated fixture unexpectedly acquired")
+			}
+			t.Logf("remember returned: %v", err)
+			var safe *Error
+			if !errors.As(err, &safe) || safe.Code != "source_changed" {
+				t.Fatalf("want source_changed, got %v", err)
+			}
+			if !mutated || !observed {
+				t.Fatalf("missing real comparison: mutated=%t observed=%t", mutated, observed)
+			}
+			if before == after {
+				t.Fatal("fixture mutation did not change observed metadata")
+			}
+			// Identity/type/link facts remain stable. Only size/write/change may differ.
+			stable := after
+			stable.Size, stable.Write, stable.Change = before.Size, before.Write, before.Change
+			if stable != before {
+				t.Fatalf("mutation changed immutable facts: before=%+v after=%+v", before, after)
+			}
+			if directory && before.Write == after.Write && before.Change == after.Change {
+				t.Fatal("child creation did not change directory timestamps")
+			}
+			if !directory && before.Size == after.Size {
+				t.Fatal("regular-file mutation did not change size")
+			}
+			if len(s.records) != 0 {
+				t.Fatal("rejected acquisition retained a record")
+			}
+		})
+	}
+}
+
+func acquisitionDiagnosticOldWrite(t *testing.T, name string) {
+	t.Helper()
+	path, err := windows.UTF16PtrFromString(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h, err := windows.CreateFile(path, windows.FILE_WRITE_ATTRIBUTES, winShare, nil, windows.OPEN_EXISTING, windows.FILE_FLAG_BACKUP_SEMANTICS|windows.FILE_FLAG_OPEN_REPARSE_POINT, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := windows.NsecToFiletime(time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC).UnixNano())
+	setErr := windows.SetFileTime(h, nil, nil, &old)
+	closeErr := windows.CloseHandle(h)
+	if setErr != nil {
+		t.Fatal(setErr)
+	}
+	if closeErr != nil {
+		t.Fatal(closeErr)
+	}
+}

--- a/install/integrationctl/agentplugins/adapters/packageview/acquisition_metadata_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/acquisition_metadata_windows_test.go
@@ -3,120 +3,153 @@
 package packageview
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
 	"golang.org/x/sys/windows"
 )
 
-// These diagnostics exercise the actual acquisition comparison on fresh NTFS
-// fixtures. A passing test proves the current rejection, not a corrected policy.
+// Real NTFS mutations verify the root-selection exception and strict package/file controls.
 func TestWindowsAcquisitionMutableMetadataDiagnostic(t *testing.T) {
 	for _, directory := range []bool{true, false} {
 		label := "regular-file-control"
 		if directory {
 			label = "directory-child-create"
 		}
-		t.Run(label, func(t *testing.T) {
-			root := t.TempDir()
-			name := filepath.Join(root, "subject")
-			if directory {
-				if err := os.Mkdir(name, 0700); err != nil {
-					t.Fatal(err)
-				}
-			} else if err := os.WriteFile(name, []byte("before"), 0600); err != nil {
-				t.Fatal(err)
-			}
-			// Give the directory a clearly distinct starting timestamp without a sleep.
-			// Mutation during remember is still an actual child create and close.
-			acquisitionDiagnosticOldWrite(t, name)
-			f, err := winOpen(0, `\??\`+name, directory)
-			if err != nil {
-				t.Fatalf("direct fixture open: %v", err)
-			}
-			defer f.Close()
-			meta, err := winMeta(f)
-			if err != nil {
-				t.Fatal(err)
-			}
-			var fs [32]uint16
-			if err := windows.GetVolumeInformationByHandle(windows.Handle(f.Fd()), nil, 0, nil, nil, nil, &fs[0], uint32(len(fs))); err != nil {
-				t.Fatal(err)
-			}
-			if windows.UTF16ToString(fs[:]) != "NTFS" {
-				t.Fatal("diagnostic requires NTFS")
-			}
-			drive, err := windows.UTF16PtrFromString(filepath.VolumeName(name) + `\`)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if windows.GetDriveType(drive) != windows.DRIVE_FIXED {
-				t.Fatal("diagnostic requires local fixed drive")
-			}
-			s := &source{volume: meta.Volume, records: make(map[winSnapshot]*winObservation)}
-			defer s.close()
-			mutated, observed := false, false
-			var before, after winSnapshot
-			s.acquisitionHook = func(stage string, initial, current winSnapshot, queryErr error) {
-				switch stage {
-				case "before-after-stat":
-					if mutated {
-						t.Fatal("mutation hook invoked more than once")
-					}
-					mutated = true
-					target := name
-					if directory {
-						target = filepath.Join(name, "new-child")
-					}
-					if err := os.WriteFile(target, []byte("actual fixture mutation, larger than before"), 0600); err != nil {
+		for _, rootSelection := range []bool{true, false} {
+			t.Run(fmt.Sprintf("%s/root-selection=%t", label, rootSelection), func(t *testing.T) {
+				root := t.TempDir()
+				name := filepath.Join(root, "subject")
+				if directory {
+					if err := os.Mkdir(name, 0700); err != nil {
 						t.Fatal(err)
 					}
-				case "after-stat":
-					observed = true
-					before, after = initial, current
-					t.Logf("stage=%s before=%+v after=%+v query_error=%v", stage, before, after, queryErr)
-					if queryErr != nil {
-						t.Fatalf("metadata query failed instead of comparison: %v", queryErr)
-					}
-				default:
-					t.Fatalf("unexpected acquisition stage %q", stage)
+				} else if err := os.WriteFile(name, []byte("before"), 0600); err != nil {
+					t.Fatal(err)
 				}
-			}
-			pin, err := s.remember(f)
-			if pin != nil {
-				pin.file.Close()
-				t.Fatal("mutated fixture unexpectedly acquired")
-			}
-			t.Logf("remember returned: %v", err)
-			var safe *Error
-			if !errors.As(err, &safe) || safe.Code != "source_changed" {
-				t.Fatalf("want source_changed, got %v", err)
-			}
-			if !mutated || !observed {
-				t.Fatalf("missing real comparison: mutated=%t observed=%t", mutated, observed)
-			}
-			if before == after {
-				t.Fatal("fixture mutation did not change observed metadata")
-			}
-			// Identity/type/link facts remain stable. Only size/write/change may differ.
-			stable := after
-			stable.Size, stable.Write, stable.Change = before.Size, before.Write, before.Change
-			if stable != before {
-				t.Fatalf("mutation changed immutable facts: before=%+v after=%+v", before, after)
-			}
-			if directory && before.Write == after.Write && before.Change == after.Change {
-				t.Fatal("child creation did not change directory timestamps")
-			}
-			if !directory && before.Size == after.Size {
-				t.Fatal("regular-file mutation did not change size")
-			}
-			if len(s.records) != 0 {
-				t.Fatal("rejected acquisition retained a record")
-			}
-		})
+				// Give the directory a clearly distinct starting timestamp without a sleep.
+				// Mutation during remember is still an actual child create and close.
+				acquisitionDiagnosticOldWrite(t, name)
+				f, err := winOpen(0, `\??\`+name, directory)
+				if err != nil {
+					t.Fatalf("direct fixture open: %v", err)
+				}
+				defer f.Close()
+				meta, err := winMeta(f)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var fs [32]uint16
+				if err := windows.GetVolumeInformationByHandle(windows.Handle(f.Fd()), nil, 0, nil, nil, nil, &fs[0], uint32(len(fs))); err != nil {
+					t.Fatal(err)
+				}
+				if windows.UTF16ToString(fs[:]) != "NTFS" {
+					t.Fatal("diagnostic requires NTFS")
+				}
+				drive, err := windows.UTF16PtrFromString(filepath.VolumeName(name) + `\`)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if windows.GetDriveType(drive) != windows.DRIVE_FIXED {
+					t.Fatal("diagnostic requires local fixed drive")
+				}
+				baseline := winRecordCount()
+				s := &source{volume: meta.Volume, records: make(map[winSnapshot]*winObservation)}
+				defer s.close()
+				mutated, observed := false, false
+				var before, after winSnapshot
+				s.acquisitionHook = func(stage string, initial, current winSnapshot, queryErr error) {
+					switch stage {
+					case "before-after-stat":
+						if mutated {
+							t.Fatal("mutation hook invoked more than once")
+						}
+						mutated = true
+						target := name
+						if directory {
+							target = filepath.Join(name, "new-child")
+						}
+						if err := os.WriteFile(target, []byte("actual fixture mutation, larger than before"), 0600); err != nil {
+							t.Fatal(err)
+						}
+					case "after-stat":
+						observed = true
+						before, after = initial, current
+						t.Logf("stage=%s before=%+v after=%+v query_error=%v", stage, before, after, queryErr)
+						if queryErr != nil {
+							t.Fatalf("metadata query failed instead of comparison: %v", queryErr)
+						}
+					case "after-reopen":
+						t.Logf("stage=%s before=%+v after=%+v query_error=%v", stage, initial, current, queryErr)
+						if queryErr != nil {
+							t.Fatal(queryErr)
+						}
+					default:
+						t.Fatalf("unexpected acquisition stage %q", stage)
+					}
+				}
+				pin, err := s.remember(f, rootSelection)
+				t.Logf("remember returned: %v", err)
+				accepted := directory && rootSelection
+				if pin != nil {
+					defer pin.file.Close()
+				}
+				if accepted {
+					if err != nil || pin == nil {
+						t.Fatalf("root-selection directory rejected: %v", err)
+					}
+					if err := pin.file.Close(); err != nil {
+						t.Fatal(err)
+					}
+				} else {
+					var safe *Error
+					if pin != nil || !errors.As(err, &safe) || safe.Code != "source_changed" {
+						t.Fatalf("want source_changed, got pin=%v err=%v", pin != nil, err)
+					}
+				}
+				if !mutated || !observed {
+					t.Fatalf("missing real comparison: mutated=%t observed=%t", mutated, observed)
+				}
+				if before == after {
+					t.Fatal("fixture mutation did not change observed metadata")
+				}
+				// Identity/type/link facts remain stable. Only size/write/change may differ.
+				stable := after
+				stable.Size, stable.Write, stable.Change = before.Size, before.Write, before.Change
+				if stable != before {
+					t.Fatalf("mutation changed immutable facts: before=%+v after=%+v", before, after)
+				}
+				if directory && before.Write == after.Write && before.Change == after.Change {
+					t.Fatal("child creation did not change directory timestamps")
+				}
+				if !directory && before.Size == after.Size {
+					t.Fatal("regular-file mutation did not change size")
+				}
+				if !accepted && len(s.records) != 0 {
+					t.Fatal("rejected acquisition retained a record")
+				}
+				if err := s.close(); err != nil {
+					t.Fatal(err)
+				}
+				if winRecordCount() != baseline {
+					t.Fatal("acquisition retained metadata records")
+				}
+				if _, err := winMeta(f); err == nil {
+					t.Fatal("initial handle remains open")
+				}
+				if pin != nil {
+					if _, err := winMeta(pin.file); err == nil {
+						t.Fatal("pin handle remains open")
+					}
+				}
+			})
+		}
 	}
 }
 
@@ -138,5 +171,60 @@ func acquisitionDiagnosticOldWrite(t *testing.T, name string) {
 	}
 	if closeErr != nil {
 		t.Fatal(closeErr)
+	}
+}
+
+// Shared roots reproduce sibling scratch activity while all leases are independent.
+func TestWindowsConcurrentSharedSourceScratch(t *testing.T) {
+	root, scratch := t.TempDir(), t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "plugin.json"), []byte(`{"name":"concurrent-fixture"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	before := winRecordCount()
+	const workers, rounds = 8, 8
+	start := make(chan struct{})
+	errs := make(chan error, workers*rounds)
+	var wg sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for round := 0; round < rounds; round++ {
+				lease, err := (Reader{TempDir: scratch}).Open(context.Background(), root)
+				if err != nil {
+					errs <- fmt.Errorf("open: %w", err)
+					continue
+				}
+				in, captureErr := lease.Capture(context.Background())
+				closeErr := lease.Close()
+				if captureErr == nil && (in.Plugin.State != Present || !in.Coverage.InventoryComplete || !in.Coverage.TreeComplete) {
+					captureErr = fmt.Errorf("incomplete capture: %+v", in.Coverage)
+				}
+				if err := errors.Join(captureErr, closeErr); err != nil {
+					errs <- err
+				}
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+	if winRecordCount() != before {
+		t.Error("concurrent capture retained metadata records")
+	}
+	entries, err := os.ReadDir(scratch)
+	if err != nil || len(entries) != 0 {
+		t.Errorf("scratch not empty: entries=%d err=%v", len(entries), err)
+	}
+	// Directory pins deny delete sharing; removal proves none survive the drained leases.
+	if err := os.RemoveAll(root); err != nil {
+		t.Errorf("source handles retained: %v", err)
+	}
+	if err := os.Remove(scratch); err != nil {
+		t.Errorf("scratch handles retained: %v", err)
 	}
 }

--- a/install/integrationctl/agentplugins/adapters/packageview/bootstrap_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/bootstrap_windows_test.go
@@ -110,7 +110,7 @@ func TestWindowsBootstrapStages(t *testing.T) {
 			t.Fatal("bootstrap fixture requires NTFS; native success unproven")
 		}
 		bootstrapMetadata(t, "drive", f)
-		p, err := s.rememberMustDuplicate(f)
+		p, err := s.rememberMustDuplicate(f, true)
 		bootstrapCheck(t, "drive/remember(DuplicateHandle,ReOpenFile,metadata)", err)
 		old := s.anchor
 		s.anchor = p.file
@@ -126,7 +126,7 @@ func TestWindowsBootstrapStages(t *testing.T) {
 			func() {
 				defer f.Close()
 				bootstrapMetadata(t, stage, f)
-				p, err = s.rememberMustDuplicate(f)
+				p, err = s.rememberMustDuplicate(f, true)
 				bootstrapCheck(t, stage+"/remember(DuplicateHandle,ReOpenFile,metadata)", err)
 			}()
 			old = s.anchor

--- a/install/integrationctl/agentplugins/adapters/packageview/final_cleanup_stages_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/final_cleanup_stages_windows_test.go
@@ -158,7 +158,7 @@ func windowsFinalCleanupSource(t *testing.T, role, name string) (_ *source, err 
 // to obtain them, and the diagnostic never retries remember after failure.
 func windowsFinalCleanupRemember(t *testing.T, stage string, s *source, f *os.File) (*pinned, error) {
 	before, beforeErr := winMeta(f)
-	p, err := s.rememberMustDuplicate(f)
+	p, err := s.rememberMustDuplicate(f, true)
 	if err != nil {
 		after, afterErr := winMeta(f)
 		t.Logf("stage=%s surrounding snapshots before=%+v err=%v after=%+v err=%v (not internal comparison evidence)", stage, before, beforeErr, after, afterErr)

--- a/install/integrationctl/agentplugins/adapters/packageview/nt_self_reopen_regression_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/nt_self_reopen_regression_windows_test.go
@@ -39,7 +39,7 @@ func TestWindowsNTSelfOpenAccessAndRead(t *testing.T) {
 					t.Fatalf("metadata probe read: n=%d err=%v", n, err)
 				}
 			}
-			pin, err := s.rememberMustDuplicate(probe)
+			pin, err := s.rememberMustDuplicate(probe, false)
 			bootstrapCheck(t, "protected pin", err)
 			defer pin.file.Close()
 			access := uint32(windows.FILE_READ_ATTRIBUTES | windows.DELETE)
@@ -112,7 +112,7 @@ func TestWindowsNTSelfOpenDirectoryAfterNameReplacement(t *testing.T) {
 	// Prove the first protected self-open and subsequent list still select the
 	// held directory. Existing file replacement tests cover both read boundaries
 	// and the production requirement to reject changed capture metadata.
-	pin, err := s.rememberMustDuplicate(probe)
+	pin, err := s.rememberMustDuplicate(probe, false)
 	bootstrapCheck(t, "protect renamed directory", err)
 	defer pin.file.Close()
 	if !os.SameFile(original, pin.info) {
@@ -165,7 +165,7 @@ func TestWindowsNTSelfOpenExistingConflictsAndCleanup(t *testing.T) {
 					directoryGuardMetadataAccess(t, probe)
 					// remember owns/consumes probe even on failed protection. Require
 					// NTSTATUS conversion to the precise existing Win32 contract.
-					pin, err := s.remember(probe)
+					pin, err := s.remember(probe, false)
 					if pin != nil {
 						pin.file.Close()
 						t.Fatal("protected pin accepted incompatible existing handle")

--- a/install/integrationctl/agentplugins/adapters/packageview/source_windows.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_windows.go
@@ -32,6 +32,8 @@ type source struct {
 	legacyInfo os.FileInfo
 	volume     uint32
 	records    map[winSnapshot]*winObservation
+	// Instance-local acquisition diagnostic; nil in normal sources.
+	acquisitionHook func(stage string, before, after winSnapshot, err error)
 }
 type pinned struct {
 	file *os.File
@@ -196,7 +198,13 @@ func (s *source) remember(f *os.File) (*pinned, error) {
 	if e != nil {
 		return nil, e
 	}
+	if s.acquisitionHook != nil {
+		s.acquisitionHook("before-after-stat", meta, winSnapshot{}, nil)
+	}
 	after, e := winMeta(f)
+	if s.acquisitionHook != nil {
+		s.acquisitionHook("after-stat", meta, after, e)
+	}
 	if e != nil || meta != after {
 		return nil, fail("source_changed")
 	}

--- a/install/integrationctl/agentplugins/adapters/packageview/source_windows.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_windows.go
@@ -180,7 +180,19 @@ func winDup(f *os.File) (*os.File, error) {
 	}
 	return os.NewFile(uintptr(h), "source-pin"), nil
 }
-func (s *source) remember(f *os.File) (*pinned, error) {
+
+// Root-selection ancestors are identity/ancestry pins, not captured inventory.
+// Unrelated child activity may update their size and timestamps during acquisition.
+// All identity, type, reparse, link-count and creation facts remain exact; package
+// inventory and regular files retain the full snapshot comparison.
+func winAcquisitionEqual(before, after winSnapshot, rootSelection bool) bool {
+	if rootSelection && before.Attributes&(windows.FILE_ATTRIBUTE_DIRECTORY|windows.FILE_ATTRIBUTE_REPARSE_POINT) == windows.FILE_ATTRIBUTE_DIRECTORY {
+		after.Size, after.Write, after.Change = before.Size, before.Write, before.Change
+	}
+	return before == after
+}
+
+func (s *source) remember(f *os.File, rootSelection bool) (*pinned, error) {
 	// Takes ownership on all paths; hard bounds include root-selection ancestors.
 	defer f.Close()
 	meta, e := winMeta(f)
@@ -205,7 +217,7 @@ func (s *source) remember(f *os.File) (*pinned, error) {
 	if s.acquisitionHook != nil {
 		s.acquisitionHook("after-stat", meta, after, e)
 	}
-	if e != nil || meta != after {
+	if e != nil || !winAcquisitionEqual(meta, after, rootSelection) {
 		return nil, fail("source_changed")
 	}
 	if meta.Attributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
@@ -244,7 +256,10 @@ func (s *source) remember(f *os.File) (*pinned, error) {
 		return nil, e
 	}
 	locked, e := winMeta(held)
-	if e != nil || locked != meta {
+	if s.acquisitionHook != nil {
+		s.acquisitionHook("after-reopen", meta, locked, e)
+	}
+	if e != nil || !winAcquisitionEqual(meta, locked, rootSelection) {
 		held.Close()
 		return nil, fail("source_changed")
 	}
@@ -291,7 +306,7 @@ func openSource(name string) (_ *source, err error) {
 	if windows.GetVolumeInformationByHandle(windows.Handle(f.Fd()), nil, 0, &s.volume, nil, nil, &fs[0], uint32(len(fs))) != nil || windows.UTF16ToString(fs[:]) != "NTFS" {
 		return nil, fail("filesystem_unavailable")
 	}
-	p, e := s.rememberMustDuplicate(f)
+	p, e := s.rememberMustDuplicate(f, true)
 	if e != nil {
 		return nil, fail("platform_unavailable")
 	}
@@ -320,12 +335,12 @@ func openSource(name string) (_ *source, err error) {
 	}
 	return s, nil
 }
-func (s *source) rememberMustDuplicate(f *os.File) (*pinned, error) {
+func (s *source) rememberMustDuplicate(f *os.File, rootSelection bool) (*pinned, error) {
 	dup, e := winDup(f)
 	if e != nil {
 		return nil, e
 	}
-	return s.remember(dup)
+	return s.remember(dup, rootSelection)
 }
 func (s *source) close() error {
 	var es []error
@@ -377,7 +392,7 @@ func (s *source) walk(rel string, nofollow, rootSelection bool) (*pinned, error)
 			if len(todo) > 0 {
 				continue
 			}
-			return s.rememberMustDuplicate(stack[len(stack)-1])
+			return s.rememberMustDuplicate(stack[len(stack)-1], rootSelection)
 		}
 		if n == ".." {
 			if len(stack) == 1 {
@@ -388,7 +403,7 @@ func (s *source) walk(rel string, nofollow, rootSelection bool) (*pinned, error)
 			if len(todo) > 0 {
 				continue
 			}
-			return s.rememberMustDuplicate(stack[len(stack)-1])
+			return s.rememberMustDuplicate(stack[len(stack)-1], rootSelection)
 		}
 		// Keep the ordinary Win32 root-selection contract: reject DOS devices and
 		// terminal dots/spaces even though overlap identity is now handle-derived.
@@ -401,7 +416,7 @@ func (s *source) walk(rel string, nofollow, rootSelection bool) (*pinned, error)
 		if e != nil {
 			return nil, e
 		}
-		p, e := s.remember(f)
+		p, e := s.remember(f, rootSelection)
 		if e != nil {
 			return nil, e
 		}

--- a/install/integrationctl/agentplugins/adapters/packageview/source_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_windows_test.go
@@ -541,7 +541,7 @@ func TestWindowsMetadataProbeReplacement(t *testing.T) {
 	if e := nativeDistinctReplacement(filepath.Join(root, "old"), filepath.Join(root, "plugin.json")); e != nil {
 		t.Fatal(e)
 	}
-	p, e := s.remember(f) // consumes f, upgrades by handle, never by replaced name
+	p, e := s.remember(f, false) // consumes f, upgrades by handle, never by replaced name
 	if e != nil {
 		t.Fatal(e)
 	}

--- a/install/integrationctl/agentplugins/providers/codex_marketplace_cleanup.go
+++ b/install/integrationctl/agentplugins/providers/codex_marketplace_cleanup.go
@@ -88,22 +88,22 @@ func managedCodexPluginEntryPresent(configRoot, declaredName, marketplace string
 
 // equivalentLocalPath compares the filesystem identity rather than only the
 // spelling of a path. macOS commonly exposes /tmp through /private/tmp, and
-// the same aliasing can occur in containerized or symlinked test homes. Both
-// paths must resolve successfully before an alias is accepted; an unreadable
-// or missing source remains fail-closed.
+// Windows can expose the same directory with an extended-length path prefix.
+// Identical cleaned paths are accepted directly; differing paths must both
+// stat successfully and identify the same file before an alias is accepted.
 func equivalentLocalPath(left, right string) bool {
 	left = filepath.Clean(left)
 	right = filepath.Clean(right)
 	if left == right {
 		return true
 	}
-	resolvedLeft, err := filepath.EvalSymlinks(left)
+	leftInfo, err := os.Stat(left)
 	if err != nil {
 		return false
 	}
-	resolvedRight, err := filepath.EvalSymlinks(right)
+	rightInfo, err := os.Stat(right)
 	if err != nil {
 		return false
 	}
-	return filepath.Clean(resolvedLeft) == filepath.Clean(resolvedRight)
+	return os.SameFile(leftInfo, rightInfo)
 }

--- a/install/integrationctl/agentplugins/providers/codex_marketplace_cleanup_test.go
+++ b/install/integrationctl/agentplugins/providers/codex_marketplace_cleanup_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"testing"
 )
 
@@ -24,7 +25,7 @@ func TestManagedCodexMarketplaceRegisteredAcceptsFilesystemAlias(t *testing.T) {
 	if err := os.Symlink(root, aliasRoot); err != nil {
 		t.Fatal(err)
 	}
-	config := "[marketplaces.agentplugins-test]\nsource_type = \"local\"\nsource = \"" + filepath.Join(aliasRoot, "managed") + "\"\n"
+	config := "[marketplaces.agentplugins-test]\nsource_type = \"local\"\nsource = " + strconv.Quote(filepath.Join(aliasRoot, "managed")) + "\n"
 	if err := os.WriteFile(filepath.Join(configRoot, "config.toml"), []byte(config), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -47,12 +48,30 @@ func TestManagedCodexMarketplaceRegisteredRejectsDifferentResolvedPath(t *testin
 			t.Fatal(err)
 		}
 	}
-	config := "[marketplaces.agentplugins-test]\nsource_type = \"local\"\nsource = \"" + other + "\"\n"
+	config := "[marketplaces.agentplugins-test]\nsource_type = \"local\"\nsource = " + strconv.Quote(other) + "\n"
 	if err := os.WriteFile(filepath.Join(configRoot, "config.toml"), []byte(config), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	registered, err := managedCodexMarketplaceRegistered(configRoot, "agentplugins-test", managed)
 	if err == nil || registered {
 		t.Fatalf("different resolved path must fail closed: registered=%v err=%v", registered, err)
+	}
+}
+
+func TestEquivalentLocalPathRejectsUnresolvedAlias(t *testing.T) {
+	root := t.TempDir()
+	missing := filepath.Join(root, "missing")
+	for _, pair := range [][2]string{{missing, root}, {root, missing}} {
+		if equivalentLocalPath(pair[0], pair[1]) {
+			t.Fatalf("unresolved alias must fail closed: %q and %q", pair[0], pair[1])
+		}
+	}
+}
+
+func TestEquivalentLocalPathAcceptsIdenticalCleanedPath(t *testing.T) {
+	root := t.TempDir()
+	missing := filepath.Join(root, "missing")
+	if !equivalentLocalPath(missing+string(filepath.Separator)+".", missing) {
+		t.Fatal("identical cleaned paths must remain accepted without filesystem evidence")
 	}
 }

--- a/install/integrationctl/agentplugins/providers/codex_marketplace_cleanup_windows_test.go
+++ b/install/integrationctl/agentplugins/providers/codex_marketplace_cleanup_windows_test.go
@@ -1,0 +1,60 @@
+package providers
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestManagedCodexMarketplaceRegisteredExtendedWindowsPath(t *testing.T) {
+	root := t.TempDir()
+	managed := filepath.Join(root, "managed")
+	foreign := filepath.Join(root, "foreign")
+	for _, path := range []string{managed, foreign} {
+		if err := os.Mkdir(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	extendedPath := func(path string) string {
+		absolute, err := filepath.Abs(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.HasPrefix(absolute, `\\?\`) {
+			return absolute
+		}
+		if strings.HasPrefix(absolute, `\\`) {
+			return `\\?\UNC\` + strings.TrimPrefix(absolute, `\\`)
+		}
+		return `\\?\` + absolute
+	}
+	for _, tc := range []struct {
+		name, source string
+		want         bool
+	}{
+		{"managed", extendedPath(managed), true},
+		{"foreign", extendedPath(foreign), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Prove the extended path exists so a rejection cannot hide a bad fixture.
+			if _, err := os.Stat(tc.source); err != nil {
+				t.Fatal(err)
+			}
+			configRoot := t.TempDir()
+			config := "[marketplaces.agentplugins-test]\nsource_type = \"local\"\nsource = " + strconv.Quote(tc.source) + "\n"
+			if err := os.WriteFile(filepath.Join(configRoot, "config.toml"), []byte(config), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			registered, err := managedCodexMarketplaceRegistered(configRoot, "agentplugins-test", managed)
+			if tc.want {
+				if err != nil || !registered {
+					t.Fatalf("same directory must be accepted: registered=%v err=%v", registered, err)
+				}
+			} else if registered || err == nil || !strings.Contains(err.Error(), "no longer points at the managed artifact") {
+				t.Fatalf("foreign directory must fail ownership check: registered=%v err=%v", registered, err)
+			}
+		})
+	}
+}

--- a/repotests/agentplugins_claude_native_e2e_test.go
+++ b/repotests/agentplugins_claude_native_e2e_test.go
@@ -694,27 +694,8 @@ func claudeAssertNoWindowsStdio(t *testing.T, root, installPath string, names ..
 	if err != nil {
 		t.Fatal(err)
 	}
-	var config struct {
-		Servers map[string]map[string]any `json:"mcpServers"`
-	}
-	if err := json.Unmarshal(body, &config); err != nil {
+	if err := claudeWindowsMCPProjection(body, names...); err != nil {
 		t.Fatal(err)
-	}
-	if len(config.Servers) == 0 {
-		t.Fatal("missing projected HTTP inventory")
-	}
-	for _, name := range names {
-		if _, ok := config.Servers[name]; ok {
-			t.Fatalf("unsupported stdio projected: %s", name)
-		}
-	}
-	for name, server := range config.Servers {
-		if server["command"] != nil || server["args"] != nil || server["type"] == "stdio" {
-			t.Fatalf("stdio command projected: %s %+v", name, server)
-		}
-	}
-	if strings.Contains(string(body), "--internal-stdio-v1") {
-		t.Fatal("managed stdio launcher projected")
 	}
 	err = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
@@ -749,6 +730,61 @@ func TestClaudeWindowsStdioPlan(t *testing.T) {
 			}
 			if err := claudeWindowsStdioPlan(r, "default", "explicit"); (err != nil) != tc.wantError {
 				t.Fatalf("classification error = %v, wantError = %v", err, tc.wantError)
+			}
+		})
+	}
+}
+
+// Claude's generated .mcp.json is a flat server-name map, not the portable
+// package mcp.json envelope. Fail closed on wrappers and non-network entries.
+func claudeWindowsMCPProjection(body []byte, excluded ...string) error {
+	var servers map[string]map[string]any
+	if err := json.Unmarshal(body, &servers); err != nil {
+		return err
+	}
+	if len(servers) == 0 {
+		return fmt.Errorf("missing projected HTTP inventory")
+	}
+	for _, name := range excluded {
+		if _, ok := servers[name]; ok {
+			return fmt.Errorf("unsupported stdio projected: %s", name)
+		}
+	}
+	for name, server := range servers {
+		if server["command"] != nil || server["args"] != nil || server["type"] == "stdio" {
+			return fmt.Errorf("stdio command projected: %s %+v", name, server)
+		}
+		url, _ := server["url"].(string)
+		if (server["type"] != "http" && server["type"] != "sse") || url == "" {
+			return fmt.Errorf("invalid projected network server: %s %+v", name, server)
+		}
+	}
+	if strings.Contains(string(body), "--internal-stdio-v1") {
+		return fmt.Errorf("managed stdio launcher projected")
+	}
+	return nil
+}
+
+func TestClaudeWindowsMCPProjection(t *testing.T) {
+	// Exact flat shape written by projectClaudeMCP; streamable-http becomes http.
+	const httpProjection = `{"http":{"type":"http","url":"http://127.0.0.1:1234/mcp"}}`
+	for _, tc := range []struct {
+		name, body string
+		wantError  bool
+	}{
+		{"flat generated HTTP", httpProjection, false},
+		{"flat generated HTTP and SSE", `{"remote-http":{"type":"http","url":"http://127.0.0.1:9/mcp"},"remote-sse":{"type":"sse","url":"http://127.0.0.1:9/sse"}}`, false},
+		{"portable wrapper", `{"mcpServers":` + httpProjection + `}`, true},
+		{"empty", `{}`, true},
+		{"excluded stdio name", `{"default":{"type":"http","url":"http://127.0.0.1/mcp"}}`, true},
+		{"implicit stdio", `{"other":{"command":"sh","args":["-c","cat"]}}`, true},
+		{"explicit stdio", `{"other":{"type":"stdio"}}`, true},
+		{"hidden command", `{"http":{"type":"http","url":"http://127.0.0.1/mcp","command":"sh"}}`, true},
+		{"helper reference", `{"http":{"type":"http","url":"http://127.0.0.1/--internal-stdio-v1"}}`, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := claudeWindowsMCPProjection([]byte(tc.body), "default", "explicit", "local"); (err != nil) != tc.wantError {
+				t.Fatalf("projection error = %v, wantError = %v", err, tc.wantError)
 			}
 		})
 	}

--- a/repotests/agentplugins_claude_native_e2e_test.go
+++ b/repotests/agentplugins_claude_native_e2e_test.go
@@ -134,6 +134,16 @@ func claudeRunInstaller(t *testing.T, f *claudeNativeFixture, installer, clientD
 			t.Fatalf("decode installer output for %v: %v\n%s", args, jsonErr, out)
 		}
 	}
+	if runtime.GOOS == "windows" && len(args) > 0 && (args[0] == "add" || args[0] == "update" || args[0] == "repair") {
+		// Both fixture families use a fixed, explicit stdio inventory.
+		names := []string{"local"}
+		if strings.Contains(string(out), `"plugin":"native-proof"`) {
+			names = []string{"default", "explicit"}
+		}
+		if err := claudeWindowsStdioPlan(decoded, names...); err != nil {
+			t.Fatal(err)
+		}
+	}
 	return decoded
 }
 
@@ -372,6 +382,7 @@ func TestAgentpluginsClaudeNativeLifecycle(t *testing.T) {
 	// evidence file instead of silently vanishing from an otherwise-complete-
 	// looking JSON document.
 	stages := map[string]claudeNativeStage{
+		"stdio_discovery":         {Status: "not_evaluated", Reason: "not reached"},
 		"install":                 {Status: "not_evaluated", Reason: "not reached"},
 		"skill_discovery":         {Status: "not_evaluated", Reason: "not reached"},
 		"mcp_transport_discovery": {Status: "not_evaluated", Reason: "not reached"},
@@ -395,6 +406,10 @@ func TestAgentpluginsClaudeNativeLifecycle(t *testing.T) {
 			"installer_patch_sha256":  os.Getenv("AGENTPLUGINS_INSTALLER_PATCH_SHA256"),
 			"stages":                  stages,
 			"transcript_sha256":       f.transcriptSHA256,
+		}
+		if runtime.GOOS == "windows" {
+			evidence["stdio"] = stages["stdio_discovery"]
+			evidence["stdio_runtime_cwd_argv_env_data"] = "not_evaluated"
 		}
 		body, _ := json.MarshalIndent(evidence, "", "  ")
 		_ = os.WriteFile(filepath.Join(f.Root, "evidence.json"), body, 0600)
@@ -431,7 +446,7 @@ func TestAgentpluginsClaudeNativeLifecycle(t *testing.T) {
 
 	// skill discovery: exact plugin-attributed skill, exact bytes
 	details := claudePluginDetails(t, f, client, "claude-native-proof@skills-dir", "details-after-install")
-	if !strings.Contains(details, "demo-skill") || !strings.Contains(details, "MCP servers (3)") {
+	if !strings.Contains(details, "demo-skill") || !strings.Contains(details, claudeExpectedMCPInventory()) {
 		t.Fatalf("claude plugin details did not attribute the exact skill/MCP inventory: %s", details)
 	}
 	installedSkill := claudeReadInstalledSkill(t, installPath)
@@ -451,11 +466,22 @@ func TestAgentpluginsClaudeNativeLifecycle(t *testing.T) {
 	for _, want := range []string{
 		"plugin:claude-native-proof:remote-http:", "(HTTP)",
 		"plugin:claude-native-proof:remote-sse:", "(SSE)",
-		"plugin:claude-native-proof:local:",
 	} {
 		if !strings.Contains(mcpList, want) {
 			t.Fatalf("claude mcp list did not classify the declared transports as expected (missing %q): %s", want, mcpList)
 		}
+	}
+	if runtime.GOOS == "windows" {
+		claudeAssertNoWindowsStdio(t, f.Root, installPath, "local")
+		if strings.Contains(mcpList, "plugin:claude-native-proof:local:") {
+			t.Fatal("unsupported local stdio exposed by Claude")
+		}
+		stages["stdio_discovery"] = claudeNativeStage{Status: "observed_unsupported", Reason: "managed_stdio_platform_unsupported"}
+	} else {
+		if !strings.Contains(mcpList, "plugin:claude-native-proof:local:") {
+			t.Fatal("missing local stdio discovery")
+		}
+		stages["stdio_discovery"] = claudeNativeStage{Status: "passed", Reason: "local stdio enumerated by native CLI; no successful tool call claimed"}
 	}
 	stages["mcp_transport_discovery"] = claudeNativeStage{Status: "passed", Reason: "claude mcp list classified remote-http as (HTTP) and remote-sse as (SSE) and attempted a real (loopback-refused) connection to each, distinct from plugin details' shallow key enumeration; no live tool call or successful connection claimed"}
 
@@ -539,8 +565,11 @@ func TestAgentpluginsClaudeNativeLifecycle(t *testing.T) {
 		t.Fatalf("repair did not restore .mcp.json: %v", err)
 	}
 	repairDetails := claudePluginDetails(t, f, client, "claude-native-proof@skills-dir", "details-after-repair")
-	if !strings.Contains(repairDetails, "MCP servers (3)") {
+	if !strings.Contains(repairDetails, claudeExpectedMCPInventory()) {
 		t.Fatalf("claude plugin details after repair did not attribute the restored MCP inventory: %s", repairDetails)
+	}
+	if runtime.GOOS == "windows" {
+		claudeAssertNoWindowsStdio(t, f.Root, installPath, "local")
 	}
 	// Known, pre-existing, non-Codex-specific audit-trail gap (not
 	// introduced or fixed by this checkpoint): repair's recorded
@@ -616,4 +645,111 @@ func TestAgentpluginsClaudeNativeLifecycle(t *testing.T) {
 		t.Fatalf("repeated remove of an absent installation was not refused: err=%v out=%s", repeatErr, repeatOut)
 	}
 	stages["repeat_remove"] = claudeNativeStage{Status: "passed", Reason: "exact expected refusal message"}
+}
+
+func claudeExpectedMCPInventory() string {
+	if runtime.GOOS == "windows" {
+		return "MCP servers (2)"
+	}
+	return "MCP servers (3)"
+}
+
+// Assert the exact product limitation, never infer unsupported from absent tools.
+func claudeWindowsStdioPlan(r map[string]any, names ...string) error {
+	data, _ := r["data"].(map[string]any)
+	targets, _ := data["targets"].([]any)
+	if len(targets) != 1 {
+		return fmt.Errorf("expected one Claude target: %+v", r)
+	}
+	target, _ := targets[0].(map[string]any)
+	output, _ := target["output"].(map[string]any)
+	result, _ := output["result"].(map[string]any)
+	plan, _ := result["plan"].(map[string]any)
+	components, _ := plan["components"].([]any)
+	if target["target"] != "claude" || plan["client_id"] != "claude" {
+		return fmt.Errorf("wrong client plan: %+v", plan)
+	}
+	for _, name := range names {
+		count := 0
+		for _, raw := range components {
+			c, _ := raw.(map[string]any)
+			if c["kind"] == "mcp_server" && c["name"] == name {
+				count++
+				if c["support"] != "unsupported" || c["reason"] != "managed_stdio_platform_unsupported" {
+					return fmt.Errorf("unexpected stdio classification: %+v", c)
+				}
+			}
+		}
+		if count != 1 {
+			return fmt.Errorf("expected exactly one unsupported stdio component %q, got %d", name, count)
+		}
+	}
+	return nil
+}
+
+func claudeAssertNoWindowsStdio(t *testing.T, root, installPath string, names ...string) {
+	t.Helper()
+	nativeRequireContained(t, root, installPath)
+	body, err := os.ReadFile(filepath.Join(installPath, ".mcp.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var config struct {
+		Servers map[string]map[string]any `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(body, &config); err != nil {
+		t.Fatal(err)
+	}
+	if len(config.Servers) == 0 {
+		t.Fatal("missing projected HTTP inventory")
+	}
+	for _, name := range names {
+		if _, ok := config.Servers[name]; ok {
+			t.Fatalf("unsupported stdio projected: %s", name)
+		}
+	}
+	for name, server := range config.Servers {
+		if server["command"] != nil || server["args"] != nil || server["type"] == "stdio" {
+			t.Fatalf("stdio command projected: %s %+v", name, server)
+		}
+	}
+	if strings.Contains(string(body), "--internal-stdio-v1") {
+		t.Fatal("managed stdio launcher projected")
+	}
+	err = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.Name() == "managed-stdio-v1" {
+			return fmt.Errorf("unsupported managed stdio helper exists: %s", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClaudeWindowsStdioPlan(t *testing.T) {
+	const fixture = `{"data":{"targets":[{"target":"claude","output":{"result":{"plan":{"client_id":"claude","components":[{"kind":"mcp_server","name":"default","support":"unsupported","reason":"managed_stdio_platform_unsupported"},{"kind":"mcp_server","name":"explicit","support":"unsupported","reason":"managed_stdio_platform_unsupported"}]}}}}]}}`
+	for _, tc := range []struct {
+		name, input string
+		wantError   bool
+	}{
+		{"exact", fixture, false},
+		{"wrong support", strings.Replace(fixture, `"unsupported"`, `"projected"`, 1), true},
+		{"wrong reason", strings.Replace(fixture, "managed_stdio_platform_unsupported", "command_not_found", 1), true},
+		{"missing explicit", strings.Replace(fixture, `"explicit"`, `"other"`, 1), true},
+		{"wrong client", strings.Replace(fixture, `"client_id":"claude"`, `"client_id":"codex"`, 1), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var r map[string]any
+			if err := json.Unmarshal([]byte(tc.input), &r); err != nil {
+				t.Fatal(err)
+			}
+			if err := claudeWindowsStdioPlan(r, "default", "explicit"); (err != nil) != tc.wantError {
+				t.Fatalf("classification error = %v, wantError = %v", err, tc.wantError)
+			}
+		})
+	}
 }

--- a/repotests/agentplugins_claude_native_e2e_test.go
+++ b/repotests/agentplugins_claude_native_e2e_test.go
@@ -1,7 +1,8 @@
 package pluginkitairepo_test
 
 // This opt-in suite uses only disposable fixture paths. Native execution requires
-// an isolated Linux container; a redirected HOME cannot isolate the macOS keychain.
+// a disposable image/VM or explicitly opted-in hosted runner; redirected HOME
+// alone cannot isolate the macOS keychain.
 
 import (
 	"context"

--- a/repotests/agentplugins_claude_native_e2e_test.go
+++ b/repotests/agentplugins_claude_native_e2e_test.go
@@ -40,7 +40,7 @@ func claudeNativeBinary(t *testing.T, key string) string {
 		t.Fatalf("%s must name an absolute scratch binary", key)
 	}
 	st, err := os.Stat(p)
-	if err != nil || !st.Mode().IsRegular() || st.Mode()&0111 == 0 {
+	if err != nil || !st.Mode().IsRegular() || (runtime.GOOS != "windows" && st.Mode()&0111 == 0) {
 		t.Fatalf("invalid %s binary", key)
 	}
 	return p
@@ -94,19 +94,7 @@ func newClaudeNativeFixture(t *testing.T) *claudeNativeFixture {
 // inherited ambient credentials beyond PATH/LANG, and updater/telemetry
 // disabled where the client honors that.
 func (f *claudeNativeFixture) env(clientDir string) []string {
-	return []string{
-		"HOME=" + f.Home,
-		"CLAUDE_CONFIG_DIR=" + f.ConfigDir,
-		"AGENTPLUGINS_HOME=" + f.StateHome,
-		"XDG_CONFIG_HOME=" + filepath.Join(f.Root, "xdg-config"),
-		"XDG_DATA_HOME=" + filepath.Join(f.Root, "xdg-data"),
-		"XDG_CACHE_HOME=" + filepath.Join(f.Root, "xdg-cache"),
-		"TMPDIR=" + filepath.Join(f.Root, "tmp"),
-		"PATH=" + clientDir + ":/usr/bin:/bin",
-		"DISABLE_AUTOUPDATER=1",
-		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1",
-		"LANG=en_US.UTF-8",
-	}
+	return append(nativePlatformEnvironment(f.Root, f.Home, clientDir), "CLAUDE_CONFIG_DIR="+f.ConfigDir, "AGENTPLUGINS_HOME="+f.StateHome, "DISABLE_AUTOUPDATER=1", "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1")
 }
 
 // record saves a command's combined stdout+stderr to its own evidence file
@@ -367,9 +355,7 @@ func TestAgentpluginsClaudeNativeLifecycle(t *testing.T) {
 	if os.Getenv("AGENTPLUGINS_CLAUDE_NATIVE_E2E") != "1" {
 		t.Skip("opt-in native client execution")
 	}
-	if runtime.GOOS != "linux" {
-		t.Fatal("native Claude requires isolated Linux runtime")
-	}
+	nativeRequireDisposable(t)
 	client := claudeNativeBinary(t, "AGENTPLUGINS_CLAUDE_BIN")
 	installer := claudeNativeBinary(t, "AGENTPLUGINS_INSTALLER_BIN")
 	if expected := os.Getenv("AGENTPLUGINS_CLAUDE_SHA256"); len(expected) != 64 || claudeSHA256(t, client) != expected {

--- a/repotests/agentplugins_claude_runtime_fixture_test.go
+++ b/repotests/agentplugins_claude_runtime_fixture_test.go
@@ -30,6 +30,13 @@ type claudeGateway struct {
 
 func claudeRuntimeSession(t *testing.T, f *nativeFixture, cf *claudeNativeFixture, client, label, revision, operation string) string {
 	t.Helper()
+	if runtime.GOOS == "windows" {
+		entries := claudePluginList(t, cf, client, label+"-projection")
+		if len(entries) != 1 {
+			t.Fatalf("expected one projection: %+v", entries)
+		}
+		claudeAssertNoWindowsStdio(t, cf.Root, entries[0].InstallPath, "default", "explicit")
+	}
 	g := &claudeGateway{results: map[string]json.RawMessage{}, calls: map[string]string{}}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1/messages/count_tokens" {
@@ -145,8 +152,12 @@ func claudeRuntimeSession(t *testing.T, f *nativeFixture, cf *claudeNativeFixtur
 	if !g.skillBodySeen {
 		t.Fatal("installed selected skill body was not observed in outgoing provider context")
 	}
-	if len(g.results) != 3 {
-		t.Fatalf("expected installed stdio and HTTP tools returned through native client, got %d; see gateway evidence", len(g.results))
+	expectedTools := 3
+	if runtime.GOOS == "windows" {
+		expectedTools = 1
+	}
+	if len(g.results) != expectedTools {
+		t.Fatalf("expected %d platform-supported tools returned through native client, got %d; see gateway evidence", expectedTools, len(g.results))
 	}
 	seen := map[string]bool{}
 	var markerPath string
@@ -193,8 +204,8 @@ func claudeRuntimeSession(t *testing.T, f *nativeFixture, cf *claudeNativeFixtur
 			t.Fatalf("runtime semantics: %+v", facts)
 		}
 	}
-	if !seen["default"] || !seen["explicit"] || !seen["http"] {
-		t.Fatal("missing default/explicit stdio tools")
+	if !seen["http"] || (runtime.GOOS != "windows" && (!seen["default"] || !seen["explicit"])) || (runtime.GOOS == "windows" && (seen["default"] || seen["explicit"])) {
+		t.Fatal("native tool inventory does not match platform contract")
 	}
 	return markerPath
 }
@@ -223,6 +234,13 @@ func TestAgentpluginsClaudeNativeRuntimeLifecycle(t *testing.T) {
 		evidence["transcript_sha256"] = cf.transcriptSHA256
 		nativeJSON(t, filepath.Join(f.Root, "evidence.json"), evidence)
 	}()
+	evidence["installer_data_retention"] = "not_evaluated"
+	evidence["stdio_runtime"] = "not_evaluated"
+	evidence["stdio_cwd_argv_env_data"] = "not_evaluated"
+	evidence["runtime_scope"] = "stdio_default+stdio_explicit+HTTP+skill"
+	if runtime.GOOS == "windows" {
+		evidence["runtime_scope"] = "HTTP+installed-skill"
+	}
 	evidence["scanner"] = nativeProvisionScanner(t, f)
 	version := claudeVersionString(t, cf, client)
 	evidence["client_version"] = version
@@ -237,10 +255,20 @@ func TestAgentpluginsClaudeNativeRuntimeLifecycle(t *testing.T) {
 			t.Fatal("first add did not use local scanner")
 		}
 		if label == "remove" {
+			// Final-binding removal calls EnsureData even when Windows excluded
+			// every stdio component. This proves ownership retention, not stdio data use.
 			if err := claudeRetainedRemovalResult(r); err != nil {
 				t.Fatal(err)
 			}
+			evidence["installer_data_retention"] = "passed"
 			return
+		}
+		if runtime.GOOS == "windows" {
+			if err := claudeWindowsStdioPlan(r, "default", "explicit"); err != nil {
+				t.Fatal(err)
+			}
+			evidence["stdio_runtime"] = "observed_unsupported"
+			evidence["stdio_reason"] = "managed_stdio_platform_unsupported"
 		}
 		if d["status"] != "completed" {
 			t.Fatalf("%s: %+v", label, r)
@@ -276,7 +304,12 @@ func TestAgentpluginsClaudeNativeRuntimeLifecycle(t *testing.T) {
 	}
 	run("repair", "repair", "native-proof", "--target", "claude")
 	markerPath := claudeRuntimeSession(t, f, cf, client, "runtime-repair", "C", "read")
-	markerDigest := nativeSHA(t, markerPath)
+	markerDigest := ""
+	if runtime.GOOS != "windows" {
+		markerDigest = nativeSHA(t, markerPath)
+		evidence["stdio_runtime"] = "passed"
+		evidence["stdio_cwd_argv_env_data"] = "passed"
+	}
 	stages["repair"] = "passed"
 	stages["remove"] = "failed"
 	run("remove", "remove", "native-proof", "--target", "claude")
@@ -286,7 +319,7 @@ func TestAgentpluginsClaudeNativeRuntimeLifecycle(t *testing.T) {
 	if _, err := os.Stat(entries[0].InstallPath); !os.IsNotExist(err) {
 		t.Fatalf("managed artifact survived remove: %v", err)
 	}
-	if nativeSHA(t, markerPath) != markerDigest {
+	if runtime.GOOS != "windows" && nativeSHA(t, markerPath) != markerDigest {
 		t.Fatal("safe remove changed retained marker")
 	}
 	stages["remove"] = "passed"

--- a/repotests/agentplugins_claude_runtime_fixture_test.go
+++ b/repotests/agentplugins_claude_runtime_fixture_test.go
@@ -203,9 +203,7 @@ func TestAgentpluginsClaudeNativeRuntimeLifecycle(t *testing.T) {
 	if os.Getenv("AGENTPLUGINS_CLAUDE_NATIVE_E2E") != "1" {
 		t.Skip("opt-in native client execution")
 	}
-	if runtime.GOOS != "linux" {
-		t.Fatal("native Claude requires isolated Linux runtime; macOS keychain is not isolated")
-	}
+	nativeRequireDisposable(t)
 	client := claudeNativeBinary(t, "AGENTPLUGINS_CLAUDE_BIN")
 	installer := claudeNativeBinary(t, "AGENTPLUGINS_INSTALLER_BIN")
 	if expected := os.Getenv("AGENTPLUGINS_CLAUDE_SHA256"); len(expected) != 64 || claudeSHA256(t, client) != expected {

--- a/repotests/agentplugins_codex_native_e2e_test.go
+++ b/repotests/agentplugins_codex_native_e2e_test.go
@@ -20,7 +20,7 @@ import (
 
 // This suite is intentionally opt-in and uses only a freshly provisioned binary.
 // macOS release binaries read managed CFPreferences independently of HOME; this
-// runner requires a clean Linux container/VM until that boundary is isolated.
+// runner requires a disposable image/VM or explicitly opted-in hosted runner.
 func nativeBinary(t *testing.T, key string) string {
 	t.Helper()
 	p := os.Getenv(key)

--- a/repotests/agentplugins_codex_native_e2e_test.go
+++ b/repotests/agentplugins_codex_native_e2e_test.go
@@ -28,7 +28,7 @@ func nativeBinary(t *testing.T, key string) string {
 		t.Fatalf("%s must name an absolute scratch binary", key)
 	}
 	st, err := os.Stat(p)
-	if err != nil || !st.Mode().IsRegular() || st.Mode()&0111 == 0 {
+	if err != nil || !st.Mode().IsRegular() || (runtime.GOOS != "windows" && st.Mode()&0111 == 0) {
 		t.Fatalf("invalid %s binary", key)
 	}
 	return p
@@ -257,11 +257,11 @@ func nativeSession(t *testing.T, f *nativeFixture, client, label, revision, oper
 		}
 		for _, p := range []string{facts.Root, facts.Data, facts.CWD} {
 			rel, err := filepath.Rel(f.Root, p)
-			if err != nil || rel == ".." || strings.HasPrefix(rel, "../") {
+			if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 				t.Fatalf("runtime path escapes fixture: %s", p)
 			}
 		}
-		if !strings.Contains(facts.Root, string(filepath.Separator)+"plugins/cache/") {
+		if !strings.Contains(filepath.ToSlash(facts.Root), "/plugins/cache/") {
 			t.Fatalf("not native installed cache: %s", facts.Root)
 		}
 		for _, path := range []string{"plugin.json", ".codex-plugin/plugin.json"} {
@@ -363,9 +363,7 @@ func TestAgentpluginsCodexNativeLifecycle(t *testing.T) {
 	if os.Getenv("AGENTPLUGINS_CODEX_NATIVE_E2E") != "1" {
 		t.Skip("opt-in native client execution")
 	}
-	if runtime.GOOS != "linux" || os.Getenv("AGENTPLUGINS_NATIVE_DISPOSABLE_LINUX") != "1" {
-		t.Fatal("requires a newly provisioned disposable Linux container/VM; macOS managed preferences are not isolated by HOME")
-	}
+	nativeRequireDisposable(t)
 	if _, err := os.Lstat("/etc/codex"); !os.IsNotExist(err) {
 		t.Fatal("system Codex config must be absent in disposable image")
 	}
@@ -613,7 +611,7 @@ func TestAgentpluginsCodexNativeLifecycle(t *testing.T) {
 	}
 	partialServers := partialMCP["mcpServers"].(map[string]any)
 	partialServers["unavailable"] = map[string]any{"type": "stdio", "command": "uap-deliberately-unavailable-" + f.Nonce}
-	partialServers["startup-failure"] = map[string]any{"type": "stdio", "command": "./bin/probe", "args": []string{"--fail-startup"}, "env": map[string]string{"UAP_TEST_ROOT": f.Root, "UAP_TEST_EVENTS": f.Events, "UAP_TEST_NONCE": f.Nonce}}
+	partialServers["startup-failure"] = map[string]any{"type": "stdio", "command": "./bin/" + nativeExecutableName("probe"), "args": []string{"--fail-startup"}, "env": map[string]string{"UAP_TEST_ROOT": f.Root, "UAP_TEST_EVENTS": f.Events, "UAP_TEST_NONCE": f.Nonce}}
 	partialServers["unsupported-sse"] = map[string]any{"type": "sse", "url": f.HTTPURL + "/unsupported-sse"}
 	nativeJSON(t, filepath.Join(f.Package, "mcp.json"), partialMCP)
 	nativeWrite(t, filepath.Join(f.Package, "skills", "invalid-proof", "SKILL.md"), []byte("No required skill frontmatter"), 0600)
@@ -770,7 +768,7 @@ func nativeRequireContained(t *testing.T, root, path string) {
 		t.Fatal(err)
 	}
 	rel, err := filepath.Rel(root, resolved)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, "../") {
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		t.Fatalf("path escapes disposable fixture: %s", path)
 	}
 }
@@ -1030,9 +1028,7 @@ func TestAgentpluginsCodexImmutableGitDiscovery(t *testing.T) {
 	if os.Getenv("AGENTPLUGINS_CODEX_GIT_E2E") != "1" {
 		t.Skip("opt-in public immutable Git native discovery")
 	}
-	if runtime.GOOS != "linux" || os.Getenv("AGENTPLUGINS_NATIVE_DISPOSABLE_LINUX") != "1" {
-		t.Fatal("requires disposable Linux boundary")
-	}
+	nativeRequireDisposable(t)
 	if _, err := os.Lstat("/etc/codex"); !os.IsNotExist(err) {
 		t.Fatal("system Codex config must be absent")
 	}
@@ -1187,7 +1183,7 @@ func TestAgentpluginsCodexImmutableGitDiscovery(t *testing.T) {
 				continue
 			}
 			nativeRequireContained(t, f.Root, skill.Path)
-			if !strings.Contains(skill.Path, "/plugins/cache/") || !strings.HasSuffix(skill.Path, "/skills/alpha/SKILL.md") {
+			if !strings.Contains(filepath.ToSlash(skill.Path), "/plugins/cache/") || !strings.HasSuffix(filepath.ToSlash(skill.Path), "/skills/alpha/SKILL.md") {
 				t.Fatal("skill is not from installed native cache")
 			}
 			body, err := os.ReadFile(skill.Path)

--- a/repotests/agentplugins_native_fixture_test.go
+++ b/repotests/agentplugins_native_fixture_test.go
@@ -97,7 +97,7 @@ func newNativeFixture(t *testing.T, preserve bool) *nativeFixture {
 	if _, err := rand.Read(nonce[:]); err != nil {
 		t.Fatal(err)
 	}
-	f := &nativeFixture{Root: root, Project: filepath.Join(root, "project"), Home: filepath.Join(root, "home"), CodexHome: filepath.Join(root, "home", ".codex"), Package: filepath.Join(root, "package"), Probe: filepath.Join(root, "native-probe"), Events: filepath.Join(root, "events.jsonl"), Nonce: hex.EncodeToString(nonce[:])}
+	f := &nativeFixture{Root: root, Project: filepath.Join(root, "project"), Home: filepath.Join(root, "home"), CodexHome: filepath.Join(root, "home", ".codex"), Package: filepath.Join(root, "package"), Probe: filepath.Join(root, nativeExecutableName("native-probe")), Events: filepath.Join(root, "events.jsonl"), Nonce: hex.EncodeToString(nonce[:])}
 	for _, p := range []string{f.Project, f.Home, f.CodexHome, filepath.Join(root, "tmp"), filepath.Join(root, "xdg-config"), filepath.Join(root, "xdg-data"), filepath.Join(root, "xdg-cache"), filepath.Join(root, "xdg-state")} {
 		if err := os.MkdirAll(p, 0700); err != nil {
 			t.Fatal(err)
@@ -127,7 +127,7 @@ func (f *nativeFixture) env(binDir string) []string {
 	if clientDir == "" {
 		clientDir = binDir
 	}
-	return []string{"HOME=" + f.Home, "AGENTPLUGINS_HOME=" + filepath.Join(f.Root, "installer-state"), "CODEX_HOME=" + f.CodexHome, "XDG_CONFIG_HOME=" + filepath.Join(f.Root, "xdg-config"), "XDG_DATA_HOME=" + filepath.Join(f.Root, "xdg-data"), "XDG_CACHE_HOME=" + filepath.Join(f.Root, "xdg-cache"), "XDG_STATE_HOME=" + filepath.Join(f.Root, "xdg-state"), "TMPDIR=" + filepath.Join(f.Root, "tmp"), "PATH=" + binDir + ":" + clientDir + ":/usr/bin:/bin", "LANG=en_US.UTF-8", "TERM=dumb"}
+	return append(nativePlatformEnvironment(f.Root, f.Home, binDir, clientDir), "AGENTPLUGINS_HOME="+filepath.Join(f.Root, "installer-state"), "CODEX_HOME="+f.CodexHome)
 }
 func (f *nativeFixture) writePackage(t *testing.T, revision, version string) {
 	t.Helper()
@@ -137,10 +137,10 @@ func (f *nativeFixture) writePackage(t *testing.T, revision, version string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	nativeWrite(t, filepath.Join(f.Package, "bin", "probe"), b, 0700)
+	nativeWrite(t, filepath.Join(f.Package, "bin", nativeExecutableName("probe")), b, 0700)
 	env := map[string]string{"UAP_TEST_ROOT": f.Root, "UAP_TEST_EVENTS": f.Events, "UAP_TEST_NONCE": f.Nonce, "UAP_TEST_REVISION": revision, "UAP_TEST_LITERAL": "literal ${UNKNOWN} $HOME", "UAP_TEST_ONCE": "${PLUGIN_ROOT}/${UNKNOWN}"}
 	server := func(cwd string) map[string]any {
-		m := map[string]any{"type": "stdio", "command": "./bin/../bin/probe", "args": []string{"argument with spaces", "${PLUGIN_ROOT}/argument", "${UNKNOWN}"}, "env": env}
+		m := map[string]any{"type": "stdio", "command": "./bin/../bin/" + nativeExecutableName("probe"), "args": []string{"argument with spaces", "${PLUGIN_ROOT}/argument", "${UNKNOWN}"}, "env": env}
 		if cwd != "" {
 			m["cwd"] = cwd
 		}
@@ -474,28 +474,33 @@ func nativeProvisionScanner(t *testing.T, f *nativeFixture) map[string]string {
 	// Platform/digest pins mirror agentplugins/adapters/securityscan/release.go's
 	// releaseAssets table exactly, so this cache prepopulation stays consistent
 	// with what the real ReleaseScanner would resolve to on the same host.
-	var platform, archive string
-	switch runtime.GOARCH {
-	case "arm64":
-		platform = "linux-arm64"
-		archive = "132a37610575bd251ecaf0be4c6090dad144dd1397c99aad989a3944c63c3d4a"
-	case "amd64":
-		platform = "linux-amd64"
-		archive = "2b3d176db752433b904a4b42375543ff398f4841d22e48f7d4f23ded925b72da"
+	platform := runtime.GOOS + "-" + runtime.GOARCH
+	if platform == "linux-amd64" {
 		for _, path := range []string{"/lib/ld-musl-x86_64.so.1", "/lib64/ld-musl-x86_64.so.1"} {
 			if _, err := os.Stat(path); err == nil {
-				platform = "linux-amd64-musl"
-				archive = "3da60f749c61e2caca029a44a9ce422d570aef8c57f82ce51c411c8cec12f61b"
+				platform += "-musl"
 				break
 			}
 		}
-	default:
-		t.Fatalf("lintai security scanner has no pinned platform asset for linux/%s", runtime.GOARCH)
 	}
+	pins := map[string]string{
+		"darwin-arm64":     "be8b263e2323074080d928ea7c2129458299a6d03f7a9f178dfc1aa8e6bc17ff",
+		"darwin-amd64":     "abc170612a847bf1a896ef85a4ee93977baa8275f303dac3ed27bf34050b7513",
+		"linux-arm64":      "132a37610575bd251ecaf0be4c6090dad144dd1397c99aad989a3944c63c3d4a",
+		"linux-amd64":      "2b3d176db752433b904a4b42375543ff398f4841d22e48f7d4f23ded925b72da",
+		"linux-amd64-musl": "3da60f749c61e2caca029a44a9ce422d570aef8c57f82ce51c411c8cec12f61b",
+		"windows-amd64":    "2f61f6a83a160afa3feed9ea1722b82d0d938ebff865a4e20d39b5f55270c911",
+		"windows-arm64":    "484c30e7ef55310e0aec595c06870dbb5454ae7d29404ca797e00acad6011453",
+	}
+	archive, ok := pins[platform]
+	if !ok {
+		t.Fatalf("lintai security scanner has no pinned platform asset for %s", platform)
+	}
+
 	if os.Getenv("AGENTPLUGINS_LINTAI_ARCHIVE_SHA256") != archive {
 		t.Fatal("lintai archive provenance does not match pinned platform asset")
 	}
-	destination := filepath.Join(f.Root, "installer-state", "security", "lintai", "0.1.3", platform, "lintai")
+	destination := filepath.Join(f.Root, "installer-state", "security", "lintai", "0.1.3", platform, nativeExecutableName("lintai"))
 	b, err := os.ReadFile(binary)
 	if err != nil {
 		t.Fatal(err)
@@ -517,7 +522,7 @@ func TestAgentpluginsNativeFixtureAdmission(t *testing.T) {
 		t.Fatal(err)
 	}
 	load := func() domain.PackageEnvelope {
-		envelope, err := (loader.Loader{Registry: registry}).Load(context.Background(), domain.LoadInput{SnapshotRoot: f.Package, ExecutableFiles: []string{"bin/probe"}})
+		envelope, err := (loader.Loader{Registry: registry}).Load(context.Background(), domain.LoadInput{SnapshotRoot: f.Package, ExecutableFiles: []string{"bin/" + nativeExecutableName("probe")}})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/repotests/agentplugins_native_platform_test.go
+++ b/repotests/agentplugins_native_platform_test.go
@@ -1,0 +1,98 @@
+package pluginkitairepo_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Explicit disposable boundaries are required before any native client launch.
+func nativeDisposableAllowed(goos, linux, hosted, actions, environment string) bool {
+	if goos == "linux" {
+		return linux == "1"
+	}
+	return (goos == "darwin" || goos == "windows") && hosted == "1" && actions == "true" && environment == "github-hosted"
+}
+func nativeRequireDisposable(t *testing.T) {
+	t.Helper()
+	if !nativeDisposableAllowed(runtime.GOOS, os.Getenv("AGENTPLUGINS_NATIVE_DISPOSABLE_LINUX"), os.Getenv("AGENTPLUGINS_NATIVE_DISPOSABLE_HOSTED"), os.Getenv("GITHUB_ACTIONS"), os.Getenv("RUNNER_ENVIRONMENT")) {
+		t.Fatal("native execution requires an opted-in disposable Linux image or explicitly opted-in GitHub-hosted macOS/Windows runner")
+	}
+}
+func nativeExecutableName(name string) string {
+	if runtime.GOOS == "windows" {
+		return name + ".exe"
+	}
+	return name
+}
+
+// No inherited profile, credentials, proxy, PATH or shell configuration.
+func nativePlatformEnvironment(root, home string, binDirs ...string) []string {
+	env := []string{"HOME=" + home, "USERPROFILE=" + home, "APPDATA=" + filepath.Join(home, "AppData", "Roaming"), "LOCALAPPDATA=" + filepath.Join(home, "AppData", "Local"), "TMPDIR=" + filepath.Join(root, "tmp"), "TEMP=" + filepath.Join(root, "tmp"), "TMP=" + filepath.Join(root, "tmp"), "XDG_CONFIG_HOME=" + filepath.Join(root, "xdg-config"), "XDG_DATA_HOME=" + filepath.Join(root, "xdg-data"), "XDG_CACHE_HOME=" + filepath.Join(root, "xdg-cache"), "XDG_STATE_HOME=" + filepath.Join(root, "xdg-state"), "LANG=en_US.UTF-8", "TERM=dumb"}
+	paths := append([]string{}, binDirs...)
+	if runtime.GOOS == "windows" {
+		// Derive the shell from the OS directory, never inherit an arbitrary COMSPEC.
+		if nativeDisposableAllowed(runtime.GOOS, "", os.Getenv("AGENTPLUGINS_NATIVE_DISPOSABLE_HOSTED"), os.Getenv("GITHUB_ACTIONS"), os.Getenv("RUNNER_ENVIRONMENT")) {
+			if gitDir := os.Getenv("AGENTPLUGINS_NATIVE_GIT_BIN_DIR"); filepath.IsAbs(gitDir) {
+				paths = append(paths, gitDir)
+			}
+			if bash := os.Getenv("AGENTPLUGINS_NATIVE_GIT_BASH_PATH"); filepath.IsAbs(bash) {
+				env = append(env, "CLAUDE_CODE_GIT_BASH_PATH="+bash)
+			}
+		}
+		systemRoot := os.Getenv("SystemRoot")
+		if filepath.IsAbs(systemRoot) && !strings.HasPrefix(systemRoot, `\\`) {
+			env = append(env, "SystemRoot="+systemRoot, "COMSPEC="+filepath.Join(systemRoot, "System32", "cmd.exe"))
+			paths = append(paths, filepath.Join(systemRoot, "System32"), systemRoot)
+		}
+	} else {
+		paths = append(paths, "/usr/bin", "/bin")
+	}
+	return append(env, "PATH="+strings.Join(paths, string(os.PathListSeparator)))
+}
+func TestNativeDisposableBoundary(t *testing.T) {
+	for _, goos := range []string{"darwin", "windows"} {
+		if !nativeDisposableAllowed(goos, "", "1", "true", "github-hosted") {
+			t.Fatal(goos)
+		}
+		for _, args := range [][4]string{{"1", "", "true", "github-hosted"}, {"", "1", "false", "github-hosted"}, {"", "1", "true", "self-hosted"}} {
+			if nativeDisposableAllowed(goos, args[0], args[1], args[2], args[3]) {
+				t.Fatalf("unsafe boundary: %s %v", goos, args)
+			}
+		}
+	}
+	if !nativeDisposableAllowed("linux", "1", "", "", "") || nativeDisposableAllowed("linux", "", "1", "true", "github-hosted") {
+		t.Fatal("Linux boundary changed")
+	}
+}
+
+func TestNativePlatformEnvironmentIsolation(t *testing.T) {
+	t.Setenv("HOME", "ambient-home")
+	t.Setenv("PATH", "ambient-path")
+	t.Setenv("ANTHROPIC_API_KEY", "ambient-secret")
+	t.Setenv("HTTPS_PROXY", "ambient-proxy")
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	env := map[string]string{}
+	for _, entry := range nativePlatformEnvironment(root, home, filepath.Join(root, "bin")) {
+		key, value, _ := strings.Cut(entry, "=")
+		if _, exists := env[key]; exists {
+			t.Fatalf("duplicate environment key: %s", key)
+		}
+		env[key] = value
+	}
+	for _, key := range []string{"HOME", "USERPROFILE", "APPDATA", "LOCALAPPDATA", "TMPDIR", "TEMP", "TMP", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_CACHE_HOME", "XDG_STATE_HOME"} {
+		relative, err := filepath.Rel(root, env[key])
+		if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+			t.Fatalf("%s escapes scratch: %q", key, env[key])
+		}
+	}
+	if env["HOME"] != home || env["ANTHROPIC_API_KEY"] != "" || env["HTTPS_PROXY"] != "" || strings.Contains(env["PATH"], "ambient") {
+		t.Fatal("inherited ambient environment")
+	}
+	if paths := filepath.SplitList(env["PATH"]); len(paths) == 0 || paths[0] != filepath.Join(root, "bin") {
+		t.Fatal("scratch binary directory missing")
+	}
+}

--- a/repotests/agentplugins_native_platform_test.go
+++ b/repotests/agentplugins_native_platform_test.go
@@ -96,3 +96,11 @@ func TestNativePlatformEnvironmentIsolation(t *testing.T) {
 		t.Fatal("scratch binary directory missing")
 	}
 }
+
+// Hosted proof has no egress firewall. Never reuse the Linux isolation claim.
+func nativeNetworkEvidence() string {
+	if runtime.GOOS == "linux" {
+		return "pinned scanner preprovisioned; disposable Linux runner owns the network boundary"
+	}
+	return "not blocked; disposable GitHub-hosted runner; pinned scanner preprovisioned; scripted loopback provider"
+}

--- a/repotests/agentplugins_native_platform_test.go
+++ b/repotests/agentplugins_native_platform_test.go
@@ -38,6 +38,9 @@ func nativePlatformEnvironment(root, home string, binDirs ...string) []string {
 			if gitDir := os.Getenv("AGENTPLUGINS_NATIVE_GIT_BIN_DIR"); filepath.IsAbs(gitDir) {
 				paths = append(paths, gitDir)
 			}
+			if shellDir := os.Getenv("AGENTPLUGINS_NATIVE_GIT_SHELL_BIN_DIR"); filepath.IsAbs(shellDir) {
+				paths = append(paths, shellDir)
+			}
 			if bash := os.Getenv("AGENTPLUGINS_NATIVE_GIT_BASH_PATH"); filepath.IsAbs(bash) {
 				env = append(env, "CLAUDE_CODE_GIT_BASH_PATH="+bash)
 			}

--- a/repotests/agentplugins_opencode_native_e2e_test.go
+++ b/repotests/agentplugins_opencode_native_e2e_test.go
@@ -67,18 +67,7 @@ func newOpenCodeNativeFixture(t *testing.T) *openCodeNativeFixture {
 // ambient config, OPENCODE_PURE disables any implicit project/global merge
 // that could hide the owned entry.
 func (f *openCodeNativeFixture) env(clientDir string) []string {
-	return []string{
-		"HOME=" + f.Home,
-		"XDG_CONFIG_HOME=" + f.XDGConfig,
-		"XDG_DATA_HOME=" + f.XDGData,
-		"XDG_CACHE_HOME=" + f.XDGCache,
-		"XDG_STATE_HOME=" + f.XDGState,
-		"AGENTPLUGINS_HOME=" + f.StateHome,
-		"TMPDIR=" + filepath.Join(f.Root, "tmp"),
-		"OPENCODE_PURE=1",
-		"PATH=" + clientDir + ":/usr/bin:/bin",
-		"LANG=en_US.UTF-8",
-	}
+	return append(nativePlatformEnvironment(f.Root, f.Home, clientDir), "AGENTPLUGINS_HOME="+f.StateHome, "OPENCODE_PURE=1")
 }
 
 func (f *openCodeNativeFixture) record(t *testing.T, label string, out []byte) {
@@ -414,9 +403,7 @@ func openCodeReadConfigDocument(t *testing.T, body []byte, doc *map[string]any) 
 
 func openCodePrepareNative(t *testing.T, f *openCodeNativeFixture, client string) map[string]string {
 	t.Helper()
-	if runtime.GOOS != "linux" || os.Getenv("AGENTPLUGINS_NATIVE_DISPOSABLE_LINUX") != "1" {
-		t.Fatal("native OpenCode execution requires the approved disposable Linux container")
-	}
+	nativeRequireDisposable(t)
 	if expected := os.Getenv("AGENTPLUGINS_OPENCODE_SHA256"); len(expected) != 64 || openCodeSHA256(t, client) != expected {
 		t.Fatal("OpenCode binary SHA256 mismatch or missing pin")
 	}
@@ -761,7 +748,7 @@ func openCodeNativeBinary(t *testing.T, key string) string {
 		t.Fatalf("%s must name an absolute scratch binary", key)
 	}
 	st, err := os.Stat(p)
-	if err != nil || !st.Mode().IsRegular() || st.Mode()&0111 == 0 {
+	if err != nil || !st.Mode().IsRegular() || (runtime.GOOS != "windows" && st.Mode()&0111 == 0) {
 		t.Fatalf("invalid %s binary", key)
 	}
 	return p

--- a/repotests/agentplugins_opencode_native_e2e_test.go
+++ b/repotests/agentplugins_opencode_native_e2e_test.go
@@ -463,7 +463,7 @@ func openCodeNativeLifecycle(t *testing.T, route string) {
 		"installer_patch_sha256": os.Getenv("AGENTPLUGINS_INSTALLER_PATCH_SHA256"), "acquisition": "local_directory",
 		"native_surface":         "opencode debug config (effective config proof; not a handshake or tool call) plus opencode mcp list (real per-server connection attempts, still not a handshake or tool call)",
 		"config_route_exercised": route,
-		"network_dependency":     "none; pinned scanner preprovisioned; disposable container denies external network",
+		"network_dependency":     nativeNetworkEvidence(),
 		"scanner":                scanner,
 		"stages":                 stages,
 	}

--- a/repotests/agentplugins_opencode_runtime_extended_test.go
+++ b/repotests/agentplugins_opencode_runtime_extended_test.go
@@ -1,0 +1,301 @@
+package pluginkitairepo_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Real native sessions, with a scripted provider selecting tools deterministically.
+// Provider transcripts prove skill BODY delivery, never model comprehension.
+func TestAgentpluginsOpenCodeNativeRuntimeExtended(t *testing.T) {
+	if os.Getenv("AGENTPLUGINS_OPENCODE_NATIVE_E2E") != "1" {
+		t.Skip("opt-in native execution")
+	}
+	f := newOpenCodeNativeFixture(t)
+	// A replacement value itself contains a known token: recursive expansion
+	// would corrupt the literal directory name and is detected by argv/env facts.
+	oldRoot := f.Root
+	newRoot := oldRoot + "-${PLUGIN_DATA}"
+	if err := os.Rename(oldRoot, newRoot); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []*string{&f.Root, &f.Home, &f.XDGConfig, &f.XDGData, &f.XDGCache, &f.XDGState, &f.Project, &f.PackageRoot, &f.StateHome} {
+		*path = strings.Replace(*path, oldRoot, newRoot, 1)
+	}
+	t.Logf("extended native evidence: %s", f.Root)
+	client := openCodeNativeBinary(t, "AGENTPLUGINS_OPENCODE_BIN")
+	installer := openCodeNativeBinary(t, "AGENTPLUGINS_INSTALLER_BIN")
+	scanner := openCodePrepareNative(t, f, client)
+	if got := openCodeVersionString(t, f, client); got != "1.18.29" {
+		t.Fatal(got)
+	}
+	identity, err := nativeSourceIdentity(os.Getenv("AGENTPLUGINS_INSTALLER_COMMIT"), os.Getenv("AGENTPLUGINS_INSTALLER_TREE"), os.Getenv("AGENTPLUGINS_INSTALLER_PATCH_SHA256"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	nf := &nativeFixture{Root: f.Root, Package: f.PackageRoot, Probe: openCodeNativeBinary(t, "AGENTPLUGINS_NATIVE_PROBE_BIN"), Events: filepath.Join(f.Root, "events.jsonl"), Nonce: filepath.Base(oldRoot)}
+	writePackage := func(revision, version string) {
+		nf.writePackage(t, revision, version)
+		path := filepath.Join(nf.Package, "mcp.json")
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var doc map[string]any
+		if json.Unmarshal(b, &doc) != nil {
+			t.Fatal("fixture JSON")
+		}
+		for _, raw := range doc["mcpServers"].(map[string]any) {
+			env := raw.(map[string]any)["env"].(map[string]any)
+			env["UAP_TEST_ROOT"] = "${PLUGIN_ROOT}/../../../../.."
+			env["UAP_TEST_EVENTS"] = "${PLUGIN_ROOT}/../../../../../events.jsonl"
+		}
+		nativeJSON(t, path, doc)
+	}
+
+	var mu sync.Mutex
+	var requests []json.RawMessage
+	var step int
+	removed := false
+	operation := "write"
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(io.LimitReader(r.Body, 4<<20))
+		mu.Lock()
+		defer mu.Unlock()
+		requests = append(requests, append(json.RawMessage(nil), b...))
+		w.Header().Set("Content-Type", "text/event-stream")
+		emit := func(delta any, finish any) {
+			body, _ := json.Marshal(map[string]any{"id": "fixture", "object": "chat.completion.chunk", "created": 1, "model": "fixture", "choices": []any{map[string]any{"index": 0, "delta": delta, "finish_reason": finish}}})
+			fmt.Fprintf(w, "data: %s\n\n", body)
+		}
+		names := []string{"default_inspect_runtime", "explicit_inspect_runtime", "skill"}
+		var request struct {
+			Tools []struct {
+				Function struct {
+					Name string `json:"name"`
+				} `json:"function"`
+			} `json:"tools"`
+		}
+		mainRequest := false
+		if json.Unmarshal(b, &request) == nil {
+			for _, tool := range request.Tools {
+				if tool.Function.Name == "default_inspect_runtime" {
+					mainRequest = true
+				}
+			}
+		}
+		if !removed && step < len(names) && mainRequest {
+			var args any = map[string]string{"nonce": nf.Nonce, "operation": operation, "marker": nf.Nonce}
+			if step == 2 {
+				args = map[string]string{"name": "native-proof"}
+			}
+			a, _ := json.Marshal(args)
+			emit(map[string]any{"role": "assistant", "tool_calls": []any{map[string]any{"index": 0, "id": fmt.Sprintf("call-%d", step), "type": "function", "function": map[string]any{"name": names[step], "arguments": string(a)}}}}, nil)
+			emit(map[string]any{}, "tool_calls")
+			step++
+		} else {
+			emit(map[string]any{"role": "assistant", "content": "Fixture complete"}, nil)
+			emit(map[string]any{}, "stop")
+		}
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer provider.Close()
+	nativeJSON(t, filepath.Join(f.XDGConfig, "opencode", "opencode.json"), map[string]any{"provider": map[string]any{"uap-fixture": map[string]any{"npm": "@ai-sdk/openai-compatible", "env": []string{}, "models": map[string]any{"fixture": map[string]any{"name": "Fixture", "tool_call": true, "limit": map[string]any{"context": 32000, "output": 1024}}}, "options": map[string]any{"apiKey": "fixture", "baseURL": provider.URL + "/v1"}}}, "model": "uap-fixture/fixture", "small_model": "uap-fixture/fixture", "permission": "allow"})
+	stages := map[string]any{}
+	evidence := map[string]any{"status": "failed", "source_identity": identity, "client_sha256": openCodeSHA256(t, client), "installer_sha256": openCodeSHA256(t, installer), "probe_sha256": openCodeSHA256(t, nf.Probe), "scanner": scanner, "stages": stages, "provider": "scripted_loopback_no_real_model", "transcript_sha256": f.transcriptSHA256}
+	defer func() { nativeJSON(t, filepath.Join(f.Root, "extended-runtime-evidence.json"), evidence) }()
+	var root, data string
+	session := func(label, revision string) {
+		t.Helper()
+		mu.Lock()
+		step = 0
+		requests = nil
+		mu.Unlock()
+		nativeWrite(t, nf.Events, nil, 0600)
+		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, client, "run", "--model", "uap-fixture/fixture", "--format", "json", "Inspect the disposable runtime and load the native-proof skill, then finish.")
+		cmd.Dir = f.Project
+		cmd.Env = f.env(filepath.Dir(client))
+		out, err := cmd.CombinedOutput()
+		f.record(t, label, out)
+		mu.Lock()
+		captured := append([]json.RawMessage(nil), requests...)
+		mu.Unlock()
+		nativeJSON(t, filepath.Join(f.Root, label+"-provider.json"), captured)
+		providerBytes, marshalErr := json.Marshal(captured)
+		if marshalErr != nil {
+			t.Fatal(marshalErr)
+		}
+		f.record(t, label+"-provider", providerBytes)
+		if err != nil {
+			t.Fatalf("session %s: %v\n%s", label, err, out)
+		}
+		events, err := os.ReadFile(nf.Events)
+		if err != nil {
+			t.Fatal(err)
+		}
+		f.record(t, label+"-events", events)
+		var facts []nativeFacts
+		for _, line := range strings.Split(strings.TrimSpace(string(events)), "\n") {
+			var e struct {
+				Method string      `json:"method"`
+				Facts  nativeFacts `json:"facts"`
+			}
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
+			if err := json.Unmarshal([]byte(line), &e); err != nil {
+				t.Fatal(err)
+			}
+			if e.Method == "tools/call" {
+				facts = append(facts, e.Facts)
+			}
+		}
+		if removed {
+			if len(strings.TrimSpace(string(events))) != 0 {
+				t.Fatal("removed runtime dispatched")
+			}
+			if len(captured) == 0 {
+				t.Fatal("no removed session provider request")
+			}
+			mainSeen := false
+			for _, request := range captured {
+				var req struct {
+					Messages []struct {
+						Role    string          `json:"role"`
+						Content json.RawMessage `json:"content"`
+					} `json:"messages"`
+					Tools json.RawMessage `json:"tools"`
+				}
+				if json.Unmarshal(request, &req) != nil {
+					t.Fatal("bad provider capture")
+				}
+				if len(req.Tools) > 2 {
+					mainSeen = true
+				}
+				for _, message := range req.Messages {
+					if message.Role == "system" && (strings.Contains(string(message.Content), "native-proof") || strings.Contains(string(message.Content), "UAP_SKILL_BODY_")) {
+						t.Fatal("removed skill metadata still in outgoing system context")
+					}
+				}
+				for _, forbidden := range []string{"default_inspect_runtime", "explicit_inspect_runtime", "native-proof", "UAP_SKILL_BODY_"} {
+					if strings.Contains(string(req.Tools), forbidden) {
+						t.Fatalf("removed runtime still advertised: %s", forbidden)
+					}
+				}
+			}
+
+			if !mainSeen {
+				t.Fatal("removed session had no main request")
+			}
+			stages[label] = map[string]any{"status": "passed"}
+			return
+		}
+		if len(facts) != 2 {
+			t.Fatalf("want two native calls, got %d\n%s", len(facts), out)
+		}
+		for i, v := range facts {
+			if root == "" {
+				root = v.Root
+				data = v.Data
+			}
+			wantCWD := root
+			if i == 1 {
+				wantCWD = filepath.Join(root, "skills")
+			}
+			if v.Root != root || v.Data != data || v.CWD != wantCWD || v.Revision != revision || v.Marker != nf.Nonce || v.Literal != "literal ${UNKNOWN} $HOME" || v.Once != root+"/${UNKNOWN}" || !reflect.DeepEqual(v.Argv, []string{"argument with spaces", root + "/argument", "${UNKNOWN}"}) {
+				t.Fatalf("bad runtime facts: %+v", v)
+			}
+		}
+		bodyNonce := "UAP_SKILL_BODY_" + revision + "_" + nf.Nonce
+		bodySeen := false
+		returned := map[string]nativeFacts{}
+		for _, request := range captured {
+			var req struct {
+				Tools    json.RawMessage `json:"tools"`
+				Messages []struct {
+					Role    string          `json:"role"`
+					Content json.RawMessage `json:"content"`
+				} `json:"messages"`
+			}
+			if json.Unmarshal(request, &req) != nil {
+				t.Fatal("bad provider capture")
+			}
+			if strings.Contains(string(req.Tools), bodyNonce) {
+				t.Fatal("BODY leaked into tools metadata")
+			}
+			for _, message := range req.Messages {
+				if strings.Contains(string(message.Content), bodyNonce) {
+					if message.Role != "tool" {
+						t.Fatal("BODY leaked before native skill tool")
+					}
+					bodySeen = true
+				}
+				if message.Role == "tool" {
+					var content string
+					if json.Unmarshal(message.Content, &content) == nil {
+						var got nativeFacts
+						if json.Unmarshal([]byte(content), &got) == nil && got.Nonce == nf.Nonce {
+							returned[got.Session] = got
+						}
+					}
+				}
+			}
+		}
+		if !bodySeen || strings.Contains(string(captured[0]), bodyNonce) {
+			t.Fatal("skill BODY not proven in outgoing tool context")
+		}
+		for _, v := range facts {
+			nativeAssertEvent(t, nf, v)
+			if !reflect.DeepEqual(returned[v.Session], v) {
+				t.Fatal("native protocol facts did not return to provider")
+			}
+		}
+
+		stages[label] = map[string]any{"status": "passed", "facts": facts, "skill_body_outgoing": true}
+
+	}
+	writePackage("A", "1.0.0")
+	added := openCodeRunInstaller(t, f, installer, filepath.Dir(client), "add", "add", f.PackageRoot, "--target", "opencode")
+	openCodeAssertCompleted(t, "add", added)
+	session("install", "A")
+	operation = "read"
+	for _, u := range []struct{ label, revision, version string }{{"update", "B", "2.0.0"}, {"refresh", "C", "2.0.0"}} {
+		writePackage(u.revision, u.version)
+		result := openCodeRunInstaller(t, f, installer, filepath.Dir(client), u.label, "update", f.PackageRoot, "--target", "opencode")
+		openCodeAssertCompleted(t, u.label, result)
+		openCodeAssertMutated(t, result, true)
+		session(u.label, u.revision)
+	}
+	if err := os.RemoveAll(root); err != nil {
+		t.Fatal(err)
+	}
+	repaired := openCodeRunInstaller(t, f, installer, filepath.Dir(client), "repair", "repair", "native-proof", "--target", "opencode")
+	openCodeAssertCompleted(t, "repair", repaired)
+	session("repaired", "C")
+	result := openCodeRunInstaller(t, f, installer, filepath.Dir(client), "remove", "remove", "native-proof", "--target", "opencode")
+	d, _ := result["data"].(map[string]any)
+	if result["result"] != "success" || d["status"] != "data_retained" {
+		t.Fatal(result)
+	}
+	marker, err := os.ReadFile(filepath.Join(data, "native-marker.txt"))
+	if err != nil || string(marker) != nf.Nonce {
+		t.Fatal("persistent data lost", err)
+	}
+	removed = true
+	session("removed", "")
+	evidence["status"] = "passed"
+}

--- a/repotests/agentplugins_opencode_runtime_extended_test.go
+++ b/repotests/agentplugins_opencode_runtime_extended_test.go
@@ -280,6 +280,7 @@ func TestAgentpluginsOpenCodeNativeRuntimeExtended(t *testing.T) {
 		openCodeAssertMutated(t, result, true)
 		session(u.label, u.revision)
 	}
+	nativeRequireContained(t, f.Root, root)
 	if err := os.RemoveAll(root); err != nil {
 		t.Fatal(err)
 	}

--- a/scripts/run-native-client-matrix.py
+++ b/scripts/run-native-client-matrix.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Pinned real-client proof, exclusively on disposable GitHub-hosted machines.
+
+Downloads do not run npm scripts. Runtime receives an explicit credential-free
+allowlist and a new project/profile. No firewall isolation or real model/OAuth
+proof is claimed. Native fixture evidence, not this wrapper, proves behavior.
+"""
+import argparse
+import base64
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+import urllib.request
+import zipfile
+
+PINS = {
+    "darwin-arm64": {
+        "rg": ("github", "BurntSushi/ripgrep", "15.2.0", "ripgrep-15.2.0-aarch64-apple-darwin.tar.gz", "sha256:3750b2e93f37e0c692657da574d7019a101c0084da05a790c83fd335bad973e4", "rg"),
+        "codex": ("github", "openai/codex", "rust-v0.153.4", "codex-aarch64-apple-darwin.tar.gz", "sha256:8cf911ea676523bfb2121ec561848d2aba564890ad536db4d8a3353f2b9850b1", "codex-aarch64-apple-darwin"),
+        "claude": ("npm", "@anthropic-ai/claude-code-darwin-arm64", "2.1.263", "claude-code-darwin-arm64-2.1.263.tgz", "sha512-yLv8MtgulGMGCWTwDUSmlEL0+94sxKP3vJm0SAXZX+0qVQ09PrjVSRC0ibtVeW7xymyhvP1JaUimOyp+t2wO5g==", "claude"),
+        "opencode": ("npm", "opencode-darwin-arm64", "1.18.29", "opencode-darwin-arm64-1.18.29.tgz", "sha512-EU0qma5GPJXcDp5rENvedSfqJjqxatQW/Qzjs71pR2YdbrSh7YmBwtvnIb2/KIvfQr0DErX4ST14sbBQI2mQdg==", "opencode"),
+        "lintai": ("github", "777genius/lintai", "v0.1.3", "lintai-v0.1.3-aarch64-apple-darwin.tar.gz", "sha256:be8b263e2323074080d928ea7c2129458299a6d03f7a9f178dfc1aa8e6bc17ff", "lintai"),
+    },
+    "windows-amd64": {
+        "rg": ("github", "BurntSushi/ripgrep", "15.2.0", "ripgrep-15.2.0-x86_64-pc-windows-msvc.zip", "sha256:71b2fef860abe467217a538ff31de02f5258807c0129f771846f87bd029aafc5", "rg.exe"),
+        "codex": ("github", "openai/codex", "rust-v0.153.4", "codex-x86_64-pc-windows-msvc.exe.zip", "sha256:c016b0e6968b78586919c720d2685a03712f6d5f11bcd9d6f92c91eb8c41ba16", "codex-x86_64-pc-windows-msvc.exe"),
+        "claude": ("npm", "@anthropic-ai/claude-code-win32-x64", "2.1.263", "claude-code-win32-x64-2.1.263.tgz", "sha512-P1LnudAWj2ptyE0IZzCZKAe7nU7LxqlkcLdBfp8FsHlH5dp75Og4JJ6TClvfjanHn3shYW4CYN6oI1vSqZlkHw==", "claude.exe"),
+        "opencode": ("npm", "opencode-windows-x64", "1.18.29", "opencode-windows-x64-1.18.29.tgz", "sha512-xtWiZNMiwFtBl7q9yMG+XK/BTYGfgFoHLDx4ruWVYCoxjV0NYwjJi6rB9B3xIVbTclzu81YLKNFcT3kNBEG9Yw==", "opencode.exe"),
+        "lintai": ("github", "777genius/lintai", "v0.1.3", "lintai-v0.1.3-x86_64-pc-windows-msvc.zip", "sha256:2f61f6a83a160afa3feed9ea1722b82d0d938ebff865a4e20d39b5f55270c911", "lintai.exe"),
+    },
+}
+PATTERNS = {
+    "codex": r"^TestAgentpluginsCodexNativeLifecycle$",
+    "claude": r"^TestAgentpluginsClaudeNative(Lifecycle|RuntimeLifecycle)$",
+    "opencode": r"^TestAgentpluginsOpenCodeNative",
+}
+REQUIRED_TESTS = {
+    "codex": {"TestAgentpluginsCodexNativeLifecycle"},
+    "claude": {"TestAgentpluginsClaudeNativeLifecycle", "TestAgentpluginsClaudeNativeRuntimeLifecycle"},
+    "opencode": {"TestAgentpluginsOpenCodeNativeLifecycle", "TestAgentpluginsOpenCodeNativeToolCollision"},
+}
+
+
+def verify_digest(body, pin):
+    if pin.startswith("sha256:"):
+        actual = "sha256:" + hashlib.sha256(body).hexdigest()
+    elif pin.startswith("sha512-"):
+        actual = "sha512-" + base64.b64encode(hashlib.sha512(body).digest()).decode()
+    else:
+        raise ValueError("unsupported archive digest")
+    if actual != pin:
+        raise ValueError("archive integrity mismatch")
+
+
+def extract_binary(body, archive, basename):
+    # Only materialize the exact regular binary; archive paths never become paths
+    # on disk, so symlinks, traversal, and arbitrary package scripts cannot run.
+    if archive.endswith(".zip"):
+        with zipfile.ZipFile(io.BytesIO(body)) as source:
+            matches = [m for m in source.infolist() if not m.is_dir() and Path(m.filename).name == basename and ((m.external_attr >> 16) & 0o170000) != 0o120000]
+            if len(matches) != 1:
+                raise ValueError(f"expected one {basename} binary, found {len(matches)}")
+            return source.read(matches[0])
+    with tarfile.open(fileobj=io.BytesIO(body), mode="r:gz") as source:
+        matches = [m for m in source.getmembers() if m.isfile() and Path(m.name).name == basename]
+        if len(matches) != 1:
+            raise ValueError(f"expected one {basename} binary, found {len(matches)}")
+        return source.extractfile(matches[0]).read()
+
+
+def provision(pin, directory, name):
+    kind, repository, version, archive, digest, basename = pin
+    if kind == "github":
+        subprocess.run(["gh", "release", "download", version, "--repo", repository, "--pattern", archive, "--dir", str(directory)], check=True, timeout=240)
+        body = (directory / archive).read_bytes()
+        source = f"https://github.com/{repository}/releases/tag/{version}"
+    else:
+        url = f"https://registry.npmjs.org/{repository}/-/{archive}"
+        with urllib.request.urlopen(url, timeout=180) as response:
+            body = response.read(400 << 20)
+        source = url
+    verify_digest(body, digest)
+    binary = extract_binary(body, archive, basename)
+    path = directory / (name + (".exe" if os.name == "nt" else ""))
+    path.write_bytes(binary)
+    path.chmod(0o700)
+    (directory / archive).unlink(missing_ok=True)
+    return path, {"source": source, "version": version, "archive": archive, "archive_integrity": digest, "binary_sha256": hashlib.sha256(binary).hexdigest()}
+
+
+def require_hosted(target):
+    if any(os.environ.get(k) != v for k, v in {"GITHUB_ACTIONS": "true", "RUNNER_ENVIRONMENT": "github-hosted", "AGENTPLUGINS_NATIVE_DISPOSABLE_HOSTED": "1"}.items()):
+        raise RuntimeError("native proof requires explicit opt-in on a disposable GitHub-hosted runner")
+    machine = {"aarch64": "arm64", "arm64": "arm64", "x86_64": "amd64", "amd64": "amd64"}.get(platform.machine().lower())
+    actual = platform.system().lower() + "-" + str(machine)
+    if actual != target:
+        raise RuntimeError(f"target {target} does not match actual native platform {actual}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--client", choices=PATTERNS, required=True)
+    parser.add_argument("--target", choices=PINS, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    require_hosted(args.target)
+    source = Path(__file__).resolve().parents[1]
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=False)
+    scratch = Path(tempfile.mkdtemp(prefix="uap-native-hosted-", dir=os.environ["RUNNER_TEMP"])).resolve()
+    identity = {"schema_version": 1, "client": args.client, "target": args.target, "started_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), "isolation": "disposable GitHub-hosted machine; explicit runtime environment; fresh project and profiles", "network": "not blocked; scripted loopback model endpoints; no real-model or OAuth proof", "status": "failed", "scratch": str(scratch)}
+    try:
+        for key, rev in [("commit", "HEAD"), ("tree", "HEAD^{tree}")]:
+            identity[key] = subprocess.check_output(["git", "rev-parse", rev], cwd=source, text=True).strip()
+        expected = os.environ.get("EXPECTED_COMMIT", "")
+        if not re.fullmatch(r"[0-9a-f]{40}", expected) or identity["commit"] != expected:
+            raise RuntimeError("checkout differs from expected exact workflow source commit")
+        if subprocess.check_output(["git", "status", "--porcelain", "--untracked-files=normal"], cwd=source):
+            raise RuntimeError("native proof must build a clean exact checkout")
+        binary_dir = scratch / "bin"
+        binary_dir.mkdir()
+        client, client_evidence = provision(PINS[args.target][args.client], binary_dir, args.client)
+        scanner, scanner_evidence = provision(PINS[args.target]["lintai"], binary_dir, "lintai")
+        identity["client_asset"] = client_evidence
+        identity["scanner_asset"] = scanner_evidence
+        _, identity["ripgrep_asset"] = provision(PINS[args.target]["rg"], binary_dir, "rg")
+        suffix = ".exe" if os.name == "nt" else ""
+        installer, probe, tests = [binary_dir / (p + suffix) for p in ("agentplugins", "native-probe", "repotests")]
+        for command, cwd in [(["go", "build", "-trimpath", "-o", str(installer), "./cmd/agentplugins"], source / "cli/plugin-kit-ai"), (["go", "build", "-trimpath", "-o", str(probe), "./repotests/testdata/agentplugins_native_probe"], source), (["go", "test", "-c", "-o", str(tests), "./repotests"], source)]:
+            subprocess.run(command, cwd=cwd, check=True, timeout=360)
+        identity["build_sha256"] = {p.name: hashlib.sha256(p.read_bytes()).hexdigest() for p in (installer, probe, tests)}
+        project = scratch / "project"
+        project.mkdir()
+        evidence_root = scratch / "evidence"
+        evidence_root.mkdir()
+        home = scratch / "home"
+        home.mkdir()
+        env = {"HOME": str(home), "USERPROFILE": str(home), "TEMP": str(evidence_root), "TMP": str(evidence_root), "TMPDIR": str(evidence_root), "PATH": str(binary_dir), "LANG": "en_US.UTF-8", "GITHUB_ACTIONS": "true", "RUNNER_ENVIRONMENT": "github-hosted", "AGENTPLUGINS_NATIVE_DISPOSABLE_HOSTED": "1", "AGENTPLUGINS_INSTALLER_BIN": str(installer), "AGENTPLUGINS_INSTALLER_COMMIT": identity["commit"], "AGENTPLUGINS_INSTALLER_TREE": identity["tree"], "AGENTPLUGINS_NATIVE_PROBE_BIN": str(probe), "AGENTPLUGINS_LINTAI_BIN": str(scanner), "AGENTPLUGINS_LINTAI_SHA256": scanner_evidence["binary_sha256"], "AGENTPLUGINS_LINTAI_ARCHIVE_SHA256": PINS[args.target]["lintai"][4].split(":", 1)[1]}
+        if os.name == "nt":
+            env["SystemRoot"] = os.environ["SystemRoot"]
+            env["COMSPEC"] = str(Path(env["SystemRoot"]) / "System32/cmd.exe")
+            env["PATH"] += os.pathsep + str(Path(env["SystemRoot"]) / "System32")
+            git = shutil.which("git")
+            if not git:
+                raise RuntimeError("Windows native proof requires the runner Git installation")
+            if git:
+                env["PATH"] += os.pathsep + str(Path(git).parent)
+                env["AGENTPLUGINS_NATIVE_GIT_BIN_DIR"] = str(Path(git).parent)
+                identity["git_version"] = subprocess.check_output([git, "--version"], text=True).strip()
+                bash = Path(git).parent.parent / "bin/bash.exe"
+                if bash.is_file():
+                    env["AGENTPLUGINS_NATIVE_GIT_BASH_PATH"] = str(bash)
+                    identity["git_bash_sha256"] = hashlib.sha256(bash.read_bytes()).hexdigest()
+        else:
+            env["PATH"] += ":/usr/bin:/bin"
+        prefix = "AGENTPLUGINS_" + args.client.upper()
+        env[prefix + "_NATIVE_E2E"] = "1"
+        env[prefix + "_BIN"] = str(client)
+        env[prefix + "_SHA256"] = client_evidence["binary_sha256"]
+        env[prefix + "_VERSION"] = {"codex": "0.153.4", "claude": "2.1.263 (Claude Code)", "opencode": "1.18.29"}[args.client]
+        command = [str(tests), "-test.v", "-test.timeout=15m", "-test.run=" + PATTERNS[args.client]]
+        identity["test_command"] = command
+        with (output / "native-tests.log").open("w", encoding="utf-8") as transcript:
+            result = subprocess.run(command, cwd=project, env=env, stdout=transcript, stderr=subprocess.STDOUT, timeout=930)
+        identity["exit_code"] = result.returncode
+        log = (output / "native-tests.log").read_text(encoding="utf-8", errors="replace")
+        print(log[-40000:])
+        passed = set(re.findall(r"^--- PASS: (\w+)", log, re.M))
+        skipped = re.findall(r"^\s*--- SKIP: ([^\s]+)", log, re.M)
+        identity["passed_tests"] = sorted(passed)
+        identity["skipped_tests"] = skipped
+        if result.returncode or skipped or not REQUIRED_TESTS[args.client].issubset(passed):
+            raise RuntimeError("native suite failed, skipped, or omitted a required test; inspect transcript")
+        identity["status"] = "passed"
+    finally:
+        identity["finished_utc"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        # Keep structured evidence and transcripts, never copy client caches,
+        # profile databases, source payload binaries, or ephemeral client auth.
+        evidence_dir = scratch / "evidence"
+        allowed = {".json", ".jsonl", ".log"}
+        if evidence_dir.exists():
+            for fixture in evidence_dir.iterdir():
+                if not fixture.is_dir():
+                    continue
+                for path in fixture.iterdir():
+                    if path.is_file() and path.suffix in allowed:
+                        destination = output / fixture.name / path.name
+                        destination.parent.mkdir(parents=True, exist_ok=True)
+                        shutil.copyfile(path, destination)
+        identity["artifact_sha256"] = {str(p.relative_to(output)): hashlib.sha256(p.read_bytes()).hexdigest() for p in output.rglob("*") if p.is_file()}
+        (output / "runner-evidence.json").write_text(json.dumps(identity, indent=2) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run-native-client-matrix.py
+++ b/scripts/run-native-client-matrix.py
@@ -47,7 +47,7 @@ PATTERNS = {
 REQUIRED_TESTS = {
     "codex": {"TestAgentpluginsCodexNativeLifecycle"},
     "claude": {"TestAgentpluginsClaudeNativeLifecycle", "TestAgentpluginsClaudeNativeRuntimeLifecycle"},
-    "opencode": {"TestAgentpluginsOpenCodeNativeLifecycle", "TestAgentpluginsOpenCodeNativeToolCollision"},
+    "opencode": {"TestAgentpluginsOpenCodeNativeLifecycle", "TestAgentpluginsOpenCodeNativeToolCollision", "TestAgentpluginsOpenCodeNativeRuntimeExtended"},
 }
 
 

--- a/scripts/run-native-client-matrix.py
+++ b/scripts/run-native-client-matrix.py
@@ -107,6 +107,17 @@ def require_hosted(target):
         raise RuntimeError(f"target {target} does not match actual native platform {actual}")
 
 
+def find_git_bash(git):
+    # GitHub runners may expose Git through bin, cmd, or mingw64/bin.
+    # Search only the detected installation ancestors, never an ambient shell.
+    path = Path(git).resolve()
+    for parent in list(path.parents)[:3]:
+        candidate = parent / "bin/bash.exe"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--client", choices=PATTERNS, required=True)
@@ -156,10 +167,20 @@ def main():
             if git:
                 env["PATH"] += os.pathsep + str(Path(git).parent)
                 env["AGENTPLUGINS_NATIVE_GIT_BIN_DIR"] = str(Path(git).parent)
+                identity["git_path"] = git
                 identity["git_version"] = subprocess.check_output([git, "--version"], text=True).strip()
-                bash = Path(git).parent.parent / "bin/bash.exe"
-                if bash.is_file():
+                bash = find_git_bash(git)
+                if args.client == "claude" and bash is None:
+                    raise RuntimeError("Claude Windows proof requires Git Bash in the detected Git installation")
+                if bash is not None:
                     env["AGENTPLUGINS_NATIVE_GIT_BASH_PATH"] = str(bash)
+                    env["AGENTPLUGINS_NATIVE_GIT_SHELL_BIN_DIR"] = str(bash.parent)
+                    env["PATH"] += os.pathsep + str(bash.parent)
+                    shell = bash.parent / "sh.exe"
+                    if args.client == "opencode" and not shell.is_file():
+                        raise RuntimeError("OpenCode lifecycle fixture requires sh.exe from the detected Git installation")
+                    if shell.is_file():
+                        identity["git_sh_sha256"] = hashlib.sha256(shell.read_bytes()).hexdigest()
                     identity["git_bash_sha256"] = hashlib.sha256(bash.read_bytes()).hexdigest()
         else:
             env["PATH"] += ":/usr/bin:/bin"
@@ -197,7 +218,7 @@ def main():
                         destination = output / fixture.name / path.name
                         destination.parent.mkdir(parents=True, exist_ok=True)
                         shutil.copyfile(path, destination)
-        identity["artifact_sha256"] = {str(p.relative_to(output)): hashlib.sha256(p.read_bytes()).hexdigest() for p in output.rglob("*") if p.is_file()}
+        identity["artifact_sha256"] = {p.relative_to(output).as_posix(): hashlib.sha256(p.read_bytes()).hexdigest() for p in output.rglob("*") if p.is_file()}
         (output / "runner-evidence.json").write_text(json.dumps(identity, indent=2) + "\n", encoding="utf-8")
 
 

--- a/scripts/test_native_client_matrix.py
+++ b/scripts/test_native_client_matrix.py
@@ -15,6 +15,9 @@ SPEC.loader.exec_module(matrix)
 
 
 class NativeMatrixTests(unittest.TestCase):
+    def test_extended_runtime_is_required_for_opencode_proof(self):
+        self.assertIn("TestAgentpluginsOpenCodeNativeRuntimeExtended", matrix.REQUIRED_TESTS["opencode"])
+
     def test_runtime_rejects_ambient_and_self_hosted_machine(self):
         for env in [{}, {"GITHUB_ACTIONS": "true", "RUNNER_ENVIRONMENT": "self-hosted", "AGENTPLUGINS_NATIVE_DISPOSABLE_HOSTED": "1"}]:
             with patch.dict(matrix.os.environ, env, clear=True):

--- a/scripts/test_native_client_matrix.py
+++ b/scripts/test_native_client_matrix.py
@@ -1,0 +1,65 @@
+"""Bootstrap security tests. Never downloads or executes a native client."""
+import base64
+import hashlib
+import importlib.util
+import io
+from pathlib import Path
+import tarfile
+import unittest
+from unittest.mock import patch
+import zipfile
+
+SPEC = importlib.util.spec_from_file_location("native_matrix", Path(__file__).with_name("run-native-client-matrix.py"))
+matrix = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(matrix)
+
+
+class NativeMatrixTests(unittest.TestCase):
+    def test_runtime_rejects_ambient_and_self_hosted_machine(self):
+        for env in [{}, {"GITHUB_ACTIONS": "true", "RUNNER_ENVIRONMENT": "self-hosted", "AGENTPLUGINS_NATIVE_DISPOSABLE_HOSTED": "1"}]:
+            with patch.dict(matrix.os.environ, env, clear=True):
+                with self.assertRaises(RuntimeError):
+                    matrix.require_hosted("darwin-arm64")
+
+    def test_target_must_be_native(self):
+        env = {"GITHUB_ACTIONS": "true", "RUNNER_ENVIRONMENT": "github-hosted", "AGENTPLUGINS_NATIVE_DISPOSABLE_HOSTED": "1"}
+        with patch.dict(matrix.os.environ, env, clear=True), patch.object(matrix.platform, "system", return_value="Darwin"), patch.object(matrix.platform, "machine", return_value="arm64"):
+            matrix.require_hosted("darwin-arm64")
+            with self.assertRaises(RuntimeError):
+                matrix.require_hosted("windows-amd64")
+
+    def test_integrity_checks_exact_archive(self):
+        body = b"native-client-fixture"
+        for pin in ["sha256:" + hashlib.sha256(body).hexdigest(), "sha512-" + base64.b64encode(hashlib.sha512(body).digest()).decode()]:
+            matrix.verify_digest(body, pin)
+            with self.assertRaises(ValueError):
+                matrix.verify_digest(body + b"changed", pin)
+
+    def test_tar_selects_only_regular_exact_binary(self):
+        archive = io.BytesIO()
+        with tarfile.open(fileobj=archive, mode="w:gz") as out:
+            link = tarfile.TarInfo("client")
+            link.type = tarfile.SYMTYPE
+            link.linkname = "/etc/passwd"
+            out.addfile(link)
+        with self.assertRaises(ValueError):
+            matrix.extract_binary(archive.getvalue(), "client.tgz", "client")
+
+    def test_duplicate_binaries_rejected(self):
+        archive = io.BytesIO()
+        with zipfile.ZipFile(archive, "w") as out:
+            out.writestr("one/client.exe", b"one")
+            out.writestr("two/client.exe", b"two")
+        with self.assertRaises(ValueError):
+            matrix.extract_binary(archive.getvalue(), "client.zip", "client.exe")
+
+    def test_archive_paths_never_materialized(self):
+        archive = io.BytesIO()
+        with zipfile.ZipFile(archive, "w") as out:
+            out.writestr("../../client.exe", b"binary")
+            out.writestr("postinstall.sh", b"must never run")
+        self.assertEqual(matrix.extract_binary(archive.getvalue(), "client.zip", "client.exe"), b"binary")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_native_client_matrix.py
+++ b/scripts/test_native_client_matrix.py
@@ -5,6 +5,7 @@ import importlib.util
 import io
 from pathlib import Path
 import tarfile
+import tempfile
 import unittest
 from unittest.mock import patch
 import zipfile
@@ -15,6 +16,16 @@ SPEC.loader.exec_module(matrix)
 
 
 class NativeMatrixTests(unittest.TestCase):
+    def test_git_bash_discovery_supports_runner_git_layouts(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp).resolve()
+            (root / "bin").mkdir()
+            bash = root / "bin/bash.exe"
+            bash.write_bytes(b"fixture")
+            for relative in ["bin/git.exe", "cmd/git.exe", "mingw64/bin/git.exe"]:
+                self.assertEqual(matrix.find_git_bash(root / relative), bash)
+            self.assertIsNone(matrix.find_git_bash(root / "unrelated/deep/tree/git.exe"))
+
     def test_extended_runtime_is_required_for_opencode_proof(self):
         self.assertIn("TestAgentpluginsOpenCodeNativeRuntimeExtended", matrix.REQUIRED_TESTS["opencode"])
 


### PR DESCRIPTION
Codex on Windows can report a managed marketplace with an extended-length path prefix, causing removal to refuse its own directory. Compare filesystem identity for differently spelled paths while retaining refusal for different or unresolved objects. OpenCode lifecycle output explicitly separates successful configuration delivery from unverified callable tool-ID uniqueness, including human and JSON success/no-change paths.

The new OpenCode native suite verifies actual stdio calls, default/explicit cwd, argument and environment substitution, plugin-data continuity, and Skill BODY in outgoing context through install/update/repair/remove. Six isolated macOS ARM64 and Windows AMD64 jobs pin client archives, record exact source and artifact identities, and fail on missing or skipped required tests. Claude managed stdio remains explicitly unsupported on Windows; its Windows suite verifies that refusal together with real HTTP and Skill lifecycle behavior.

Windows verification also reproduced a directory-acquisition race: sibling writes changed directory timestamps while object identity stayed stable. Tolerate mutable directory content metadata only during initial root selection. File identity, attributes, links, regular-file checks, package inventory, and protected-handle checks remain strict. Four real NTFS mutation controls, 64 concurrent captures, and existing adversarial tests verify this boundary. Test-only diagnostics retain raw concurrent-init failures; their earlier precise cause remains unproven.

Independent reviews covered output semantics, ownership-safe cleanup, acquisition security, platform isolation, and native assertions. Both CodeRabbit findings are fixed: containment is checked before fixture deletion, and Python bootstrap regressions execute in CI. All 23 checks passed on a5f2e756677beb10d21cbeb3295678fc4eae7805, including Required with the pinned corpus (133/133, no warnings), all six native client jobs, both Authoring jobs, and Windows Polyglot Smoke. Scripted providers prove native dispatch/context, not real-model or OAuth behavior.

The public compatibility matrix is a following documentation-only PR so it can cite completed runtime evidence without rerunning unchanged native code. No release, APM/dependency-management feature, or maintainer outreach is included.

Refs #185
