### PR TITLE
fix(test): harden released native proof on Windows

### DIFF
--- a/scripts/run-native-client-matrix.py
+++ b/scripts/run-native-client-matrix.py
@@ -113,10 +113,10 @@ def provision_release(source, directory, target, tag, commit, repository):
         raise ValueError("an exact producer source commit is required")
     if repository != "777genius/universal-agent-plugins":
         raise ValueError("unsupported binary producer repository")
-    metadata = json.loads(subprocess.check_output(["gh", "api", f"repos/{repository}/releases/tags/{tag}"], text=True))
+    metadata = json.loads(subprocess.check_output(["gh", "api", f"repos/{repository}/releases/tags/{tag}"], encoding="utf-8", errors="strict"))
     if metadata.get("draft") is not False or metadata.get("prerelease") is not False or metadata.get("tag_name") != tag:
         raise ValueError("native release proof requires an exact public stable release")
-    tagged = json.loads(subprocess.check_output(["gh", "api", f"repos/{repository}/commits/{tag}"], text=True))
+    tagged = json.loads(subprocess.check_output(["gh", "api", f"repos/{repository}/commits/{tag}"], encoding="utf-8", errors="strict"))
     if tagged.get("sha") != commit:
         raise ValueError("producer release tag differs from expected commit")
     tree = tagged["commit"]["tree"]["sha"]
@@ -125,7 +125,7 @@ def provision_release(source, directory, target, tag, commit, repository):
     assets = directory / "release-assets"
     assets.mkdir()
     subprocess.run(["gh", "release", "download", tag, "--repo", repository, "--dir", str(assets)], check=True, timeout=300)
-    verified = json.loads(subprocess.check_output(["node", str(source / "npm/agentplugins/scripts/release-assets.js"), "verify", str(assets), tag, commit], text=True, timeout=60))
+    verified = json.loads(subprocess.check_output(["node", str(source / "npm/agentplugins/scripts/release-assets.js"), "verify", str(assets), tag, commit], encoding="utf-8", errors="strict", timeout=60))
     selected = verified["assets"][target]
     installer = assets / selected["file"]
     attestations = {}
