### PR TITLE
docs: publish released native compatibility evidence

### DIFF
--- a/docs/evidence/client-compatibility-released-0.1.53.json
+++ b/docs/evidence/client-compatibility-released-0.1.53.json
@@ -1,0 +1,510 @@
+{
+  "schema_version": 1,
+  "record_date": "2026-09-08",
+  "evidence_kind": "public_release_native_client_runtime",
+  "release": {
+    "repository": "777genius/universal-agent-plugins",
+    "tag": "agentplugins-v0.1.53",
+    "version": "0.1.53",
+    "commit": "28cf05af0a1e4fea642825dd34b78f9c99094ab5",
+    "tree": "9e3bcc3a951031b9a1bd83de12c36b70270f45dc",
+    "manifest_sha256": "9278d6f755adc53002c08ed6078457f0f2fba2fb55057f1f739d05cfeb1bf696",
+    "checksums_sha256": "cb800621c8b7f0e6de636a8a719b61b666a8aaa07135e35438e2b5e880fd53d9"
+  },
+  "native_workflow": {
+    "run_id": 34166817934,
+    "url": "https://github.com/777genius/universal-agent-plugins/actions/runs/34166817934",
+    "harness_commit": "9c33cfac81fc00e61205591321c89c5675fedb60",
+    "harness_tree": "d17e72793961e6798d09eb44256c832465f2d8c7",
+    "conclusion": "success"
+  },
+  "launcher_workflow": {
+    "run_id": 34164699278,
+    "url": "https://github.com/777genius/universal-agent-plugins/actions/runs/34164699278",
+    "commit": "28cf05af0a1e4fea642825dd34b78f9c99094ab5",
+    "conclusion": "success",
+    "targets": [
+      "darwin-amd64",
+      "darwin-arm64",
+      "linux-amd64",
+      "linux-arm64",
+      "windows-amd64",
+      "windows-arm64"
+    ],
+    "boundary": "Frozen installer bootstrap and synthetic lifecycle, separate from native-client runtime."
+  },
+  "archive": {
+    "publication_status": "published_verified_download",
+    "evidence_tag": "native-evidence-0.1.53-34166817934",
+    "release_url": "https://github.com/777genius/universal-agent-plugins/releases/tag/native-evidence-0.1.53-34166817934",
+    "asset_url": "https://github.com/777genius/universal-agent-plugins/releases/download/native-evidence-0.1.53-34166817934/uap-0.1.53-native-34166817934.zip",
+    "filename": "uap-0.1.53-native-34166817934.zip",
+    "sha256": "0d315f3a24bb6c41d184f0632d76a7228e18a6c1c41be2774e23c8066dfd3af6",
+    "size_bytes": 3165833,
+    "original_file_count": 529,
+    "zip_entry_count": 530,
+    "sidecar_url": "https://github.com/777genius/universal-agent-plugins/releases/download/native-evidence-0.1.53-34166817934/uap-0.1.53-native-34166817934.zip.sha256"
+  },
+  "verification": {
+    "kind": "offline_hash_and_record_consistency",
+    "verifier_source_path": "scripts/verify-released-native-evidence.py",
+    "verifier_source_sha256": "b2a7b9cf620dff0ed67d2a1fcfb046c2e1805fc122d020a4d415597a76d01224",
+    "source_boundary": "Verifier is delivered by the later documentation commit, not present at the original runtime harness commit. Pin that documentation commit when reproducing archive verification.",
+    "provenance": "Public release attestations verified by hosted runner before installer execution; offline packaging does not repeat cryptographic verification.",
+    "publication_boundary": "Separate public evidence ZIP and checksum sidecar re-downloaded through gh and verified against the recorded SHA-256 on 2026-09-08."
+  },
+  "lanes": [
+    {
+      "client": "claude",
+      "target": "darwin-arm64",
+      "status": "passed",
+      "client_asset": {
+        "source": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.263.tgz",
+        "version": "2.1.263",
+        "archive": "claude-code-darwin-arm64-2.1.263.tgz",
+        "archive_integrity": "sha512-yLv8MtgulGMGCWTwDUSmlEL0+94sxKP3vJm0SAXZX+0qVQ09PrjVSRC0ibtVeW7xymyhvP1JaUimOyp+t2wO5g==",
+        "binary_sha256": "ef5d2909c8af49f31ab6d5487e90316777bc2fac170adfe8160716caa8aaf4f9"
+      },
+      "scanner_asset": {
+        "source": "https://github.com/777genius/lintai/releases/tag/v0.1.3",
+        "version": "v0.1.3",
+        "archive": "lintai-v0.1.3-aarch64-apple-darwin.tar.gz",
+        "archive_integrity": "sha256:be8b263e2323074080d928ea7c2129458299a6d03f7a9f178dfc1aa8e6bc17ff",
+        "binary_sha256": "37342414aa7feadc09b8473d1bfafe95fd79ab99f284d37518c930fcb7986c57"
+      },
+      "ripgrep_asset": {
+        "source": "https://github.com/BurntSushi/ripgrep/releases/tag/15.2.0",
+        "version": "15.2.0",
+        "archive": "ripgrep-15.2.0-aarch64-apple-darwin.tar.gz",
+        "archive_integrity": "sha256:3750b2e93f37e0c692657da574d7019a101c0084da05a790c83fd335bad973e4",
+        "binary_sha256": "a326a1fb48074202e9ad41e4cd1e389eeea372c8c6f7d7e80da81176d5d9430e"
+      },
+      "installer_asset": {
+        "file": "agentplugins_0.1.53_darwin_arm64",
+        "size": 12584322,
+        "binary_sha256": "7bc16e2183786963803fb83f1e5a351615362f49c578d174611293859fa12cd0"
+      },
+      "installer_version_measured": "agentplugins 0.1.53",
+      "harness_build_sha256": {
+        "native-probe": "28905662e18b27d90e4b6dfa3e9e57af5de0042eb098243ef82038d3f9614032",
+        "repotests": "29d47f69d7a6ce52bb843314fca88518ae8ec968de100c6121231a74fa6c10a2"
+      },
+      "runner_evidence_path": "released-native-client-claude-darwin-arm64/runner-evidence.json",
+      "runner_evidence_sha256": "481c04db3b5b17142414ab10c3174ce0d70ca405f092a724b7e925e66cbf871f",
+      "passed_tests": [
+        "TestAgentpluginsClaudeNativeLifecycle",
+        "TestAgentpluginsClaudeNativeRuntimeLifecycle"
+      ],
+      "skipped_tests": [],
+      "indexed_artifact_count": 37,
+      "structured_fixture_paths": [
+        "uap-claude-native-evidence-3842199758/evidence.json",
+        "uap-native-evidence-155688856/evidence.json"
+      ]
+    },
+    {
+      "client": "claude",
+      "target": "linux-arm64",
+      "status": "passed",
+      "client_asset": {
+        "source": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.263.tgz",
+        "version": "2.1.263",
+        "archive": "claude-code-linux-arm64-2.1.263.tgz",
+        "archive_integrity": "sha512-RlJtLbl8xqFMf2zUdOKD4o5FkNhcgGjlS3Un8PNfSbv1fLQg3SqBQgEJhNEtSeKlEsOs26RnCG/jVk4yah8Udw==",
+        "binary_sha256": "7d25d7c8ae6c6e009cc7dae4e817f674179fd31fb7761bcd56fee4c2902b4c03"
+      },
+      "scanner_asset": {
+        "source": "https://github.com/777genius/lintai/releases/tag/v0.1.3",
+        "version": "v0.1.3",
+        "archive": "lintai-v0.1.3-aarch64-unknown-linux-gnu.tar.gz",
+        "archive_integrity": "sha256:132a37610575bd251ecaf0be4c6090dad144dd1397c99aad989a3944c63c3d4a",
+        "binary_sha256": "7eb11068063a95160c2adb38e1e4e118dbde98b35ecdfb2c627f2d5624b70b0c"
+      },
+      "ripgrep_asset": {
+        "source": "https://github.com/BurntSushi/ripgrep/releases/tag/15.2.0",
+        "version": "15.2.0",
+        "archive": "ripgrep-15.2.0-aarch64-unknown-linux-gnu.tar.gz",
+        "archive_integrity": "sha256:a740b91c82eaf9914cfedd353572f2791cbe0162c84101ee0951058f4dcbc90d",
+        "binary_sha256": "e36d0eb52e70696bdf1781392722e05a21bb91d3b7b762ef5ec20e5df2ec687b"
+      },
+      "installer_asset": {
+        "file": "agentplugins_0.1.53_linux_arm64",
+        "size": 12452024,
+        "binary_sha256": "f33a5b72a53d503416e573f0fae8cef7d5193f48edd2cfe4bcf8e36c3e57fb99"
+      },
+      "installer_version_measured": "agentplugins 0.1.53",
+      "harness_build_sha256": {
+        "native-probe": "6012a9e02420c5e0423fd086ce65a60d93bfc03e808c10b9b73957e931acdca8",
+        "repotests": "92146d77e0f5416be777032026608bcc58dc07b1e6c1dc8d99ac4e21c373c231"
+      },
+      "runner_evidence_path": "released-native-client-claude-linux-arm64/runner-evidence.json",
+      "runner_evidence_sha256": "3dc1e9fe45ef0cb1222a6425e8b7019dfedc7d5761f508b143368e7fbd7e58bb",
+      "passed_tests": [
+        "TestAgentpluginsClaudeNativeLifecycle",
+        "TestAgentpluginsClaudeNativeRuntimeLifecycle"
+      ],
+      "skipped_tests": [],
+      "indexed_artifact_count": 37,
+      "structured_fixture_paths": [
+        "uap-claude-native-evidence-3269414146/evidence.json",
+        "uap-native-evidence-2420074862/evidence.json"
+      ]
+    },
+    {
+      "client": "claude",
+      "target": "windows-amd64",
+      "status": "passed",
+      "client_asset": {
+        "source": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.263.tgz",
+        "version": "2.1.263",
+        "archive": "claude-code-win32-x64-2.1.263.tgz",
+        "archive_integrity": "sha512-P1LnudAWj2ptyE0IZzCZKAe7nU7LxqlkcLdBfp8FsHlH5dp75Og4JJ6TClvfjanHn3shYW4CYN6oI1vSqZlkHw==",
+        "binary_sha256": "0b35df94c1307004f07b738390bfef8dfca5e9af29aaf6517f305bf086b95b03"
+      },
+      "scanner_asset": {
+        "source": "https://github.com/777genius/lintai/releases/tag/v0.1.3",
+        "version": "v0.1.3",
+        "archive": "lintai-v0.1.3-x86_64-pc-windows-msvc.zip",
+        "archive_integrity": "sha256:2f61f6a83a160afa3feed9ea1722b82d0d938ebff865a4e20d39b5f55270c911",
+        "binary_sha256": "9d486e5b66875384c12a147b8a19007beebe2691bc6d23a7867bf019b70be453"
+      },
+      "ripgrep_asset": {
+        "source": "https://github.com/BurntSushi/ripgrep/releases/tag/15.2.0",
+        "version": "15.2.0",
+        "archive": "ripgrep-15.2.0-x86_64-pc-windows-msvc.zip",
+        "archive_integrity": "sha256:71b2fef860abe467217a538ff31de02f5258807c0129f771846f87bd029aafc5",
+        "binary_sha256": "14231169855ec5205cf5a1b6f1db358ff4aed4247c86b69ce8aae647c77f6680"
+      },
+      "installer_asset": {
+        "file": "agentplugins_0.1.53_windows_amd64.exe",
+        "size": 13676032,
+        "binary_sha256": "4acfe85614ba34069e9d77addaa877bb44e3c519fbe77423703a7bd4709addde"
+      },
+      "installer_version_measured": "agentplugins 0.1.53",
+      "harness_build_sha256": {
+        "native-probe.exe": "9d16c5d926807a526c89047a6dd7cf817eb3ec44c0c51c9ded4854950def1a0a",
+        "repotests.exe": "af08548cc279df4bcc063eec3290c19ae314183a503bd4f1a7c7b6ce24ee45e1"
+      },
+      "runner_evidence_path": "released-native-client-claude-windows-amd64/runner-evidence.json",
+      "runner_evidence_sha256": "596d02a0cc97d920922098833ea8723c3eec9c679450c0c23818a657604e2374",
+      "passed_tests": [
+        "TestAgentpluginsClaudeNativeLifecycle",
+        "TestAgentpluginsClaudeNativeRuntimeLifecycle"
+      ],
+      "skipped_tests": [],
+      "indexed_artifact_count": 41,
+      "structured_fixture_paths": [
+        "uap-claude-native-evidence-2348571833/evidence.json",
+        "uap-native-evidence-1935402644/evidence.json"
+      ]
+    },
+    {
+      "client": "codex",
+      "target": "darwin-arm64",
+      "status": "passed",
+      "client_asset": {
+        "source": "https://github.com/openai/codex/releases/tag/rust-v0.153.4",
+        "version": "rust-v0.153.4",
+        "archive": "codex-aarch64-apple-darwin.tar.gz",
+        "archive_integrity": "sha256:8cf911ea676523bfb2121ec561848d2aba564890ad536db4d8a3353f2b9850b1",
+        "binary_sha256": "b973d440acac501fd2594a43e7ca9ce41e0a65b9dfb28d0d7a7837c99e1261e3"
+      },
+      "scanner_asset": {
+        "source": "https://github.com/777genius/lintai/releases/tag/v0.1.3",
+        "version": "v0.1.3",
+        "archive": "lintai-v0.1.3-aarch64-apple-darwin.tar.gz",
+        "archive_integrity": "sha256:be8b263e2323074080d928ea7c2129458299a6d03f7a9f178dfc1aa8e6bc17ff",
+        "binary_sha256": "37342414aa7feadc09b8473d1bfafe95fd79ab99f284d37518c930fcb7986c57"
+      },
+      "ripgrep_asset": {
+        "source": "https://github.com/BurntSushi/ripgrep/releases/tag/15.2.0",
+        "version": "15.2.0",
+        "archive": "ripgrep-15.2.0-aarch64-apple-darwin.tar.gz",
+        "archive_integrity": "sha256:3750b2e93f37e0c692657da574d7019a101c0084da05a790c83fd335bad973e4",
+        "binary_sha256": "a326a1fb48074202e9ad41e4cd1e389eeea372c8c6f7d7e80da81176d5d9430e"
+      },
+      "installer_asset": {
+        "file": "agentplugins_0.1.53_darwin_arm64",
+        "size": 12584322,
+        "binary_sha256": "7bc16e2183786963803fb83f1e5a351615362f49c578d174611293859fa12cd0"
+      },
+      "installer_version_measured": "agentplugins 0.1.53",
+      "harness_build_sha256": {
+        "native-probe": "28905662e18b27d90e4b6dfa3e9e57af5de0042eb098243ef82038d3f9614032",
+        "repotests": "29d47f69d7a6ce52bb843314fca88518ae8ec968de100c6121231a74fa6c10a2"
+      },
+      "runner_evidence_path": "released-native-client-codex-darwin-arm64/runner-evidence.json",
+      "runner_evidence_sha256": "1497bbe38a5d2b980cc914b8f457ab5d630c01bbf8eab3456a9e0656ce7ec325",
+      "passed_tests": [
+        "TestAgentpluginsCodexNativeLifecycle"
+      ],
+      "skipped_tests": [],
+      "indexed_artifact_count": 52,
+      "structured_fixture_paths": [
+        "uap-native-evidence-42330369/evidence.json"
+      ]
+    },
+    {
+      "client": "codex",
+      "target": "linux-arm64",
+      "status": "passed",
+      "client_asset": {
+        "source": "https://github.com/openai/codex/releases/tag/rust-v0.153.4",
+        "version": "rust-v0.153.4",
+        "archive": "codex-aarch64-unknown-linux-musl.tar.gz",
+        "archive_integrity": "sha256:5cda6182bd94c3a30f2eb63a495489ebf7f691fddb14d70f48c6c1a5071b6cde",
+        "binary_sha256": "4d76e542c222ea8c75861d8c4ade60a1a332a63255ce1c60bdaebf7c2a2869e6"
+      },
+      "scanner_asset": {
+        "source": "https://github.com/777genius/lintai/releases/tag/v0.1.3",
+        "version": "v0.1.3",
+        "archive": "lintai-v0.1.3-aarch64-unknown-linux-gnu.tar.gz",
+        "archive_integrity": "sha256:132a37610575bd251ecaf0be4c6090dad144dd1397c99aad989a3944c63c3d4a",
+        "binary_sha256": "7eb11068063a95160c2adb38e1e4e118dbde98b35ecdfb2c627f2d5624b70b0c"
+      },
+      "ripgrep_asset": {
+        "source": "https://github.com/BurntSushi/ripgrep/releases/tag/15.2.0",
+        "version": "15.2.0",
+        "archive": "ripgrep-15.2.0-aarch64-unknown-linux-gnu.tar.gz",
+        "archive_integrity": "sha256:a740b91c82eaf9914cfedd353572f2791cbe0162c84101ee0951058f4dcbc90d",
+        "binary_sha256": "e36d0eb52e70696bdf1781392722e05a21bb91d3b7b762ef5ec20e5df2ec687b"
+      },
+      "installer_asset": {
+        "file": "agentplugins_0.1.53_linux_arm64",
+        "size": 12452024,
+        "binary_sha256": "f33a5b72a53d503416e573f0fae8cef7d5193f48edd2cfe4bcf8e36c3e57fb99"
+      },
+      "installer_version_measured": "agentplugins 0.1.53",
+      "harness_build_sha256": {
+        "native-probe": "6012a9e02420c5e0423fd086ce65a60d93bfc03e808c10b9b73957e931acdca8",
+        "repotests": "92146d77e0f5416be777032026608bcc58dc07b1e6c1dc8d99ac4e21c373c231"
+      },
+      "runner_evidence_path": "released-native-client-codex-linux-arm64/runner-evidence.json",
+      "runner_evidence_sha256": "fa49105c7d01bc8bf128feac7e8c8f92febbfcf0e1326362840aed727324d674",
+      "passed_tests": [
+        "TestAgentpluginsCodexNativeLifecycle"
+      ],
+      "skipped_tests": [],
+      "indexed_artifact_count": 52,
+      "structured_fixture_paths": [
+        "uap-native-evidence-1087345249/evidence.json"
+      ]
+    },
+    {
+      "client": "codex",
+      "target": "windows-amd64",
+      "status": "passed",
+      "client_asset": {
+        "source": "https://github.com/openai/codex/releases/tag/rust-v0.153.4",
+        "version": "rust-v0.153.4",
+        "archive": "codex-x86_64-pc-windows-msvc.exe.zip",
+        "archive_integrity": "sha256:c016b0e6968b78586919c720d2685a03712f6d5f11bcd9d6f92c91eb8c41ba16",
+        "binary_sha256": "444a3f0008050605cae73cd9b7a2dcac61294062dfaab56dd20430fd6498518b"
+      },
+      "scanner_asset": {
+        "source": "https://github.com/777genius/lintai/releases/tag/v0.1.3",
+        "version": "v0.1.3",
+        "archive": "lintai-v0.1.3-x86_64-pc-windows-msvc.zip",
+        "archive_integrity": "sha256:2f61f6a83a160afa3feed9ea1722b82d0d938ebff865a4e20d39b5f55270c911",
+        "binary_sha256": "9d486e5b66875384c12a147b8a19007beebe2691bc6d23a7867bf019b70be453"
+      },
+      "ripgrep_asset": {
+        "source": "https://github.com/BurntSushi/ripgrep/releases/tag/15.2.0",
+        "version": "15.2.0",
+        "archive": "ripgrep-15.2.0-x86_64-pc-windows-msvc.zip",
+        "archive_integrity": "sha256:71b2fef860abe467217a538ff31de02f5258807c0129f771846f87bd029aafc5",
+        "binary_sha256": "14231169855ec5205cf5a1b6f1db358ff4aed4247c86b69ce8aae647c77f6680"
+      },
+      "installer_asset": {
+        "file": "agentplugins_0.1.53_windows_amd64.exe",
+        "size": 13676032,
+        "binary_sha256": "4acfe85614ba34069e9d77addaa877bb44e3c519fbe77423703a7bd4709addde"
+      },
+      "installer_version_measured": "agentplugins 0.1.53",
+      "harness_build_sha256": {
+        "native-probe.exe": "9d16c5d926807a526c89047a6dd7cf817eb3ec44c0c51c9ded4854950def1a0a",
+        "repotests.exe": "af08548cc279df4bcc063eec3290c19ae314183a503bd4f1a7c7b6ce24ee45e1"
+      },
+      "runner_evidence_path": "released-native-client-codex-windows-amd64/runner-evidence.json",
+      "runner_evidence_sha256": "290e38147177cac3568acf3d2af9817f1ebf8e881c8891ad2a3ecfbd5ba8d92a",
+      "passed_tests": [
+        "TestAgentpluginsCodexNativeLifecycle"
+      ],
+      "skipped_tests": [],
+      "indexed_artifact_count": 52,
+      "structured_fixture_paths": [
+        "uap-native-evidence-1243279788/evidence.json"
+      ]
+    },
+    {
+      "client": "opencode",
+      "target": "darwin-arm64",
+      "status": "passed",
+      "client_asset": {
+        "source": "https://registry.npmjs.org/opencode-darwin-arm64/-/opencode-darwin-arm64-1.18.29.tgz",
+        "version": "1.18.29",
+        "archive": "opencode-darwin-arm64-1.18.29.tgz",
+        "archive_integrity": "sha512-EU0qma5GPJXcDp5rENvedSfqJjqxatQW/Qzjs71pR2YdbrSh7YmBwtvnIb2/KIvfQr0DErX4ST14sbBQI2mQdg==",
+        "binary_sha256": "2f24593f1b8e578d0b7ed7ca399440d4b6c125330eece20a69ad8d380190d669"
+      },
+      "scanner_asset": {
+        "source": "https://github.com/777genius/lintai/releases/tag/v0.1.3",
+        "version": "v0.1.3",
+        "archive": "lintai-v0.1.3-aarch64-apple-darwin.tar.gz",
+        "archive_integrity": "sha256:be8b263e2323074080d928ea7c2129458299a6d03f7a9f178dfc1aa8e6bc17ff",
+        "binary_sha256": "37342414aa7feadc09b8473d1bfafe95fd79ab99f284d37518c930fcb7986c57"
+      },
+      "ripgrep_asset": {
+        "source": "https://github.com/BurntSushi/ripgrep/releases/tag/15.2.0",
+        "version": "15.2.0",
+        "archive": "ripgrep-15.2.0-aarch64-apple-darwin.tar.gz",
+        "archive_integrity": "sha256:3750b2e93f37e0c692657da574d7019a101c0084da05a790c83fd335bad973e4",
+        "binary_sha256": "a326a1fb48074202e9ad41e4cd1e389eeea372c8c6f7d7e80da81176d5d9430e"
+      },
+      "installer_asset": {
+        "file": "agentplugins_0.1.53_darwin_arm64",
+        "size": 12584322,
+        "binary_sha256": "7bc16e2183786963803fb83f1e5a351615362f49c578d174611293859fa12cd0"
+      },
+      "installer_version_measured": "agentplugins 0.1.53",
+      "harness_build_sha256": {
+        "native-probe": "28905662e18b27d90e4b6dfa3e9e57af5de0042eb098243ef82038d3f9614032",
+        "repotests": "29d47f69d7a6ce52bb843314fca88518ae8ec968de100c6121231a74fa6c10a2"
+      },
+      "runner_evidence_path": "released-native-client-opencode-darwin-arm64/runner-evidence.json",
+      "runner_evidence_sha256": "2f28a2c73cab27ca15e6302768cc239bb4eccde6a5f35ef74115e94585d68248",
+      "passed_tests": [
+        "TestAgentpluginsOpenCodeNativeLifecycle",
+        "TestAgentpluginsOpenCodeNativeRuntimeExtended",
+        "TestAgentpluginsOpenCodeNativeToolCollision"
+      ],
+      "skipped_tests": [],
+      "indexed_artifact_count": 83,
+      "structured_fixture_paths": [
+        "uap-opencode-native-evidence-147098728-${PLUGIN_DATA}/extended-runtime-evidence.json",
+        "uap-opencode-native-evidence-1968185407/tool-collision-evidence.json",
+        "uap-opencode-native-evidence-4035282982/evidence.json",
+        "uap-opencode-native-evidence-4151479889/evidence.json",
+        "uap-opencode-native-evidence-4245959109/tool-collision-evidence.json",
+        "uap-opencode-native-evidence-593598528/tool-collision-evidence.json"
+      ]
+    },
+    {
+      "client": "opencode",
+      "target": "linux-arm64",
+      "status": "passed",
+      "client_asset": {
+        "source": "https://registry.npmjs.org/opencode-linux-arm64/-/opencode-linux-arm64-1.18.29.tgz",
+        "version": "1.18.29",
+        "archive": "opencode-linux-arm64-1.18.29.tgz",
+        "archive_integrity": "sha512-Lr7XXik5wPJZBV5RW+aR6Uogf1n5GogpB565m+D/jiO/vRXr9LhvCpixgAr1tiwuH1ZfMsqOOlbFQz5jgH3Tqg==",
+        "binary_sha256": "e94d9ebec16ce2611eae94026afe8ec87f2e2dcc66db40bc4f889955b026eb75"
+      },
+      "scanner_asset": {
+        "source": "https://github.com/777genius/lintai/releases/tag/v0.1.3",
+        "version": "v0.1.3",
+        "archive": "lintai-v0.1.3-aarch64-unknown-linux-gnu.tar.gz",
+        "archive_integrity": "sha256:132a37610575bd251ecaf0be4c6090dad144dd1397c99aad989a3944c63c3d4a",
+        "binary_sha256": "7eb11068063a95160c2adb38e1e4e118dbde98b35ecdfb2c627f2d5624b70b0c"
+      },
+      "ripgrep_asset": {
+        "source": "https://github.com/BurntSushi/ripgrep/releases/tag/15.2.0",
+        "version": "15.2.0",
+        "archive": "ripgrep-15.2.0-aarch64-unknown-linux-gnu.tar.gz",
+        "archive_integrity": "sha256:a740b91c82eaf9914cfedd353572f2791cbe0162c84101ee0951058f4dcbc90d",
+        "binary_sha256": "e36d0eb52e70696bdf1781392722e05a21bb91d3b7b762ef5ec20e5df2ec687b"
+      },
+      "installer_asset": {
+        "file": "agentplugins_0.1.53_linux_arm64",
+        "size": 12452024,
+        "binary_sha256": "f33a5b72a53d503416e573f0fae8cef7d5193f48edd2cfe4bcf8e36c3e57fb99"
+      },
+      "installer_version_measured": "agentplugins 0.1.53",
+      "harness_build_sha256": {
+        "native-probe": "6012a9e02420c5e0423fd086ce65a60d93bfc03e808c10b9b73957e931acdca8",
+        "repotests": "92146d77e0f5416be777032026608bcc58dc07b1e6c1dc8d99ac4e21c373c231"
+      },
+      "runner_evidence_path": "released-native-client-opencode-linux-arm64/runner-evidence.json",
+      "runner_evidence_sha256": "27f96f59db4254b46cabc9945b1ccb5b565f29d266908172d03cd6a66911993c",
+      "passed_tests": [
+        "TestAgentpluginsOpenCodeNativeLifecycle",
+        "TestAgentpluginsOpenCodeNativeRuntimeExtended",
+        "TestAgentpluginsOpenCodeNativeToolCollision"
+      ],
+      "skipped_tests": [],
+      "indexed_artifact_count": 83,
+      "structured_fixture_paths": [
+        "uap-opencode-native-evidence-1612502745/tool-collision-evidence.json",
+        "uap-opencode-native-evidence-1912629362/tool-collision-evidence.json",
+        "uap-opencode-native-evidence-3069872216/evidence.json",
+        "uap-opencode-native-evidence-3150781017-${PLUGIN_DATA}/extended-runtime-evidence.json",
+        "uap-opencode-native-evidence-3157749506/tool-collision-evidence.json",
+        "uap-opencode-native-evidence-4224510229/evidence.json"
+      ]
+    },
+    {
+      "client": "opencode",
+      "target": "windows-amd64",
+      "status": "passed",
+      "client_asset": {
+        "source": "https://registry.npmjs.org/opencode-windows-x64/-/opencode-windows-x64-1.18.29.tgz",
+        "version": "1.18.29",
+        "archive": "opencode-windows-x64-1.18.29.tgz",
+        "archive_integrity": "sha512-xtWiZNMiwFtBl7q9yMG+XK/BTYGfgFoHLDx4ruWVYCoxjV0NYwjJi6rB9B3xIVbTclzu81YLKNFcT3kNBEG9Yw==",
+        "binary_sha256": "88d2fa691b2d9e32fde6d1039382a850ddf96fe49cd41683c6375fe1dc8ec2a5"
+      },
+      "scanner_asset": {
+        "source": "https://github.com/777genius/lintai/releases/tag/v0.1.3",
+        "version": "v0.1.3",
+        "archive": "lintai-v0.1.3-x86_64-pc-windows-msvc.zip",
+        "archive_integrity": "sha256:2f61f6a83a160afa3feed9ea1722b82d0d938ebff865a4e20d39b5f55270c911",
+        "binary_sha256": "9d486e5b66875384c12a147b8a19007beebe2691bc6d23a7867bf019b70be453"
+      },
+      "ripgrep_asset": {
+        "source": "https://github.com/BurntSushi/ripgrep/releases/tag/15.2.0",
+        "version": "15.2.0",
+        "archive": "ripgrep-15.2.0-x86_64-pc-windows-msvc.zip",
+        "archive_integrity": "sha256:71b2fef860abe467217a538ff31de02f5258807c0129f771846f87bd029aafc5",
+        "binary_sha256": "14231169855ec5205cf5a1b6f1db358ff4aed4247c86b69ce8aae647c77f6680"
+      },
+      "installer_asset": {
+        "file": "agentplugins_0.1.53_windows_amd64.exe",
+        "size": 13676032,
+        "binary_sha256": "4acfe85614ba34069e9d77addaa877bb44e3c519fbe77423703a7bd4709addde"
+      },
+      "installer_version_measured": "agentplugins 0.1.53",
+      "harness_build_sha256": {
+        "native-probe.exe": "9d16c5d926807a526c89047a6dd7cf817eb3ec44c0c51c9ded4854950def1a0a",
+        "repotests.exe": "af08548cc279df4bcc063eec3290c19ae314183a503bd4f1a7c7b6ce24ee45e1"
+      },
+      "runner_evidence_path": "released-native-client-opencode-windows-amd64/runner-evidence.json",
+      "runner_evidence_sha256": "0c96ba83972e26ad56220f3d8d6035bc3ce61091cbccf641eee4b63c4437a521",
+      "passed_tests": [
+        "TestAgentpluginsOpenCodeNativeLifecycle",
+        "TestAgentpluginsOpenCodeNativeRuntimeExtended",
+        "TestAgentpluginsOpenCodeNativeToolCollision"
+      ],
+      "skipped_tests": [],
+      "indexed_artifact_count": 83,
+      "structured_fixture_paths": [
+        "uap-opencode-native-evidence-1363583405/tool-collision-evidence.json",
+        "uap-opencode-native-evidence-1707362956-${PLUGIN_DATA}/extended-runtime-evidence.json",
+        "uap-opencode-native-evidence-2065339359/tool-collision-evidence.json",
+        "uap-opencode-native-evidence-2743315151/evidence.json",
+        "uap-opencode-native-evidence-3436990270/evidence.json",
+        "uap-opencode-native-evidence-4103962442/tool-collision-evidence.json"
+      ]
+    }
+  ],
+  "limits": [
+    "Fresh GitHub-hosted projects and profiles; scripted loopback providers; network not blocked.",
+    "Windows Claude: managed stdio unsupported, runtime HTTP and installed skill only.",
+    "OpenCode: JSON/JSONC lifecycle and HTTP collision fixtures; separate global JSON stdio and skill-body proof. No inferred JSONC stdio/body proof.",
+    "OpenCode colliding runtime tool names were observed, not fixed; opencode_tool_namespace_not_evaluated remains applicable.",
+    "Codex immutable Git acquisition seam is not native public Git runtime proof in this required suite.",
+    "No real-model quality, OAuth/login, desktop application or live external-service availability proof.",
+    "Native targets limited to Linux arm64, macOS arm64, Windows amd64; launcher targets do not expand them.",
+    "Maintainer-run evidence is not independent external testing, adoption or certification."
+  ],
+  "historical_source_record": "https://github.com/777genius/universal-agent-plugins/blob/9c33cfac81fc00e61205591321c89c5675fedb60/docs/evidence/client-compatibility-2026-09-07.json"
+}

