### PR TITLE
fix(authoring): bound Windows init rename contention

### DIFF
--- a/cli/plugin-kit-ai/internal/authoring/scaffold/apply.go
+++ b/cli/plugin-kit-ai/internal/authoring/scaffold/apply.go
@@ -42,7 +42,7 @@ func (e *CleanupError) Error() string { return e.Err.Error() }
 func (e *CleanupError) Unwrap() error { return e.Err }
 
 func Apply(ctx context.Context, p Plan, o ApplyOptions) (Result, error) {
-	return apply(ctx, p, o, applyOps{write: writeTree, rename: renameExclusive})
+	return apply(ctx, p, o, applyOps{write: writeTree, publish: renamePackage})
 }
 
 // Private operation seam for deterministic I/O failure and commit-race tests.
@@ -50,6 +50,8 @@ func Apply(ctx context.Context, p Plan, o ApplyOptions) (Result, error) {
 type applyOps struct {
 	write  func(context.Context, *os.Root, []File) error
 	rename func(*os.File, string, *os.File, string) error
+	// Package publication alone supports a checked retry; ApplySkill uses rename.
+	publish func(context.Context, *os.File, string, *os.File, string, func() error) error
 }
 
 func apply(ctx context.Context, p Plan, o ApplyOptions, ops applyOps) (result Result, err error) {
@@ -171,20 +173,29 @@ func apply(ctx context.Context, p Plan, o ApplyOptions, ops applyOps) (result Re
 	if e = ctx.Err(); e != nil {
 		return result, e
 	}
-	if e = checkParent(parentPath, parentInfo); e != nil {
-		return result, e
-	}
-	current, e = parent.Lstat(stage)
-	if e != nil || !os.SameFile(stageInfo, current) {
-		return result, fmt.Errorf("staging ownership changed: %w", errOr(e, fs.ErrInvalid))
-	}
-	payloadNow, e := owned.Lstat("payload")
-	if e != nil || !payloadNow.IsDir() || payloadNow.Mode()&os.ModeSymlink != 0 || !os.SameFile(payloadInfo, payloadNow) {
-		return result, fmt.Errorf("payload ownership changed: %w", errOr(e, fs.ErrInvalid))
-	}
-	e = verifyTree(ctx, root, files)
-	if e != nil {
-		return result, e
+	check := func() error {
+		if e := ctx.Err(); e != nil {
+			return e
+		}
+		if e := checkParent(parentPath, parentInfo); e != nil {
+			return e
+		}
+		current, e := parent.Lstat(stage)
+		if e != nil || !os.SameFile(stageInfo, current) {
+			return fmt.Errorf("staging ownership changed: %w", errOr(e, fs.ErrInvalid))
+		}
+		payloadNow, e := owned.Lstat("payload")
+		if e != nil || !payloadNow.IsDir() || payloadNow.Mode()&os.ModeSymlink != 0 || !os.SameFile(payloadInfo, payloadNow) {
+			return fmt.Errorf("payload ownership changed: %w", errOr(e, fs.ErrInvalid))
+		}
+		if e := verifyTree(ctx, root, files); e != nil {
+			return e
+		}
+		// Diagnostic only; the kernel still enforces no replacement.
+		if e := absent(parent, destination); e != nil {
+			return e
+		}
+		return ctx.Err()
 	}
 	from, e := owned.Open(".")
 	if e != nil {
@@ -194,13 +205,9 @@ func apply(ctx context.Context, p Plan, o ApplyOptions, ops applyOps) (result Re
 	if e != nil {
 		return result, errors.Join(e, from.Close())
 	}
-	// Existence check improves diagnostics only. The kernel primitive below is
-	// the authoritative no-replace operation, including for empty directories.
-	e = absent(parent, destination)
-	if e == nil {
-		e = ctx.Err()
-	}
-	if e == nil {
+	if ops.publish != nil {
+		e = ops.publish(ctx, from, "payload", to, destination, check)
+	} else if e = check(); e == nil {
 		e = ops.rename(from, "payload", to, destination)
 	}
 	if e == nil {

--- a/cli/plugin-kit-ai/internal/authoring/scaffold/rename_package_other.go
+++ b/cli/plugin-kit-ai/internal/authoring/scaffold/rename_package_other.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package scaffold
+
+import (
+	"context"
+	"os"
+)
+
+func renamePackage(_ context.Context, from *os.File, old string, to *os.File, new string, check func() error) error {
+	if err := check(); err != nil {
+		return err
+	}
+	return renameExclusive(from, old, to, new)
+}

--- a/cli/plugin-kit-ai/internal/authoring/scaffold/rename_retry_windows_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/scaffold/rename_retry_windows_test.go
@@ -1,0 +1,284 @@
+//go:build windows
+
+package scaffold
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// A real separate process owns the reader pins. EOF releases them; stdout
+// acknowledges acquisition before the publishing process attempts its syscall.
+func TestRenamePinProcess(t *testing.T) {
+	marker := -1
+	for i, arg := range os.Args {
+		if arg == "--rename-reader" {
+			marker = i
+			break
+		}
+	}
+	if marker < 0 {
+		return
+	}
+	var handles []windows.Handle
+	for _, path := range os.Args[marker+1:] {
+		name, err := windows.UTF16PtrFromString(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		h, err := windows.CreateFile(name, windows.FILE_READ_ATTRIBUTES|windows.FILE_LIST_DIRECTORY,
+			windows.FILE_SHARE_READ, nil, windows.OPEN_EXISTING,
+			windows.FILE_FLAG_BACKUP_SEMANTICS|windows.FILE_FLAG_OPEN_REPARSE_POINT, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		handles = append(handles, h)
+	}
+	fmt.Println("pinned")
+	_, _ = io.Copy(io.Discard, os.Stdin)
+	for _, h := range handles {
+		if err := windows.CloseHandle(h); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func holdRenameReader(t *testing.T, paths ...string) func() {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	args := append([]string{"-test.run=^TestRenamePinProcess$", "--", "--rename-reader"}, paths...)
+	cmd := exec.CommandContext(ctx, os.Args[0], args...)
+	in, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	released := false
+	release := func() {
+		if released {
+			return
+		}
+		released = true
+		_ = in.Close()
+		err := cmd.Wait()
+		cancel()
+		if err != nil {
+			t.Errorf("reader process: %v: %s", err, stderr.String())
+		}
+	}
+	t.Cleanup(release)
+	line, err := bufio.NewReader(out).ReadString('\n')
+	if err != nil || strings.TrimSpace(line) != "pinned" {
+		t.Fatalf("reader readiness %q: %v", line, err)
+	}
+	return release
+}
+
+func TestPackageRenameRetryWithReaderProcess(t *testing.T) {
+	for _, kind := range []string{"release", "nested-reader", "collision", "cancel", "persistent", "tree", "parent", "stage", "payload"} {
+		t.Run(kind, func(t *testing.T) {
+			sandbox := t.TempDir()
+			parent := filepath.Join(sandbox, "parent")
+			if err := os.Mkdir(parent, 0700); err != nil {
+				t.Fatal(err)
+			}
+			dest := filepath.Join(parent, "result")
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			var payload, protected string
+			waits := 0
+			validate := realValidation(t)
+			ops := applyOps{write: writeTree}
+			ops.publish = func(ctx context.Context, from *os.File, old string, to *os.File, new string, check func() error) error {
+				paths := []string{parent}
+				if kind == "nested-reader" {
+					// A reader rooted below another init's parent also pins that common
+					// ancestor. Distinct immediate-parent lock keys would miss this overlap.
+					nested := filepath.Join(parent, "nested")
+					if err := os.Mkdir(nested, 0700); err != nil {
+						t.Fatal(err)
+					}
+					paths = append(paths, nested)
+				}
+				release := holdRenameReader(t, paths...)
+				defer release()
+				r := &renameRetry{ctx: ctx, check: check, budget: time.Second, attempts: 3}
+				r.wait = func(ctx context.Context, _ time.Duration) error {
+					waits++ // Reached only after an actual native commit sharing failure.
+					if kind == "persistent" {
+						return nil
+					}
+					release()
+					switch kind {
+					case "collision":
+						if err := os.Mkdir(dest, 0700); err != nil {
+							t.Fatal(err)
+						}
+						protected = filepath.Join(dest, "peer")
+					case "cancel":
+						cancel()
+						return ctx.Err()
+					case "tree":
+						if err := os.WriteFile(filepath.Join(payload, "README.md"), []byte("tampered"), 0600); err != nil {
+							t.Fatal(err)
+						}
+					case "parent", "stage", "payload":
+						path := payload
+						if kind == "parent" {
+							path = parent
+						}
+						if kind == "stage" {
+							path = filepath.Dir(payload)
+						}
+						if err := os.Rename(path, path+"-moved"); err != nil {
+							t.Fatal(err)
+						}
+						if err := os.Mkdir(path, 0700); err != nil {
+							t.Fatal(err)
+						}
+						protected = filepath.Join(path, "peer")
+					}
+					if protected != "" {
+						if err := os.WriteFile(protected, []byte("untouched"), 0600); err != nil {
+							t.Fatal(err)
+						}
+					}
+					return nil
+				}
+				return renameResult(from, old, to, new, renameWindows(from, old, to, new, r))
+			}
+			result, err := apply(ctx, planFor(t, "skill"), ApplyOptions{Destination: dest, Validate: func(ctx context.Context, path string) error {
+				payload = path
+				return validate(ctx, path)
+			}}, ops)
+			if kind == "release" || kind == "nested-reader" {
+				if err != nil || !result.Committed || waits != 1 {
+					t.Fatalf("result=%+v waits=%d err=%v", result, waits, err)
+				}
+				if err := validate(context.Background(), dest); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				if err == nil || result.Committed {
+					t.Fatalf("unsafe success: %+v %v", result, err)
+				}
+				if kind == "persistent" {
+					if waits != 2 || !errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
+						t.Fatalf("exhaustion waits=%d err=%v", waits, err)
+					}
+				} else if waits != 1 {
+					t.Fatalf("waits=%d: %v", waits, err)
+				}
+				if kind == "collision" && !errors.Is(err, os.ErrExist) {
+					t.Fatal(err)
+				}
+				if kind == "cancel" && !errors.Is(err, context.Canceled) {
+					t.Fatal(err)
+				}
+				if protected != "" {
+					b, e := os.ReadFile(protected)
+					if e != nil || string(b) != "untouched" {
+						t.Fatalf("peer changed: %q %v", b, e)
+					}
+				}
+				if kind != "collision" {
+					if _, e := os.Lstat(dest); !errors.Is(e, os.ErrNotExist) {
+						t.Fatalf("destination exists: %v", e)
+					}
+				}
+			}
+			if kind != "parent" && kind != "stage" && kind != "payload" {
+				entries, e := os.ReadDir(parent)
+				if e != nil {
+					t.Fatal(e)
+				}
+				for _, entry := range entries {
+					if strings.HasPrefix(entry.Name(), ".authoring-") {
+						t.Fatalf("stage leaked: %s", entry.Name())
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestRenameWaitCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := waitRename(ctx, time.Hour); !errors.Is(err, context.Canceled) {
+		t.Fatal(err)
+	}
+}
+
+func TestPackageRenameRetryEligibility(t *testing.T) {
+	for _, kind := range []string{"success", "source-sharing", "collision", "budget"} {
+		t.Run(kind, func(t *testing.T) {
+			parent := t.TempDir()
+			source := filepath.Join(parent, "source")
+			if err := os.Mkdir(source, 0700); err != nil {
+				t.Fatal(err)
+			}
+			if kind == "collision" {
+				if err := os.Mkdir(filepath.Join(parent, "destination"), 0700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			dir, err := os.Open(parent)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer dir.Close()
+			if kind == "source-sharing" {
+				defer holdRenameReader(t, source)()
+			}
+			if kind == "budget" {
+				defer holdRenameReader(t, parent)()
+			}
+			waits := 0
+			r := &renameRetry{ctx: context.Background(), check: func() error { return nil }, budget: time.Nanosecond, attempts: 32,
+				wait: func(context.Context, time.Duration) error { waits++; return nil }}
+			err = renameResult(dir, "source", dir, "destination", renameWindows(dir, "source", dir, "destination", r))
+			if waits != 0 {
+				t.Fatalf("unexpected retry: %d", waits)
+			}
+			switch kind {
+			case "success":
+				if err != nil {
+					t.Fatal(err)
+				}
+			case "collision":
+				if !errors.Is(err, os.ErrExist) {
+					t.Fatal(err)
+				}
+			case "source-sharing":
+				if !errors.Is(err, windows.ERROR_SHARING_VIOLATION) || !strings.Contains(err.Error(), "open source directory") {
+					t.Fatal(err)
+				}
+			case "budget":
+				if !errors.Is(err, windows.ERROR_SHARING_VIOLATION) || !strings.Contains(err.Error(), "commit exclusive directory") {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/cli/plugin-kit-ai/internal/authoring/scaffold/rename_retry_windows_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/scaffold/rename_retry_windows_test.go
@@ -106,6 +106,7 @@ func TestPackageRenameRetryWithReaderProcess(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			var payload, protected string
+			blockedTamper := false
 			waits := 0
 			validate := realValidation(t)
 			ops := applyOps{write: writeTree}
@@ -150,8 +151,26 @@ func TestPackageRenameRetryWithReaderProcess(t *testing.T) {
 						if kind == "stage" {
 							path = filepath.Dir(payload)
 						}
-						if err := os.Rename(path, path+"-moved"); err != nil {
+						before, err := os.Lstat(path)
+						if err != nil {
 							t.Fatal(err)
+						}
+						if err := os.Rename(path, path+"-moved"); err != nil {
+							// Windows may protect ancestors of the retained source
+							// handle from rename. Prove that protection preserved the
+							// original object; do not release handles to force tampering.
+							if (kind != "parent" && kind != "stage") || !errors.Is(err, windows.ERROR_ACCESS_DENIED) {
+								t.Fatal(err)
+							}
+							after, statErr := os.Lstat(path)
+							if statErr != nil || !os.SameFile(before, after) {
+								t.Fatalf("blocked tamper changed identity: %v", statErr)
+							}
+							if _, e := os.Lstat(path + "-moved"); !errors.Is(e, os.ErrNotExist) {
+								t.Fatalf("blocked tamper moved source: %v", e)
+							}
+							blockedTamper = true
+							break
 						}
 						if err := os.Mkdir(path, 0700); err != nil {
 							t.Fatal(err)
@@ -171,7 +190,7 @@ func TestPackageRenameRetryWithReaderProcess(t *testing.T) {
 				payload = path
 				return validate(ctx, path)
 			}}, ops)
-			if kind == "release" || kind == "nested-reader" {
+			if kind == "release" || kind == "nested-reader" || blockedTamper {
 				if err != nil || !result.Committed || waits != 1 {
 					t.Fatalf("result=%+v waits=%d err=%v", result, waits, err)
 				}
@@ -207,7 +226,7 @@ func TestPackageRenameRetryWithReaderProcess(t *testing.T) {
 					}
 				}
 			}
-			if kind != "parent" && kind != "stage" && kind != "payload" {
+			if blockedTamper || (kind != "parent" && kind != "stage" && kind != "payload") {
 				entries, e := os.ReadDir(parent)
 				if e != nil {
 					t.Fatal(e)
@@ -255,10 +274,20 @@ func TestPackageRenameRetryEligibility(t *testing.T) {
 				defer holdRenameReader(t, parent)()
 			}
 			waits := 0
-			r := &renameRetry{ctx: context.Background(), check: func() error { return nil }, budget: time.Nanosecond, attempts: 32,
-				wait: func(context.Context, time.Duration) error { waits++; return nil }}
+			r := &renameRetry{ctx: context.Background(), check: func() error { return nil }, budget: 10 * time.Millisecond, attempts: 32,
+				wait: func(ctx context.Context, delay time.Duration) error {
+					waits++
+					// Exercise actual elapsed-time exhaustion. A no-op wait with
+					// a nanosecond budget can fit all attempts in one Windows tick.
+					return waitRename(ctx, delay+20*time.Millisecond)
+				}}
+			started := time.Now()
 			err = renameResult(dir, "source", dir, "destination", renameWindows(dir, "source", dir, "destination", r))
-			if waits != 0 {
+			if kind == "budget" {
+				if waits > 1 || time.Since(started) < r.budget {
+					t.Fatalf("budget not enforced: waits=%d elapsed=%v", waits, time.Since(started))
+				}
+			} else if waits != 0 {
 				t.Fatalf("unexpected retry: %d", waits)
 			}
 			switch kind {

--- a/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows.go
+++ b/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows.go
@@ -3,10 +3,12 @@
 package scaffold
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"runtime"
+	"time"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -17,7 +19,15 @@ import (
 // This avoids MoveFileEx's pathname races and never enables REPLACE_IF_EXISTS or
 // POSIX_SEMANTICS. Unsupported filesystems fail without a weaker fallback.
 func renameExclusive(from *os.File, old string, to *os.File, new string) error {
-	err := renameWindows(from, old, to, new)
+	return renameResult(from, old, to, new, renameWindows(from, old, to, new, nil))
+}
+
+func renamePackage(ctx context.Context, from *os.File, old string, to *os.File, new string, check func() error) error {
+	r := &renameRetry{ctx: ctx, check: check, budget: time.Second, attempts: 32, wait: waitRename}
+	return renameResult(from, old, to, new, renameWindows(from, old, to, new, r))
+}
+
+func renameResult(from *os.File, old string, to *os.File, new string, err error) error {
 	runtime.KeepAlive(from)
 	runtime.KeepAlive(to)
 	if err != nil {
@@ -31,7 +41,34 @@ func renameExclusive(from *os.File, old string, to *os.File, new string) error {
 	}
 	return nil
 }
-func renameWindows(from *os.File, old string, to *os.File, new string) error {
+
+// Retry belongs to package publication only. A nil policy is the original
+// single-attempt primitive used by ApplySkill and its source CAS.
+type renameRetry struct {
+	ctx      context.Context
+	check    func() error
+	budget   time.Duration
+	attempts int
+	wait     func(context.Context, time.Duration) error
+}
+
+func waitRename(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func renameWindows(from *os.File, old string, to *os.File, new string, retry *renameRetry) error {
+	if retry != nil {
+		if err := retry.check(); err != nil {
+			return err
+		}
+	}
 	name, err := windows.NewNTUnicodeString(old)
 	if err != nil {
 		return err
@@ -65,8 +102,48 @@ func renameWindows(from *os.File, old string, to *os.File, new string) error {
 	info.RootDirectory = windows.Handle(to.Fd())
 	info.FileNameLength = uint32((len(target) - 1) * 2)
 	copy(unsafe.Slice(&info.FileName[0], len(target)-1), target[:len(target)-1])
-	if err := windows.NtSetInformationFile(handle, &status, &buffer[0], uint32(size), windows.FileRenameInformation); err != nil {
-		return fmt.Errorf("commit exclusive directory rename: %w", err)
+	var started time.Time
+	var lastFailure error
+	delay := 10 * time.Millisecond
+	for attempt := 1; ; attempt++ {
+		if retry != nil {
+			if err := retry.check(); err != nil {
+				return err
+			}
+			if err := retry.ctx.Err(); err != nil {
+				return err
+			}
+		}
+		if retry != nil && !started.IsZero() && time.Since(started) >= retry.budget {
+			return lastFailure
+		}
+		err := windows.NtSetInformationFile(handle, &status, &buffer[0], uint32(size), windows.FileRenameInformation)
+		if err == nil {
+			return nil
+		}
+		failure := fmt.Errorf("commit exclusive directory rename: %w", err)
+		lastFailure = failure
+		// Only this failed native operation is eligible. Keep the same source
+		// handle, anchored parents and no-replace request throughout the loop.
+		if retry == nil || err != windows.STATUS_SHARING_VIOLATION {
+			return failure
+		}
+		if started.IsZero() {
+			started = time.Now()
+		}
+		remaining := retry.budget - time.Since(started)
+		if attempt >= retry.attempts || remaining <= 0 {
+			return failure
+		}
+		if err := retry.wait(retry.ctx, min(delay, remaining)); err != nil {
+			return err
+		}
+		if err := retry.ctx.Err(); err != nil {
+			return err
+		}
+		if time.Since(started) >= retry.budget {
+			return failure
+		}
+		delay = min(delay*2, 50*time.Millisecond)
 	}
-	return nil
 }

--- a/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows.go
+++ b/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows.go
@@ -3,6 +3,8 @@
 package scaffold
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"runtime"
 	"unsafe"
@@ -21,8 +23,9 @@ func renameExclusive(from *os.File, old string, to *os.File, new string) error {
 	if err != nil {
 		// Native NTSTATUS errors do not implement errors.Is. Convert to the
 		// Win32 errno so callers can classify collisions with os.ErrExist.
-		if status, ok := err.(windows.NTStatus); ok {
-			err = status.Errno()
+		var status windows.NTStatus
+		if errors.As(err, &status) {
+			err = fmt.Errorf("%v: %w", err, status.Errno())
 		}
 		return &os.LinkError{Op: "rename-exclusive", Old: old, New: new, Err: err}
 	}
@@ -41,7 +44,7 @@ func renameWindows(from *os.File, old string, to *os.File, new string) error {
 		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE, windows.FILE_OPEN,
 		windows.FILE_DIRECTORY_FILE|windows.FILE_OPEN_REPARSE_POINT|windows.FILE_SYNCHRONOUS_IO_NONALERT, 0, 0)
 	if err != nil {
-		return err
+		return fmt.Errorf("open source directory for exclusive rename: %w", err)
 	}
 	defer windows.CloseHandle(handle)
 	target, err := windows.UTF16FromString(new)
@@ -62,5 +65,8 @@ func renameWindows(from *os.File, old string, to *os.File, new string) error {
 	info.RootDirectory = windows.Handle(to.Fd())
 	info.FileNameLength = uint32((len(target) - 1) * 2)
 	copy(unsafe.Slice(&info.FileName[0], len(target)-1), target[:len(target)-1])
-	return windows.NtSetInformationFile(handle, &status, &buffer[0], uint32(size), windows.FileRenameInformation)
+	if err := windows.NtSetInformationFile(handle, &status, &buffer[0], uint32(size), windows.FileRenameInformation); err != nil {
+		return fmt.Errorf("commit exclusive directory rename: %w", err)
+	}
+	return nil
 }

--- a/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows_test.go
@@ -4,6 +4,7 @@ package scaffold
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -88,6 +89,52 @@ func TestWindowsRenameExclusiveHeldDirectoryDiagnostics(t *testing.T) {
 				if readErr != nil || string(body) != name {
 					t.Fatalf("%s modified: %q %v", name, body, readErr)
 				}
+			}
+		})
+	}
+}
+
+// A peer package reader pins shared ancestors with read sharing only. Compare
+// this exact share policy against a write-sharing control without any timing.
+func TestWindowsRenameExclusiveHeldParentDiagnostics(t *testing.T) {
+	for _, share := range []uint32{windows.FILE_SHARE_READ, windows.FILE_SHARE_READ | windows.FILE_SHARE_WRITE | windows.FILE_SHARE_DELETE} {
+		t.Run(fmt.Sprintf("share-%d", share), func(t *testing.T) {
+			parent := t.TempDir()
+			if err := os.Mkdir(filepath.Join(parent, "source"), 0700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(parent, "source", "marker"), []byte("original"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			name, err := windows.UTF16PtrFromString(parent)
+			if err != nil {
+				t.Fatal(err)
+			}
+			held, err := windows.CreateFile(name, windows.FILE_READ_ATTRIBUTES|windows.FILE_LIST_DIRECTORY, share, nil, windows.OPEN_EXISTING, windows.FILE_FLAG_BACKUP_SEMANTICS|windows.FILE_FLAG_OPEN_REPARSE_POINT, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer windows.CloseHandle(held)
+			dir, err := os.Open(parent)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer dir.Close()
+			err = renameExclusive(dir, "source", dir, "destination")
+			t.Logf("parent_share=%d raw_error=%T %v exists=%t sharing=%t", share, err, err, errors.Is(err, os.ErrExist), errors.Is(err, windows.ERROR_SHARING_VIOLATION))
+			if err != nil && (!errors.Is(err, windows.ERROR_SHARING_VIOLATION) || !strings.Contains(err.Error(), "commit exclusive directory rename")) {
+				t.Fatalf("unexpected parent-pin outcome: %v", err)
+			}
+			location := "destination"
+			if err != nil {
+				location = "source"
+			}
+			body, readErr := os.ReadFile(filepath.Join(parent, location, "marker"))
+			if readErr != nil || string(body) != "original" {
+				t.Fatalf("tree changed: %q %v", body, readErr)
+			}
+			if share == windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE && err != nil {
+				t.Fatalf("fully shared control must rename: %v", err)
 			}
 		})
 	}

--- a/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/scaffold/rename_windows_test.go
@@ -6,7 +6,10 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"golang.org/x/sys/windows"
 )
 
 func TestWindowsRenameExclusiveExistingDestination(t *testing.T) {
@@ -34,5 +37,58 @@ func TestWindowsRenameExclusiveExistingDestination(t *testing.T) {
 		if err != nil || string(contents) != name {
 			t.Errorf("%s changed: contents=%q err=%v", name, contents, err)
 		}
+	}
+}
+
+// Deliberately hold a directory without delete sharing. This models a reader's
+// ancestry pin and distinguishes opening the source from committing the rename.
+func TestWindowsRenameExclusiveHeldDirectoryDiagnostics(t *testing.T) {
+	for _, heldName := range []string{"source", "destination"} {
+		t.Run(heldName, func(t *testing.T) {
+			parent := t.TempDir()
+			for _, name := range []string{"source", "destination"} {
+				dir := filepath.Join(parent, name)
+				if err := os.Mkdir(dir, 0700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "marker"), []byte(name), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			name, err := windows.UTF16PtrFromString(filepath.Join(parent, heldName))
+			if err != nil {
+				t.Fatal(err)
+			}
+			held, err := windows.CreateFile(name, windows.FILE_LIST_DIRECTORY, windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE, nil, windows.OPEN_EXISTING, windows.FILE_FLAG_BACKUP_SEMANTICS|windows.FILE_FLAG_OPEN_REPARSE_POINT, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer windows.CloseHandle(held)
+			dir, err := os.Open(parent)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer dir.Close()
+			err = renameExclusive(dir, "source", dir, "destination")
+			t.Logf("held=%s raw_error=%T %v exists=%t sharing=%t", heldName, err, err, errors.Is(err, os.ErrExist), errors.Is(err, windows.ERROR_SHARING_VIOLATION))
+			if heldName == "source" {
+				if !errors.Is(err, windows.ERROR_SHARING_VIOLATION) || !strings.Contains(err.Error(), "open source directory for exclusive rename") {
+					t.Fatalf("source pin must preserve source-open sharing error: %v", err)
+				}
+			} else {
+				// Diagnostic checkpoint: Windows can report destination sharing before
+				// name collision. Neither outcome authorizes replacing that destination.
+				// The existing end-to-end concurrency test still strictly requires ErrExist.
+				if err == nil || !strings.Contains(err.Error(), "commit exclusive directory rename") || (!errors.Is(err, os.ErrExist) && !errors.Is(err, windows.ERROR_SHARING_VIOLATION)) {
+					t.Fatalf("unexpected held-destination native result: %v", err)
+				}
+			}
+			for _, name := range []string{"source", "destination"} {
+				body, readErr := os.ReadFile(filepath.Join(parent, name, "marker"))
+				if readErr != nil || string(body) != name {
+					t.Fatalf("%s modified: %q %v", name, body, readErr)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Concurrent package init on Windows can fail with a sharing violation while another invocation validates a package under the same ancestor. Native diagnostic run 34167593344 reproduced the commit failure with an absent destination and a read-only ancestor handle, so this error cannot be mapped to destination-exists.

Retry only the package-init native rename commit on STATUS_SHARING_VIOLATION, retaining original handles and rechecking rooted identities, staged content, destination absence and cancellation within a bounded contention budget. Skill application retains its existing one-shot behavior and CAS checks. Include deterministic process-pinning, cancellation, collision and tamper regressions.

Validation so far: independently reviewed design; isolated Linux scaffold suite passed; Windows cross-compilation passed. Native checkpoint 34169238595 at 92bcd331ade345ec5a26138ccd6651a63b4c86bf completed: Linux passed; Windows failed three new subtests. Parent/stage tamper attempts were denied by retained handles, and the retry-budget assertion observed 31 retries. The original concurrent-init test passed, which alone does not establish correctness. These results are being investigated; no blind rerun was requested. Independent implementation review is unfinished because both reviewers hit their usage limit. This draft is not merge-approved, and green tests will not substitute for that review.

Refs #191. Refs #193.

Corrected test-only checkpoint `e5a530164720e53be72572286e4bd7d18697fd15` passed native run [34169525134](https://github.com/777genius/universal-agent-plugins/actions/runs/34169525134) on both Linux and Windows. Downloaded structured results show no failed tests; all retry release/nested-reader/collision/cancel/persistent/tamper/budget cases and the original concurrent-init test passed. Independent implementation review is still pending; this remains a draft.
