### PR TITLE
fix(release): match canonical default catalog selector

### DIFF
--- a/npm/agentplugins/scripts/platform-proof.js
+++ b/npm/agentplugins/scripts/platform-proof.js
@@ -164,7 +164,8 @@ function assertContext7Search(output) {
   if (output?.schema_version !== 1 || output.command !== "search" || output.result !== "success" ||
       !output.data || typeof output.data !== "object" || !Array.isArray(output.data.results) ||
       !output.data.results.some((result) => result?.product_id === "context7" &&
-        result.install_selector === "upstash/context7" &&
+        // Search emits the product selector for its active default distribution.
+        result.install_selector === "context7" &&
         result.distribution_id === "upstash/context7" &&
         result.distribution_kind === "upstream" &&
         result.trust_state === "reviewed" &&

--- a/npm/agentplugins/test/platform-proof.test.js
+++ b/npm/agentplugins/test/platform-proof.test.js
@@ -81,7 +81,7 @@ test("platform proof requires the reviewed upstream context7 distribution in sea
         { product_id: "other", distribution_id: "owner/other" },
         {
           product_id: "context7",
-          install_selector: "upstash/context7",
+          install_selector: "context7",
           distribution_id: "upstash/context7",
           distribution_kind: "upstream",
           trust_state: "reviewed",
@@ -93,6 +93,8 @@ test("platform proof requires the reviewed upstream context7 distribution in sea
   assert.doesNotThrow(() => assertContext7Search(valid));
   for (const invalid of [
     { ...valid, data: { results: [] } },
+    { ...valid, data: { results: [{ ...valid.data.results[1], install_selector: "other" }] } },
+    { ...valid, data: { results: [{ ...valid.data.results[1], install_selector: "discovery:upstash/context7//plugins/agent-plugins/context7" }] } },
     { ...valid, data: { results: [{ ...valid.data.results[1], distribution_id: "777genius/context7" }] } },
     { ...valid, data: { results: [{ ...valid.data.results[1], distribution_kind: "community_bridge" }] } },
     { ...valid, data: { results: [{ ...valid.data.results[1], trust_state: "discovered" }] } },


### PR DESCRIPTION
The 0.1.52 draft failed all six platform checks because the proof expected the qualified selector `upstash/context7`. The CLI uses the product selector `context7` for its active default distribution. Match that canonical selector while retaining the exact distribution ID, upstream provenance, reviewed trust, availability, and response-envelope checks.

The frozen 0.1.52 binary output reproduces the failure under the previous predicate and passes the corrected predicate. Added negative selector regressions; 11 focused tests pass. Independent review approved the exact patch. No native client or user project was used for reproduction.

The complete corrected platform proof also passed against the frozen 0.1.52 npm tarball and binary assets in a disposable Linux arm64 Docker container, including cold/warm bootstrap and add/info/update/remove. This diagnostic is distinct from the next release proof.

The unpublished 0.1.52 draft and tag remain unchanged. A new release candidate will use the corrected harness after this PR passes CI and merges.

Refs #188