@@ -133,7 +133,7 @@ def provision_release(source, directory, target, tag, commit, repository):
         attestations[name] = json.loads(subprocess.check_output([
             "gh", "attestation", "verify", str(assets / name), "--repo", repository,
             "--signer-workflow", f"github.com/{repository}/.github/workflows/agentplugins-release.yml",
-            "--source-digest", commit, "--deny-self-hosted-runners", "--format", "json"], text=True, timeout=180))
+            "--source-digest", commit, "--deny-self-hosted-runners", "--format", "json"], encoding="utf-8", errors="strict", timeout=180))
     installer.chmod(0o700)
     return installer, {"acquisition": "public GitHub release download", "repository": repository,
         "tag": tag, "version": verified["version"], "commit": commit, "tree": tree,
@@ -191,7 +191,7 @@ def main():
     identity = {"schema_version": 1, "client": args.client, "target": args.target, "started_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), "isolation": "disposable GitHub-hosted machine; explicit runtime environment; fresh project and profiles", "network": "not blocked; scripted loopback model endpoints; no real-model or OAuth proof", "status": "failed", "scratch": str(scratch)}
     try:
         for key, rev in [("commit", "HEAD"), ("tree", "HEAD^{tree}")]:
-            identity[key] = subprocess.check_output(["git", "rev-parse", rev], cwd=source, text=True).strip()
+            identity[key] = subprocess.check_output(["git", "rev-parse", rev], cwd=source, encoding="utf-8", errors="strict").strip()
         expected = os.environ.get("EXPECTED_COMMIT", "")
         if not re.fullmatch(r"[0-9a-f]{40}", expected) or identity["commit"] != expected:
             raise RuntimeError("checkout differs from expected exact workflow source commit")
@@ -233,7 +233,7 @@ def main():
                 env["PATH"] += os.pathsep + str(Path(git).parent)
                 env["AGENTPLUGINS_NATIVE_GIT_BIN_DIR"] = str(Path(git).parent)
                 identity["git_path"] = git
-                identity["git_version"] = subprocess.check_output([git, "--version"], text=True).strip()
+                identity["git_version"] = subprocess.check_output([git, "--version"], encoding="utf-8", errors="strict").strip()
                 bash = find_git_bash(git)
                 if args.client == "claude" and bash is None:
                     raise RuntimeError("Claude Windows proof requires Git Bash in the detected Git installation")
@@ -253,7 +253,7 @@ def main():
             release = identity["installer_release"]
             env["AGENTPLUGINS_INSTALLER_COMMIT"] = release["commit"]
             env["AGENTPLUGINS_INSTALLER_TREE"] = release["tree"]
-            measured = subprocess.check_output([str(installer), "version"], cwd=project, env=env, text=True, timeout=30).strip()
+            measured = subprocess.check_output([str(installer), "version"], cwd=project, env=env, encoding="utf-8", errors="strict", timeout=30).strip()
             identity["installer_version_measured"] = measured
             if measured != "agentplugins " + release["version"]:
                 raise RuntimeError(f"released installer version mismatch: {measured!r}")

--- a/scripts/run-native-client-matrix.py
+++ b/scripts/run-native-client-matrix.py
@@ -161,6 +161,17 @@ def disposable_runtime_environment(target):
     return env
 
 
+def profile_environment(home, target):
+    """Prepare the fresh profile before any installer probe or native test."""
+    env = {"HOME": str(home), "USERPROFILE": str(home)}
+    if target == "windows-amd64":
+        for key, directory in (("APPDATA", "Roaming"), ("LOCALAPPDATA", "Local")):
+            path = home / "AppData" / directory
+            path.mkdir(parents=True, exist_ok=False)
+            env[key] = str(path)
+    return env
+
+
 def find_git_bash(git):
     # GitHub runners may expose Git through bin, cmd, or mingw64/bin.
     # Search only the detected installation ancestors, never an ambient shell.
@@ -221,7 +232,7 @@ def main():
         evidence_root.mkdir()
         home = scratch / "home"
         home.mkdir()
-        env = {"HOME": str(home), "USERPROFILE": str(home), "TEMP": str(evidence_root), "TMP": str(evidence_root), "TMPDIR": str(evidence_root), "PATH": str(binary_dir), "LANG": "en_US.UTF-8", **disposable_runtime_environment(args.target), "AGENTPLUGINS_INSTALLER_BIN": str(installer), "AGENTPLUGINS_INSTALLER_COMMIT": identity["commit"], "AGENTPLUGINS_INSTALLER_TREE": identity["tree"], "AGENTPLUGINS_NATIVE_PROBE_BIN": str(probe), "AGENTPLUGINS_LINTAI_BIN": str(scanner), "AGENTPLUGINS_LINTAI_SHA256": scanner_evidence["binary_sha256"], "AGENTPLUGINS_LINTAI_ARCHIVE_SHA256": PINS[args.target]["lintai"][4].split(":", 1)[1]}
+        env = {**profile_environment(home, args.target), "TEMP": str(evidence_root), "TMP": str(evidence_root), "TMPDIR": str(evidence_root), "PATH": str(binary_dir), "LANG": "en_US.UTF-8", **disposable_runtime_environment(args.target), "AGENTPLUGINS_INSTALLER_BIN": str(installer), "AGENTPLUGINS_INSTALLER_COMMIT": identity["commit"], "AGENTPLUGINS_INSTALLER_TREE": identity["tree"], "AGENTPLUGINS_NATIVE_PROBE_BIN": str(probe), "AGENTPLUGINS_LINTAI_BIN": str(scanner), "AGENTPLUGINS_LINTAI_SHA256": scanner_evidence["binary_sha256"], "AGENTPLUGINS_LINTAI_ARCHIVE_SHA256": PINS[args.target]["lintai"][4].split(":", 1)[1]}
         if os.name == "nt":
             env["SystemRoot"] = os.environ["SystemRoot"]
             env["COMSPEC"] = str(Path(env["SystemRoot"]) / "System32/cmd.exe")

--- a/scripts/test_native_client_matrix.py
+++ b/scripts/test_native_client_matrix.py
@@ -75,6 +75,30 @@ class NativeMatrixTests(unittest.TestCase):
                 matrix.provision_release(Path("."), Path("."), "darwin-arm64", "agentplugins-v1.2.3", "a" * 40, "777genius/universal-agent-plugins")
             download.assert_not_called()
 
+    def test_windows_profile_is_ready_for_pretest_probe_without_ambient_appdata(self):
+        with tempfile.TemporaryDirectory() as temp:
+            home = Path(temp) / "home"
+            home.mkdir()
+            ambient = {"APPDATA": str(Path(temp) / "foreign-roaming"), "LOCALAPPDATA": str(Path(temp) / "foreign-local")}
+            with patch.dict(matrix.os.environ, ambient):
+                env = matrix.profile_environment(home, "windows-amd64")
+                # Ordinary Python child only: exercise the exact profile passed
+                # to the pre-test probe without running a client or installer.
+                if matrix.os.name == "nt":
+                    env["SystemRoot"] = matrix.os.environ["SystemRoot"]
+                output = matrix.subprocess.check_output([sys.executable, "-c",
+                    "import os,json; from pathlib import Path; "
+                    "paths={k:os.environ[k] for k in ('HOME','USERPROFILE','APPDATA','LOCALAPPDATA')}; "
+                    "[(Path(paths[k])/'probe.txt').write_text('isolated') for k in ('APPDATA','LOCALAPPDATA')]; "
+                    "print(json.dumps(paths))"], env=env, encoding="utf-8", errors="strict")
+            measured = json.loads(output)
+            self.assertEqual(measured["HOME"], str(home))
+            self.assertEqual(measured["USERPROFILE"], str(home))
+            for key, subdir in (("APPDATA", "Roaming"), ("LOCALAPPDATA", "Local")):
+                self.assertEqual(measured[key], str(home / "AppData" / subdir))
+                self.assertEqual((Path(measured[key]) / "probe.txt").read_text(), "isolated")
+                self.assertFalse(Path(ambient[key]).exists())
+
     def test_git_bash_discovery_supports_runner_git_layouts(self):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp).resolve()

--- a/scripts/test_native_client_matrix.py
+++ b/scripts/test_native_client_matrix.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 import tarfile
 import tempfile
+import sys
 import unittest
 from unittest.mock import patch
 import zipfile
@@ -43,7 +44,16 @@ class NativeMatrixTests(unittest.TestCase):
                 {"tag_name": "agentplugins-v1.2.3", "draft": False, "prerelease": False},
                 {"sha": "a" * 40, "commit": {"tree": {"sha": "b" * 40}}},
                 {"version": "1.2.3", "manifest_sha256": "c" * 64, "assets": {"darwin-arm64": {"file": asset, "sha256": "d" * 64, "size": 9}}}, [], [], []]
