### PR TITLE
feat(authoring): support quiescent writable APFS package reads

### DIFF
--- a/cli/plugin-kit-ai/internal/authoring/commands/packed_installer_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/packed_installer_test.go
@@ -278,7 +278,7 @@ func (s *boundaryAssessment) Evaluate(ctx context.Context, in domain.SecurityEva
 func TestPackedInstallerAssessmentBoundaries(t *testing.T) {
 	for _, fail := range []bool{true, false} {
 		t.Run(fmt.Sprintf("assessment-error-%t", fail), func(t *testing.T) {
-			source := filepath.Join(t.TempDir(), "demo")
+			source := filepath.Join(physicalMutationRoot(t), "demo")
 			author := commands.App{Projects: project.Service{Scratch: t.TempDir()}, Revision: publicRevision, PublicContract: true}
 			if _, code, out := publicRun(t, author, []string{"init", source, "--name=demo", "--template=skill", "--format=json"}, false); code != 0 {
 				t.Fatal(out)

--- a/docs/AUTHORING_PUBLIC_CONTRACT.md
+++ b/docs/AUTHORING_PUBLIC_CONTRACT.md
@@ -40,3 +40,36 @@ references. Legacy guidance names v1 1.2.4 and says migration is unavailable.
 Optional additions are compatible; removals or semantic changes bump the numeric
 authoring version independently of the outer envelope. Version factories, release
 roots, v1 shims, distribution and public activation belong to dependent PR B.
+
+## Darwin acquisition profile (PR 1; native proof pending)
+
+Writable macOS local authoring uses `packageview-local-darwin-v2` on supported
+local APFS. During each Reader.Open-through-Lease.Close acquisition interval,
+the source tree and ancestor bindings establishing its selected location and
+containment must remain quiescent, including the gap between core decoding and
+component capture. Static package content remains untrusted. The reader retains
+metadata-first type checks, legacy identity/alias exclusion, contained resolution,
+bounded private capture, offline operation and observed-change failure. It does
+not protect acquisition from an active concurrent source or ancestor writer.
+Violation can cause a forbidden open or an out-of-scope/excluded read before an
+error; repeated checks do not equal Linux's inode-bound acquisition or prove an
+atomic source revision. Mutation-plan rechecks, public stage validation, installer
+invariants and full native macOS release gates remain required.
+
+`report.identity.read_profile` exposes this revision, including read-only APFS
+compatibility captures. Linux/Windows keep v1; ScopeID and TreeAlgorithm remain
+unchanged. Capture identity hashes the profile, so Darwin capture digests change;
+comparable complete tree content digests need not change. No new public schema,
+flag or unsafe acknowledgment is introduced. No-cgo Darwin is unavailable.
+
+On macOS, use a locally available APFS project and let saves, builds and checkouts
+finish before running authoring commands. Keep the project and its directories
+unchanged until the command returns. Detected changes fail the command; rerun
+after editing finishes. Validation checks untrusted package contents, but does
+not isolate reads from another process actively replacing source files. Files
+requiring download are unavailable to offline validation.
+
+See [the acquisition ADR](./adr/0006-standard-first-authoring.md#darwin-acquisition-clarification-2026-09-07-pr-1)
+for the exact interval, ancestor/scratch scope, unsupported automount/network
+paths and deliberate security reduction. Public activation and native release
+qualification belong to PR 2; this contract is not a macOS release qualification.

--- a/docs/STANDARD_FIRST_AUTHORING_ENGINE_IMPLEMENTATION_PLAN.md
+++ b/docs/STANDARD_FIRST_AUTHORING_ENGINE_IMPLEMENTATION_PLAN.md
@@ -671,6 +671,35 @@ so `init`, `test`, and `publish` do not depend on methods they do not use.
 
 ## Standard project model
 
+### Controlling Darwin reader clarification (2026-09-07)
+
+Writable macOS local authoring uses `packageview-local-darwin-v2` on supported
+local APFS. During each Reader.Open-through-Lease.Close acquisition interval,
+the source tree and ancestor bindings establishing its selected location and
+containment must remain quiescent, including the gap between core decoding and
+component capture. Static package content remains untrusted. The reader retains
+metadata-first type checks, legacy identity/alias exclusion, contained resolution,
+bounded private capture, offline operation and observed-change failure. It does
+not protect acquisition from an active concurrent source or ancestor writer.
+Violation can cause a forbidden open or an out-of-scope/excluded read before an
+error; repeated checks do not equal Linux's inode-bound acquisition or prove an
+atomic source revision. Mutation-plan rechecks, public stage validation, installer
+invariants and full native macOS release gates remain required.
+
+The delegated practical decision selects ordinary already-mounted local APFS
+with per-thread materialization OFF via a small Darwin arm64 libSystem cgo
+binding. No-cgo and unsupported hosts reject safely before acquisition. This
+changes the authoring concurrency boundary explicitly; installer safety and
+Linux/Windows profiles remain unchanged. Full scope, residual forbidden-open
+risk, bounds and native proof requirements are recorded in
+[ADR 0006](./adr/0006-standard-first-authoring.md#darwin-acquisition-clarification-2026-09-07-pr-1).
+PR 1 owns reader/contracts/focused tests and remains unmerged pending native
+proof. PR 2 owns actual public composition, native producers/qualification and
+user help; cross-compilation or read-only APFS tests do not prove writable
+support. All original MVP, public stage validation, Skills transaction, both
+entrypoints, installer planner and wrapper/revision gates remain required.
+
+
 Introduce a thin authoring value around the canonical `PackageEnvelope` rather
 than a second manifest model. The value must distinguish the mutable source
 tree from the sealed snapshot that was actually parsed.
@@ -2147,6 +2176,17 @@ project while it is migrated.
   global conditional spread across commands.
 
 ### Filesystem and concurrency
+
+For Darwin authoring, the explicit quiescent interval above controls concurrent
+source/ancestor writes. Keep the project and selected directory bindings unchanged
+from before Open until Close finishes, including core decoding gaps. Finish saves,
+builds, sync and checkouts first; edits between commands remain normal. Unrelated
+outer siblings may change. No timestamp/identity observation proves no ABA.
+Static containment/type/legacy checks below remain mandatory within that boundary.
+Observed changes fail fatally and discard evidence, never authorize retry or a
+narrow component finding. Native proof remains pending until measured on writable
+APFS with the real materialization policy and declared OS floor.
+
 
 - package root is explicit and real;
 - no path traversal, symlink escape, junction, reparse point, device, or FIFO;

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -25,3 +25,28 @@ This document captures the current trust boundaries for shipped `plugin-kit-ai` 
 - no per-event payload ceilings below the global 1 MiB limit
 - no new public debug API
 - real external CLI smoke still depends on opt-in local auth and network conditions
+
+## Unreleased Darwin authoring reader v2
+
+The bounded PR 1 reader deliberately reduces the hostile concurrent writer
+boundary to **quiescent local APFS**; it does not provide equivalent security.
+Static content remains untrusted. Source and ancestor bindings must stay unchanged
+from before Reader.Open resolution until Lease.Close cleanup, including the
+core-decoding gap. Unrelated outer siblings may change. A hostile writer can
+cause a FIFO/device open or an out-of-scope/excluded legacy read before a later
+error. fstat, no subsequent Read calls and repeated checks cannot undo that open
+or prove atomicity/absence of ABA. Read-only APFS proof does not cover this case.
+
+Metadata-first traversal, contained relative links, hardlink/legacy exclusion,
+private bounded capture and fatal observed-change errors remain mandatory within
+the declared boundary. Per-thread libc materialization OFF and metadata dataless
+rejection protect offline acquisition on supported already-mounted local APFS;
+no-cgo builds reject before source access. Autofs/network/third-party redirectors
+are outside the profile, and no claim covers unrelated OS background traffic.
+
+The [controlling ADR](./adr/0006-standard-first-authoring.md#darwin-acquisition-clarification-2026-09-07-pr-1)
+and [public contract](./AUTHORING_PUBLIC_CONTRACT.md#darwin-acquisition-profile-pr-1-native-proof-pending)
+define the exact interval, residual risks and native prerequisites. Native
+writable/device/dataless proof is pending; source stays unmerged until native
+review/proof. Installer invariants, Linux/Windows security, real stage validation,
+transaction rechecks and macOS release gates are retained.

--- a/docs/adr/0006-standard-first-authoring.md
+++ b/docs/adr/0006-standard-first-authoring.md
@@ -142,3 +142,88 @@ commands, implement a second manifest, or establish an authoring runtime SDK.
   conformance with security and weakens an established safety boundary.
 - Replacing the current public root before the vertical slice: breaks working
   v1 behavior and advertises unfinished commands.
+
+## Darwin acquisition clarification (2026-09-07, PR 1)
+
+Accepted delegated technical decision: bounded quiescent writable APFS, an
+explicit reduction of the hostile concurrent writer guarantee, **not equivalent
+security**. This supersedes read-only-only authoring admission, not installer
+acquisition. Implementation stays unmerged until actual native review/proof;
+Linux cross-compilation cannot qualify Darwin. PR 2 owns public composition,
+release producers, workflows, help and current user-guide activation.
+
+Writable macOS local authoring uses `packageview-local-darwin-v2` on supported
+local APFS. During each Reader.Open-through-Lease.Close acquisition interval,
+the source tree and ancestor bindings establishing its selected location and
+containment must remain quiescent, including the gap between core decoding and
+component capture. Static package content remains untrusted. The reader retains
+metadata-first type checks, legacy identity/alias exclusion, contained resolution,
+bounded private capture, offline operation and observed-change failure. It does
+not protect acquisition from an active concurrent source or ancestor writer.
+Violation can cause a forbidden open or an out-of-scope/excluded read before an
+error; repeated checks do not equal Linux's inode-bound acquisition or prove an
+atomic source revision. Mutation-plan rechecks, public stage validation, installer
+invariants and full native macOS release gates remain required.
+
+Quiescence begins before the first source-path resolution/metadata operation
+and ends only after source access and cleanup through Close (or failed Open
+cleanup). It includes writes, truncation, rename/replacement, link changes,
+permissions/types and directory membership, including excluded legacy metadata.
+Root-name, relative CWD, allowed ancestor symlink targets and descendant bindings
+must remain stable and attached. Unrelated siblings outside the package may
+change; ancestor comparisons therefore ignore size/mtime/ctime/link-count changes
+caused by siblings, while checking identity, type, access mode, owner, flags and
+generation. Trusted kernel/mount administration and private storage remain
+assumptions. A private 0700 directory does not exclude another same-account process.
+
+Use public fstatat(AT_SYMLINK_NOFOLLOW), bounded readlinkat, single-component
+openat with O_DIRECTORY/O_NOFOLLOW for directories, and metadata-approved
+regular opens with O_NOFOLLOW/O_NONBLOCK/O_NOCTTY. The held pin owns the parent,
+not the final inode. Directory prefixes are replayed with finite metadata
+records instead of retaining a handle per entry. Checks detect observed identity,
+metadata, entry-set, link, byte and legacy changes as fatal `source_changed`,
+discarding partial Input/digest. No retry-until-stable loop is added. ABA,
+same-tick changes and substitutions after checks can evade observation; a FIFO
+or device open, detached-tree read or legacy read cannot be undone by fstat or
+zero subsequent Read calls. The writable profile relinquishes precisely this
+hostile-concurrency protection. Read-only APFS/EROFS tests remain separate,
+stronger evidence for their filesystem precondition.
+
+Each synchronous Open/Capture/Close phase runs on a short-lived locked OS
+thread. A small Darwin arm64 cgo binding to system libSystem saves the documented
+getiopolicy_np/setiopolicy_np thread materialization policy, sets
+IOPOL_MATERIALIZE_DATALESS_FILES_OFF, reads back, runs the phase, then restores
+and verifies the saved policy. Restore failure invalidates success and retires
+the still-locked thread; panic/error cleanup precedes delivery. Cancellation
+waits for terminal cleanup. No process-wide policy change, helper, dependency,
+source hardlink, source lockfile, snapshot, watch or second engine is added.
+Darwin without cgo rejects before source acquisition as `platform_unavailable`.
+Observed SF_DATALESS entries reject before payload open. Supported resolution
+paths are already mounted ordinary local APFS, not autofs triggers, network or
+third-party redirectors; trusted mounts must stay stable. APFS alone does not
+prove residency and OFF does not suppress unrelated OS background traffic.
+
+Existing limits remain 10,000 entries, depth 64, file 64 MiB, total 256 MiB,
+plugin 1 MiB, MCP 4 MiB, Skill 1 MiB and documents 16 MiB; paths/links 4,096 bytes,
+40 expansions and 8,192 resolver steps. Metadata records are separately bounded
+by entries plus resolver work. Reads retain size+1, <=32 KiB chunks and finite
+byte verification, private 0600 numeric files sealed to 0400, and exact-child
+cleanup. Source writes are never performed. Legacy initial/current identities
+and conservative multiple-hardlink rejection remain; independently copied bytes
+are not identified by semantic resemblance to YAML.
+
+Init must finish staging before real public validation. Skills must close its
+initial and core-recheck leases before staging/publication and acquire fresh
+post-commit evidence. Mutation root/parent/stage/payload checks, affected-input
+digests, exclusive publication and committed-state reporting remain mandatory.
+No CLI flag, environment opt-in or advisory ritual enforces quiescence.
+
+Native proof requires disposable writable local APFS on macOS arm64, unprivileged
+reader execution, exact revision/binary hashes, Go 1.25.13, Apple SDK/clang and
+deployment target, OS floor/build, FSID/device/mount flags, native open observations,
+real thread policy restoration and genuine disposable dataless rejection without
+download. No real cloud/profile/device/provisioning experiment is authorized.
+Missing device/dataless prerequisites remain required-unproven. Both entrypoints,
+five template journeys, installer dry-run and same-revision native cgo release
+assets/wrappers remain PR 2 and release gates. Keep `macos_writable=unproven`
+until native evidence passes; no CGO=0 replacement asset qualifies.

--- a/install/integrationctl/agentplugins/adapters/packageview/contract_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/contract_test.go
@@ -61,6 +61,31 @@ func TestLimitsAndSafeErrors(t *testing.T) {
 	if e := l.Close(); e != nil {
 		t.Fatal(e)
 	}
+	if e := l.Close(); e != nil {
+		t.Fatal("repeated zero-value Close", e)
+	}
+}
+
+// Remapping must retain the observed typed error, including wrapped cancellation,
+// and must not invent cancellation in place of an already observed edit.
+func TestAcquisitionErrorPreservesCause(t *testing.T) {
+	for _, cause := range []error{context.Canceled, context.DeadlineExceeded} {
+		original := &Error{Code: "canceled", cancellation: cause}
+		got := acquisitionError(original, "source_changed")
+		if got != original || !errors.Is(got, cause) {
+			t.Fatalf("lost cancellation: %v", got)
+		}
+	}
+	for _, code := range []string{"source_changed", "path_limit", "filesystem_unavailable"} {
+		original := fail(code)
+		if got := acquisitionError(original, "scratch_unavailable"); got != original {
+			t.Fatalf("lost observed %s: %v", code, got)
+		}
+	}
+	var safe *Error
+	if got := acquisitionError(errors.New("private host detail"), "source_changed"); !errors.As(got, &safe) || safe.Code != "source_changed" {
+		t.Fatalf("lost sanitized fallback: %v", got)
+	}
 }
 
 // GeneratedStaging is the only seam that can relax Darwin's read-only-mount

--- a/install/integrationctl/agentplugins/adapters/packageview/inventory.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/inventory.go
@@ -111,8 +111,9 @@ func (l *Lease) capturePhase(ctx context.Context) (_ Input, err error) {
 		}
 		p, e := l.source.pin(rel, false)
 		if e != nil {
-			return Input{}, fail("source_changed")
+			return Input{}, acquisitionError(e, "source_changed")
 		}
+		defer p.file.Close() // panic ownership; normal iterations close immediately
 		ok := same(l.observations[rel], p.info)
 		if ok && p.info.IsDir() {
 			if e := l.verifyDirectory(ctx, rel, p); e != nil {
@@ -142,12 +143,19 @@ func (l *Lease) capturePhase(ctx context.Context) (_ Input, err error) {
 		}
 		p, e := l.source.pin(o.Path, true)
 		if e != nil {
-			return Input{}, fail("source_changed")
+			return Input{}, acquisitionError(e, "source_changed")
 		}
+		defer p.file.Close() // panic ownership; normal iterations close immediately
 		target, e := p.link(l.limits.FileBytes)
 		ok := same(l.linkInfos[o.Path], p.info)
 		ce := p.file.Close()
-		if e != nil || !ok || target != o.Target {
+		if !ok {
+			return Input{}, fail("source_changed")
+		}
+		if e != nil {
+			return Input{}, acquisitionError(e, "source_changed")
+		}
+		if target != o.Target {
 			return Input{}, fail("source_changed")
 		}
 		if ce != nil {
@@ -305,7 +313,7 @@ func (l *Lease) verifyDirectory(ctx context.Context, rel string, p *pinned) erro
 	}
 	f, e := p.reopen(true)
 	if e != nil {
-		return fail("source_changed")
+		return acquisitionError(e, "source_changed")
 	}
 	defer f.Close()
 	for {
@@ -378,6 +386,7 @@ func (l *Lease) walk(ctx context.Context, dir string, depth int) error {
 			l.omit(Observation{Path: rel, State: stateOf(e)}, "inventory_"+string(stateOf(e)))
 			continue
 		}
+		defer p.file.Close() // bounded entry count; close on panic before loop cleanup
 		if rel == ".plugin-kit-ai.lock" && !p.info.IsDir() {
 			if ce := p.file.Close(); ce != nil {
 				return fail("close_failed")
@@ -412,6 +421,7 @@ func (l *Lease) walk(ctx context.Context, dir string, depth int) error {
 				}
 				o.State = stateOf(e)
 			} else {
+				defer q.file.Close() // also own the target during legacy authorization
 				if !q.info.IsDir() && !q.info.Mode().IsRegular() {
 					o.State = WrongKind
 				}

--- a/install/integrationctl/agentplugins/adapters/packageview/inventory.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/inventory.go
@@ -17,13 +17,28 @@ import (
 // inventory. It never interprets them. On fatal I/O/change/budget/cancel it closes
 // the lease and returns no partial Input. Component availability findings retain
 // safe siblings. Repeated successful calls return independent copies.
-func (l *Lease) Capture(ctx context.Context) (_ Input, err error) {
+func (l *Lease) Capture(ctx context.Context) (Input, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	var in Input
+	err := sourceIO(func() (err error) { in, err = l.capturePhase(ctx); return }, func() {
+		l.input = Input{}
+		_ = l.close()
+	})
+	if err != nil {
+		markCleanupFailure(err, l)
+		return Input{}, err
+	}
+	return in, nil
+}
+func (l *Lease) capturePhase(ctx context.Context) (_ Input, err error) {
 	if l.closed {
 		return Input{}, fail("lease_closed")
 	}
 	defer l.finish(&err)
+	if l.source != nil {
+		l.source.phaseContext(ctx)
+	}
 	if err = contextError(ctx); err != nil {
 		return Input{}, err
 	}
@@ -51,6 +66,9 @@ func (l *Lease) Capture(ctx context.Context) (_ Input, err error) {
 		rel := "skills/" + name
 		p, e := l.metadata(rel, false)
 		if e != nil {
+			if fatal := fatalAcquisition(e); fatal != nil {
+				return Input{}, fatal
+			}
 			d := Document{Path: rel + "/SKILL.md", State: stateOf(e)}
 			l.input.Skills = append(l.input.Skills, Skill{rel, d})
 			l.find("host", "skill_"+string(d.State), rel)
@@ -143,6 +161,9 @@ func (l *Lease) Capture(ctx context.Context) (_ Input, err error) {
 	if legacy != l.input.Legacy {
 		return Input{}, fail("source_changed")
 	}
+	if e := l.source.verifyBindings(); e != nil {
+		return Input{}, e
+	}
 	if l.input.Coverage.TreeComplete {
 		retained := make(map[string]Observation, len(l.input.Inventory))
 		for _, o := range l.input.Inventory {
@@ -212,7 +233,7 @@ func (l *Lease) list(ctx context.Context, rel string) ([]string, State, error) {
 	}
 	p, e := l.metadata(rel, false)
 	if e != nil {
-		return nil, stateOf(e), nil
+		return nil, stateOf(e), fatalAcquisition(e)
 	}
 	defer p.file.Close()
 	if !p.info.IsDir() {
@@ -351,6 +372,9 @@ func (l *Lease) walk(ctx context.Context, dir string, depth int) error {
 		}
 		p, e := l.metadata(rel, true)
 		if e != nil {
+			if fatal := fatalAcquisition(e); fatal != nil {
+				return fatal
+			}
 			l.omit(Observation{Path: rel, State: stateOf(e)}, "inventory_"+string(stateOf(e)))
 			continue
 		}
@@ -382,13 +406,25 @@ func (l *Lease) walk(ctx context.Context, dir string, depth int) error {
 			l.total += o.Size
 			q, e := l.source.pin(rel, false)
 			if e != nil {
+				if fatal := fatalAcquisition(e); fatal != nil {
+					p.file.Close()
+					return fatal
+				}
 				o.State = stateOf(e)
 			} else {
 				if !q.info.IsDir() && !q.info.Mode().IsRegular() {
 					o.State = WrongKind
 				}
-				if q.info.Mode().IsRegular() && !l.legacyGuard(q.info) {
-					o.State = Blocked
+				if q.info.Mode().IsRegular() {
+					allowed, e := l.legacyGuard(q.info)
+					if e != nil {
+						q.file.Close()
+						p.file.Close()
+						return e
+					}
+					if !allowed {
+						o.State = Blocked
+					}
 				}
 				if ce := q.file.Close(); ce != nil {
 					_ = p.file.Close()
@@ -402,7 +438,12 @@ func (l *Lease) walk(ctx context.Context, dir string, depth int) error {
 		case p.info.Mode().IsRegular():
 			o.Kind = "file"
 			o.Executable = p.info.Mode()&0111 != 0
-			if !l.legacyGuard(p.info) {
+			allowed, e := l.legacyGuard(p.info)
+			if e != nil {
+				p.file.Close()
+				return e
+			}
+			if !allowed {
 				o.State = Blocked
 			} else {
 				_, e := l.read(ctx, rel, p, l.limits.FileBytes)

--- a/install/integrationctl/agentplugins/adapters/packageview/profile_darwin.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/profile_darwin.go
@@ -1,0 +1,5 @@
+//go:build darwin && arm64
+
+package packageview
+
+const ReadProfile = "packageview-local-darwin-v2"

--- a/install/integrationctl/agentplugins/adapters/packageview/profile_other.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/profile_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin || !arm64
+
+package packageview
+
+import "runtime"
+
+const ReadProfile = "packageview-local-" + runtime.GOOS + "-v1"

--- a/install/integrationctl/agentplugins/adapters/packageview/read.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/read.go
@@ -151,7 +151,7 @@ func (l *Lease) read(ctx context.Context, rel string, p *pinned, limit int64) ([
 		return nil, e
 	}
 	defer f.Close() // also covers a panic during post-open legacy authorization
-	opened, statErr := f.Stat()
+	opened, statErr := p.postOpenInfo(f)
 	if statErr != nil {
 		f.Close()
 		return nil, fail("source_changed")
@@ -300,7 +300,7 @@ func (l *Lease) verifyCaptured(ctx context.Context, rel string, p *pinned) error
 		return fail("verification_failed")
 	}
 	defer f.Close() // also covers a panic during post-open legacy authorization
-	opened, statErr := f.Stat()
+	opened, statErr := p.postOpenInfo(f)
 	if statErr != nil {
 		f.Close()
 		return fail("source_changed")

--- a/install/integrationctl/agentplugins/adapters/packageview/read.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/read.go
@@ -13,11 +13,13 @@ import (
 func (l *Lease) legacy() (State, error) {
 	p, e := l.source.pin("plugin/plugin.yaml", false)
 	if e != nil {
-		return stateOf(e), nil
+		return stateOf(e), fatalAcquisition(e)
 	}
 	defer p.file.Close()
 	if l.source.legacyInfo == nil {
 		l.source.legacyInfo = p.info
+	} else if !same(l.source.legacyInfo, p.info) {
+		return Blocked, fail("source_changed")
 	}
 	if p.info.Mode().IsRegular() {
 		return Present, nil
@@ -28,19 +30,19 @@ func (l *Lease) legacy() (State, error) {
 // legacyGuard checks both initial and current exact sentinel identity without
 // opening data. Hardlinks are withheld, even when the sentinel is absent, so a
 // canonical hardlink alias cannot be hidden by moving its directory entry.
-func (l *Lease) legacyGuard(info os.FileInfo) bool {
+func (l *Lease) legacyGuard(info os.FileInfo) (bool, error) {
 	if multipleLinks(info) {
-		return false
+		return false, nil
 	}
-	if l.source.legacyInfo != nil && os.SameFile(info, l.source.legacyInfo) {
-		return false
+	if l.source.legacyInfo != nil && sameIdentity(info, l.source.legacyInfo) {
+		return false, nil
 	}
 	p, e := l.source.pin("plugin/plugin.yaml", false)
 	if e != nil {
-		return stateOf(e) == Absent || stateOf(e) == WrongKind
+		return stateOf(e) == Absent || stateOf(e) == WrongKind, fatalAcquisition(e)
 	}
 	defer p.file.Close()
-	return !os.SameFile(info, p.info)
+	return !sameIdentity(info, p.info), nil
 }
 func (l *Lease) metadata(rel string, nofollow bool) (*pinned, error) {
 	if l.hooks != nil && l.hooks.metadata != nil {
@@ -57,6 +59,9 @@ func (l *Lease) document(ctx context.Context, rel string, limit int64) (Document
 	}
 	p, e := l.metadata(rel, false)
 	if e != nil {
+		if fatal := fatalAcquisition(e); fatal != nil {
+			return d, fatal
+		}
 		d.State = stateOf(e)
 		if d.State != Absent {
 			l.find("host", "document_"+string(d.State), rel)
@@ -69,7 +74,11 @@ func (l *Lease) document(ctx context.Context, rel string, limit int64) (Document
 		l.find("host", "document_wrong_kind", rel)
 		return d, nil
 	}
-	if !l.legacyGuard(p.info) {
+	allowed, e := l.legacyGuard(p.info)
+	if e != nil {
+		return d, e
+	}
+	if !allowed {
 		l.find("host", "excluded_alias", rel)
 		return d, nil
 	}
@@ -108,8 +117,9 @@ func (l *Lease) read(ctx context.Context, rel string, p *pinned, limit int64) ([
 	if l.hooks != nil && l.hooks.beforeDataOpen != nil {
 		l.hooks.beforeDataOpen(rel)
 	}
-	// Recheck the name before data access; a replacement cannot be opened because
-	// reopen uses the already-verified inode. Changes also invalidate the capture.
+	// Recheck before access. Linux/Windows retain their native pin guarantees;
+	// Darwin owns a parent/name and relies on the published quiescence interval.
+	// A later error cannot undo a forbidden Darwin open under hostile replacement.
 	current, e := l.source.pin(rel, false)
 	if e != nil {
 		return nil, fail("source_changed")
@@ -122,7 +132,7 @@ func (l *Lease) read(ctx context.Context, rel string, p *pinned, limit int64) ([
 	if ce != nil {
 		return nil, fail("close_failed")
 	}
-	if !l.legacyGuard(p.info) {
+	if allowed, guardErr := l.legacyGuard(p.info); guardErr != nil || !allowed {
 		return nil, fail("source_changed")
 	}
 	if e := contextError(ctx); e != nil {
@@ -139,6 +149,16 @@ func (l *Lease) read(ctx context.Context, rel string, p *pinned, limit int64) ([
 	f, e := p.reopen(false)
 	if e != nil {
 		return nil, e
+	}
+	defer f.Close() // also covers a panic during post-open legacy authorization
+	opened, statErr := f.Stat()
+	if statErr != nil {
+		f.Close()
+		return nil, fail("source_changed")
+	}
+	if allowed, guardErr := l.legacyGuard(opened); guardErr != nil || !allowed {
+		f.Close()
+		return nil, fail("source_changed")
 	}
 	closed := false
 	defer func() {
@@ -194,7 +214,7 @@ func (l *Lease) read(ctx context.Context, rel string, p *pinned, limit int64) ([
 	}
 	ok = same(p.info, current.info)
 	ce = current.file.Close()
-	if !ok || !l.legacyGuard(p.info) {
+	if allowed, guardErr := l.legacyGuard(p.info); !ok || guardErr != nil || !allowed {
 		return nil, fail("source_changed")
 	}
 	if ce != nil {
@@ -263,12 +283,25 @@ func verifyRead(ctx context.Context, f *os.File, want []byte) error {
 // caller-authorized component stage, even if metadata has the same clock tick.
 func (l *Lease) verifyCaptured(ctx context.Context, rel string, p *pinned) error {
 	want, ok := l.contents[rel]
-	if !ok || !l.legacyGuard(p.info) {
+	if allowed, guardErr := l.legacyGuard(p.info); !ok || guardErr != nil || !allowed {
 		return fail("source_changed")
 	}
 	f, e := p.reopen(false)
 	if e != nil {
+		if fatal := fatalAcquisition(e); fatal != nil {
+			return fatal
+		}
 		return fail("verification_failed")
+	}
+	defer f.Close() // also covers a panic during post-open legacy authorization
+	opened, statErr := f.Stat()
+	if statErr != nil {
+		f.Close()
+		return fail("source_changed")
+	}
+	if allowed, guardErr := l.legacyGuard(opened); guardErr != nil || !allowed {
+		f.Close()
+		return fail("source_changed")
 	}
 	e = verifyRead(ctx, f, want)
 	after, se := f.Stat()
@@ -292,11 +325,20 @@ func (l *Lease) verifyCaptured(ctx context.Context, rel string, p *pinned) error
 	}
 	ok = same(p.info, current.info)
 	ce = current.file.Close()
-	if !ok || !l.legacyGuard(p.info) {
+	if allowed, guardErr := l.legacyGuard(p.info); !ok || guardErr != nil || !allowed {
 		return fail("source_changed")
 	}
 	if ce != nil {
 		return fail("close_failed")
+	}
+	return nil
+}
+
+// Typed acquisition failures cannot be downgraded to component availability.
+func fatalAcquisition(e error) error {
+	var safe *Error
+	if errors.As(e, &safe) {
+		return e
 	}
 	return nil
 }

--- a/install/integrationctl/agentplugins/adapters/packageview/read.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/read.go
@@ -122,7 +122,7 @@ func (l *Lease) read(ctx context.Context, rel string, p *pinned, limit int64) ([
 	// A later error cannot undo a forbidden Darwin open under hostile replacement.
 	current, e := l.source.pin(rel, false)
 	if e != nil {
-		return nil, fail("source_changed")
+		return nil, acquisitionError(e, "source_changed")
 	}
 	ok := same(p.info, current.info)
 	ce := current.file.Close()
@@ -133,7 +133,7 @@ func (l *Lease) read(ctx context.Context, rel string, p *pinned, limit int64) ([
 		return nil, fail("close_failed")
 	}
 	if allowed, guardErr := l.legacyGuard(p.info); guardErr != nil || !allowed {
-		return nil, fail("source_changed")
+		return nil, acquisitionError(guardErr, "source_changed")
 	}
 	if e := contextError(ctx); e != nil {
 		return nil, e
@@ -158,7 +158,7 @@ func (l *Lease) read(ctx context.Context, rel string, p *pinned, limit int64) ([
 	}
 	if allowed, guardErr := l.legacyGuard(opened); guardErr != nil || !allowed {
 		f.Close()
-		return nil, fail("source_changed")
+		return nil, acquisitionError(guardErr, "source_changed")
 	}
 	closed := false
 	defer func() {
@@ -210,12 +210,15 @@ func (l *Lease) read(ctx context.Context, rel string, p *pinned, limit int64) ([
 	}
 	current, e = l.source.pin(rel, false)
 	if e != nil {
-		return nil, fail("source_changed")
+		return nil, acquisitionError(e, "source_changed")
 	}
 	ok = same(p.info, current.info)
 	ce = current.file.Close()
-	if allowed, guardErr := l.legacyGuard(p.info); !ok || guardErr != nil || !allowed {
+	if !ok {
 		return nil, fail("source_changed")
+	}
+	if allowed, guardErr := l.legacyGuard(p.info); guardErr != nil || !allowed {
+		return nil, acquisitionError(guardErr, "source_changed")
 	}
 	if ce != nil {
 		return nil, fail("close_failed")
@@ -283,8 +286,11 @@ func verifyRead(ctx context.Context, f *os.File, want []byte) error {
 // caller-authorized component stage, even if metadata has the same clock tick.
 func (l *Lease) verifyCaptured(ctx context.Context, rel string, p *pinned) error {
 	want, ok := l.contents[rel]
-	if allowed, guardErr := l.legacyGuard(p.info); !ok || guardErr != nil || !allowed {
+	if !ok {
 		return fail("source_changed")
+	}
+	if allowed, guardErr := l.legacyGuard(p.info); guardErr != nil || !allowed {
+		return acquisitionError(guardErr, "source_changed")
 	}
 	f, e := p.reopen(false)
 	if e != nil {
@@ -301,7 +307,7 @@ func (l *Lease) verifyCaptured(ctx context.Context, rel string, p *pinned) error
 	}
 	if allowed, guardErr := l.legacyGuard(opened); guardErr != nil || !allowed {
 		f.Close()
-		return fail("source_changed")
+		return acquisitionError(guardErr, "source_changed")
 	}
 	e = verifyRead(ctx, f, want)
 	after, se := f.Stat()
@@ -321,12 +327,15 @@ func (l *Lease) verifyCaptured(ctx context.Context, rel string, p *pinned) error
 	}
 	current, e := l.source.pin(rel, false)
 	if e != nil {
-		return fail("source_changed")
+		return acquisitionError(e, "source_changed")
 	}
 	ok = same(p.info, current.info)
 	ce = current.file.Close()
-	if allowed, guardErr := l.legacyGuard(p.info); !ok || guardErr != nil || !allowed {
+	if !ok {
 		return fail("source_changed")
+	}
+	if allowed, guardErr := l.legacyGuard(p.info); guardErr != nil || !allowed {
+		return acquisitionError(guardErr, "source_changed")
 	}
 	if ce != nil {
 		return fail("close_failed")
@@ -341,4 +350,13 @@ func fatalAcquisition(e error) error {
 		return e
 	}
 	return nil
+}
+
+// Preserve the error actually observed; do not replace it by probing the context
+// again, which could mask a previously detected source change.
+func acquisitionError(e error, fallback string) error {
+	if fatal := fatalAcquisition(e); fatal != nil {
+		return fatal
+	}
+	return fail(fallback)
 }

--- a/install/integrationctl/agentplugins/adapters/packageview/read_info_other.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/read_info_other.go
@@ -1,0 +1,9 @@
+//go:build !windows || !(amd64 || arm64)
+
+package packageview
+
+import "os"
+
+// Linux and Darwin carry link metadata directly in FileInfo. Keep the fresh
+// post-open observation, including Darwin's additional legacy authorization.
+func (*pinned) postOpenInfo(f *os.File) (os.FileInfo, error) { return f.Stat() }

--- a/install/integrationctl/agentplugins/adapters/packageview/read_info_windows.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/read_info_windows.go
@@ -1,0 +1,19 @@
+//go:build windows && (amd64 || arm64)
+
+package packageview
+
+import "os"
+
+// postOpenInfo binds the reopened file to its genuine, lease-owned observation.
+// A fresh Windows File.Stat lacks the registered native link/change metadata
+// required by legacyGuard. same checks its identity and ordinary metadata and
+// revalidates the protected pin's complete native snapshot before we use p.info.
+// legacyGuard then rechecks that live snapshot and its link count. Nothing is
+// registered here; unknown FileInfo values must continue to fail closed.
+func (p *pinned) postOpenInfo(f *os.File) (os.FileInfo, error) {
+	opened, err := f.Stat()
+	if err != nil || !same(p.info, opened) {
+		return nil, fail("source_changed")
+	}
+	return p.info, nil
+}

--- a/install/integrationctl/agentplugins/adapters/packageview/read_info_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/read_info_windows_test.go
@@ -1,0 +1,102 @@
+//go:build windows && (amd64 || arm64)
+
+package packageview
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+func TestWindowsOrdinaryPostOpenObservation(t *testing.T) {
+	root := nativeFixture(t, func(root string) { nativeWrite(t, root, "plugin.json", "ordinary") })
+	s := nativeSource(t, root)
+	p, err := s.pin("plugin.json", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.file.Close()
+	f, err := p.reopen(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	raw, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := winRecordCount()
+	observed, err := p.postOpenInfo(f)
+	if err != nil || multipleLinks(observed) {
+		t.Fatalf("ordinary post-open observation rejected: %v", err)
+	}
+	if !multipleLinks(raw) {
+		t.Fatal("unregistered File.Stat must remain fail-closed")
+	}
+	if got := winRecordCount(); got != before {
+		t.Fatalf("post-open observation registered metadata: before=%d after=%d", before, got)
+	}
+}
+
+func TestWindowsOrdinaryReadStages(t *testing.T) {
+	for _, legacy := range []bool{false, true} {
+		t.Run(map[bool]string{false: "without-legacy", true: "with-legacy"}[legacy], func(t *testing.T) {
+			before := winRecordCount()
+			const core = `{"name":"ordinary"}`
+			const mcp = `{}`
+			root := nativeFixture(t, func(root string) {
+				nativeWrite(t, root, "plugin.json", core)
+				nativeWrite(t, root, "mcp.json", mcp)
+				nativeWrite(t, root, "opaque", "ordinary bytes")
+				if legacy {
+					nativeWrite(t, root, "plugin/plugin.yaml", "DO NOT READ LEGACY")
+				}
+			})
+			scratch := t.TempDir()
+			l, err := (Reader{TempDir: scratch}).Open(context.Background(), root)
+			if err != nil {
+				t.Fatalf("ordinary Reader.Open: %v", err)
+			}
+			defer l.Close()
+			coreInput := l.Data()
+			if coreInput.Plugin.State != Present || string(coreInput.Plugin.Bytes) != core || coreInput.Coverage.ComponentsRequested {
+				t.Fatalf("ordinary core capture: %+v", coreInput)
+			}
+			// Capture must pass the separate verifyCaptured post-open guard for
+			// every retained regular file, including the already captured core.
+			in, err := l.Capture(context.Background())
+			if err != nil {
+				t.Fatalf("ordinary Capture/final verification: %v", err)
+			}
+			if in.Plugin.State != Present || string(in.Plugin.Bytes) != core || in.MCP.State != Present || string(in.MCP.Bytes) != mcp {
+				t.Fatalf("ordinary document bytes: %+v", in)
+			}
+			wantLegacy := Absent
+			if legacy {
+				wantLegacy = Present
+			}
+			if in.Legacy != wantLegacy || !in.Coverage.ComponentsRequested || !in.Coverage.InventoryComplete || in.Coverage.TreeComplete != !legacy {
+				t.Fatalf("ordinary capture coverage: %+v", in)
+			}
+			if string(l.contents["opaque"]) != "ordinary bytes" {
+				t.Fatal("ordinary inventory file was not captured")
+			}
+			if _, captured := l.contents["plugin/plugin.yaml"]; captured {
+				t.Fatal("legacy bytes were captured")
+			}
+			if err := l.Close(); err != nil {
+				t.Fatalf("ordinary Close: %v", err)
+			}
+			if err := l.Close(); err != nil {
+				t.Fatalf("idempotent Close: %v", err)
+			}
+			if got := winRecordCount(); got != before {
+				t.Fatalf("metadata records after Close: got %d, want %d", got, before)
+			}
+			entries, err := os.ReadDir(scratch)
+			if err != nil || len(entries) != 0 {
+				t.Fatalf("ordinary scratch cleanup: entries=%d, err=%v", len(entries), err)
+			}
+		})
+	}
+}

--- a/install/integrationctl/agentplugins/adapters/packageview/scratch_darwin.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/scratch_darwin.go
@@ -1,0 +1,30 @@
+//go:build darwin && arm64
+
+package packageview
+
+import "strings"
+
+// Resolve scratch through the same directory-relative local APFS admission.
+// Compare against the selected root identity, not a newly resolved source argv.
+func scratchParent(s *source, _ string, tempDir string) (string, func() error, error) {
+	scratch, e := openSourceContext(s.ctx, tempDir)
+	if e != nil {
+		return "", nil, fail("scratch_unavailable")
+	}
+	release := func() error { return scratch.close() }
+	if e := s.verifyBindings(); e != nil {
+		release()
+		return "", nil, e
+	}
+	for _, info := range scratch.bindings {
+		if sameIdentity(info, s.bindings[s.physical]) {
+			release()
+			return "", nil, fail("scratch_overlaps_source")
+		}
+	}
+	if scratch.physical == s.physical || strings.HasPrefix(scratch.physical, s.physical+"/") {
+		release()
+		return "", nil, fail("scratch_overlaps_source")
+	}
+	return scratch.physical, release, nil
+}

--- a/install/integrationctl/agentplugins/adapters/packageview/scratch_darwin.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/scratch_darwin.go
@@ -7,24 +7,34 @@ import "strings"
 // Resolve scratch through the same directory-relative local APFS admission.
 // Compare against the selected root identity, not a newly resolved source argv.
 func scratchParent(s *source, _ string, tempDir string) (string, func() error, error) {
-	scratch, e := openSourceContext(s.ctx, tempDir)
-	if e != nil {
-		return "", nil, fail("scratch_unavailable")
+	var hooks *captureHooks
+	if s.hooks != nil {
+		hooks = &captureHooks{nativeOpen: s.hooks.scratchOpen}
 	}
+	scratch, e := openSelectedDirectory(s.ctx, tempDir, false, hooks)
+	if e != nil {
+		return "", nil, acquisitionError(e, "scratch_unavailable")
+	}
+	// Own the anchor until successful transfer to the lease. In particular,
+	// source binding replay below can panic before scratchClose is assigned.
+	transferred := false
+	defer func() {
+		if !transferred {
+			_ = scratch.close()
+		}
+	}()
 	release := func() error { return scratch.close() }
 	if e := s.verifyBindings(); e != nil {
-		release()
 		return "", nil, e
 	}
 	for _, info := range scratch.bindings {
 		if sameIdentity(info, s.bindings[s.physical]) {
-			release()
 			return "", nil, fail("scratch_overlaps_source")
 		}
 	}
 	if scratch.physical == s.physical || strings.HasPrefix(scratch.physical, s.physical+"/") {
-		release()
 		return "", nil, fail("scratch_overlaps_source")
 	}
+	transferred = true
 	return scratch.physical, release, nil
 }

--- a/install/integrationctl/agentplugins/adapters/packageview/scratch_other.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/scratch_other.go
@@ -1,4 +1,4 @@
-//go:build !windows || !(amd64 || arm64)
+//go:build (!windows || !(amd64 || arm64)) && (!darwin || !arm64)
 
 package packageview
 

--- a/install/integrationctl/agentplugins/adapters/packageview/source_binding_other.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_binding_other.go
@@ -1,0 +1,17 @@
+//go:build !darwin || !arm64
+
+package packageview
+
+import (
+	"context"
+	"os"
+)
+
+func (s *source) verifyBindings() error  { return nil }
+func sameIdentity(a, b os.FileInfo) bool { return os.SameFile(a, b) }
+
+func (s *source) sourceHooks(*captureHooks) {}
+
+func openSourceContext(_ context.Context, name string) (*source, error) { return openSource(name) }
+
+func (s *source) phaseContext(context.Context) {}

--- a/install/integrationctl/agentplugins/adapters/packageview/source_binding_other.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_binding_other.go
@@ -12,6 +12,8 @@ func sameIdentity(a, b os.FileInfo) bool { return os.SameFile(a, b) }
 
 func (s *source) sourceHooks(*captureHooks) {}
 
-func openSourceContext(_ context.Context, name string) (*source, error) { return openSource(name) }
+func openSourceContext(_ context.Context, name string) (*source, error) {
+	return openSource(name, GeneratedStaging{})
+}
 
 func (s *source) phaseContext(context.Context) {}

--- a/install/integrationctl/agentplugins/adapters/packageview/source_darwin.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_darwin.go
@@ -3,49 +3,41 @@
 package packageview
 
 import (
+	"context"
 	"errors"
+	"golang.org/x/sys/unix"
 	"os"
 	"runtime"
-	"strconv"
 	"strings"
 	"syscall"
-
-	"golang.org/x/sys/unix"
 )
 
-// Darwin has no O_PATH -> data-descriptor upgrade in the Go/xsys seam.
-// This profile therefore requires a READ-ONLY LOCAL APFS volume, UNLESS the
-// caller supplied a matching GeneratedStaging proof (see openSource), in
-// which case only this exact, caller-proven directory is exempt from the
-// read-only requirement; it must still be local APFS. The held directory plus
-// immutable directory entry pins an object before any data open. A privileged
-// remount, hostile mount namespace or underlying block-device writer is
-// outside the profile. Arbitrary writable APFS remains deliberately
-// unavailable. In particular O_EVTONLY and /dev/fd are NOT used to upgrade
-// file access.
+// Writable APFS requires quiescence from Open through Close, including ancestor
+// bindings. A parent/name pin is NOT an inode capability. Hostile replacement
+// can cause a forbidden open before fstat detects it. See ADR 0006.
 type source struct {
-	root       *os.Root
+	work  int
+	ctx   context.Context
+	hooks *captureHooks
+
 	anchor     *os.File
 	legacyInfo os.FileInfo
 	dev        int32
 	fsid       unix.Fsid
-	// trustedWritable is set only when openSource verified a GeneratedStaging
-	// proof against this exact opened directory. It never widens to a
-	// separately opened or path-resolved object.
-	trustedWritable bool
+	physical   string
+	bindings   map[string]os.FileInfo
+	links      map[string]string
+	ancestors  map[string]bool
 }
 type pinned struct {
-	file   *os.File // owned parent directory, NOT a data handle to the entry
+	file   *os.File // owns only the final physical parent
 	info   os.FileInfo
-	name   string // one component in the immutable parent
+	name   string
+	parent string
 	source *source
 }
 
-// darwinFS enforces the local-APFS profile. trustedWritable, which only
-// openSource can set (and only after a live-handle identity match), is the
-// sole thing that exempts a source from the MNT_RDONLY requirement; MNT_LOCAL
-// and the apfs filesystem type are always required, trusted or not.
-func darwinFS(fd int, trustedWritable bool) (unix.Statfs_t, error) {
+func darwinFS(fd int) (unix.Statfs_t, error) {
 	var fs unix.Statfs_t
 	if e := unix.Fstatfs(fd, &fs); e != nil {
 		return fs, e
@@ -53,189 +45,84 @@ func darwinFS(fd int, trustedWritable bool) (unix.Statfs_t, error) {
 	if unix.ByteSliceToString(fs.Fstypename[:]) != "apfs" || fs.Flags&unix.MNT_LOCAL == 0 {
 		return fs, fail("filesystem_unavailable")
 	}
-	if !trustedWritable && fs.Flags&unix.MNT_RDONLY == 0 {
-		return fs, fail("filesystem_unavailable")
-	}
 	return fs, nil
 }
-func openSource(name string, generated GeneratedStaging) (_ *source, err error) {
-	if n := strings.TrimRight(name, "/"); n != "" {
-		name = n
-	}
-	before, e := os.Lstat(name)
-	if e != nil {
-		if os.IsNotExist(e) {
-			return nil, fail("root_absent")
-		}
-		return nil, fail("root_unreadable")
-	}
-	if !before.IsDir() || before.Mode()&os.ModeSymlink != 0 {
-		return nil, fail("root_wrong_kind")
-	}
-	// O_DIRECTORY constrains type in the kernel before open; O_NOFOLLOW applies
-	// to the final component even if the caller supplied a trailing slash.
-	fd, e := unix.Open(name, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
-	if e != nil {
-		return nil, fail("root_unreadable")
-	}
-	s := &source{anchor: os.NewFile(uintptr(fd), "source-root")}
+// This profile already permits ordinary quiescent writable local APFS (see
+// ADR 0006), so a generated-staging proof adds nothing here and is
+// intentionally ignored, matching source_linux.go's identical reasoning.
+func openSource(name string, _ GeneratedStaging) (*source, error) {
+	return openSourceContext(context.Background(), name)
+}
+func openSourceContext(ctx context.Context, name string) (result *source, err error) {
+	s := &source{ctx: ctx, bindings: map[string]os.FileInfo{}, links: map[string]string{}, ancestors: map[string]bool{}}
 	defer func() {
-		if err != nil {
+		if result == nil {
 			_ = s.close()
 		}
 	}()
-	opened, e := s.anchor.Stat()
-	if e != nil || !os.SameFile(before, opened) {
-		return nil, fail("source_changed")
+	name = strings.TrimRight(name, "/")
+	if name == "" {
+		name = "/"
 	}
-	// A supplied proof must match the exact object just opened by path, or the
-	// call fails closed: a stale/mismatched proof is never silently downgraded
-	// to the ordinary strict profile, since that would mask a swapped root.
-	if generated.present() {
-		if !generated.matches(opened) {
-			return nil, fail("generated_staging_mismatch")
+	if !strings.HasPrefix(name, "/") {
+		cwd, e := os.Getwd()
+		if e != nil {
+			return nil, fail("root_unreadable")
 		}
-		s.trustedWritable = true
+		name = cwd + "/" + name
 	}
-	fs, e := darwinFS(fd, s.trustedWritable)
+	// No filepath.Clean: a/.. must visit a before ascending.
+	p, e := s.resolve(name, true, true)
+	if e != nil {
+		if fatal := fatalAcquisition(e); fatal != nil {
+			return nil, fatal
+		}
+		if errors.Is(e, syscall.ENOENT) {
+			return nil, fail("root_absent")
+		}
+		if errors.Is(e, syscall.ENOTDIR) {
+			return nil, fail("root_wrong_kind")
+		}
+		return nil, fail("root_unreadable")
+	}
+	defer p.file.Close()
+	if !p.info.IsDir() {
+		return nil, fail("root_wrong_kind")
+	}
+	s.physical = physicalName(p.parent, p.name)
+	s.anchor, e = p.openDirectory()
 	if e != nil {
 		return nil, e
 	}
+	fs, e := darwinFS(int(s.anchor.Fd()))
+	if e != nil {
+		return nil, e
+	}
+	s.dev = p.info.Sys().(*syscall.Stat_t).Dev
 	s.fsid = fs.Fsid
-	st, ok := opened.Sys().(*syscall.Stat_t)
-	if !ok {
-		return nil, fail("platform_unavailable")
+	// Only root-selection records tolerate unrelated sibling directory activity.
+	for path := range s.bindings {
+		s.ancestors[path] = path != s.physical
 	}
-	s.dev = st.Dev
-	// Go has no Root-from-descriptor constructor. Only this synthesized owned
-	// DIRECTORY descriptor is passed through trusted devfs, never source text.
-	var dfs unix.Statfs_t
-	if unix.Statfs("/dev/fd", &dfs) != nil || unix.ByteSliceToString(dfs.Fstypename[:]) != "devfs" {
-		return nil, fail("platform_unavailable")
-	}
-	s.root, e = os.OpenRoot("/dev/fd/" + strconv.Itoa(fd))
-	if e != nil {
-		return nil, fail("platform_unavailable")
-	}
-	f, e := s.root.OpenFile(".", unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
-	if e != nil {
-		return nil, fail("platform_unavailable")
-	}
-	ri, se := f.Stat()
-	ce := f.Close()
-	if se != nil || ce != nil || !os.SameFile(opened, ri) {
-		return nil, fail("source_changed")
-	}
-	after, e := os.Lstat(name)
-	if e != nil || !after.IsDir() || !os.SameFile(opened, after) {
-		return nil, fail("source_changed")
+	if e := s.verifyBindings(); e != nil {
+		return nil, e
 	}
 	return s, nil
 }
 func (s *source) close() error {
-	var a, b error
-	if s.root != nil {
-		a = s.root.Close()
-		s.root = nil
+	if s.anchor == nil {
+		return nil
 	}
-	if s.anchor != nil {
-		b = s.anchor.Close()
-		s.anchor = nil
-	}
-	return errors.Join(a, b)
+	e := s.anchor.Close()
+	s.anchor = nil
+	return e
 }
 func (s *source) pin(rel string, nofollow bool) (*pinned, error) {
-	if rel == "" || strings.HasPrefix(rel, "/") || strings.IndexByte(rel, 0) >= 0 || len(rel) > 4096 {
-		return nil, syscall.EXDEV
+	s.work = 0
+	if e := s.verifyAncestors(); e != nil {
+		return nil, e
 	}
-	todo := strings.Split(rel, "/")
-	var done []string
-	links, steps := 0, 0
-	for len(todo) > 0 {
-		steps++
-		if steps > 8192 {
-			return nil, syscall.ELOOP
-		}
-		n := todo[0]
-		todo = todo[1:]
-		if n == "" || n == "." {
-			if len(todo) > 0 {
-				continue
-			}
-			n = "."
-		}
-		if n == ".." {
-			if len(done) == 0 {
-				return nil, syscall.EXDEV
-			}
-			done = done[:len(done)-1]
-			if len(todo) > 0 {
-				continue
-			}
-			n = "."
-		}
-		parent := "."
-		if len(done) > 0 {
-			parent = strings.Join(done, "/")
-		}
-		// All parent components were checked as physical directories, on the same
-		// immutable filesystem. No source symlink reaches this OpenFile call.
-		dir, e := s.root.OpenFile(parent, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
-		if e != nil {
-			return nil, e
-		}
-		fs, e := darwinFS(int(dir.Fd()), s.trustedWritable)
-		if e != nil || fs.Fsid != s.fsid {
-			dir.Close()
-			return nil, syscall.EXDEV
-		}
-		path := parent + "/" + n
-		info, e := s.root.Lstat(path)
-		if e != nil {
-			dir.Close()
-			return nil, e
-		}
-		st, ok := info.Sys().(*syscall.Stat_t)
-		if !ok || st.Dev != s.dev {
-			dir.Close()
-			return nil, syscall.EXDEV
-		}
-		p := &pinned{file: dir, info: info, name: n, source: s}
-		if info.Mode()&os.ModeSymlink != 0 && (!nofollow || len(todo) > 0) {
-			links++
-			if links > 40 {
-				dir.Close()
-				return nil, syscall.ELOOP
-			}
-			target, e := p.link(4096)
-			ce := dir.Close()
-			if e != nil {
-				return nil, e
-			}
-			if ce != nil {
-				return nil, ce
-			}
-			if target == "" || strings.HasPrefix(target, "/") {
-				return nil, syscall.EXDEV
-			}
-			todo = append(strings.Split(target, "/"), todo...)
-			continue
-		}
-		if len(todo) == 0 {
-			return p, nil
-		}
-		if !info.IsDir() {
-			dir.Close()
-			return nil, syscall.ENOTDIR
-		}
-		if e := dir.Close(); e != nil {
-			return nil, e
-		}
-		if n != "." {
-			done = append(done, n)
-		}
-	}
-	return nil, syscall.ENOENT
+	return s.resolve(rel, nofollow, false)
 }
 func (p *pinned) link(limit int64) (string, error) {
 	defer runtime.KeepAlive(p)
@@ -253,37 +140,83 @@ func (p *pinned) link(limit int64) (string, error) {
 	if n == len(b) || int64(n) > limit {
 		return "", fail("byte_limit")
 	}
-	return string(b[:n]), nil
+	target := string(b[:n])
+	path := physicalName(p.parent, p.name)
+	if prior, ok := p.source.links[path]; ok && prior != target {
+		return "", fail("source_changed")
+	}
+	p.source.links[path] = target
+	return target, nil
 }
-func (p *pinned) reopen(directory bool) (*os.File, error) {
-	if (directory && !p.info.IsDir()) || (!directory && !p.info.Mode().IsRegular()) {
-		return nil, fail("wrong_kind")
+func (p *pinned) openDirectory() (*os.File, error) {
+	return p.open(unix.O_RDONLY | unix.O_DIRECTORY | unix.O_NOFOLLOW | unix.O_CLOEXEC)
+}
+func (p *pinned) open(flags int) (*os.File, error) {
+	if p.source.hooks != nil && p.source.hooks.nativeOpen != nil {
+		p.source.hooks.nativeOpen(p.name, flags)
 	}
-	fs, e := darwinFS(int(p.file.Fd()), p.source.trustedWritable)
-	if e != nil || fs.Fsid != p.source.fsid {
-		return nil, fail("filesystem_unavailable")
-	}
-	flags := unix.O_RDONLY | unix.O_NOFOLLOW | unix.O_NONBLOCK | unix.O_CLOEXEC
-	if directory {
-		flags |= unix.O_DIRECTORY
-	}
-	// Safe only because the checked immutable entry cannot change type/object.
 	fd, e := unix.Openat(int(p.file.Fd()), p.name, flags, 0)
 	if e != nil {
 		return nil, e
 	}
 	f := os.NewFile(uintptr(fd), "source-data")
-	openedFS, e := darwinFS(fd, p.source.trustedWritable)
-	if e != nil || openedFS.Fsid != p.source.fsid {
-		f.Close()
-		return nil, fail("filesystem_unavailable")
-	}
 	info, e := f.Stat()
-	if e != nil || !same(p.info, info) {
+	equal := e == nil && same(p.info, info)
+	if e == nil && p.info.IsDir() && (p.source.anchor == nil || p.source.ancestors[physicalName(p.parent, p.name)]) {
+		equal = bindingSame(p.info, info)
+	}
+	if !equal {
 		f.Close()
 		return nil, fail("source_changed")
 	}
+	fs, e := darwinFS(fd)
+	if e != nil {
+		f.Close()
+		return nil, e
+	}
+	if p.source.anchor != nil && (p.parent == p.source.physical || strings.HasPrefix(p.parent, p.source.physical+"/")) && fs.Fsid != p.source.fsid {
+		f.Close()
+		return nil, fail("filesystem_unavailable")
+	}
 	return f, nil
+}
+func (p *pinned) reopen(directory bool) (*os.File, error) {
+	p.source.work = 0
+	if (directory && !p.info.IsDir()) || (!directory && !p.info.Mode().IsRegular()) {
+		return nil, fail("wrong_kind")
+	}
+	if e := p.source.verifyAncestors(); e != nil {
+		return nil, e
+	}
+	// Replay the physical parent directory by directory and compare the held FD.
+	dir, e := p.source.directory(p.parent)
+	if e != nil {
+		return nil, e
+	}
+	current, e := dir.Stat()
+	held, he := p.file.Stat()
+	ce := dir.Close()
+	if e != nil || he != nil || ce != nil || !same(current, held) {
+		return nil, fail("source_changed")
+	}
+	now, e := darwinStat(int(p.file.Fd()), p.name)
+	if e != nil || !same(p.info, now) {
+		return nil, fail("source_changed")
+	}
+	flags := unix.O_RDONLY | unix.O_NOFOLLOW | unix.O_NONBLOCK | unix.O_NOCTTY | unix.O_CLOEXEC
+	if directory {
+		flags |= unix.O_DIRECTORY
+	}
+	// Quiescence supplies name stability, NOT the flags or post-open comparison.
+	return p.open(flags)
+}
+func sameIdentity(a, b os.FileInfo) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	x, ok := a.Sys().(*syscall.Stat_t)
+	y, ok2 := b.Sys().(*syscall.Stat_t)
+	return ok && ok2 && x.Dev == y.Dev && x.Ino == y.Ino
 }
 func stateOf(e error) State {
 	if errors.Is(e, syscall.ENOENT) {
@@ -298,14 +231,18 @@ func stateOf(e error) State {
 	return Unreadable
 }
 func same(a, b os.FileInfo) bool {
-	if a == nil || b == nil || !os.SameFile(a, b) || a.Mode() != b.Mode() || a.Size() != b.Size() || !a.ModTime().Equal(b.ModTime()) {
+	if a == nil || b == nil || !sameIdentity(a, b) || a.Mode() != b.Mode() || a.Size() != b.Size() || !a.ModTime().Equal(b.ModTime()) {
 		return false
 	}
 	x, ok := a.Sys().(*syscall.Stat_t)
 	y, ok2 := b.Sys().(*syscall.Stat_t)
-	return ok && ok2 && x.Ctimespec == y.Ctimespec && x.Nlink == y.Nlink && x.Gen == y.Gen
+	return ok && ok2 && x.Ctimespec == y.Ctimespec && x.Nlink == y.Nlink && x.Gen == y.Gen && x.Flags == y.Flags && x.Uid == y.Uid && x.Gid == y.Gid
 }
 func multipleLinks(i os.FileInfo) bool {
 	s, ok := i.Sys().(*syscall.Stat_t)
 	return !ok || s.Nlink != 1
 }
+
+func (s *source) sourceHooks(h *captureHooks) { s.hooks = h }
+
+func (s *source) phaseContext(ctx context.Context) { s.ctx = ctx }

--- a/install/integrationctl/agentplugins/adapters/packageview/source_darwin.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_darwin.go
@@ -53,8 +53,13 @@ func darwinFS(fd int) (unix.Statfs_t, error) {
 func openSource(name string, _ GeneratedStaging) (*source, error) {
 	return openSourceContext(context.Background(), name)
 }
-func openSourceContext(ctx context.Context, name string) (result *source, err error) {
-	s := &source{ctx: ctx, bindings: map[string]os.FileInfo{}, links: map[string]string{}, ancestors: map[string]bool{}}
+func openSourceContext(ctx context.Context, name string) (*source, error) {
+	return openSelectedDirectory(ctx, name, true, nil)
+}
+
+// Only trusted scratch selection follows the final directory symlink.
+func openSelectedDirectory(ctx context.Context, name string, nofollow bool, hooks *captureHooks) (result *source, err error) {
+	s := &source{ctx: ctx, hooks: hooks, bindings: map[string]os.FileInfo{}, links: map[string]string{}, ancestors: map[string]bool{}}
 	defer func() {
 		if result == nil {
 			_ = s.close()
@@ -72,7 +77,7 @@ func openSourceContext(ctx context.Context, name string) (result *source, err er
 		name = cwd + "/" + name
 	}
 	// No filepath.Clean: a/.. must visit a before ascending.
-	p, e := s.resolve(name, true, true)
+	p, e := s.resolve(name, nofollow, true)
 	if e != nil {
 		if fatal := fatalAcquisition(e); fatal != nil {
 			return nil, fatal
@@ -200,7 +205,10 @@ func (p *pinned) reopen(directory bool) (*os.File, error) {
 		return nil, fail("source_changed")
 	}
 	now, e := darwinStat(int(p.file.Fd()), p.name)
-	if e != nil || !same(p.info, now) {
+	if e != nil {
+		return nil, acquisitionError(e, "source_changed")
+	}
+	if !same(p.info, now) {
 		return nil, fail("source_changed")
 	}
 	flags := unix.O_RDONLY | unix.O_NOFOLLOW | unix.O_NONBLOCK | unix.O_NOCTTY | unix.O_CLOEXEC

--- a/install/integrationctl/agentplugins/adapters/packageview/source_darwin.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_darwin.go
@@ -47,6 +47,7 @@ func darwinFS(fd int) (unix.Statfs_t, error) {
 	}
 	return fs, nil
 }
+
 // This profile already permits ordinary quiescent writable local APFS (see
 // ADR 0006), so a generated-staging proof adds nothing here and is
 // intentionally ignored, matching source_linux.go's identical reasoning.

--- a/install/integrationctl/agentplugins/adapters/packageview/source_darwin_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_darwin_test.go
@@ -55,14 +55,14 @@ func nativeFixture(t *testing.T, build func(string)) string {
 	run("attach", "-readonly", "-nobrowse", "-noautoopen", "-mountpoint", mount, dmg)
 	return root
 }
-func TestDarwinWritableProfileRejected(t *testing.T) {
-	s, e := openSource(t.TempDir(), GeneratedStaging{})
-	if e == nil {
-		s.close()
-		t.Fatal("writable filesystem accepted")
+func TestDarwinWritableProfileAdmission(t *testing.T) {
+	root, scratch := writableFixture(t)
+	l, e := (Reader{TempDir: scratch}).Open(context.Background(), root)
+	if e != nil {
+		t.Fatalf("UNPROVEN writable admission: %v", e)
 	}
-	var safe *Error
-	if !errors.As(e, &safe) || safe.Code != "filesystem_unavailable" {
+	defer l.Close()
+	if _, e = l.Capture(context.Background()); e != nil {
 		t.Fatal(e)
 	}
 }

--- a/install/integrationctl/agentplugins/adapters/packageview/source_darwin_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_darwin_test.go
@@ -245,71 +245,9 @@ func TestDarwinRootSelectionTraversalOrder(t *testing.T) {
 	}
 }
 
-// A matching GeneratedStaging proof is the only way an ordinary writable
-// local APFS directory is ever accepted; TestDarwinWritableProfileRejected
-// above proves the zero-value (untrusted) path still rejects it.
-func TestDarwinGeneratedStagingProofAcceptsOwnWritableRoot(t *testing.T) {
-	root := t.TempDir()
-	nativeWrite(t, root, "plugin.json", "core")
-	dir, e := os.OpenRoot(root)
-	if e != nil {
-		t.Fatal(e)
-	}
-	defer dir.Close()
-	proof, e := NewGeneratedStaging(dir)
-	if e != nil {
-		t.Fatal(e)
-	}
-	s, e := openSource(root, proof)
-	if e != nil {
-		t.Fatal("trusted generated-staging proof rejected on its own writable root:", e)
-	}
-	defer s.close()
-	if !s.trustedWritable {
-		t.Fatal("trusted flag not set from a matching proof")
-	}
-	// The relaxation must still require local APFS and every other check:
-	// this exercises the same darwinFS/pin/reopen path the untrusted case uses.
-	p, e := s.pin("plugin.json", true)
-	if e != nil {
-		t.Fatal(e)
-	}
-	defer p.file.Close()
-	f, e := p.reopen(false)
-	if e != nil {
-		t.Fatal("trusted data reopen failed:", e)
-	}
-	defer f.Close()
-}
-
-// A GeneratedStaging proof built from one directory must never authorize a
-// different one: the caller could otherwise mint a proof against a trivially
-// creatable writable directory and pass an unrelated path to openSource.
-func TestDarwinGeneratedStagingProofMismatchFailsClosed(t *testing.T) {
-	a := filepath.Join(t.TempDir(), "a")
-	b := filepath.Join(t.TempDir(), "b")
-	for _, d := range []string{a, b} {
-		if e := os.Mkdir(d, 0700); e != nil {
-			t.Fatal(e)
-		}
-	}
-	dirA, e := os.OpenRoot(a)
-	if e != nil {
-		t.Fatal(e)
-	}
-	defer dirA.Close()
-	proof, e := NewGeneratedStaging(dirA)
-	if e != nil {
-		t.Fatal(e)
-	}
-	s, e := openSource(b, proof)
-	if e == nil {
-		s.close()
-		t.Fatal("mismatched generated-staging proof accepted a different directory")
-	}
-	var safe *Error
-	if !errors.As(e, &safe) || safe.Code != "generated_staging_mismatch" {
-		t.Fatal(e)
-	}
-}
+// GeneratedStaging is intentionally ignored on Darwin v2 (see openSource):
+// TestDarwinWritableProfileAdmission already proves ordinary writable local
+// APFS is accepted generally, so no proof-specific trust/mismatch test is
+// needed here; the caller-proven-directory mechanism from the prior
+// read-only-only profile no longer applies.
 func nativeLinkPrivilegeError(e error) bool { return os.IsPermission(e) }

--- a/install/integrationctl/agentplugins/adapters/packageview/source_darwin_walk.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_darwin_walk.go
@@ -1,0 +1,357 @@
+//go:build darwin && arm64
+
+package packageview
+
+import (
+	"golang.org/x/sys/unix"
+	"os"
+	"path"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// FileInfo for metadata-only fstatat. Sys uses the same stat representation as
+// os.File.Stat; os.SameFile itself only accepts Go's private fileStat type.
+type darwinInfo struct {
+	name string
+	st   syscall.Stat_t
+}
+
+func (i darwinInfo) Name() string       { return i.name }
+func (i darwinInfo) Size() int64        { return i.st.Size }
+func (i darwinInfo) ModTime() time.Time { return time.Unix(i.st.Mtimespec.Sec, i.st.Mtimespec.Nsec) }
+func (i darwinInfo) IsDir() bool        { return i.Mode().IsDir() }
+func (i darwinInfo) Sys() any           { s := i.st; return &s }
+func (i darwinInfo) Mode() os.FileMode {
+	m := os.FileMode(i.st.Mode & 0777)
+	switch i.st.Mode & unix.S_IFMT {
+	case unix.S_IFDIR:
+		m |= os.ModeDir
+	case unix.S_IFLNK:
+		m |= os.ModeSymlink
+	case unix.S_IFIFO:
+		m |= os.ModeNamedPipe
+	case unix.S_IFSOCK:
+		m |= os.ModeSocket
+	case unix.S_IFCHR:
+		m |= os.ModeDevice | os.ModeCharDevice
+	case unix.S_IFBLK:
+		m |= os.ModeDevice
+	case unix.S_IFREG:
+	default:
+		m |= os.ModeIrregular
+	}
+	if i.st.Mode&unix.S_ISUID != 0 {
+		m |= os.ModeSetuid
+	}
+	if i.st.Mode&unix.S_ISGID != 0 {
+		m |= os.ModeSetgid
+	}
+	if i.st.Mode&unix.S_ISVTX != 0 {
+		m |= os.ModeSticky
+	}
+	return m
+}
+func darwinStat(fd int, name string) (os.FileInfo, error) {
+	var u unix.Stat_t
+	if e := unix.Fstatat(fd, name, &u, unix.AT_SYMLINK_NOFOLLOW); e != nil {
+		return nil, e
+	}
+	// SF_DATALESS is public Darwin stat metadata. OFF is also required to guard
+	// a transition after this observation; APFS does not imply resident content.
+	if u.Flags&unix.SF_DATALESS != 0 {
+		return nil, fail("filesystem_unavailable")
+	}
+	s := syscall.Stat_t{Dev: u.Dev, Ino: u.Ino, Mode: u.Mode, Nlink: u.Nlink, Uid: u.Uid, Gid: u.Gid, Rdev: u.Rdev,
+		Size: u.Size, Flags: u.Flags, Gen: u.Gen,
+		Mtimespec: syscall.Timespec{Sec: u.Mtim.Sec, Nsec: u.Mtim.Nsec},
+		Ctimespec: syscall.Timespec{Sec: u.Ctim.Sec, Nsec: u.Ctim.Nsec}}
+	return darwinInfo{name, s}, nil
+}
+func physicalName(parent, name string) string {
+	if name == "." {
+		return parent
+	}
+	if parent == "/" {
+		return "/" + name
+	}
+	return parent + "/" + name
+}
+func bindingSame(a, b os.FileInfo) bool {
+	if !sameIdentity(a, b) || a.Mode() != b.Mode() {
+		return false
+	}
+	x := a.Sys().(*syscall.Stat_t)
+	y := b.Sys().(*syscall.Stat_t)
+	// Parent mtime/size/ctime/nlink can change from unrelated sibling activity.
+	return x.Uid == y.Uid && x.Gid == y.Gid && x.Flags == y.Flags && x.Gen == y.Gen
+}
+func (s *source) observe(name string, info os.FileInfo) error {
+	if len(name) > 4096 {
+		return fail("path_limit")
+	}
+	if old, ok := s.bindings[name]; ok {
+		equal := same(old, info)
+		if s.ancestors[name] || s.anchor == nil {
+			equal = bindingSame(old, info)
+		}
+		if !equal {
+			return fail("source_changed")
+		}
+		return nil
+	}
+	// Finite metadata ownership, never one FD per entry. Includes root selection
+	// and up to the existing resolver step budget of physical aliases.
+	if len(s.bindings) >= 10000+8192 {
+		return fail("entry_limit")
+	}
+	s.bindings[name] = info
+	return nil
+}
+
+// directory replays physical prefixes using only single-component openat.
+// Each prior binding is compared before opening/discovering the next child.
+func (s *source) directory(name string) (result *os.File, err error) {
+	if e := s.step(); e != nil {
+		return nil, e
+	}
+	fd, e := unix.Open("/", unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if e != nil {
+		return nil, e
+	}
+	f := os.NewFile(uintptr(fd), "source-directory")
+	defer func() {
+		if result == nil {
+			f.Close()
+		}
+	}()
+	info, e := f.Stat()
+	if e != nil {
+		return nil, e
+	}
+	if _, e := darwinFS(fd); e != nil {
+		return nil, e
+	}
+	if e := s.observe("/", info); e != nil {
+		return nil, e
+	}
+	prefix := "/"
+	for _, n := range strings.Split(strings.TrimPrefix(name, "/"), "/") {
+		if e := s.step(); e != nil {
+			return nil, e
+		}
+		if n == "" {
+			continue
+		}
+		info, e := darwinStat(int(f.Fd()), n)
+		next := physicalName(prefix, n)
+		if e != nil {
+			if _, seen := s.bindings[next]; seen {
+				return nil, fail("source_changed")
+			}
+			return nil, e
+		}
+		if e := s.observe(next, info); e != nil {
+			return nil, e
+		}
+		if !info.IsDir() {
+			return nil, fail("source_changed")
+		}
+		p := &pinned{file: f, info: info, name: n, parent: prefix, source: s}
+		child, e := p.openDirectory()
+		if e != nil {
+			return nil, e
+		}
+		if e := f.Close(); e != nil {
+			child.Close()
+			return nil, fail("close_failed")
+		}
+		f = child
+		prefix = next
+	}
+	return f, nil
+}
+func (s *source) resolve(rel string, nofollow, selecting bool) (*pinned, error) {
+	if rel == "" || len(rel) > 4096 || strings.IndexByte(rel, 0) >= 0 || (!selecting && strings.HasPrefix(rel, "/")) {
+		return nil, syscall.EXDEV
+	}
+	base := s.physical
+	if selecting {
+		base = "/"
+	}
+	parent := base
+	todo := strings.Split(strings.TrimPrefix(rel, "/"), "/")
+	links, steps := 0, 0
+	var owned *os.File
+	defer func() {
+		if owned != nil {
+			owned.Close()
+		}
+	}()
+	for len(todo) > 0 {
+		if e := s.step(); e != nil {
+			return nil, e
+		}
+		steps++
+		if steps > 8192 {
+			return nil, syscall.ELOOP
+		}
+		n := todo[0]
+		todo = todo[1:]
+		if n == "" || n == "." {
+			if len(todo) > 0 {
+				continue
+			}
+			n = "."
+		}
+		if n == ".." {
+			if !selecting && parent == base {
+				return nil, syscall.EXDEV
+			}
+			parent = path.Dir(parent)
+			if len(todo) > 0 {
+				continue
+			}
+			n = "."
+		}
+		dir, e := s.directory(parent)
+		if e != nil {
+			return nil, e
+		}
+		owned = dir
+		info, e := darwinStat(int(dir.Fd()), n)
+		physical := physicalName(parent, n)
+		if e != nil {
+			dir.Close()
+			if _, seen := s.bindings[physical]; seen {
+				return nil, fail("source_changed")
+			}
+			return nil, e
+		}
+		if e = s.observe(physical, info); e != nil {
+			dir.Close()
+			return nil, e
+		}
+		if !selecting && info.Sys().(*syscall.Stat_t).Dev != s.dev {
+			dir.Close()
+			return nil, syscall.EXDEV
+		}
+		p := &pinned{file: dir, info: info, name: n, parent: parent, source: s}
+		if info.Mode()&os.ModeSymlink != 0 && (!nofollow || len(todo) > 0) {
+			links++
+			if links > 40 {
+				dir.Close()
+				return nil, syscall.ELOOP
+			}
+			target, e := p.link(4096)
+			ce := dir.Close()
+			if e != nil {
+				return nil, e
+			}
+			if ce != nil {
+				return nil, fail("close_failed")
+			}
+			if target == "" || (!selecting && strings.HasPrefix(target, "/")) {
+				return nil, syscall.EXDEV
+			}
+			if strings.HasPrefix(target, "/") {
+				parent = "/"
+			}
+			if len(todo)+strings.Count(target, "/")+1 > 8192 {
+				return nil, syscall.ELOOP
+			}
+			todo = append(strings.Split(target, "/"), todo...)
+			continue
+		}
+		if len(todo) == 0 {
+			owned = nil
+			return p, nil
+		}
+		if !info.IsDir() {
+			dir.Close()
+			return nil, syscall.ENOTDIR
+		}
+		// Approve and bind before advancing even if the next component is '..'.
+		child, e := p.openDirectory()
+		ce := dir.Close()
+		if e != nil {
+			return nil, e
+		}
+		childErr := child.Close()
+		if ce != nil || childErr != nil {
+			return nil, fail("close_failed")
+		}
+		parent = physical
+	}
+	return nil, syscall.ENOENT
+}
+func (s *source) verifyBinding(name string, old os.FileInfo) error {
+	parent, n := path.Dir(name), path.Base(name)
+	if name == "/" {
+		parent = "/"
+		n = "."
+	}
+	dir, e := s.directory(parent)
+	if e != nil {
+		if s.ctx.Err() != nil {
+			return contextError(s.ctx)
+		}
+		return fail("source_changed")
+	}
+	defer dir.Close()
+	info, e := darwinStat(int(dir.Fd()), n)
+	if e != nil {
+		return fail("source_changed")
+	}
+	equal := same(old, info)
+	if s.ancestors[name] {
+		equal = bindingSame(old, info)
+	}
+	if !equal {
+		return fail("source_changed")
+	}
+	if text, ok := s.links[name]; ok {
+		p := &pinned{file: dir, info: info, name: n, parent: parent, source: s}
+		got, e := p.link(4096)
+		if e != nil || got != text {
+			return fail("source_changed")
+		}
+	}
+	return nil
+}
+func (s *source) verifyAncestors() error {
+	for name := range s.ancestors {
+		if e := s.verifyBinding(name, s.bindings[name]); e != nil {
+			return e
+		}
+	}
+	if s.anchor != nil {
+		old := s.bindings[s.physical]
+		if e := s.verifyBinding(s.physical, old); e != nil {
+			return e
+		}
+	}
+	return nil
+}
+func (s *source) verifyBindings() error {
+	for name, info := range s.bindings {
+		s.work = 0
+		if e := s.verifyBinding(name, info); e != nil {
+			return e
+		}
+	}
+	return nil
+}
+
+// Include replay work in the resolver ceiling, not only pending link expansion.
+func (s *source) step() error {
+	if e := contextError(s.ctx); e != nil {
+		return e
+	}
+	s.work++
+	if s.work > 8192 {
+		return fail("path_limit")
+	}
+	return nil
+}

--- a/install/integrationctl/agentplugins/adapters/packageview/source_darwin_walk.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_darwin_walk.go
@@ -148,7 +148,7 @@ func (s *source) directory(name string) (result *os.File, err error) {
 		next := physicalName(prefix, n)
 		if e != nil {
 			if _, seen := s.bindings[next]; seen {
-				return nil, fail("source_changed")
+				return nil, acquisitionError(e, "source_changed")
 			}
 			return nil, e
 		}
@@ -225,7 +225,7 @@ func (s *source) resolve(rel string, nofollow, selecting bool) (*pinned, error) 
 		if e != nil {
 			dir.Close()
 			if _, seen := s.bindings[physical]; seen {
-				return nil, fail("source_changed")
+				return nil, acquisitionError(e, "source_changed")
 			}
 			return nil, e
 		}
@@ -294,15 +294,12 @@ func (s *source) verifyBinding(name string, old os.FileInfo) error {
 	}
 	dir, e := s.directory(parent)
 	if e != nil {
-		if s.ctx.Err() != nil {
-			return contextError(s.ctx)
-		}
-		return fail("source_changed")
+		return acquisitionError(e, "source_changed")
 	}
 	defer dir.Close()
 	info, e := darwinStat(int(dir.Fd()), n)
 	if e != nil {
-		return fail("source_changed")
+		return acquisitionError(e, "source_changed")
 	}
 	equal := same(old, info)
 	if s.ancestors[name] {
@@ -314,7 +311,10 @@ func (s *source) verifyBinding(name string, old os.FileInfo) error {
 	if text, ok := s.links[name]; ok {
 		p := &pinned{file: dir, info: info, name: n, parent: parent, source: s}
 		got, e := p.link(4096)
-		if e != nil || got != text {
+		if e != nil {
+			return acquisitionError(e, "source_changed")
+		}
+		if got != text {
 			return fail("source_changed")
 		}
 	}

--- a/install/integrationctl/agentplugins/adapters/packageview/source_darwin_writable_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_darwin_writable_test.go
@@ -239,7 +239,7 @@ func TestDarwinWritableOuterSiblingAndPaths(t *testing.T) {
 		t.Fatal("unrelated sibling rejected", e)
 	}
 	l.Close()
-	s, e := openSource(root + "/linked/..")
+	s, e := openSource(root+"/linked/..", GeneratedStaging{})
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -252,7 +252,7 @@ func TestDarwinWritableOuterSiblingAndPaths(t *testing.T) {
 	if e != nil || !sameIdentity(got, want) {
 		t.Fatal("a/.. was cleaned", e)
 	}
-	if linked, e := openSource(root + "/linked/"); e == nil {
+	if linked, e := openSource(root+"/linked/", GeneratedStaging{}); e == nil {
 		linked.close()
 		t.Fatal("linked final root accepted")
 	}

--- a/install/integrationctl/agentplugins/adapters/packageview/source_darwin_writable_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_darwin_writable_test.go
@@ -8,9 +8,11 @@ import (
 	"golang.org/x/sys/unix"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 // No mounting, cloud, device creation or real-project inputs. Unsupported
@@ -329,21 +331,65 @@ func TestDarwinWritablePanicAndFDs(t *testing.T) {
 	if count() != before {
 		t.Fatal("FD observer failed closed control")
 	}
-	for i := 0; i < 3; i++ {
-		var caught any
-		func() {
-			defer func() { caught = recover() }()
-			_, _ = (Reader{TempDir: scratch}).open(context.Background(), root, &captureHooks{nativeOpen: func(string, int) { panic("owned panic") }})
-		}()
-		if caught != "owned panic" {
-			t.Fatal("panic not relayed", caught)
-		}
-		if count() != before {
-			t.Fatal("descriptor leak after panic")
-		}
-		entries, e := os.ReadDir(scratch)
-		if e != nil || len(entries) != 0 {
-			t.Fatal("panic scratch cleanup", e, entries)
+	// Keep the original first-native-open schedule: scratch owns an anchor,
+	// source binding replay panics, and the lease has not received scratchClose.
+	// Later phases exercise the held pin and data FD ownership as well.
+	nativeWrite(t, root, "opaque", "inert payload")
+	for _, phase := range []string{"scratch-handoff", "core-read", "inventory-read", "final-verification"} {
+		for i := 0; i < 3; i++ {
+			fired, coreOpens := false, 0
+			var l *Lease
+			var caught any
+			var runErr error
+			hooks := &captureHooks{}
+			boom := func() { fired = true; panic("owned panic") }
+			switch phase {
+			case "scratch-handoff":
+				hooks.nativeOpen = func(string, int) { boom() }
+			case "core-read", "inventory-read":
+				hooks.afterChunk = func(n string) {
+					if phase == "core-read" && n == "plugin.json" || phase == "inventory-read" && n == "opaque" {
+						boom()
+					}
+				}
+			case "final-verification":
+				hooks.nativeOpen = func(n string, flags int) {
+					if n == "plugin.json" && flags&unix.O_DIRECTORY == 0 {
+						coreOpens++
+						if coreOpens == 2 {
+							boom()
+						}
+					}
+				}
+			}
+			func() {
+				defer func() { caught = recover() }()
+				l, runErr = (Reader{TempDir: scratch}).open(context.Background(), root, hooks)
+				if runErr == nil && l != nil {
+					_, runErr = l.Capture(context.Background())
+				}
+			}()
+			if !fired || caught != "owned panic" || runErr != nil {
+				t.Fatalf("%s panic not relayed: fired=%v panic=%v err=%v", phase, fired, caught, runErr)
+			}
+			if count() != before {
+				t.Fatalf("descriptor leak after panic: phase=%s", phase)
+			}
+			if l != nil {
+				if !reflect.DeepEqual(l.Data(), Input{}) {
+					t.Fatal("panic retained partial Input")
+				}
+				if e := l.Close(); e != nil {
+					t.Fatal("panic Close", e)
+				}
+				if e := l.Close(); e != nil {
+					t.Fatal("repeated panic Close", e)
+				}
+			}
+			entries, e := os.ReadDir(scratch)
+			if e != nil || len(entries) != 0 {
+				t.Fatal("panic scratch cleanup", e, entries)
+			}
 		}
 	}
 }
@@ -436,5 +482,174 @@ func TestDarwinWritableReplacedPrivateChild(t *testing.T) {
 	got, e := os.ReadFile(filepath.Join(l.private, "foreign"))
 	if e != nil || string(got) != "keep" {
 		t.Fatal("foreign child modified", e)
+	}
+}
+
+// The context switches to a real terminal context at a synchronous traversal
+// boundary. This makes cancellation and deadline cases deterministic without
+// timers racing the filesystem or replacing resolver errors with mock errors.
+type darwinTraversalContext struct{ context.Context }
+
+func TestDarwinWritableTraversalCancellation(t *testing.T) {
+	for _, cause := range []error{context.Canceled, context.DeadlineExceeded} {
+		for _, phase := range []string{"after-metadata", "descendant-replay", "scratch-resolution", "post-open-guard", "final-guard"} {
+			t.Run(cause.Error()+"/"+phase, func(t *testing.T) {
+				root, scratch := writableFixture(t)
+				nativeWrite(t, root, "skills/a/SKILL.md", "# inert")
+				ctx := &darwinTraversalContext{Context: context.Background()}
+				var terminal context.Context
+				var cancel context.CancelFunc
+				if cause == context.Canceled {
+					terminal, cancel = context.WithCancel(context.Background())
+					cancel()
+				} else {
+					terminal, cancel = context.WithDeadline(context.Background(), time.Unix(1, 0))
+				}
+				defer cancel()
+				fired, armed, coreOpens := false, false, 0
+				stop := func() { fired = true; ctx.Context = terminal }
+				hooks := &captureHooks{}
+				switch phase {
+				case "after-metadata":
+					hooks.beforeDataOpen = func(n string) {
+						if n == "plugin.json" {
+							stop()
+						}
+					}
+				case "descendant-replay":
+					hooks.metadata = func(n string) error { armed = n == "skills/a/SKILL.md"; return nil }
+					hooks.nativeOpen = func(n string, flags int) {
+						if armed && n == "a" && flags&unix.O_DIRECTORY != 0 {
+							stop()
+						}
+					}
+				case "scratch-resolution":
+					// Opens the real scratch directory; a subsequent prefix replay
+					// step returns cancellation before ownership reaches the lease.
+					hooks.scratchOpen = func(n string, flags int) {
+						if n == "scratch" && flags&unix.O_DIRECTORY != 0 {
+							stop()
+						}
+					}
+				case "post-open-guard", "final-guard":
+					hooks.nativeOpen = func(n string, flags int) {
+						if n == "plugin.json" && flags&unix.O_DIRECTORY == 0 {
+							coreOpens++
+							if phase == "post-open-guard" || coreOpens == 2 {
+								stop()
+							}
+						}
+					}
+				}
+				l, e := (Reader{TempDir: scratch}).open(ctx, root, hooks)
+				if phase == "descendant-replay" || phase == "final-guard" {
+					if e != nil {
+						t.Fatal("Open prerequisite", e)
+					}
+					defer l.Close()
+					in, captureErr := l.Capture(ctx)
+					e = captureErr
+					if !reflect.DeepEqual(in, Input{}) || !reflect.DeepEqual(l.Data(), Input{}) {
+						t.Fatal("usable partial Input")
+					}
+				} else if l != nil {
+					l.Close()
+					t.Fatal("partial Open lease")
+				}
+				var safe *Error
+				if !fired || !errors.Is(e, cause) || !errors.As(e, &safe) || safe.Code != "canceled" || safe.CleanupFailed {
+					t.Fatalf("traversal cancellation lost: fired=%v err=%v", fired, e)
+				}
+				entries, e := os.ReadDir(scratch)
+				if e != nil || len(entries) != 0 {
+					t.Fatal("owned cleanup", entries, e)
+				}
+			})
+		}
+	}
+}
+
+func TestDarwinWritableScratchFinalSymlink(t *testing.T) {
+	root, scratch := writableFixture(t)
+	external := filepath.Join(filepath.Dir(scratch), "scratch-alias")
+	inside := filepath.Join(filepath.Dir(scratch), "inside-alias")
+	sourceAlias := filepath.Join(filepath.Dir(scratch), "source-alias")
+	nativeWrite(t, root, "inside/keep", "source sentinel")
+	for alias, target := range map[string]string{external: scratch, inside: filepath.Join(root, "inside"), sourceAlias: root} {
+		if e := os.Symlink(target, alias); e != nil {
+			t.Fatal(e)
+		}
+	}
+	for _, temp := range []string{scratch, external} {
+		l, e := (Reader{TempDir: temp}).Open(context.Background(), root)
+		if e != nil {
+			t.Fatal("trusted scratch rejected", temp, e)
+		}
+		if filepath.Dir(l.private) != scratch {
+			t.Fatal("private child is not physical", l.private)
+		}
+		if _, e := l.Capture(context.Background()); e != nil {
+			t.Fatal(e)
+		}
+		if e := l.Close(); e != nil {
+			t.Fatal(e)
+		}
+		entries, e := os.ReadDir(scratch)
+		if e != nil || len(entries) != 0 {
+			t.Fatal("scratch cleanup", entries, e)
+		}
+	}
+	for _, temp := range []string{inside, sourceAlias} {
+		l, e := (Reader{TempDir: temp}).Open(context.Background(), root)
+		if l != nil {
+			l.Close()
+			t.Fatal("overlap accepted")
+		}
+		var safe *Error
+		if !errors.As(e, &safe) || safe.Code != "scratch_overlaps_source" {
+			t.Fatal("physical overlap not rejected", e)
+		}
+	}
+	if l, e := (Reader{TempDir: external}).Open(context.Background(), sourceAlias); e == nil || l != nil {
+		if l != nil {
+			l.Close()
+		}
+		t.Fatal("final source symlink accepted")
+	}
+	got, e := os.ReadFile(filepath.Join(root, "inside/keep"))
+	if e != nil || string(got) != "source sentinel" {
+		t.Fatal("source changed", e)
+	}
+}
+
+func TestDarwinWritableObservedChangePrecedesCancellation(t *testing.T) {
+	root, scratch := writableFixture(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	fired := false
+	var mutationErr error
+	l, e := (Reader{TempDir: scratch}).open(ctx, root, &captureHooks{nativeOpen: func(n string, flags int) {
+		if !fired && n == "parent" && flags&unix.O_DIRECTORY != 0 {
+			fired = true
+			mutationErr = os.Chmod(filepath.Dir(root), 0750)
+			cancel()
+		}
+	}})
+	if l != nil {
+		l.Close()
+		t.Fatal("partial lease")
+	}
+	if !fired || mutationErr != nil {
+		t.Fatal("mutation prerequisite", fired, mutationErr)
+	}
+	// p.open observes the changed mode before directory/verifyBinding unwind.
+	// A later ctx.Err probe must not overwrite that already observed change.
+	requireChanged(t, e)
+	if errors.Is(e, context.Canceled) {
+		t.Fatal("observed change masked by cancellation")
+	}
+	entries, e := os.ReadDir(scratch)
+	if e != nil || len(entries) != 0 {
+		t.Fatal("owned cleanup", entries, e)
 	}
 }

--- a/install/integrationctl/agentplugins/adapters/packageview/source_darwin_writable_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_darwin_writable_test.go
@@ -485,10 +485,23 @@ func TestDarwinWritableReplacedPrivateChild(t *testing.T) {
 	}
 }
 
-// The context switches to a real terminal context at a synchronous traversal
-// boundary. This makes cancellation and deadline cases deterministic without
-// timers racing the filesystem or replacing resolver errors with mock errors.
-type darwinTraversalContext struct{ context.Context }
+// darwinTraversalDeadlineCause is synthetic cause-propagation evidence, not a
+// wall-clock deadline test. Its controlled clock reaches the fixed deadline
+// when the traversal hook closes done. Deadline and Done stay unchanged, and
+// Err transitions exactly once with that channel; no timer races filesystem I/O.
+type darwinTraversalDeadlineCause struct{ done <-chan struct{} }
+
+func (c darwinTraversalDeadlineCause) Deadline() (time.Time, bool) { return time.Unix(1, 0), true }
+func (c darwinTraversalDeadlineCause) Done() <-chan struct{}       { return c.done }
+func (c darwinTraversalDeadlineCause) Value(any) any               { return nil }
+func (c darwinTraversalDeadlineCause) Err() error {
+	select {
+	case <-c.done:
+		return context.DeadlineExceeded
+	default:
+		return nil
+	}
+}
 
 func TestDarwinWritableTraversalCancellation(t *testing.T) {
 	for _, cause := range []error{context.Canceled, context.DeadlineExceeded} {
@@ -496,18 +509,19 @@ func TestDarwinWritableTraversalCancellation(t *testing.T) {
 			t.Run(cause.Error()+"/"+phase, func(t *testing.T) {
 				root, scratch := writableFixture(t)
 				nativeWrite(t, root, "skills/a/SKILL.md", "# inert")
-				ctx := &darwinTraversalContext{Context: context.Background()}
-				var terminal context.Context
-				var cancel context.CancelFunc
-				if cause == context.Canceled {
-					terminal, cancel = context.WithCancel(context.Background())
-					cancel()
-				} else {
-					terminal, cancel = context.WithDeadline(context.Background(), time.Unix(1, 0))
-				}
+				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
+				if cause == context.DeadlineExceeded {
+					ctx = darwinTraversalDeadlineCause{done: ctx.Done()}
+					t.Log("synthetic deadline cause propagation; no wall-clock expiry claim")
+				}
+				done := ctx.Done()
+				deadline, hasDeadline := ctx.Deadline()
+				if done == nil || ctx.Err() != nil {
+					t.Fatal("context must start live with a stable Done channel")
+				}
 				fired, armed, coreOpens := false, false, 0
-				stop := func() { fired = true; ctx.Context = terminal }
+				stop := func() { fired = true; cancel() }
 				hooks := &captureHooks{}
 				switch phase {
 				case "after-metadata":
@@ -560,12 +574,50 @@ func TestDarwinWritableTraversalCancellation(t *testing.T) {
 				if !fired || !errors.Is(e, cause) || !errors.As(e, &safe) || safe.Code != "canceled" || safe.CleanupFailed {
 					t.Fatalf("traversal cancellation lost: fired=%v err=%v", fired, e)
 				}
+				if after, ok := ctx.Deadline(); after != deadline || ok != hasDeadline || ctx.Done() != done || ctx.Err() != cause {
+					t.Fatal("context contract changed at traversal boundary")
+				}
+				select {
+				case <-done:
+				default:
+					t.Fatal("original Done channel did not close")
+				}
 				entries, e := os.ReadDir(scratch)
 				if e != nil || len(entries) != 0 {
 					t.Fatal("owned cleanup", entries, e)
 				}
 			})
 		}
+	}
+}
+
+func TestDarwinWritableCaptureContextHandoff(t *testing.T) {
+	root, scratch := writableFixture(t)
+	openCtx, cancelOpen := context.WithCancel(context.Background())
+	defer cancelOpen()
+	l, e := (Reader{TempDir: scratch}).Open(openCtx, root)
+	if e != nil {
+		t.Fatal("Open prerequisite", e)
+	}
+	defer l.Close()
+	// A resolver retaining Open's context must fail this otherwise live Capture.
+	// Merely observing Capture's argument at a shared polling site cannot pass.
+	cancelOpen()
+	captureCtx, cancelCapture := context.WithCancel(context.Background())
+	defer cancelCapture()
+	in, e := l.Capture(captureCtx)
+	if e != nil || !in.Coverage.TreeComplete || in.Identity.TreeDigest == "" {
+		t.Fatalf("Capture retained stale Open context: %v", e)
+	}
+	if openCtx.Err() != context.Canceled || captureCtx.Err() != nil {
+		t.Fatal("distinct phase context prerequisite")
+	}
+	if e := l.Close(); e != nil {
+		t.Fatal(e)
+	}
+	entries, e := os.ReadDir(scratch)
+	if e != nil || len(entries) != 0 {
+		t.Fatal("owned cleanup", entries, e)
 	}
 }
 

--- a/install/integrationctl/agentplugins/adapters/packageview/source_darwin_writable_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_darwin_writable_test.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/sys/unix"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -16,7 +17,12 @@ import (
 // fixture storage is a failed prerequisite, never a native success/skip.
 func writableFixture(t *testing.T) (string, string) {
 	t.Helper()
-	base, e := filepath.EvalSymlinks(t.TempDir())
+	return writableFixtureAt(t, t.TempDir())
+}
+
+func writableFixtureAt(t *testing.T, dir string) (string, string) {
+	t.Helper()
+	base, e := filepath.EvalSymlinks(dir)
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -73,7 +79,22 @@ func TestDarwinWritableCapture(t *testing.T) {
 	}
 }
 func TestDarwinWritableStaticOpenBoundary(t *testing.T) {
-	root, scratch := writableFixture(t)
+	// Darwin's sockaddr_un cannot hold a typical testing.T temp path. Own a
+	// short directory independently of TMPDIR; never remove the shared root.
+	base, e := os.MkdirTemp("/private/tmp", "pv-")
+	if e != nil {
+		t.Fatal(e)
+	}
+	t.Cleanup(func() {
+		if e := os.RemoveAll(base); e != nil {
+			t.Error(e)
+		}
+	})
+	root, scratch := writableFixtureAt(t, base)
+	socketPath := filepath.Join(root, "socket")
+	if len(socketPath) >= len((unix.RawSockaddrUnix{}).Path) {
+		t.Fatalf("socket fixture path exceeds host sockaddr_un capacity: %q", socketPath)
+	}
 	nativeWrite(t, root, "plugin/plugin.yaml", "excluded")
 	nativeLink(t, root, "plugin/plugin.yaml", "legacy-alias")
 	nativeLink(t, root, "/outside", "absolute")
@@ -91,7 +112,7 @@ func TestDarwinWritableStaticOpenBoundary(t *testing.T) {
 		t.Fatal(e)
 	}
 	defer unix.Close(fd)
-	if e := unix.Bind(fd, &unix.SockaddrUnix{Name: filepath.Join(root, "socket")}); e != nil {
+	if e := unix.Bind(fd, &unix.SockaddrUnix{Name: socketPath}); e != nil {
 		t.Fatal(e)
 	}
 	opens := map[string]int{}
@@ -264,22 +285,50 @@ func TestDarwinWritablePanicAndFDs(t *testing.T) {
 		t.Fatal(e)
 	}
 	count := func() int {
-		entries, e := os.ReadDir("/dev/fd")
+		// Names only: ReadDir may stat volatile /dev/fd entries on Darwin.
+		dir, e := os.Open("/dev/fd")
 		if e != nil {
 			t.Fatal(e)
 		}
-		return len(entries)
+		observer := strconv.FormatUint(uint64(dir.Fd()), 10)
+		names, readErr := dir.Readdirnames(-1)
+		closeErr := dir.Close() // Close even on enumeration failure, before comparing.
+		if readErr != nil || closeErr != nil {
+			t.Fatalf("FD enumeration: read=%v close=%v", readErr, closeErr)
+		}
+		n := 0
+		seenObserver := false
+		for _, name := range names {
+			if name == observer {
+				seenObserver = true
+				continue
+			}
+			if _, e := strconv.ParseUint(name, 10, 64); e != nil {
+				t.Fatalf("unexpected FD name %q: %v", name, e)
+			}
+			n++
+		}
+		if !seenObserver {
+			t.Fatal("FD observer did not enumerate itself")
+		}
+		return n
 	}
 	before := count()
 	held, e := os.Open(filepath.Join(root, "plugin.json"))
 	if e != nil {
 		t.Fatal(e)
 	}
-	if count() <= before {
+	defer held.Close()
+	if count() != before+1 {
 		held.Close()
 		t.Fatal("FD observer failed positive control")
 	}
-	held.Close()
+	if e := held.Close(); e != nil {
+		t.Fatal(e)
+	}
+	if count() != before {
+		t.Fatal("FD observer failed closed control")
+	}
 	for i := 0; i < 3; i++ {
 		var caught any
 		func() {

--- a/install/integrationctl/agentplugins/adapters/packageview/source_darwin_writable_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_darwin_writable_test.go
@@ -1,0 +1,391 @@
+//go:build darwin && arm64
+
+package packageview
+
+import (
+	"context"
+	"errors"
+	"golang.org/x/sys/unix"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// No mounting, cloud, device creation or real-project inputs. Unsupported
+// fixture storage is a failed prerequisite, never a native success/skip.
+func writableFixture(t *testing.T) (string, string) {
+	t.Helper()
+	base, e := filepath.EvalSymlinks(t.TempDir())
+	if e != nil {
+		t.Fatal(e)
+	}
+	root, scratch := filepath.Join(base, "parent", "source"), filepath.Join(base, "scratch")
+	for _, p := range []string{root, scratch} {
+		if e := os.MkdirAll(p, 0700); e != nil {
+			t.Fatal(e)
+		}
+	}
+	var fs unix.Statfs_t
+	if e := unix.Statfs(root, &fs); e != nil || unix.ByteSliceToString(fs.Fstypename[:]) != "apfs" || fs.Flags&unix.MNT_RDONLY != 0 || fs.Flags&unix.MNT_LOCAL == 0 {
+		t.Fatalf("UNPROVEN writable local APFS prerequisite: %+v %v", fs, e)
+	}
+	t.Logf("writable APFS fsid=%v flags=%x profile=%s", fs.Fsid, fs.Flags, ReadProfile)
+	nativeWrite(t, root, "plugin.json", `{"name":"fixture"}`)
+	return root, scratch
+}
+func requireChanged(t *testing.T, e error) {
+	t.Helper()
+	var safe *Error
+	if !errors.As(e, &safe) || safe.Code != "source_changed" {
+		t.Fatalf("want source_changed: %v", e)
+	}
+}
+func TestDarwinWritableCapture(t *testing.T) {
+	root, scratch := writableFixture(t)
+	nativeWrite(t, root, "mcp.json", `{}`)
+	nativeWrite(t, root, "skills/a/SKILL.md", "# inert")
+	nativeWrite(t, root, "dir/opaque", "payload")
+	nativeLink(t, root, "dir/../dir/opaque", "alias")
+	l, e := (Reader{TempDir: scratch}).Open(context.Background(), root)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if l.Data().Coverage.ComponentsRequested {
+		t.Fatal("core authorized components")
+	}
+	in, e := l.Capture(context.Background())
+	if e != nil {
+		t.Fatal(e)
+	}
+	if !in.Coverage.TreeComplete || in.Identity.TreeDigest == "" || ReadProfile != "packageview-local-darwin-v2" {
+		t.Fatalf("incomplete capture: %+v", in)
+	}
+	if e = l.Close(); e != nil {
+		t.Fatal(e)
+	}
+	if e = l.Close(); e != nil {
+		t.Fatal(e)
+	}
+	entries, e := os.ReadDir(scratch)
+	if e != nil || len(entries) != 0 {
+		t.Fatal("cleanup", entries, e)
+	}
+}
+func TestDarwinWritableStaticOpenBoundary(t *testing.T) {
+	root, scratch := writableFixture(t)
+	nativeWrite(t, root, "plugin/plugin.yaml", "excluded")
+	nativeLink(t, root, "plugin/plugin.yaml", "legacy-alias")
+	nativeLink(t, root, "/outside", "absolute")
+	nativeLink(t, root, "../outside", "escape")
+	nativeLink(t, root, "cycle", "cycle")
+	nativeWrite(t, root, "hard", "excluded hardlinks")
+	if e := os.Link(filepath.Join(root, "hard"), filepath.Join(root, "hard-alias")); e != nil {
+		t.Fatal(e)
+	}
+	if e := unix.Mkfifo(filepath.Join(root, "fifo"), 0600); e != nil {
+		t.Fatal(e)
+	}
+	fd, e := unix.Socket(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	if e != nil {
+		t.Fatal(e)
+	}
+	defer unix.Close(fd)
+	if e := unix.Bind(fd, &unix.SockaddrUnix{Name: filepath.Join(root, "socket")}); e != nil {
+		t.Fatal(e)
+	}
+	opens := map[string]int{}
+	l, e := (Reader{TempDir: scratch}).open(context.Background(), root, &captureHooks{nativeOpen: func(n string, flags int) {
+		if flags&unix.O_DIRECTORY == 0 {
+			opens[n]++
+		}
+	}})
+	if e != nil {
+		t.Fatal(e)
+	}
+	defer l.Close()
+	in, e := l.Capture(context.Background())
+	if e != nil {
+		t.Fatal(e)
+	}
+	if in.Coverage.TreeComplete || opens["plugin.json"] == 0 {
+		t.Fatal("open observer not calibrated", opens)
+	}
+	for _, n := range []string{"plugin.yaml", "legacy-alias", "absolute", "escape", "cycle", "hard", "hard-alias", "fifo", "socket"} {
+		if opens[n] != 0 {
+			t.Fatalf("forbidden native openat boundary: %s", n)
+		}
+	}
+}
+func TestDarwinWritableObservedChanges(t *testing.T) {
+	for _, where := range []string{"before-open", "after-name", "native-open", "after-chunk", "gap-core", "gap-legacy", "gap-link", "gap-directory", "gap-root", "gap-ancestor"} {
+		t.Run(where, func(t *testing.T) {
+			root, scratch := writableFixture(t)
+			nativeWrite(t, root, "plugin/plugin.yaml", "legacy")
+			nativeWrite(t, root, "dir/payload", strings.Repeat("x", 65536))
+			nativeLink(t, root, "dir/payload", "alias")
+			mutated := false
+			var mutationErr error
+			mutate := func(n string) {
+				if n != "plugin.json" || mutated {
+					return
+				}
+				mutated = true
+				// Harmless regular substitution even after the final metadata check.
+				mutationErr = os.Rename(filepath.Join(root, n), filepath.Join(root, "old-core"))
+				if mutationErr == nil {
+					mutationErr = os.WriteFile(filepath.Join(root, n), []byte(`{"name":"changed"}`), 0600)
+				}
+			}
+			hooks := &captureHooks{}
+			switch where {
+			case "before-open":
+				hooks.beforeDataOpen = mutate
+			case "after-name":
+				hooks.afterNameCheck = mutate
+			case "native-open":
+				hooks.nativeOpen = func(n string, flags int) {
+					if flags&unix.O_DIRECTORY == 0 {
+						mutate(n)
+					}
+				}
+			case "after-chunk":
+				hooks.afterChunk = mutate
+			}
+			l, e := (Reader{TempDir: scratch}).open(context.Background(), root, hooks)
+			if !strings.HasPrefix(where, "gap-") {
+				if !mutated || mutationErr != nil {
+					t.Fatal("mutation prerequisite", mutated, mutationErr)
+				}
+				requireChanged(t, e)
+				if l != nil {
+					l.Close()
+					t.Fatal("partial lease")
+				}
+				return
+			}
+			if e != nil {
+				t.Fatal(e)
+			}
+			switch where {
+			case "gap-core":
+				mutationErr = os.Chmod(filepath.Join(root, "plugin.json"), 0400)
+			case "gap-legacy":
+				mutationErr = os.WriteFile(filepath.Join(root, "plugin/plugin.yaml"), []byte("changed"), 0600)
+			case "gap-link":
+				mutationErr = os.Remove(filepath.Join(root, "alias"))
+				if mutationErr == nil {
+					mutationErr = os.Symlink("plugin.json", filepath.Join(root, "alias"))
+				}
+			case "gap-directory":
+				mutationErr = os.WriteFile(filepath.Join(root, "new"), []byte("x"), 0600)
+			case "gap-root":
+				mutationErr = os.Rename(root, root+"-moved")
+			case "gap-ancestor":
+				// Scratch is outside this selected ancestor.
+				mutationErr = os.Rename(filepath.Dir(root), filepath.Dir(root)+"-moved")
+			}
+			if mutationErr != nil {
+				l.Close()
+				t.Fatal(mutationErr)
+			}
+			in, e := l.Capture(context.Background())
+			requireChanged(t, e)
+			if in.Identity.Digest != "" || l.Data().Identity.Digest != "" {
+				t.Fatal("usable partial evidence")
+			}
+			entries, e := os.ReadDir(scratch)
+			if e != nil || len(entries) != 0 {
+				t.Fatal("owned cleanup", e, entries)
+			}
+		})
+	}
+}
+func TestDarwinWritableOuterSiblingAndPaths(t *testing.T) {
+	root, scratch := writableFixture(t)
+	nativeWrite(t, root, "a/nested/keep", "x")
+	nativeLink(t, root, "a/nested", "linked")
+	l, e := (Reader{TempDir: scratch}).Open(context.Background(), root)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if e := os.WriteFile(filepath.Join(filepath.Dir(root), "unrelated"), []byte("safe sibling"), 0600); e != nil {
+		t.Fatal(e)
+	}
+	if _, e := l.Capture(context.Background()); e != nil {
+		t.Fatal("unrelated sibling rejected", e)
+	}
+	l.Close()
+	s, e := openSource(root + "/linked/..")
+	if e != nil {
+		t.Fatal(e)
+	}
+	defer s.close()
+	want, e := os.Stat(filepath.Join(root, "a"))
+	if e != nil {
+		t.Fatal(e)
+	}
+	got, e := s.anchor.Stat()
+	if e != nil || !sameIdentity(got, want) {
+		t.Fatal("a/.. was cleaned", e)
+	}
+	if linked, e := openSource(root + "/linked/"); e == nil {
+		linked.close()
+		t.Fatal("linked final root accepted")
+	}
+}
+func TestDarwinWritableOverlapAndCloseBinding(t *testing.T) {
+	root, scratch := writableFixture(t)
+	if l, e := (Reader{TempDir: root}).Open(context.Background(), root); e == nil {
+		l.Close()
+		t.Fatal("overlap accepted")
+	}
+	l, e := (Reader{TempDir: scratch}).Open(context.Background(), root)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if e := os.Rename(root, root+"-moved"); e != nil {
+		t.Fatal(e)
+	}
+	requireChanged(t, l.Close())
+	if l.Data().Identity.Digest != "" {
+		t.Fatal("Close retained invalid input")
+	}
+}
+
+func TestDarwinWritablePanicAndFDs(t *testing.T) {
+	root, scratch := writableFixture(t)
+	// Warm the real scoped policy path before measuring descriptor ownership.
+	l, e := (Reader{TempDir: scratch}).Open(context.Background(), root)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if e = l.Close(); e != nil {
+		t.Fatal(e)
+	}
+	count := func() int {
+		entries, e := os.ReadDir("/dev/fd")
+		if e != nil {
+			t.Fatal(e)
+		}
+		return len(entries)
+	}
+	before := count()
+	held, e := os.Open(filepath.Join(root, "plugin.json"))
+	if e != nil {
+		t.Fatal(e)
+	}
+	if count() <= before {
+		held.Close()
+		t.Fatal("FD observer failed positive control")
+	}
+	held.Close()
+	for i := 0; i < 3; i++ {
+		var caught any
+		func() {
+			defer func() { caught = recover() }()
+			_, _ = (Reader{TempDir: scratch}).open(context.Background(), root, &captureHooks{nativeOpen: func(string, int) { panic("owned panic") }})
+		}()
+		if caught != "owned panic" {
+			t.Fatal("panic not relayed", caught)
+		}
+		if count() != before {
+			t.Fatal("descriptor leak after panic")
+		}
+		entries, e := os.ReadDir(scratch)
+		if e != nil || len(entries) != 0 {
+			t.Fatal("panic scratch cleanup", e, entries)
+		}
+	}
+}
+
+func TestDarwinWritableWrongCoreAndBounds(t *testing.T) {
+	for _, kind := range []string{"fifo", "directory", "legacy", "limit", "cancel"} {
+		t.Run(kind, func(t *testing.T) {
+			root, scratch := writableFixture(t)
+			if e := os.Remove(filepath.Join(root, "plugin.json")); e != nil {
+				t.Fatal(e)
+			}
+			switch kind {
+			case "fifo":
+				if e := unix.Mkfifo(filepath.Join(root, "plugin.json"), 0600); e != nil {
+					t.Fatal(e)
+				}
+			case "directory":
+				if e := os.Mkdir(filepath.Join(root, "plugin.json"), 0700); e != nil {
+					t.Fatal(e)
+				}
+			case "legacy":
+				nativeWrite(t, root, "plugin/plugin.yaml", "excluded")
+				nativeLink(t, root, "plugin/plugin.yaml", "plugin.json")
+			default:
+				nativeWrite(t, root, "plugin.json", "oversize")
+			}
+			opened := 0
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if kind == "cancel" {
+				cancel()
+			}
+			limits := Limits{}
+			if kind == "limit" {
+				limits.PluginBytes = 1
+			}
+			l, e := (Reader{TempDir: scratch, Limits: limits}).open(ctx, root, &captureHooks{nativeOpen: func(_ string, flags int) {
+				if flags&unix.O_DIRECTORY == 0 {
+					opened++
+				}
+			}})
+			if opened != 0 {
+				t.Fatal("unsafe/unapproved core data open", opened)
+			}
+			if kind == "limit" || kind == "cancel" {
+				if e == nil || l != nil {
+					t.Fatal("expected fatal bound/cancel", e)
+				}
+				return
+			}
+			if e != nil {
+				t.Fatal(e)
+			}
+			defer l.Close()
+			if l.Data().Plugin.State == Present || l.Data().Coverage.ComponentsRequested {
+				t.Fatal("wrong core authorized capture")
+			}
+			if _, e := l.Capture(ctx); e == nil {
+				t.Fatal("wrong core captured components")
+			}
+		})
+	}
+}
+
+func TestDarwinWritableReplacedPrivateChild(t *testing.T) {
+	root, scratch := writableFixture(t)
+	l, e := (Reader{TempDir: scratch}).Open(context.Background(), root)
+	if e != nil {
+		t.Fatal(e)
+	}
+	replaced := false
+	l.hooks = &captureHooks{cleanup: func() error {
+		if e := os.Rename(l.private, l.private+"-owned-moved"); e != nil {
+			return e
+		}
+		if e := os.Mkdir(l.private, 0700); e != nil {
+			return e
+		}
+		if e := os.WriteFile(filepath.Join(l.private, "foreign"), []byte("keep"), 0600); e != nil {
+			return e
+		}
+		replaced = true
+		return nil
+	}}
+	e = l.Close()
+	var safe *Error
+	if !replaced || !errors.As(e, &safe) || !safe.CleanupFailed {
+		t.Fatal("cleanup replacement not detected", e, replaced)
+	}
+	got, e := os.ReadFile(filepath.Join(l.private, "foreign"))
+	if e != nil || string(got) != "keep" {
+		t.Fatal("foreign child modified", e)
+	}
+}

--- a/install/integrationctl/agentplugins/adapters/packageview/source_io_darwin.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_io_darwin.go
@@ -1,0 +1,71 @@
+//go:build darwin && arm64
+
+package packageview
+
+import "runtime"
+
+// Each phase owns a fresh goroutine/thread, never the caller's thread. Waiting
+// is unconditional: cancellation must not abandon an active phase or cleanup.
+func sourceIO(work func() error, abort func()) error {
+	return darwinIO(work, abort, materializationGet, materializationSet)
+}
+func darwinIO(work func() error, abort func(), get func() (int, error), set func(int) error) error {
+	type result struct {
+		err        error
+		panicValue any
+	}
+	done := make(chan result, 1)
+	go func() {
+		runtime.LockOSThread()
+		reusable := false
+		r := result{}
+		defer func() {
+			if p := recover(); p != nil {
+				r.panicValue = p
+			}
+			if reusable {
+				runtime.UnlockOSThread()
+			}
+			// Exiting locked retires this OS thread after a failed restore.
+			done <- r
+		}()
+		previous, e := get()
+		if e != nil {
+			r.err = fail("platform_unavailable")
+			abort()
+			reusable = true
+			return
+		}
+		// Even a failed set can have changed state. Always restore and read back.
+		defer func() {
+			p := recover()
+			if p != nil {
+				r.panicValue = p
+				abort()
+			}
+			restoreErr := set(previous)
+			current, readErr := get()
+			reusable = restoreErr == nil && readErr == nil && current == previous
+			if !reusable {
+				r.err = fail("platform_unavailable")
+				abort()
+			}
+		}()
+		e = set(materializationOff)
+		current, readErr := get()
+		if e != nil || readErr != nil || current != materializationOff {
+			r.err = fail("platform_unavailable")
+			abort()
+			return
+		}
+		r.err = work()
+		if r.err != nil {
+			abort()
+		}
+	}()
+	r := <-done
+	if r.panicValue != nil {
+		panic(r.panicValue)
+	}
+	return r.err
+}

--- a/install/integrationctl/agentplugins/adapters/packageview/source_io_darwin_cgo.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_io_darwin_cgo.go
@@ -1,0 +1,32 @@
+//go:build darwin && arm64 && cgo
+
+package packageview
+
+/*
+#include <sys/resource.h>
+static int pv_get(void) {
+ return getiopolicy_np(IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES, IOPOL_SCOPE_THREAD);
+}
+static int pv_set(int value) {
+ return setiopolicy_np(IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES, IOPOL_SCOPE_THREAD, value);
+}
+*/
+import "C"
+
+const materializationOff = int(C.IOPOL_MATERIALIZE_DATALESS_FILES_OFF)
+
+func materializationGet() (int, error) {
+	n := int(C.pv_get())
+	if n < 0 {
+		return 0, fail("platform_unavailable")
+	}
+	return n, nil
+}
+func materializationSet(n int) error {
+	if C.pv_set(C.int(n)) != 0 {
+		return fail("platform_unavailable")
+	}
+	return nil
+}
+
+const darwinCGO = true

--- a/install/integrationctl/agentplugins/adapters/packageview/source_io_darwin_nocgo.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_io_darwin_nocgo.go
@@ -1,0 +1,11 @@
+//go:build darwin && arm64 && !cgo
+
+package packageview
+
+// No source resolution is allowed when the real libc binding is absent.
+const materializationOff = 0
+
+func materializationGet() (int, error) { return 0, fail("platform_unavailable") }
+func materializationSet(int) error     { return fail("platform_unavailable") }
+
+const darwinCGO = false

--- a/install/integrationctl/agentplugins/adapters/packageview/source_io_darwin_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_io_darwin_test.go
@@ -1,0 +1,128 @@
+//go:build darwin && arm64
+
+package packageview
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"testing"
+)
+
+func TestDarwinPolicyFaults(t *testing.T) {
+	for _, fault := range []string{"get", "set", "readback", "restore", "restore-readback", "work", "panic", "success"} {
+		t.Run(fault, func(t *testing.T) {
+			policy := 97
+			gets, sets, worked, aborted := 0, 0, 0, 0
+			get := func() (int, error) {
+				gets++
+				if fault == "get" && gets == 1 || fault == "restore-readback" && gets == 3 {
+					return 0, errors.New("injected")
+				}
+				if fault == "readback" && gets == 2 {
+					return 98, nil
+				}
+				return policy, nil
+			}
+			set := func(n int) error {
+				sets++
+				if fault == "set" && sets == 1 || fault == "restore" && sets == 2 {
+					return errors.New("injected")
+				}
+				policy = n
+				return nil
+			}
+			var e error
+			var panicked any
+			func() {
+				defer func() { panicked = recover() }()
+				e = darwinIO(func() error {
+					worked++
+					if fault == "panic" {
+						panic("test panic")
+					}
+					if fault == "work" {
+						return fail("canceled")
+					}
+					return nil
+				}, func() { aborted++ }, get, set)
+			}()
+			if fault == "panic" {
+				if panicked != "test panic" || aborted == 0 {
+					t.Fatal("panic cleanup", panicked, aborted)
+				}
+			} else if panicked != nil {
+				t.Fatal(panicked)
+			}
+			if fault == "success" {
+				if e != nil || worked != 1 || aborted != 0 {
+					t.Fatal(e, worked, aborted)
+				}
+			} else if fault != "panic" && (e == nil || aborted == 0) {
+				t.Fatal("failure not propagated", e, aborted)
+			}
+			if (fault == "get" || fault == "set" || fault == "readback") && worked != 0 {
+				t.Fatal("source ran before policy setup")
+			}
+			if fault != "restore" && policy != 97 {
+				t.Fatal("policy not restored", policy)
+			}
+		})
+	}
+}
+func TestDarwinRealThreadPolicy(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	before, e := materializationGet()
+	if e != nil {
+		t.Fatalf("UNPROVEN real libc policy prerequisite: %v", e)
+	}
+	for _, mode := range []string{"success", "error", "cancel", "panic"} {
+		var caught any
+		func() {
+			defer func() { caught = recover() }()
+			e = sourceIO(func() error {
+				now, e := materializationGet()
+				if e != nil || now != materializationOff {
+					return fail("platform_unavailable")
+				}
+				switch mode {
+				case "error":
+					return fail("fixture_error")
+				case "cancel":
+					ctx, cancel := context.WithCancel(context.Background())
+					cancel()
+					return contextError(ctx)
+				case "panic":
+					panic("real policy panic")
+				}
+				return nil
+			}, func() {})
+		}()
+		if mode == "success" && e != nil {
+			t.Fatal(e)
+		}
+		if mode == "panic" && caught != "real policy panic" {
+			t.Fatal("panic not relayed", caught)
+		}
+		if mode != "success" && mode != "panic" && e == nil {
+			t.Fatal("failure lost")
+		}
+		after, e := materializationGet()
+		if e != nil || after != before {
+			t.Fatal("caller thread policy changed", before, after, e)
+		}
+	}
+}
+
+func TestDarwinNoCGORejects(t *testing.T) {
+	if darwinCGO {
+		t.Skip("specific no-cgo rejection gate; run CGO_ENABLED=0")
+	}
+	reached := false
+	l, e := (Reader{TempDir: "/must-not-resolve-scratch"}).open(context.Background(), "/must-not-resolve-source", &captureHooks{metadata: func(string) error { reached = true; return nil }})
+	var safe *Error
+	if l != nil || reached || !errors.As(e, &safe) || safe.Code != "platform_unavailable" {
+		t.Fatal("no-cgo accessed source or accepted", e)
+	}
+}

--- a/install/integrationctl/agentplugins/adapters/packageview/source_io_other.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_io_other.go
@@ -1,0 +1,5 @@
+//go:build !darwin || !arm64
+
+package packageview
+
+func sourceIO(work func() error, abort func()) error { return work() }

--- a/install/integrationctl/agentplugins/adapters/packageview/source_unsupported.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_unsupported.go
@@ -13,7 +13,7 @@ type pinned struct {
 }
 
 func openSource(string, GeneratedStaging) (*source, error) { return nil, fail("platform_unavailable") }
-func (*source) close() error                                { return nil }
+func (*source) close() error                               { return nil }
 func (*source) pin(string, bool) (*pinned, error) {
 	return nil, fail("platform_unavailable")
 }

--- a/install/integrationctl/agentplugins/adapters/packageview/source_windows_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/source_windows_test.go
@@ -594,7 +594,7 @@ func TestWindowsRootAndIntermediateReparseRejected(t *testing.T) {
 	}
 	before := winRecordCount()
 	for i := 0; i < 10; i++ {
-		s, e := openSource(root + `\missing\root`, GeneratedStaging{})
+		s, e := openSource(root+`\missing\root`, GeneratedStaging{})
 		if e == nil {
 			s.close()
 			t.Fatal("accepted missing root")

--- a/install/integrationctl/agentplugins/adapters/packageview/view.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/view.go
@@ -223,7 +223,8 @@ type Lease struct {
 	hooks *captureHooks
 }
 type captureHooks struct {
-	nativeOpen func(string, int) // immediately before Darwin single-name openat
+	scratchOpen func(string, int) // Darwin scratch traversal only
+	nativeOpen  func(string, int) // immediately before Darwin single-name openat
 
 	beforeDataOpen func(string)
 	dataOpenError  func(string) error
@@ -350,6 +351,9 @@ func (l *Lease) Close() error {
 	defer l.mu.Unlock()
 	if l.closed {
 		return l.closeErr
+	}
+	if l.source == nil && l.private == "" && l.scratchClose == nil {
+		return l.close()
 	}
 	err := sourceIO(func() error {
 		if l.source != nil {

--- a/install/integrationctl/agentplugins/adapters/packageview/view.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/view.go
@@ -4,7 +4,7 @@
 // component and opaque-tree capture. Never call Capture after a fatal core/schema
 // result. Convert these private input records to conformance types in the caller.
 //
-// Linux uses openat2/O_PATH. Darwin requires read-only local APFS; Windows
+// Linux uses openat2/O_PATH. Darwin requires quiescent local APFS; Windows
 // requires local fixed-drive NTFS. Native execution remains a release gate.
 // The profile assumes a trusted kernel/mount namespace and ordinary local files;
 // it is not an atomic filesystem snapshot or protection from the same principal
@@ -20,16 +20,12 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strconv"
 	"sync"
 )
 
 const ScopeID = "agentplugins-captured-input-sha256-v1"
-
-// Each native profile has its own filesystem and kernel capability contract.
-const ReadProfile = "packageview-local-" + runtime.GOOS + "-v1"
 
 const TreeAlgorithm = "agentplugins-tree-sha256-v1"
 
@@ -227,6 +223,8 @@ type Lease struct {
 	hooks *captureHooks
 }
 type captureHooks struct {
+	nativeOpen func(string, int) // immediately before Darwin single-name openat
+
 	beforeDataOpen func(string)
 	dataOpenError  func(string) error
 	afterNameCheck func(string)
@@ -238,7 +236,21 @@ type captureHooks struct {
 func (r Reader) Open(ctx context.Context, exactRoot string) (_ *Lease, err error) {
 	return r.open(ctx, exactRoot, nil)
 }
-func (r Reader) open(ctx context.Context, exactRoot string, hooks *captureHooks) (_ *Lease, err error) {
+func (r Reader) open(ctx context.Context, exactRoot string, hooks *captureHooks) (*Lease, error) {
+	var l *Lease
+	err := sourceIO(func() (err error) { l, err = r.openPhase(ctx, exactRoot, hooks); return }, func() {
+		if l != nil {
+			l.input = Input{}
+			_ = l.close()
+		}
+	})
+	if err != nil {
+		markCleanupFailure(err, l)
+		return nil, err
+	}
+	return l, nil
+}
+func (r Reader) openPhase(ctx context.Context, exactRoot string, hooks *captureHooks) (_ *Lease, err error) {
 	if err = contextError(ctx); err != nil {
 		return nil, err
 	}
@@ -249,12 +261,19 @@ func (r Reader) open(ctx context.Context, exactRoot string, hooks *captureHooks)
 	if exactRoot == "" || r.TempDir == "" {
 		return nil, fail("explicit_roots_required")
 	}
-	s, err := openSource(exactRoot, r.Generated)
+	// GeneratedStaging (r.Generated) is intentionally not threaded through here:
+	// every platform's openSource already ignores it (see each source_*.go's
+	// comment), since this profile already admits ordinary writable local
+	// sources without needing that narrower proof. openSourceContext instead
+	// carries ctx through for platforms (Darwin v2) that observe cancellation
+	// during acquisition.
+	s, err := openSourceContext(ctx, exactRoot)
 	if err != nil {
 		return nil, err
 	}
 	l := &Lease{source: s, limits: limits, observations: map[string]os.FileInfo{}, linkInfos: map[string]os.FileInfo{}, directoryEntries: map[string][]string{}, contents: map[string][]byte{}, hooks: hooks}
 	defer l.finish(&err)
+	s.sourceHooks(hooks)
 	tmp, release, err := scratchParent(s, exactRoot, r.TempDir)
 	if err != nil {
 		return nil, err
@@ -326,7 +345,28 @@ func clone(v Input) Input {
 	v.Findings = append([]Finding(nil), v.Findings...)
 	return v
 }
-func (l *Lease) Close() error { l.mu.Lock(); defer l.mu.Unlock(); return l.close() }
+func (l *Lease) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		return l.closeErr
+	}
+	err := sourceIO(func() error {
+		if l.source != nil {
+			l.source.phaseContext(context.Background())
+			if e := l.source.verifyBindings(); e != nil {
+				return e
+			}
+		}
+		return l.close()
+	}, func() { l.input = Input{}; _ = l.close() })
+	if err != nil {
+		l.input = Input{}
+		markCleanupFailure(err, l)
+		l.closeErr = err
+	}
+	return err
+}
 func (l *Lease) close() error {
 	if l.closed {
 		return l.closeErr
@@ -347,6 +387,12 @@ func (l *Lease) close() error {
 				e = l.hooks.cleanup()
 			} else {
 				e = nil
+			}
+			if e == nil {
+				current, statErr := os.Lstat(l.private)
+				if statErr != nil || !os.SameFile(current, l.privateInfo) || !current.IsDir() {
+					e = fail("cleanup_failed")
+				}
 			}
 			if e == nil {
 				e = os.Chmod(l.private, 0700)
@@ -433,4 +479,18 @@ func (l *Lease) identity() {
 	}{ScopeID, ReadProfile, l.limits, l.input.Coverage, l.input.Legacy, l.input.SkillsRoot, records, l.input.Findings})
 	l.input.Identity.ScopeID = ScopeID
 	l.input.Identity.Digest = "sha256:" + hex.EncodeToString(h.Sum(nil))
+}
+
+func markCleanupFailure(err error, l *Lease) {
+	if l == nil || l.closeErr == nil {
+		return
+	}
+	var cleanup *Error
+	if !errors.As(l.closeErr, &cleanup) || !cleanup.CleanupFailed {
+		return
+	}
+	var safe *Error
+	if errors.As(err, &safe) {
+		safe.CleanupFailed = true
+	}
 }

--- a/install/integrationctl/agentplugins/adapters/packageview/view_linux_test.go
+++ b/install/integrationctl/agentplugins/adapters/packageview/view_linux_test.go
@@ -696,3 +696,70 @@ func TestReadOpenFailureDistinctFromAbsentAndRedacted(t *testing.T) {
 		t.Fatal("raw read-open error leaked")
 	}
 }
+
+func TestInventoryPanicClosesPins(t *testing.T) {
+	root, r := fixture(t)
+	put(t, root, "opaque", "inert payload")
+	warm, e := r.Open(context.Background(), root)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if e := warm.Close(); e != nil {
+		t.Fatal(e)
+	}
+	count := func() int {
+		entries, e := os.ReadDir("/proc/self/fd")
+		if e != nil {
+			t.Fatal(e)
+		}
+		return len(entries)
+	}
+	before := count()
+	held, e := os.Open(filepath.Join(root, "opaque"))
+	if e != nil {
+		t.Fatal(e)
+	}
+	defer held.Close()
+	if count() != before+1 {
+		t.Fatal("FD observer failed positive control")
+	}
+	if e := held.Close(); e != nil {
+		t.Fatal(e)
+	}
+	if count() != before {
+		t.Fatal("FD observer failed closed control")
+	}
+	for i := 0; i < 3; i++ {
+		fired := false
+		l, e := r.open(context.Background(), root, &captureHooks{afterChunk: func(n string) {
+			if n == "opaque" {
+				fired = true
+				panic("inventory panic")
+			}
+		}})
+		if e != nil {
+			t.Fatal(e)
+		}
+		var caught any
+		func() {
+			defer func() { caught = recover() }()
+			_, _ = l.Capture(context.Background())
+		}()
+		if !fired || caught != "inventory panic" {
+			t.Fatal("panic prerequisite", fired, caught)
+		}
+		if count() != before {
+			t.Fatal("descriptor leak after inventory panic")
+		}
+		if !reflect.DeepEqual(l.Data(), Input{}) {
+			t.Fatal("usable partial Input")
+		}
+		if e := l.Close(); e != nil {
+			t.Fatal(e)
+		}
+		if e := l.Close(); e != nil {
+			t.Fatal(e)
+		}
+		empty(t, r.TempDir)
+	}
+}


### PR DESCRIPTION
## Problem and behavior

The standard-first package reader needs writable ordinary local APFS support under the accepted quiescent-source contract. This change adds bounded ordered path resolution, thread-scoped materialization policy and explicit ownership/cleanup for the Darwin reader. The source and ancestor bindings must remain unchanged from Open through Close, including the Open/Capture gap. Hostile concurrent writers are outside this contract.

Stacked on #183 (`test/authoring-physical-fixture-delivery`); do not retarget to main without rebasing the dependency stack. This is the reader/contracts checkpoint. Command integration, producer qualification and release activation remain later gates in the implementation plan.

The shared post-open guard also preserves Windows native metadata registration: ordinary reads use the existing verified lease observation, while unknown metadata and hardlinks remain rejected.

## Validation

- Linux packageview and 29 regression package groups passed on the implementation checkpoints; Darwin no-cgo and Windows cross-compilation passed. Cross-compilation is not native qualification.
- Native Darwin arm64, macOS 15.6.1 / ordinary APFS, Go 1.25.13: focused reader/policy/shared tests and no-cgo rejection/zero-value Close tests passed on afc579c.
- Exact final test-only patch in b9f98ac2: all five native focused tests passed, including ten traversal cancellation/cause cases, distinct Capture context handoff, panic/FD cleanup, scratch aliases and observed-change precedence.
- Independent reviews accepted the production corrections and the final C1 test correction. Deadline fixture cases explicitly prove synthetic cause propagation, not wall-clock timer expiry.
- Exact head `178dfd823bb3cc083b2abc75bbc0752529a6826b`: all GitHub checks passed, including native Linux/Windows amd64 and arm64, packed Linux, source acquisition and both polyglot smoke jobs. Windows artifacts were inspected: zero failure or skip records, with both new ordinary-read tests and the unchanged hardlink test passing on each architecture.
- The same head passed focused native Darwin arm64 regression tests for ordinary capture, legacy/hardlink rejection, cleanup and writable APFS cancellation/context handoff/panic/FD behavior. Independent static review found no actionable defect in the four-file Windows correction. This remains a draft reader checkpoint; later release qualification is separate.

## Scope and remaining gates

Useful legacy YAML code, dependencies, tests and assets remain preserved. No YAML fallback or second engine is introduced. No public release or Pages activation is included.

The existing Windows parent-sharing gate remains unresolved. Device/dataless behavior, advertised macOS floor, ambient policy interaction, producer and CLI release qualification are not established by the focused native results. These limits must remain explicit before release.

Review size is 2,366 changed lines across 26 files, slightly above the 2,000-line target. The reader contract, resolver, scoped I/O policy and causal cleanup tests form one coherent acquisition invariant; splitting them would leave intermediate behavior unsupported. Most additions are focused tests and contract documentation.

## Update: rebased onto feat/authoring-frozen-native, real blocker found and proven - holding, not merging

Rebased the 5 commits unique to this PR onto the current `feat/authoring-frozen-native` (independently reviewed: reconciled `openSource`/`openSourceContext` with the `GeneratedStaging` cross-platform contract this session's earlier work added after this PR was originally written; removed two now-obsolete tests for the superseded v1 `trustedWritable` mechanism; fixed a real macOS `/var` symlink test bug in the new `TestPackedInstallerAssessmentBoundaries`). Verified clean via `go vet` across darwin/arm64, darwin/amd64, linux/amd64, linux/arm64, windows/amd64 on both affected modules, and the full packageview + authoring test suites pass on real native darwin/arm64 hardware, including real hdiutil-backed fixtures.

**Real, proven exact-head CI blocker on `Milestone A / darwin-arm64`:** `author.init` fails with `platform_unavailable` at the `host_safety` layer, reading `"read_profile":"packageview-local-darwin-v2"`. Root cause, traced to source:

- `source_io_darwin_nocgo.go`'s fallback intentionally rejects with `platform_unavailable` when cgo isn't available - exactly as this PR's own ADR 0006 documents ("Darwin without cgo rejects before source acquisition as `platform_unavailable`").
- `npm/agentplugins/scripts/stage-dual-authoring-candidate.js` hard-requires and cryptographically verifies `CGO_ENABLED=0` for all six shipped platform binaries, built from one trusted Linux amd64 builder (`GOHOSTOS !== "linux" || GOHOSTARCH !== "amd64"` throws; per-target `buildInfo()` throws `embedded Go build setting mismatch` if `CGO_ENABLED` isn't exactly `"0"`). This is a deliberate, verified hermetic single-builder reproducibility invariant, not a build script oversight.
- v2 unconditionally replaces v1 for all darwin+arm64 builds at compile time (`profile_darwin.go`'s `const ReadProfile = "packageview-local-darwin-v2"`), and requires cgo for every operation on that profile, not only the new writable-admission path - including the simple read-only `validate` flow that previously passed on v1 without cgo across PRs #171-183 on this exact stack.

Net effect: this PR, merged as-is, would regress the currently-green darwin-arm64 Milestone A E2E lane (read-only-mount validate, no writable admission needed) purely because v2 categorically requires cgo and the project's verified build pipeline categorically forbids it. This is a real architecture conflict between this PR's cgo-dependent design and the existing hermetic-build invariant, confirmed by direct CI log + source inspection, not a hypothesis.

**Not merging this PR right now.** The rest of the accelerated Milestone A / authoring stack (#171-183) does not depend on this PR and is already merged and green independently. Holding #186 open until either: the cgo requirement is made optional/gracefully-degrading for the already-working read-only case, or the build pipeline gains a deliberately-reviewed cgo-enabled darwin/arm64 path - both are real design decisions, not something to improvise inside this review.