--- a/docs/external-installer-testing.md
+++ b/docs/external-installer-testing.md
@@ -1,0 +1,156 @@
+# External installer test protocol
+
+This is a reproducible test invitation template, not a completed test report or
+evidence of independent adoption. UAP is a community-maintained installer;
+testing does not imply endorsement or certification.
+
+## Choose an exact public release
+
+Use an exact version already published to both GitHub and npm. Record its release
+URL, source commit, checksums and verified artifact provenance using the
+[release runbook](agentplugins-release.md). Do not use `latest` or an unpublished
+candidate. Verified public target: `universal-agent-plugins@0.1.53`,
+[binary release agentplugins-v0.1.53](https://github.com/777genius/universal-agent-plugins/releases/tag/agentplugins-v0.1.53),
+source commit `28cf05af0a1e4fea642825dd34b78f9c99094ab5`. Both GitHub and npm
+availability were checked on 2026-09-08. The retained 0.1.52 draft is not the
+test target. This publication check does not claim the external protocol ran.
+
+The commands below require Bash, Node.js 22+ and npm on macOS or Linux. Use a
+disposable VM with a fresh OS account and project, without personal credentials
+or mounted user projects. A temporary `HOME` on your regular desktop is not
+equivalent isolation. Have the supported Codex client installed in that VM so
+the installer can detect its target. The add operation runs real Codex plugin
+marketplace registration, plugin installation and inventory commands. No
+interactive model session or login is needed. Use Codex CLI `0.153.4`, the
+version whose native command contract this protocol follows. The exact
+[client archive pins](https://github.com/777genius/universal-agent-plugins/blob/9c33cfac81fc00e61205591321c89c5675fedb60/scripts/run-native-client-matrix.py)
+and [Codex lifecycle adapter](https://github.com/777genius/universal-agent-plugins/blob/28cf05af0a1e4fea642825dd34b78f9c99094ab5/install/integrationctl/agentplugins/providers/activator.go)
+identify the harness and released implementation separately.
+
+## Skills-only local fixture
+
+The example pins 0.1.53; change it only after verifying another exact release. These commands install into the
+VM account's user scope. They do not require Directory registration.
+
+```bash
+set -e
+UAP_VERSION='0.1.53'
+mkdir uap-external-test
+cd uap-external-test
+mkdir -p fixture/skills/uap-external-check logs
+printf 'preserve this unrelated file\n' > unrelated-sentinel.txt
+cp unrelated-sentinel.txt unrelated-sentinel.expected
+node --version
+npm --version
+cat > fixture/plugin.json <<'JSON'
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "uap-external-check",
+  "version": "1.0.0",
+  "description": "Disposable external installer test",
+  "license": "MIT"
+}
+JSON
+cat > fixture/skills/uap-external-check/SKILL.md <<'SKILL'
+---
+name: uap-external-check
+description: Return a fixed marker when explicitly asked to run this disposable test skill.
+---
+When explicitly invoked, respond with UAP_EXTERNAL_CHECK_OK.
+SKILL
+
+run_command() {
+  local step="$1" rc=0
+  shift
+  "$@" > "logs/$step.txt" 2>&1 || rc=$?
+  cat "logs/$step.txt"
+  printf '%s exit=%s\n' "$step" "$rc" | tee -a logs/exit-codes.txt
+  return "$rc"
+}
+run_step() {
+  local step="$1"
+  shift
+  run_command "$step" npx --yes "universal-agent-plugins@$UAP_VERSION" "$@"
+}
+run_command client-version codex --version
+run_step version version
+run_step validate validate ./fixture --format json
+run_step add add ./fixture --target codex --format json
+```
+
+Check that the version matches, validation reports one skill and no MCP servers
+or app bindings, and installation reports its exact state label. Record the
+validation tree/manifest digests and generated locations. Inspect only the test
+plugin's managed files. Stop on failure or an unavailable target and report the
+message; do not retry against your real profile.
+
+Then run:
+
+```bash
+run_step repair repair uap-external-check --target codex --format json
+run_command native-before-remove codex plugin list --json
+```
+
+This repair call checks an intact installation and may be a no-op; it does not
+prove recovery from corruption. In the native inventory, locate exactly the
+`uap-external-check` entry whose `source.path` matches the managed path recorded
+by add. Copy its `pluginId` and `marketplaceName`; verify that the former is
+`uap-external-check@` followed by the latter. Stop if the identity is ambiguous,
+missing or mismatched. Do not substitute an unrelated plugin or marketplace.
+
+Unregister that exact plugin and marketplace before acknowledging external
+uninstallation to UAP. Replace both placeholders from the verified inventory:
+
+```bash
+NATIVE_PLUGIN_ID='<verified-pluginId>'
+NATIVE_MARKETPLACE='<verified-marketplaceName>'
+run_command native-remove codex plugin remove "$NATIVE_PLUGIN_ID" --json
+run_command native-marketplace-remove codex plugin marketplace remove "$NATIVE_MARKETPLACE" --json
+run_command native-after-remove codex plugin list --json
+```
+
+Inspect the new inventory and confirm the exact plugin is no longer installed
+or enabled. Only after both unregister commands succeed and that check passes,
+run the following acknowledgement. If either command or inspection fails, stop
+and report it; do not assert `--external-uninstalled` merely to bypass the gate.
+
+```bash
+run_step remove remove uap-external-check --target codex --external-uninstalled --format json
+cmp unrelated-sentinel.expected unrelated-sentinel.txt
+```
+
+Confirm the test plugin's managed files were removed. The sentinel comparison
+checks only unrelated project-file preservation, not all user-profile data.
+Report retained plugin data separately from managed client files. Destroy the
+VM after collecting redacted evidence.
+
+## Separate runtime evidence
+
+The native inventory can establish registration and enabled state; it does not
+prove skill invocation in a model session. Native-client runtime testing has a separate protocol and
+maintainer-owned runner in [released native-client proof](released-native-client-proof.md).
+Its results are not independent external observations. This baseline does not
+test MCP calls, OAuth, model quality, desktop application behavior or Windows.
+Use a separately agreed protocol for additional runtime or immutable Git-source
+tests; do not infer those results from the local fixture.
+
+## Feedback to return
+
+Include failures and `not tested` results. Redact tokens, credentials, personal
+paths and unrelated project content before sharing logs or screenshots.
+
+- Date/time, OS/architecture, Node/npm versions and detected client version.
+- Exact UAP version, release URL, source commit and artifact checksum/provenance.
+- Isolation used, fixture digests, commands, exit codes and exact state labels.
+- Validation, add, repair and remove: pass / fail / not tested, with output.
+- Managed paths inspected, unrelated-data preservation and unexpected changes.
+- Expected versus actual behavior and reproducible failure steps.
+- Relationship to the authors: independent / contributor / paid / other;
+  maintainer assistance received; one-off test versus actual ongoing use.
+- Permission to publish the report: yes / no / redacted only; separately,
+  permission to attribute your optional handle: yes / no.
+
+A report is not permission to publish identifying details. Obtain explicit
+consent before quoting it. Record external testing separately from ongoing
+adoption, and keep activation, skill execution, MCP and OAuth marked
+`not tested` unless separately observed and documented.

--- a/docs/released-native-client-proof.md
+++ b/docs/released-native-client-proof.md
@@ -78,3 +78,90 @@ All three Linux clients use the same checked-in versions as the other platforms:
 Codex `0.153.4`, Claude Code `2.1.263`, OpenCode `1.18.29`. Linux archive digests
 come from the exact GitHub release assets or npm version metadata and are
 verified before extraction; the scanner is lintai `0.1.3` and ripgrep is `15.2.0`.
+
+## Verified 0.1.53 run and archive reproduction
+
+Run [34166817934](https://github.com/777genius/universal-agent-plugins/actions/runs/34166817934)
+passed all nine jobs using public installer commit
+`28cf05af0a1e4fea642825dd34b78f9c99094ab5` and harness commit
+`9c33cfac81fc00e61205591321c89c5675fedb60`, tree
+`d17e72793961e6798d09eb44256c832465f2d8c7`. Its 529 original files plus summary
+were frozen in `uap-0.1.53-native-34166817934.zip` (3,165,833 bytes), SHA-256
+`0d315f3a24bb6c41d184f0632d76a7228e18a6c1c41be2774e23c8066dfd3af6`.
+
+The [public evidence release](https://github.com/777genius/universal-agent-plugins/releases/tag/native-evidence-0.1.53-34166817934)
+points to that exact harness commit. Its ZIP and `.sha256` sidecar were
+re-downloaded after publication and checked against the digest above on
+2026-09-08. The installer release's eight assets remain untouched.
+
+The verifier is added by a later documentation commit. It was not part of the
+runtime run and is not source for the released binary. To reproduce verification,
+use a clean checkout at the documentation commit recorded with the evidence
+publication, retaining its sibling `run-native-client-matrix.py` pins. Compare
+`scripts/verify-released-native-evidence.py` with the SHA-256 in
+[the compact record](evidence/client-compatibility-released-0.1.53.json).
+From that exact source checkout, use the durable public archive as the primary
+input. Choose fresh paths; the extraction below refuses overwritten files and
+keeps the archive summary outside the required nine-directory input:
+
+```sh
+gh release download native-evidence-0.1.53-34166817934 \
+  --repo 777genius/universal-agent-plugins --dir ./native-053-download
+python - <<'PYTHON'
+from pathlib import Path
+import hashlib, stat, zipfile
+root = Path("native-053-download")
+archive = root / "uap-0.1.53-native-34166817934.zip"
+expected = "0d315f3a24bb6c41d184f0632d76a7228e18a6c1c41be2774e23c8066dfd3af6"
+if hashlib.sha256(archive.read_bytes()).hexdigest() != expected:
+    raise SystemExit("archive digest mismatch")
+if (root / (archive.name + ".sha256")).read_text().split() != [expected, archive.name]:
+    raise SystemExit("checksum sidecar mismatch")
+output = root / "native-053-input"
+output.mkdir()
+with zipfile.ZipFile(archive) as zipped:
+    for item in zipped.infolist():
+        parts = item.filename.split("/")
+        if (any(p in ("", ".", "..") for p in parts)
+                or any(ord(c) < 32 or c in "\\:" for c in item.filename)
+                or not stat.S_ISREG(item.external_attr >> 16)):
+            raise SystemExit("unsafe archive entry")
+        if item.filename == "summary.json":
+            destination = root / "original-summary.json"
+        else:
+            if not parts[0].startswith("released-native-client-"):
+                raise SystemExit("unexpected archive entry")
+            destination = output.joinpath(*parts)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with destination.open("xb") as stream:
+            stream.write(zipped.read(item))
+PYTHON
+python scripts/verify-released-native-evidence.py ./native-053-download/native-053-input \
+  --release-version 0.1.53 \
+  --release-commit 28cf05af0a1e4fea642825dd34b78f9c99094ab5 \
+  --harness-commit 9c33cfac81fc00e61205591321c89c5675fedb60 \
+  --harness-tree d17e72793961e6798d09eb44256c832465f2d8c7 \
+  --archive ./reproduced-native-053.zip > ./reproduced-native-053-summary.json
+```
+
+The tool verifies exact job/fixture identities, required stage results, pinned
+client/tool records and every indexed file digest. Embedded release provenance
+was verified by the runner; this offline step checks recorded consistency, not
+fresh signatures. ZIP bytes are deterministic on the same Python/compression
+runtime; across implementations, compare member bytes and hashes rather than
+assuming identical compression output. It does not execute clients.
+
+While Actions artifacts remain available, `gh run download 34166817934 --repo
+777genius/universal-agent-plugins --pattern 'released-native-client-*' --dir
+./native-053-input` is an alternative acquisition route. It expires; the public
+release ZIP above is the durable route. Never execute log or fixture contents.
+
+Publication is an operator step, separate from the read-only verifier: create
+the non-installer tag at the original harness SHA, attach the exact ZIP and
+checksum sidecar without overwrite, and include release/harness identities,
+run URL, archive hash and verifier source digest in the notes. Record the later
+documentation commit as the verifier source when available. Re-download both
+published files and check their bytes before changing the compact record's
+publication status. Original logs intentionally retain dummy fixture keys,
+loopback ports, runner paths and built-in client prompts. Their disclosure review
+must inspect content; safe paths and file extensions do not sanitize logs.

--- a/scripts/test_released_native_evidence.py
+++ b/scripts/test_released_native_evidence.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+import zipfile
+
+SPEC = importlib.util.spec_from_file_location('proof', Path(__file__).with_name('verify-released-native-evidence.py'))
+proof = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(proof)
+
+
+class EvidenceTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name) / 'input'
+        self.root.mkdir()
+        for client, tests in proof.CLIENT_TESTS.items():
+            for target in proof.TARGETS:
+                folder = self.root / f'released-native-client-{client}-{target}'
+                folder.mkdir()
+                transcript = ''.join(f'--- PASS: {test} (0.1s)\n' for test in sorted(tests)).encode()
+                (folder / 'native-tests.log').write_bytes(transcript)
+                suffix = '.exe' if target.startswith('windows-') else ''
+                asset = 'agentplugins_1.2.3_' + target.replace('-', '_') + suffix
+                record = {'schema_version': 1, 'client': client, 'target': target, 'commit': 'b'*40, 'tree': 'c'*40,
+                          'status': 'passed', 'exit_code': 0, 'skipped_tests': [], 'passed_tests': sorted(tests),
+                          'artifact_sha256': {'native-tests.log': proof.digest(transcript)}, 'installer_sha256': 'd'*64,
+                          'installer_version_measured': 'agentplugins 1.2.3',
+                          'harness_build_sha256': {'native-probe'+suffix: 'e'*64, 'repotests'+suffix: 'f'*64},
+                          'installer_release': {'repository': proof.REPOSITORY, 'acquisition': 'public GitHub release download',
+                              'version': '1.2.3', 'tag': 'agentplugins-v1.2.3', 'commit': 'a'*40, 'tree': 'd'*40,
+                              'file': asset, 'size': 10, 'binary_sha256': 'd'*64, 'manifest_sha256': 'a'*64, 'checksums_sha256': 'b'*64,
+                              'attestations': {n: [{'verificationResult': {}}] for n in (asset, 'checksums.txt', 'release-manifest.json')}}}
+                self.enrich(folder, record, client, target)
+                (folder / 'runner-evidence.json').write_text(json.dumps(record))
+        self.record_path = next(self.root.rglob('runner-evidence.json'))
+
+    def enrich(self, folder, record, client, target):
+        for field, key in (('client_asset', client), ('scanner_asset', 'lintai'), ('ripgrep_asset', 'rg')):
+            kind, repo, version, archive, integrity, _ = proof.pins()[target][key]
+            record[field] = dict(source=f'https://github.com/{repo}/releases/tag/{version}' if kind == 'github' else f'https://registry.npmjs.org/{repo}/-/{archive}', version=version, archive=archive, archive_integrity=integrity, binary_sha256='1'*64)
+        release = record['installer_release']
+        for name in release['attestations']:
+            sha = {'checksums.txt':'b'*64, 'release-manifest.json':'a'*64}.get(name,'d'*64)
+            release['attestations'][name] = [{'verificationResult': {'signature': {'certificate': {
+                'sourceRepositoryURI':'https://github.com/'+proof.REPOSITORY, 'sourceRepositoryDigest':'a'*40,
+                'runnerEnvironment':'github-hosted', 'issuer':'https://token.actions.githubusercontent.com',
+                'buildSignerURI':'https://github.com/'+proof.REPOSITORY+'/.github/workflows/agentplugins-release.yml@refs/heads/main', 'buildSignerDigest':'a'*40}},
+                'statement': {'predicateType':'https://slsa.dev/provenance/v1', 'subject':[{'name':name,'digest':{'sha256':sha}}]}, 'verifiedTimestamps':[{'type':'Tlog','timestamp':'2026-09-08T00:00:00Z'}]}}]
+        shapes = {'codex':[('codex','evidence.json',{})], 'claude':[('claude-lifecycle','evidence.json',{}),('claude-runtime','evidence.json',{'runtime_scope':'stdio_default+stdio_explicit+HTTP+skill','provider':'scripted_loopback','real_model':'not_evaluated','oauth':'not_evaluated','stdio_runtime':'passed','stdio_cwd_argv_env_data':'passed','installer_data_retention':'passed'})], 'opencode':[
+            ('opencode-lifecycle','evidence.json',{'config_route_exercised':route}) for route in ('opencode.json','opencode.jsonc')] + [
+            ('opencode-extended','extended-runtime-evidence.json',{'probe_sha256':'e'*64,'status':'passed','provider':'scripted_loopback_no_real_model'})] + [
+            ('opencode-collision','tool-collision-evidence.json',{'logical_servers':names,'model':'scripted_loopback_no_real_model','oauth':'not_evaluated','status':'passed'}) for names in (['api/server'],['api server'],['api/server','api server'])]}
+        for index,(kind,name,extra) in enumerate(shapes[client]):
+            directory = folder / (f'fixture-{index}' + ('-${PLUGIN_DATA}' if kind == 'opencode-extended' else ''))
+            directory.mkdir()
+            transcript = b'fixture command transcript\n'
+            (directory/'command.log').write_bytes(transcript)
+            stages = {key:{'status':'passed'} for key in proof.STAGES[kind]}
+            if kind == 'opencode-collision' and extra['logical_servers'] == ['api/server']:
+                stages.update({key:{'status':'passed'} for key in 'version-update same-version-refresh repair remove foreign_config_preservation'.split()})
+            stages['oauth'] = {'status':'not_evaluated'}
+            data = dict(installer_base_commit='a'*40,installer_tree='d'*40,installer_patch_sha256=[], installer_sha256='d'*64,client_sha256='1'*64,
+                scanner={'binary_sha256':'1'*64,'archive_sha256':record['scanner_asset']['archive_integrity'][7:], 'platform':target,'source_tag':record['scanner_asset']['version']},
+                stages=stages,transcript_sha256={'command.log':proof.digest(transcript)},**extra)
+            data['client_version_measured' if kind in ('claude-lifecycle','opencode-lifecycle') else 'client_version'] = {'codex':'0.153.4','claude':'2.1.263 (Claude Code)','opencode':'1.18.29'}[client]
+            if kind == 'claude-runtime': data['stages'] = {k:'passed' for k in proof.STAGES[kind]}
+            if target == 'windows-amd64' and kind == 'claude-lifecycle':
+                data['stages']['stdio_discovery'] = {'status':'observed_unsupported','reason':'managed_stdio_platform_unsupported'}
+            if target == 'windows-amd64' and kind == 'claude-runtime':
+                data.update(stdio_runtime='observed_unsupported',stdio_cwd_argv_env_data='not_evaluated',runtime_scope='HTTP+installed-skill')
+            (directory/name).write_text(json.dumps(data))
+        for path in folder.rglob('*'):
+            if path.is_file(): record['artifact_sha256'][path.relative_to(folder).as_posix()] = proof.digest(path.read_bytes())
+
+    def refresh_hashes(self):
+        folder = self.record_path.parent
+        record = json.loads(self.record_path.read_text())
+        record['artifact_sha256'] = {p.relative_to(folder).as_posix():proof.digest(p.read_bytes()) for p in folder.rglob('*') if p.is_file() and p != self.record_path}
+        self.record_path.write_text(json.dumps(record))
+
+    def test_structured_evidence_and_pin_failures(self):
+        fixture = next(p for p in self.record_path.parent.rglob('evidence.json'))
+        original = fixture.read_bytes()
+        for change in (lambda r:r['stages'].update(install={'status':'failed'}),lambda r:r.update(installer_sha256='0'*64),lambda r:r['transcript_sha256'].update({'absent.log':'0'*64})):
+            fixture.write_bytes(original)
+            data=json.loads(fixture.read_text());change(data);fixture.write_text(json.dumps(data));self.refresh_hashes()
+            with self.assertRaises(ValueError):self.verify()
+        fixture.unlink(); self.refresh_hashes()
+        with self.assertRaisesRegex(ValueError,'structured fixtures'): self.verify()
+
+    def test_pin_and_empty_provenance_rejected(self):
+        original = self.record_path.read_bytes()
+        for change in (lambda r:r['client_asset'].update(archive_integrity='sha256:'+'0'*64),lambda r:r['scanner_asset'].update(version='bad'),lambda r:r['installer_release']['attestations'].update({'checksums.txt':[{'verificationResult':{}}]})):
+            self.record_path.write_bytes(original);self.mutate(change)
+            with self.assertRaises(ValueError):self.verify()
+
+    def test_literal_token_safe_but_traversal_not_safe(self):
+        proof.safe_name('fixture-${PLUGIN_DATA}/extended-runtime-evidence.json')
+        for name in ('../outside.log','/root.log','a//b.log','a/../b.log','C:/b.log','a\\b.log','a\x00b.log'):
+            with self.assertRaises(ValueError):proof.safe_name(name)
+
+    def verify(self):
+        return proof.verify(self.root, '1.2.3', 'a'*40, 'b'*40, 'c'*40)
+
+    def mutate(self, change):
+        record = json.loads(self.record_path.read_text())
+        change(record)
+        self.record_path.write_text(json.dumps(record))
+
+    def test_exact_matrix_and_deterministic_archive(self):
+        summary, files = self.verify()
+        self.assertEqual(len(summary['jobs']), 9)
+        a, b = Path(self.temp.name)/'a.zip', Path(self.temp.name)/'b.zip'
+        proof.archive(a, summary, files)
+        proof.archive(b, summary, files)
+        self.assertEqual(a.read_bytes(), b.read_bytes())
+        with zipfile.ZipFile(a) as z:
+            self.assertEqual(set(z.namelist()), set(files) | {'summary.json'})
+        with self.assertRaises(FileExistsError):
+            proof.archive(a, summary, files)
+
+    def test_identity_failures(self):
+        original = self.record_path.read_bytes()
+        changes = [lambda r: r.update(commit='0'*40), lambda r: r.update(status='failed'),
+                   lambda r: r.update(skipped_tests=['test']), lambda r: r.update(passed_tests=[]),
+                   lambda r: r.pop('installer_release'), lambda r: r['installer_release'].update(commit='0'*40),
+                   lambda r: r['installer_release'].update(attestations={}),
+                   lambda r: r['installer_release'].update(manifest_sha256='0'*64),
+                   lambda r: r.update(installer_sha256='0'*64)]
+        for change in changes:
+            with self.subTest(change=change):
+                self.record_path.write_bytes(original)
+                self.mutate(change)
+                with self.assertRaises(ValueError): self.verify()
+
+    def test_transcript_hash_and_unrecorded_content_fail(self):
+        log = self.record_path.parent / 'native-tests.log'
+        log.write_text('forged')
+        with self.assertRaisesRegex(ValueError, 'hash mismatch'): self.verify()
+        self.mutate(lambda r: r['artifact_sha256'].update({'native-tests.log': proof.digest(log.read_bytes())}))
+        with self.assertRaisesRegex(ValueError, 'transcript disagrees'): self.verify()
+
+    def test_missing_extra_and_symlink_fail(self):
+        extra = self.root / 'extra'
+        extra.mkdir()
+        with self.assertRaises(ValueError): self.verify()
+        extra.rmdir()
+        self.record_path.unlink()
+        self.record_path.symlink_to(self.root / 'not-present')
+        with self.assertRaisesRegex(ValueError, 'symlink'): self.verify()
+
+    def test_unsafe_path_and_duplicate_json_fail(self):
+        self.mutate(lambda r: r['artifact_sha256'].update({'../outside.log': 'a'*64}))
+        with self.assertRaises(ValueError): self.verify()
+        self.record_path.write_text('{"client":"codex","client":"claude"}')
+        with self.assertRaisesRegex(ValueError, 'duplicate JSON'): self.verify()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/verify-released-native-evidence.py
+++ b/scripts/verify-released-native-evidence.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Verify nine downloaded released-native artifacts and optionally freeze a ZIP.
+
+Input is a fresh directory populated by gh run download. No archives are
+extracted, clients executed, or release assets modified. Recorded attestation
+results are retained, not cryptographically reverified by this offline tool.
+Archive paths/file types are restricted; original log content is not redacted.
+Review disclosure separately before publishing under a non-agentplugins tag.
+"""
+import argparse
+import hashlib
+from functools import lru_cache
+import json
+from pathlib import Path
+import re
+import stat
+import zipfile
+
+CLIENT_TESTS = {
+    'codex': {'TestAgentpluginsCodexNativeLifecycle'},
+    'claude': {'TestAgentpluginsClaudeNativeLifecycle', 'TestAgentpluginsClaudeNativeRuntimeLifecycle'},
+    'opencode': {'TestAgentpluginsOpenCodeNativeLifecycle', 'TestAgentpluginsOpenCodeNativeToolCollision', 'TestAgentpluginsOpenCodeNativeRuntimeExtended'},
+}
+TARGETS = ('darwin-arm64', 'windows-amd64', 'linux-arm64')
+REPOSITORY = '777genius/universal-agent-plugins'
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def digest(body):
+    return hashlib.sha256(body).hexdigest()
+
+
+def exact_hex(value, length):
+    return isinstance(value, str) and re.fullmatch('[0-9a-f]{' + str(length) + '}', value) is not None
+
+
+def unique_object(pairs):
+    result = {}
+    for key, value in pairs:
+        require(key not in result, 'duplicate JSON key: ' + key)
+        result[key] = value
+    return result
+
+
+def safe_name(name):
+    require(isinstance(name, str) and name and not any(ord(c) < 32 or ord(c) == 127 or c in '\\:' for c in name) and all(part not in ('', '.', '..') for part in name.split('/')), 'unsafe artifact path: ' + str(name))
+
+
+def collect(root):
+    require(root.is_dir() and not root.is_symlink(), 'input must be a real directory')
+    files = {}
+    for entry in sorted(root.iterdir()):
+        safe_name(entry.name)
+        mode = entry.lstat()
+        require(not stat.S_ISLNK(mode.st_mode), 'symlink: ' + str(entry))
+        if stat.S_ISDIR(mode.st_mode):
+            for name, body in collect(entry).items():
+                files[entry.name + '/' + name] = body
+        else:
+            require(stat.S_ISREG(mode.st_mode) and mode.st_nlink == 1, 'nonregular or aliased file: ' + str(entry))
+            require(entry.suffix in ('.json', '.jsonl', '.log'), 'unexpected artifact file: ' + str(entry))
+            files[entry.name] = entry.read_bytes()
+    return files
+
+
+# Stage contracts are the assertions emitted by the six native test shapes.
+STAGES = {
+ 'codex': 'install local_security_scan scanner_prerequisite native_inventory A_native_tool A_skill_discovery A_cwd_default A_cwd_explicit B_native_tool B_skill_discovery B_cwd_default B_cwd_explicit B_data_identity unchanged owned_artifact_guard owned_repair native_cache_repair partial_failure all_unsupported collision_drift foreign_preservation remove repeat_remove skill_context http http_request_contract generated_protocol_header_priority immutable_git'.split(),
+ 'claude-lifecycle': 'install skill_discovery stdio_discovery mcp_transport_discovery version_update same_version_refresh unchanged owned_repair foreign_content_inside_managed_directory_blocked remove repeat_remove'.split(),
+ 'claude-runtime': 'install runtime_A runtime_B same_version_refresh repair remove'.split(),
+ 'opencode-lifecycle': 'install version_update same_version_refresh unchanged owned_repair foreign_key_collision foreign_config_preservation sse_unsupported remove repeat_remove'.split(),
+ 'opencode-extended': 'install refresh update repaired removed'.split(),
+ 'opencode-collision': ['install'],
+}
+for phase in ('same_version', 'owned_repair', 'native_cache_repair', 'partial_failure'):
+    STAGES['codex'] += [phase + '_' + detail for detail in ('native_tool', 'skill_discovery', 'cwd_default', 'cwd_explicit', 'http')]
+
+
+@lru_cache(maxsize=1)
+def pins():
+    # Read literal pins without importing/executing the runtime wrapper.
+    import ast
+    tree = ast.parse(Path(__file__).with_name('run-native-client-matrix.py').read_text())
+    return next(ast.literal_eval(n.value) for n in tree.body if isinstance(n, ast.Assign) and any(isinstance(t, ast.Name) and t.id == 'PINS' for t in n.targets))
+
+
+def verify_tools(record, target, client):
+    for field, key in (('client_asset', client), ('scanner_asset', 'lintai'), ('ripgrep_asset', 'rg')):
+        kind, repo, version, archive_name, integrity, _ = pins()[target][key]
+        source = f'https://github.com/{repo}/releases/tag/{version}' if kind == 'github' else f'https://registry.npmjs.org/{repo}/-/{archive_name}'
+        asset = record.get(field, {})
+        require(all(asset.get(k) == v for k, v in {'source': source, 'version': version, 'archive': archive_name, 'archive_integrity': integrity}.items()) and exact_hex(asset.get('binary_sha256'), 64), 'wrong pinned tool: ' + field)
+
+
+def verify_attestations(release):
+    expected = {release['file']: release['binary_sha256'], 'checksums.txt': release['checksums_sha256'], 'release-manifest.json': release['manifest_sha256']}
+    records = release.get('attestations', {})
+    require(set(records) == set(expected), 'missing recorded attestations')
+    for name, sha in expected.items():
+        require(isinstance(records[name], list) and records[name], 'missing recorded attestations')
+        for item in records[name]:
+            result = item.get('verificationResult', {})
+            cert = result.get('signature', {}).get('certificate', {})
+            statement = result.get('statement', {})
+            require(cert.get('sourceRepositoryURI') == 'https://github.com/' + REPOSITORY and cert.get('sourceRepositoryDigest') == release['commit'] and cert.get('runnerEnvironment') == 'github-hosted' and cert.get('issuer') == 'https://token.actions.githubusercontent.com', 'recorded provenance source mismatch')
+            require(cert.get('buildSignerURI', '').startswith('https://github.com/' + REPOSITORY + '/.github/workflows/agentplugins-release.yml@refs/') and cert.get('buildSignerDigest') == release['commit'], 'recorded provenance signer mismatch')
+            require(statement.get('predicateType') == 'https://slsa.dev/provenance/v1' and any(s.get('name') == name and s.get('digest', {}).get('sha256') == sha for s in statement.get('subject', [])), 'recorded provenance subject mismatch')
+            require(isinstance(result.get('verifiedTimestamps'), list) and result['verifiedTimestamps'], 'missing recorded provenance timestamps')
+
+
+def verify_fixtures(bodies, record, client, target):
+    found = []
+    for path, body in bodies.items():
+        base = Path(path).name
+        if base not in ('evidence.json', 'tool-collision-evidence.json', 'extended-runtime-evidence.json'):
+            continue
+        data = json.loads(body, object_pairs_hook=unique_object)
+        if client == 'codex': kind, key = 'codex', 'codex'
+        elif client == 'claude':
+            kind = 'claude-runtime' if 'runtime_scope' in data else 'claude-lifecycle'
+            key = kind
+        elif base == 'extended-runtime-evidence.json': kind, key = 'opencode-extended', 'extended'
+        elif base == 'tool-collision-evidence.json':
+            kind, key = 'opencode-collision', tuple(data.get('logical_servers', []))
+            require(data.get('status') == 'passed' and data.get('model') == 'scripted_loopback_no_real_model' and data.get('oauth') == 'not_evaluated', 'collision boundary/status mismatch')
+        else: kind, key = 'opencode-lifecycle', data.get('config_route_exercised')
+        require(key not in found, 'duplicate fixture identity')
+        found.append(key)
+        stages = data.get('stages', {})
+        required = list(STAGES[kind])
+        windows_claude = client == 'claude' and target == 'windows-amd64'
+        if kind == 'claude-lifecycle' and windows_claude:
+            required.remove('stdio_discovery')
+            require(stages.get('stdio_discovery') == {'status': 'observed_unsupported', 'reason': 'managed_stdio_platform_unsupported'}, 'Windows Claude stdio boundary mismatch')
+        if kind == 'opencode-collision' and key == ('api/server',):
+            required += 'version-update same-version-refresh repair remove foreign_config_preservation'.split()
+        require(all((stages.get(k, {}).get('status') if isinstance(stages.get(k), dict) else stages.get(k)) == 'passed' for k in required), 'missing/failed fixture stage: ' + path)
+        for stage_name, stage in stages.items():
+            status = stage.get('status') if isinstance(stage, dict) else stage
+            require(status in ('passed', 'not_evaluated', 'not_proven', 'not_applicable') or (windows_claude and stage_name == 'stdio_discovery' and status == 'observed_unsupported'), 'failed fixture stage: ' + path)
+            for ref in stage.get('artifacts', []) if isinstance(stage, dict) else []:
+                safe_name(ref)
+                require(str(Path(path).parent / ref) in bodies, 'missing stage artifact')
+        release = record['installer_release']
+        identity = data.get('source_identity', data)
+        require(identity.get('installer_base_commit') == release['commit'] and identity.get('installer_tree') == release['tree'] and identity.get('installer_patch_sha256') in ([], ''), 'fixture source mismatch')
+        require(data.get('installer_sha256', data.get('installer_binary_sha256')) == record['installer_sha256'] and data.get('client_sha256', data.get('client_binary_sha256')) == record['client_asset']['binary_sha256'], 'fixture binary mismatch')
+        versions = {'codex': '0.153.4', 'claude': '2.1.263 (Claude Code)', 'opencode': '1.18.29'}
+        version_field = 'client_version_measured' if kind in ('claude-lifecycle', 'opencode-lifecycle') else 'client_version'
+        if kind != 'opencode-extended': require(data.get(version_field) == versions[client], 'missing fixture client version')
+        if 'installer_source_state' in identity: require(identity['installer_source_state'] == 'committed', 'uncommitted fixture source')
+        for field in ('client_version', 'client_version_measured', 'client_version_pinned'):
+            if field in data: require(data[field] == versions[client], 'fixture client version mismatch')
+        if kind != 'claude-lifecycle':
+            scanner = data.get('scanner', data.get('security_scanner', {}))
+            require(scanner.get('binary_sha256') == record['scanner_asset']['binary_sha256'] and scanner.get('archive_sha256') == record['scanner_asset']['archive_integrity'].removeprefix('sha256:') and scanner.get('platform') == target and scanner.get('source_tag') == record['scanner_asset']['version'], 'fixture scanner mismatch')
+        if kind == 'opencode-extended':
+            suffix = '.exe' if target.startswith('windows') else ''
+            require(data.get('probe_sha256') == record['harness_build_sha256']['native-probe' + suffix] and data.get('status') == 'passed' and data.get('provider') == 'scripted_loopback_no_real_model', 'extended fixture identity mismatch')
+        if kind == 'claude-runtime':
+            require(data.get('provider') == 'scripted_loopback' and data.get('real_model') == data.get('oauth') == 'not_evaluated' and data.get('installer_data_retention') == 'passed', 'Claude runtime boundary mismatch')
+            expected_stdio = ('observed_unsupported', 'not_evaluated', 'HTTP+installed-skill') if windows_claude else ('passed', 'passed', 'stdio_default+stdio_explicit+HTTP+skill')
+            require((data.get('stdio_runtime'), data.get('stdio_cwd_argv_env_data'), data.get('runtime_scope')) == expected_stdio, 'Claude stdio scope mismatch')
+        hashes = data.get('transcript_sha256', data.get('artifact_sha256', {}))
+        require(isinstance(hashes, dict) and hashes, 'missing fixture transcripts')
+        for ref, sha in hashes.items():
+            safe_name(ref)
+            full = str(Path(path).parent / ref)
+            require(full in bodies and exact_hex(sha, 64) and digest(bodies[full]) == sha, 'fixture transcript mismatch')
+    expected = {'codex': {'codex'}, 'claude': {'claude-lifecycle', 'claude-runtime'}, 'opencode': {'opencode.json', 'opencode.jsonc', 'extended', ('api/server',), ('api server',), ('api/server', 'api server')}}
+    require(set(found) == expected[client], 'missing or unexpected structured fixtures')
+
+def verify(root, version, release_commit, harness_commit, harness_tree):
+    require(re.fullmatch(r'(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)', version), 'exact stable version required')
+    for value in (release_commit, harness_commit, harness_tree):
+        require(exact_hex(value, 40), 'exact source SHA required')
+    names = {f'released-native-client-{client}-{target}' for client in CLIENT_TESTS for target in TARGETS}
+    require(root.is_dir() and not root.is_symlink(), 'input must be a real directory')
+    require({p.name for p in root.iterdir()} == names, 'exactly nine expected artifact directories required')
+    files, jobs, release_trees, manifests, checksums = {}, [], set(), set(), set()
+    by_target = {}
+    for client, required in CLIENT_TESTS.items():
+        for target in TARGETS:
+            name = f'released-native-client-{client}-{target}'
+            bodies = collect(root / name)
+            require('runner-evidence.json' in bodies, 'missing runner evidence: ' + name)
+            record = json.loads(bodies['runner-evidence.json'], object_pairs_hook=unique_object)
+            require(record.get('schema_version') == 1 and record.get('client') == client and record.get('target') == target, 'wrong job identity: ' + name)
+            require(record.get('commit') == harness_commit and record.get('tree') == harness_tree, 'wrong harness identity: ' + name)
+            require(record.get('status') == 'passed' and type(record.get('exit_code')) is int and record['exit_code'] == 0 and record.get('skipped_tests') == [], 'failed/skipped job: ' + name)
+            passed = record.get('passed_tests')
+            require(isinstance(passed, list) and all(isinstance(t, str) for t in passed) and required.issubset(passed), 'missing required tests: ' + name)
+            hashes = record.get('artifact_sha256')
+            require(isinstance(hashes, dict) and set(hashes) == set(bodies) - {'runner-evidence.json'}, 'artifact inventory mismatch: ' + name)
+            for path, expected in hashes.items():
+                safe_name(path)
+                require(exact_hex(expected, 64) and digest(bodies[path]) == expected, 'artifact hash mismatch: ' + name + '/' + path)
+            require('native-tests.log' in bodies, 'missing test transcript: ' + name)
+            log = bodies['native-tests.log'].decode('utf-8')
+            actual = set(re.findall(r'^--- PASS: (\w+)', log, re.M))
+            require(set(passed) == actual and required.issubset(actual) and not re.search(r'^\s*--- (SKIP|FAIL):', log, re.M), 'test transcript disagrees: ' + name)
+            release = record.get('installer_release', {})
+            require(release.get('repository') == REPOSITORY and release.get('acquisition') == 'public GitHub release download', 'not a public released installer: ' + name)
+            require(release.get('version') == version and release.get('tag') == 'agentplugins-v' + version and release.get('commit') == release_commit, 'wrong release identity: ' + name)
+            require(record.get('installer_version_measured') == 'agentplugins ' + version, 'wrong measured version: ' + name)
+            asset = 'agentplugins_' + version + '_' + target.replace('-', '_') + ('.exe' if target.startswith('windows-') else '')
+            require(release.get('file') == asset and type(release.get('size')) is int and release['size'] > 0, 'wrong binary asset: ' + name)
+            binary_hash = release.get('binary_sha256')
+            require(exact_hex(binary_hash, 64) and record.get('installer_sha256') == binary_hash, 'installer hash disagreement: ' + name)
+            require(exact_hex(release.get('tree'), 40), 'missing release tree: ' + name)
+            for field in ('manifest_sha256', 'checksums_sha256'):
+                require(exact_hex(release.get(field), 64), 'missing release digest: ' + name)
+            verify_tools(record, target, client)
+            verify_attestations(release)
+            suffix = '.exe' if target.startswith('windows-') else ''
+            helpers = record.get('harness_build_sha256', {})
+            require(set(helpers) == {'native-probe' + suffix, 'repotests' + suffix} and all(exact_hex(v, 64) for v in helpers.values()), 'missing harness helper hashes: ' + name)
+            verify_fixtures(bodies, record, client, target)
+            require(target not in by_target or by_target[target] == (binary_hash, release['size']), 'cross-job binary mismatch: ' + name)
+            by_target[target] = (binary_hash, release['size'])
+            release_trees.add(release['tree'])
+            manifests.add(release['manifest_sha256'])
+            checksums.add(release['checksums_sha256'])
+            files.update({name + '/' + p: b for p, b in bodies.items()})
+            jobs.append({'client': client, 'target': target, 'binary_sha256': binary_hash, 'passed_tests': sorted(actual)})
+    require(len(release_trees) == len(manifests) == len(checksums) == 1, 'cross-job release metadata mismatch')
+    summary = {'schema_version': 1, 'status': 'passed', 'release_version': version, 'release_commit': release_commit,
+               'release_tree': next(iter(release_trees)), 'harness_commit': harness_commit, 'harness_tree': harness_tree,
+               'jobs': jobs, 'files_sha256': {p: digest(b) for p, b in sorted(files.items())},
+               'boundary': 'Fixture assertions only; no real-model quality or OAuth claim. Hash and record consistency verification only. Embedded provenance was verified by the runner, not cryptographically reverified here. Log content is unredacted; publication needs disclosure review.'}
+    return summary, files
+
+
+def archive(output, summary, files):
+    """Freeze already verified bytes, not mutable source paths; refuse overwrite."""
+    payload = dict(files)
+    payload['summary.json'] = (json.dumps(summary, indent=2, sort_keys=True) + '\n').encode()
+    with output.open('xb') as stream:
+        with zipfile.ZipFile(stream, 'w', compression=zipfile.ZIP_DEFLATED) as zipped:
+            for name, body in sorted(payload.items()):
+                safe_name(name)
+                info = zipfile.ZipInfo(name, (1980, 1, 1, 0, 0, 0))
+                info.external_attr = (stat.S_IFREG | 0o644) << 16
+                zipped.writestr(info, body, compress_type=zipfile.ZIP_DEFLATED)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('input', type=Path)
+    for name in ('release-version', 'release-commit', 'harness-commit', 'harness-tree'):
+        parser.add_argument('--' + name, required=True)
+    parser.add_argument('--archive', type=Path, help='new durable ZIP path outside input')
+    args = parser.parse_args()
+    if args.archive:
+        require(not args.archive.resolve().is_relative_to(args.input.resolve()), 'archive must be outside input')
+    summary, files = verify(args.input, args.release_version, args.release_commit, args.harness_commit, args.harness_tree)
+    if args.archive:
+        archive(args.archive, summary, files)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+if __name__ == '__main__':
+    main()

--- a/website/source/en/reference/client-compatibility.md
+++ b/website/source/en/reference/client-compatibility.md
@@ -10,12 +10,56 @@ translationRequired: false
 
 # UAP client compatibility evidence
 
+## Released installer 0.1.53
+
+[Public release 0.1.53](https://github.com/777genius/universal-agent-plugins/releases/tag/agentplugins-v0.1.53)
+uses installer commit `28cf05af0a1e4fea642825dd34b78f9c99094ab5`.
+[Native run 34166817934](https://github.com/777genius/universal-agent-plugins/actions/runs/34166817934)
+passed all nine jobs and 18 required tests without skips. It downloaded the public
+binaries, checked their manifest and attestations before execution, and used
+separate source-built test/probe helpers at harness commit
+`9c33cfac81fc00e61205591321c89c5675fedb60`.
+
+| Tested client | Linux arm64 | macOS arm64 | Windows amd64 |
+| --- | --- | --- | --- |
+| Codex 0.153.4 | Passed stdio/HTTP and skill-context lifecycle | Same scope passed | Same scope passed |
+| Claude Code 2.1.263 | Passed stdio/HTTP/skill lifecycle | Same scope passed | Passed HTTP/installed-skill lifecycle; managed stdio unsupported |
+| OpenCode 1.18.29 | Passed lifecycle, collision-observation and extended stdio/skill suites | Same scope passed | Same scope passed |
+
+Lifecycle includes install, update, same-version refresh, repair and removal.
+OpenCode JSON/JSONC lifecycle and HTTP collision fixtures are separate from its
+global JSON stdio/skill-body suite; JSONC stdio/body coverage is not inferred.
+The observed colliding OpenCode tool names remain a limitation, with
+`opencode_tool_namespace_not_evaluated` advisory. The required Codex suite's Git
+acquisition seam is not a new public-Git native runtime claim.
+
+These are maintainer-run observations in fresh GitHub-hosted profiles with
+scripted loopback providers and network access. They do not prove real-model
+quality, OAuth/login, desktop applications, live services, independent adoption
+or vendor certification. Package validation, installation, activation/discovery
+and runtime remain separate evidence layers. The separate
+[six-platform launcher run](https://github.com/777genius/universal-agent-plugins/actions/runs/34164699278)
+does not extend this native-client table to other architectures.
+
+[Released evidence identities](https://github.com/777genius/universal-agent-plugins/blob/main/docs/evidence/client-compatibility-released-0.1.53.json)
+record all nine lanes and exact hashes. A verified archive contains 529 original
+files plus its summary, SHA-256
+`0d315f3a24bb6c41d184f0632d76a7228e18a6c1c41be2774e23c8066dfd3af6`.
+[Public evidence archive](https://github.com/777genius/universal-agent-plugins/releases/download/native-evidence-0.1.53-34166817934/uap-0.1.53-native-34166817934.zip)
+and [checksum sidecar](https://github.com/777genius/universal-agent-plugins/releases/download/native-evidence-0.1.53-34166817934/uap-0.1.53-native-34166817934.zip.sha256)
+were re-downloaded and hash-checked after publication on the
+[separate evidence release](https://github.com/777genius/universal-agent-plugins/releases/tag/native-evidence-0.1.53-34166817934).
+[Reproduction and publication procedure](https://github.com/777genius/universal-agent-plugins/blob/main/docs/released-native-client-proof.md)
+keeps those assets separate from the immutable installer release.
+
+## Historical source-built observations
+
 Snapshot: **2026-09-07**. These are bounded native CLI observations for the
 `agentplugins` installer. They do not establish support for every version of a
 client, Desktop application, operating system, package, or authentication flow.
 UAP is independent community tooling; this matrix is not vendor certification.
 
-## Source and release boundary
+### Historical source and release boundary
 
 The macOS/Windows checkpoint below is `ef20b93`; Linux evidence retains its
 separate historical identity. No result is implicitly carried to another SHA.
@@ -29,7 +73,7 @@ from product tree `dcd9090458b036515c9aed77ee5d3e66f0dcb4f5`, base commit
 The delivery was merged in [PR #184](https://github.com/777genius/universal-agent-plugins/pull/184)
 as [`7d17c77599306d662e0bec0e0fd77d35a4f8941c`](https://github.com/777genius/universal-agent-plugins/commit/7d17c77599306d662e0bec0e0fd77d35a4f8941c).
 These historical runs identify their tested premerge product tree, not a runtime
-rerun of that merge commit. The latest release verified for this snapshot is
+rerun of that merge commit. The latest release verified for the 2026-09-07 source snapshot is
 **0.1.51 (2026-09-06)**, which does **not** contain PR #184. Do not apply these
 candidate runtime results to that published binary.
 
@@ -40,7 +84,7 @@ audited `opencode-extended-11`. Raw transcripts are not
 bundled with this summary; hashes identify retained artifacts, not a publicly
 replayable transcript archive.
 
-## Linux arm64 native CLI matrix
+### Historical Linux arm64 native CLI matrix
 
 Each run used a fresh test project and isolated HOME/client/XDG roots in a
 container. Runtime used loopback MCP servers and scripted providers, without
@@ -76,7 +120,7 @@ manifest hashes. The skill BODY nonce reaches outgoing tool context and is
 absent from initial metadata/tool definitions; this does not establish model
 comprehension. The run does not prove new installer code or another OS.
 
-## Limitations observed and narrower proofs
+### Historical limitations and narrower proofs
 
 - **OpenCode tool-name collision:** logical keys `api/server` and `api server`
   each work alone, but together expose one `api_server_inspect_runtime` callable
@@ -107,7 +151,7 @@ comprehension. The run does not prove new installer code or another OS.
   switch/update were not evaluated. Claude/OpenCode native Git runs were not
   evaluated. Local and immutable Git installation do not require the Directory.
 
-## macOS arm64 and Windows amd64 source checkpoint
+### Historical macOS arm64 and Windows amd64 source checkpoint
 
 [GitHub Actions run 34158664586](https://github.com/777genius/universal-agent-plugins/actions/runs/34158664586)
 passed all six required native client lanes without skips on source commit


### PR DESCRIPTION
The compatibility page previously described source-built observations. Add a distinct released UAP 0.1.53 matrix tied to the nine actual native-client jobs and a permanent evidence archive, while retaining historical records and explicit unsupported boundaries.

Add an offline archive verifier and durable reproduction commands, plus isolated external testing instructions and a feedback template. The exact manual tester protocol is not yet claimed as executed; its dedicated smoke checkpoint is separate.

Validation: independent hash-bound review approved all six files; eight verifier tests pass; the documented public archive download/extraction/reproduction produced the original archive digest; local docs checks/build pass (Node 24.18, with pinned Node 22.21.1 checked in CI). Historical evidence is unchanged. Public archive: https://github.com/777genius/universal-agent-plugins/releases/tag/native-evidence-0.1.53-34166817934

After merge, the evidence release notes will link the exact documentation commit as verifier source, separate from the original runtime harness commit.

Refs #191.