-            with patch.object(matrix.subprocess, "check_output", side_effect=[json.dumps(r) for r in responses]) as check, patch.object(matrix.subprocess, "run", side_effect=download):
+            # Simulate the Windows ANSI locale while real child processes emit
+            # UTF-8 JSON. Cyrillic я contains 0x8f, undefined in cp1252.
+            payloads = iter(json.dumps({**r, "unicode_note": "я 😀"} if isinstance(r, dict) else r,
+                                       ensure_ascii=False).encode("utf-8") for r in responses)
+            real_run = matrix.subprocess.run
+            def child_output(command, **kwargs):
+                payload = next(payloads)
+                return real_run([sys.executable, "-c", "import sys; sys.stdout.buffer.write(" + repr(payload) + ")"],
+                                stdout=matrix.subprocess.PIPE, check=True, **kwargs).stdout
+            with patch.object(matrix.subprocess, "_text_encoding", return_value="cp1252"), patch.object(matrix.subprocess, "check_output", side_effect=child_output) as check, patch.object(matrix.subprocess, "run", side_effect=download):
                 installer, evidence = matrix.provision_release(Path("."), directory, "darwin-arm64", "agentplugins-v1.2.3", "a" * 40, "777genius/universal-agent-plugins")
             self.assertEqual(installer.read_bytes(), b"installer")
             self.assertEqual(evidence["commit"], "a" * 40)
@@ -54,6 +64,16 @@ class NativeMatrixTests(unittest.TestCase):
                 self.assertEqual(command[command.index("--source-digest") + 1], "a" * 40)
                 self.assertIn("github.com/777genius/universal-agent-plugins/.github/workflows/agentplugins-release.yml", command)
             self.assertEqual(set(evidence["attestations"]), {asset, "checksums.txt", "release-manifest.json"})
+
+    def test_release_json_invalid_utf8_fails_before_download(self):
+        real_run = matrix.subprocess.run
+        def child_output(command, **kwargs):
+            return real_run([sys.executable, "-c", "import sys; sys.stdout.buffer.write(b'\\xff')"],
+                            stdout=matrix.subprocess.PIPE, check=True, **kwargs).stdout
+        with patch.object(matrix.subprocess, "_text_encoding", return_value="cp1252"), patch.object(matrix.subprocess, "check_output", side_effect=child_output), patch.object(matrix.subprocess, "run") as download:
+            with self.assertRaises(UnicodeDecodeError):
+                matrix.provision_release(Path("."), Path("."), "darwin-arm64", "agentplugins-v1.2.3", "a" * 40, "777genius/universal-agent-plugins")
+            download.assert_not_called()
 
     def test_git_bash_discovery_supports_runner_git_layouts(self):
         with tempfile.TemporaryDirectory() as temp:


### PR DESCRIPTION
The released-installer proof could not reach Windows client execution: Python decoded GitHub's UTF-8 commit JSON using cp1252, and the early installer version probe lacked an isolated AppData profile. Decode subprocess text explicitly as strict UTF-8 and create fresh APPDATA/LOCALAPPDATA paths before the probe and native test subprocess. Ambient user profiles remain excluded.

A real-child subprocess regression under a forced cp1252 default reproduces the previous UnicodeDecodeError and passes with the fix. Invalid UTF-8 remains rejected before artifact download. Another child-process regression verifies profile writes stay inside fresh directories despite poisoned ambient AppData values. Sixteen focused tests pass; independent review approved both changes.

The published 0.1.53 installer is unchanged. Its six Linux/macOS native-client jobs and all six public launcher/platform proofs passed. Windows native-client proof will use the same published binary with the corrected, separately identified harness commit.

Refs #188
