### PR TITLE
feat(release): prepare paired authoring release artifacts

### DIFF
--- a/.github/workflows/agentplugins-release.yml
+++ b/.github/workflows/agentplugins-release.yml
@@ -403,8 +403,6 @@ jobs:
       KIT_VERSION: ${{ inputs.plugin_kit_version }}
       GOTOOLCHAIN: local
       GOMAXPROCS: "2"
-      GOMODCACHE: ${{ runner.temp }}/paired-modules
-      GOCACHE: ${{ runner.temp }}/paired-cache
     steps:
       - name: Validate explicit paired identity before checkout
         shell: bash
@@ -431,9 +429,15 @@ jobs:
           node-version: 22
           package-manager-cache: false
       - name: Provision declared Go modules for offline producer
+        env:
+          GOMODCACHE: ${{ runner.temp }}/paired-modules
+          GOCACHE: ${{ runner.temp }}/paired-cache
         run: go mod download
       - name: Freeze one full release-contract pair and project verified bytes
         shell: bash
+        env:
+          GOMODCACHE: ${{ runner.temp }}/paired-modules
+          GOCACHE: ${{ runner.temp }}/paired-cache
         run: |
           set -euo pipefail
           export TRUSTED_GO="$(command -v go)"

--- a/.github/workflows/agentplugins-release.yml
+++ b/.github/workflows/agentplugins-release.yml
@@ -7,12 +7,19 @@ on:
         description: Exact stable tag, for example agentplugins-v0.1.0
         required: true
       producer_mode:
-        description: Bounded release contract; publishes verified GitHub binary assets only
+        description: Binary-only publication or read-only paired native preparation
         required: true
         default: binary-only
         type: choice
         options:
           - binary-only
+          - paired-preparation
+      source_sha:
+        description: Exact source and workflow SHA (required for paired preparation)
+        required: false
+      plugin_kit_version:
+        description: Explicit plugin-kit version (paired first cut requires 2.0.0)
+        required: false
 
 permissions:
   contents: read
@@ -23,6 +30,7 @@ concurrency:
 
 jobs:
   validate:
+    if: ${{ inputs.producer_mode == 'binary-only' }}
     runs-on: ubuntu-latest
     env:
       GOWORK: "off"
@@ -144,6 +152,7 @@ jobs:
         run: npm test && npm pack --dry-run --ignore-scripts
 
   build:
+    if: ${{ inputs.producer_mode == 'binary-only' }}
     needs: validate
     runs-on: ubuntu-latest
     env:
@@ -200,6 +209,7 @@ jobs:
           retention-days: 3
 
   stage-draft:
+    if: ${{ inputs.producer_mode == 'binary-only' }}
     needs: [validate, build]
     runs-on: ubuntu-latest
     environment: agentplugins-release
@@ -308,6 +318,7 @@ jobs:
           retention-days: 7
 
   platform-proof:
+    if: ${{ inputs.producer_mode == 'binary-only' }}
     needs: [validate, stage-draft]
     uses: ./.github/workflows/agentplugins-platform-proof.yml
     permissions:
@@ -322,6 +333,7 @@ jobs:
       release_assets_artifact: ${{ needs.stage-draft.outputs.assets_artifact }}
 
   promote-release:
+    if: ${{ inputs.producer_mode == 'binary-only' }}
     needs: [validate, stage-draft, platform-proof]
     runs-on: ubuntu-latest
     environment: agentplugins-release
@@ -378,3 +390,87 @@ jobs:
           gh release edit "${TAG}" --repo "${GITHUB_REPOSITORY}" --draft=false
           gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \
             --jq 'select(.draft == false and .prerelease == false) | .tag_name' | grep -Fx -- "${TAG}"
+
+  paired-preparation:
+    if: ${{ inputs.producer_mode == 'paired-preparation' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      SOURCE_SHA: ${{ inputs.source_sha }}
+      WORKFLOW_SHA: ${{ github.sha }}
+      TAG: ${{ inputs.tag }}
+      KIT_VERSION: ${{ inputs.plugin_kit_version }}
+      GOTOOLCHAIN: local
+      GOMAXPROCS: "2"
+      GOMODCACHE: ${{ runner.temp }}/paired-modules
+      GOCACHE: ${{ runner.temp }}/paired-cache
+    steps:
+      - name: Validate explicit paired identity before checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "${SOURCE_SHA}" =~ ^[0-9a-f]{40}$ && ! "${SOURCE_SHA}" =~ ^0{40}$ ]]
+          test "${SOURCE_SHA}" = "${WORKFLOW_SHA}"
+          [[ "${TAG}" =~ ^agentplugins-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
+          test "${KIT_VERSION}" = "2.0.0"
+          test "${TAG#agentplugins-v}" != "${KIT_VERSION}"
+          test "${GITHUB_REPOSITORY}" = "777genius/universal-agent-plugins"
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.source_sha }}
+      - name: Check exact checkout
+        run: test "$(git rev-parse HEAD)" = "${SOURCE_SHA}"
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: 1.25.13
+          cache: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          package-manager-cache: false
+      - name: Provision declared Go modules for offline producer
+        run: go mod download
+      - name: Freeze one full release-contract pair and project verified bytes
+        shell: bash
+        run: |
+          set -euo pipefail
+          export TRUSTED_GO="$(command -v go)"
+          node <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const { stageCandidate } = require('./npm/agentplugins/scripts/stage-dual-authoring-candidate');
+          const { prepareAuthoringRelease, verifyAuthoringRelease } = require('./npm/agentplugins/scripts/release-assets');
+          const root = fs.mkdtempSync(path.join(process.env.RUNNER_TEMP, 'authoring-preparation-'));
+          const workParent = path.join(root, 'work');
+          fs.mkdirSync(workParent, { mode: 0o700 });
+          const identity = { repository: '777genius/universal-agent-plugins',
+            commit: process.env.SOURCE_SHA, engine_revision: process.env.SOURCE_SHA,
+            versions: { agentplugins: process.env.TAG.slice('agentplugins-v'.length), 'plugin-kit-ai': process.env.KIT_VERSION } };
+          const common = { candidate: true, identity, go: process.env.TRUSTED_GO, workParent,
+            assetScope: 'six-platform-pair', authoringMode: 'release-cli-contract-v1' };
+          // stageCandidate builds once and independently verifies before sealing.
+          const candidate = path.join(root, 'candidate');
+          const staged = stageCandidate({ ...common, repo: process.env.GITHUB_WORKSPACE,
+            modCache: process.env.GOMODCACHE, output: candidate });
+          fs.writeFileSync(path.join(root, 'candidate-identity.json'), JSON.stringify({ identity, ...staged }, null, 2) + '\n', { flag: 'wx' });
+          const options = { ...common, root: candidate, manifestDigest: staged.manifest_sha256,
+            outputs: { agentplugins: path.join(root, 'agentplugins'), 'plugin-kit-ai': path.join(root, 'plugin-kit-ai') },
+            pairMarker: path.join(root, 'pair-prepared.json') };
+          prepareAuthoringRelease(options);
+          verifyAuthoringRelease(options);
+          fs.appendFileSync(process.env.GITHUB_ENV, `PAIRED_OUTPUT=${root}\n`);
+          NODE
+      - name: Upload candidate identity and both prepared projections together
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: authoring-preparation-${{ inputs.source_sha }}
+          path: |
+            ${{ env.PAIRED_OUTPUT }}/candidate-identity.json
+            ${{ env.PAIRED_OUTPUT }}/candidate/candidate.json
+            ${{ env.PAIRED_OUTPUT }}/pair-prepared.json
+            ${{ env.PAIRED_OUTPUT }}/agentplugins/*
+            ${{ env.PAIRED_OUTPUT }}/plugin-kit-ai/*
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -16,6 +16,16 @@ jobs:
       attestations: write
       artifact-metadata: write
     steps:
+      - name: Reject standard-first versions on legacy producer
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${RELEASE_TAG}" =~ ^v1\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "Legacy GoReleaser supports plugin-kit-ai v1 only. Use agentplugins-release.yml paired-preparation for plugin-kit-ai major 2; publication requires later qualification." >&2
+            exit 1
+          fi
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0

--- a/cli/plugin-kit-ai/cmd/agentplugins/release_workflow_test.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins/release_workflow_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -85,11 +86,13 @@ type producerWorkflow struct {
 		Needs       any               `yaml:"needs"`
 		Uses        string            `yaml:"uses"`
 		Permissions map[string]string `yaml:"permissions"`
+		Env         map[string]string `yaml:"env"`
 		Steps       []struct {
-			Name string         `yaml:"name"`
-			Run  string         `yaml:"run"`
-			Uses string         `yaml:"uses"`
-			With map[string]any `yaml:"with"`
+			Name string            `yaml:"name"`
+			Run  string            `yaml:"run"`
+			Uses string            `yaml:"uses"`
+			With map[string]any    `yaml:"with"`
+			Env  map[string]string `yaml:"env"`
 		} `yaml:"steps"`
 	} `yaml:"jobs"`
 }
@@ -119,6 +122,43 @@ func runProducerPreflight(t *testing.T, script string, values map[string]string,
 	body, err := command.CombinedOutput()
 	if (err == nil) != success {
 		t.Fatalf("preflight success=%v, expected %v: %v\n%s", err == nil, success, err, body)
+	}
+}
+
+// YAML decoding alone accepts runner expressions in job env, but GitHub rejects
+// that context there before creating a run. Step env supports runner instead.
+func TestReleaseWorkflowRunnerCacheContext(t *testing.T) {
+	w := readProducerWorkflow(t, "agentplugins-release.yml")
+	runnerExpression := regexp.MustCompile(`\$\{\{[^}]*\brunner\s*[.\[]`)
+	for name, job := range w.Jobs {
+		for key, value := range job.Env {
+			if runnerExpression.MatchString(value) {
+				t.Errorf("jobs.%s.env.%s uses unavailable runner context", name, key)
+			}
+		}
+	}
+	consumers := map[string]bool{
+		"Provision declared Go modules for offline producer":               false,
+		"Freeze one full release-contract pair and project verified bytes": false,
+	}
+	for _, step := range w.Jobs["paired-preparation"].Steps {
+		if _, ok := consumers[step.Name]; !ok {
+			continue
+		}
+		consumers[step.Name] = true
+		for key, want := range map[string]string{
+			"GOMODCACHE": "${{ runner.temp }}/paired-modules",
+			"GOCACHE":    "${{ runner.temp }}/paired-cache",
+		} {
+			if step.Env[key] != want {
+				t.Errorf("%s must set step env %s=%q, got %q", step.Name, key, want, step.Env[key])
+			}
+		}
+	}
+	for name, found := range consumers {
+		if !found {
+			t.Errorf("missing cache consumer %q", name)
+		}
 	}
 }
 

--- a/cli/plugin-kit-ai/cmd/agentplugins/release_workflow_test.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins/release_workflow_test.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestStableReleaseRequiresVerifiedReproducibleBootstrapBeforeBuild(t *testing.T) {
@@ -58,5 +61,193 @@ func TestStableReleaseRequiresVerifiedReproducibleBootstrapBeforeBuild(t *testin
 	}
 	if !strings.Contains(string(binaryTestBody), "forbiddenProductionDirectoryVariables") {
 		t.Fatal("release binary test does not inspect the complete forbidden conformance variable set")
+	}
+}
+
+// Parse the job graph as well as executing its preflight shell. A new job or
+// dispatch mode must not accidentally inherit the publication permissions.
+type producerWorkflow struct {
+	Name string `yaml:"name"`
+	On   struct {
+		Run struct {
+			Workflows []string `yaml:"workflows"`
+		} `yaml:"workflow_run"`
+		Dispatch struct {
+			Inputs map[string]struct {
+				Default string   `yaml:"default"`
+				Options []string `yaml:"options"`
+			} `yaml:"inputs"`
+		} `yaml:"workflow_dispatch"`
+	} `yaml:"on"`
+	Permissions map[string]string `yaml:"permissions"`
+	Jobs        map[string]struct {
+		If          string            `yaml:"if"`
+		Needs       any               `yaml:"needs"`
+		Uses        string            `yaml:"uses"`
+		Permissions map[string]string `yaml:"permissions"`
+		Steps       []struct {
+			Name string         `yaml:"name"`
+			Run  string         `yaml:"run"`
+			Uses string         `yaml:"uses"`
+			With map[string]any `yaml:"with"`
+		} `yaml:"steps"`
+	} `yaml:"jobs"`
+}
+
+func readProducerWorkflow(t *testing.T, name string) producerWorkflow {
+	t.Helper()
+	_, source, _, _ := runtime.Caller(0)
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(source), "../../../../.github/workflows", name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workflow producerWorkflow
+	if err := yaml.Unmarshal(body, &workflow); err != nil {
+		t.Fatal(err)
+	}
+	return workflow
+}
+
+func runProducerPreflight(t *testing.T, script string, values map[string]string, success bool) {
+	t.Helper()
+	command := exec.Command("/bin/bash", "-c", script)
+	command.Dir = t.TempDir()
+	command.Env = []string{"PATH=/usr/local/bin:/usr/bin:/bin"}
+	for key, value := range values {
+		command.Env = append(command.Env, key+"="+value)
+	}
+	body, err := command.CombinedOutput()
+	if (err == nil) != success {
+		t.Fatalf("preflight success=%v, expected %v: %v\n%s", err == nil, success, err, body)
+	}
+}
+
+func TestReleasePairedPreparationReadOnlyGraph(t *testing.T) {
+	w := readProducerWorkflow(t, "agentplugins-release.yml")
+	mode := w.On.Dispatch.Inputs["producer_mode"]
+	if mode.Default != "binary-only" || strings.Join(mode.Options, ",") != "binary-only,paired-preparation" {
+		t.Fatal("default binary-only dispatch contract changed")
+	}
+	if len(w.Permissions) != 1 || w.Permissions["contents"] != "read" {
+		t.Fatal("workflow must default to contents-read")
+	}
+	if len(w.Jobs) != 6 {
+		t.Fatal("review every new producer job for preparation reachability")
+	}
+	for name, job := range w.Jobs {
+		if name != "paired-preparation" {
+			if job.If != "${{ inputs.producer_mode == 'binary-only' }}" {
+				t.Fatalf("%s reachable from paired route", name)
+			}
+			continue
+		}
+		if job.If != "${{ inputs.producer_mode == 'paired-preparation' }}" || job.Needs != nil || job.Uses != "" {
+			t.Fatal("paired route must be an independent explicit job")
+		}
+		if len(job.Permissions) != 1 || job.Permissions["contents"] != "read" {
+			t.Fatal("paired route has write or attestation permission")
+		}
+		var scripts strings.Builder
+		uploads := 0
+		for _, step := range job.Steps {
+			scripts.WriteString(step.Run)
+			if step.Uses != "" && !strings.HasPrefix(step.Uses, "actions/checkout@") && !strings.HasPrefix(step.Uses, "actions/setup-go@") &&
+				!strings.HasPrefix(step.Uses, "actions/setup-node@") && !strings.HasPrefix(step.Uses, "actions/upload-artifact@") {
+				t.Fatalf("unreviewed paired action: %s", step.Uses)
+			}
+			if strings.HasPrefix(step.Uses, "actions/upload-artifact@") {
+				uploads++
+				paths, _ := step.With["path"].(string)
+				for _, required := range []string{"/candidate-identity.json", "/candidate/candidate.json", "/pair-prepared.json", "/agentplugins/*", "/plugin-kit-ai/*"} {
+					if !strings.Contains(paths, required) {
+						t.Fatalf("paired upload lacks %s", required)
+					}
+				}
+			}
+		}
+		body := scripts.String()
+		if uploads != 1 || strings.Count(body, "stageCandidate({") != 1 || strings.Count(body, "prepareAuthoringRelease(options)") != 1 ||
+			strings.Count(body, "verifyAuthoringRelease(options)") != 1 {
+			t.Fatal("must freeze once, project once and verify before one upload")
+		}
+		for _, required := range []string{"six-platform-pair", "release-cli-contract-v1", "manifestDigest: staged.manifest_sha256", "commit: process.env.SOURCE_SHA, engine_revision: process.env.SOURCE_SHA"} {
+			if !strings.Contains(body, required) {
+				t.Fatalf("missing paired binding %q", required)
+			}
+		}
+		for _, forbidden := range []string{"gh ", "goreleaser", "go build", "npm publish", "twine", "homebrew", "git push", "git tag", "workflow_dispatch"} {
+			if strings.Contains(body, forbidden) {
+				t.Fatalf("preparation reaches forbidden effect %q", forbidden)
+			}
+		}
+		if job.Steps[0].Name != "Validate explicit paired identity before checkout" {
+			t.Fatal("identity must fail before checkout/setup/build")
+		}
+		valid := map[string]string{"SOURCE_SHA": strings.Repeat("a", 40), "WORKFLOW_SHA": strings.Repeat("a", 40),
+			"TAG": "agentplugins-v0.1.54", "KIT_VERSION": "2.0.0", "GITHUB_REPOSITORY": "777genius/universal-agent-plugins"}
+		runProducerPreflight(t, job.Steps[0].Run, valid, true)
+		for key, invalid := range map[string]string{"SOURCE_SHA": "latest", "WORKFLOW_SHA": strings.Repeat("b", 40), "TAG": "agentplugins-v01.2.3", "KIT_VERSION": "1.2.4", "GITHUB_REPOSITORY": "777genius/plugin-kit-ai"} {
+			values := make(map[string]string)
+			for k, v := range valid {
+				values[k] = v
+			}
+			values[key] = invalid
+			runProducerPreflight(t, job.Steps[0].Run, values, false)
+		}
+	}
+	// Preserve the existing publication gate dependency chain.
+	for name, expected := range map[string]string{"build": "validate", "stage-draft": "validate,build", "platform-proof": "validate,stage-draft", "promote-release": "validate,stage-draft,platform-proof"} {
+		var needs []string
+		switch value := w.Jobs[name].Needs.(type) {
+		case string:
+			needs = []string{value}
+		case []any:
+			for _, item := range value {
+				needs = append(needs, item.(string))
+			}
+		}
+		if strings.Join(needs, ",") != expected {
+			t.Fatalf("%s lost required gates", name)
+		}
+	}
+}
+
+func TestReleaseLegacyGoReleaserRejectsMajorTwoBeforeEffects(t *testing.T) {
+	w := readProducerWorkflow(t, "release-assets.yml")
+	job := w.Jobs["goreleaser"]
+	if len(job.Steps) == 0 || job.Steps[0].Name != "Reject standard-first versions on legacy producer" || job.Steps[0].Uses != "" {
+		t.Fatal("legacy version guard must precede checkout, tooling and publication")
+	}
+	guard := job.Steps[0].Run
+	if !strings.Contains(guard, "paired-preparation") {
+		t.Fatal("guard must direct users to paired producer")
+	}
+	for _, tag := range []string{"v1.0.0", "v1.2.4", "v1.99.100"} {
+		runProducerPreflight(t, guard, map[string]string{"RELEASE_TAG": tag}, true)
+	}
+	for _, tag := range []string{"v2.0.0", "v2.1.0", "v20.0.0", "v2.0.0-rc.1", "v01.2.4", "latest", "", "v1.2.4; touch forbidden"} {
+		runProducerPreflight(t, guard, map[string]string{"RELEASE_TAG": tag}, false)
+	}
+}
+
+func TestReleasePairedRouteCannotTriggerDownstreamPublication(t *testing.T) {
+	paired := readProducerWorkflow(t, "agentplugins-release.yml")
+	if paired.Name != "Agentplugins Release Assets" {
+		t.Fatal("review downstream triggers before renaming producer")
+	}
+	for _, name := range []string{"npm-publish.yml", "pypi-publish.yml", "homebrew-tap.yml"} {
+		w := readProducerWorkflow(t, name)
+		if strings.Join(w.On.Run.Workflows, ",") != "Release Assets" {
+			t.Fatalf("%s may be triggered by paired producer", name)
+		}
+		for _, job := range w.Jobs {
+			if !strings.Contains(job.If, "github.event.workflow_run.conclusion == 'success'") {
+				t.Fatalf("%s can publish after rejected legacy major-2 run", name)
+			}
+		}
+	}
+	w := readProducerWorkflow(t, "agentplugins-npm-publish.yml")
+	if len(w.On.Run.Workflows) != 0 {
+		t.Fatal("agentplugins npm publication must require separate dispatch")
 	}
 }

--- a/npm/agentplugins/scripts/authoring-release.js
+++ b/npm/agentplugins/scripts/authoring-release.js
@@ -1,0 +1,151 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+// Schema v3 is an explicit projection of one sealed native pair. Historical
+// consumers continue to require v2; consistency is never publication approval.
+const c = require("./dual-authoring-candidate");
+const candidateProducer = require("./stage-dual-authoring-candidate");
+const AUTHORING_MODE = "release-cli-contract-v1";
+const AUTHORING_SCOPE = "six-platform-pair";
+const FALSE_CLAIMS = { release_eligible: false, platform_acceptance: false, attested: false };
+
+function authoringOptions(options, preparing) {
+  c.keys(options, ["candidate", "root", "identity", "manifestDigest", "go", "workParent",
+    "assetScope", "authoringMode", "outputs", "pairMarker"], "authoring release options");
+  c.identity(options.identity);
+  c.keys(options.outputs, c.PRODUCTS, "product outputs");
+  if (options.candidate !== true || options.authoringMode !== AUTHORING_MODE ||
+      options.assetScope !== AUTHORING_SCOPE || options.identity.versions["plugin-kit-ai"] !== "2.0.0" ||
+      /^0{40}$/.test(options.identity.commit)) throw new Error("explicit first-cut release pair required");
+  if (typeof options.go !== "string" || !path.isAbsolute(options.go)) throw new Error("absolute trusted Go tool required");
+  const protectedRoots = [options.root, options.workParent, path.dirname(options.go), path.resolve(__dirname, "../../..")];
+  protectedRoots.forEach(c.safeDirectory);
+  const roots = c.PRODUCTS.map((product) => options.outputs[product]);
+  const marker = options.pairMarker;
+  if (typeof marker !== "string" || !path.isAbsolute(marker) || path.resolve(marker) !== marker ||
+      !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(path.basename(marker))) throw new Error("unsafe pair marker path");
+  c.safeDirectory(path.dirname(marker));
+  // Case-fold too: these outputs must remain disjoint on every target filesystem.
+  const overlaps = (a, b) => {
+    a = a.toLowerCase(); b = b.toLowerCase();
+    return a === b || a.startsWith(b.endsWith(path.sep) ? b : b + path.sep) ||
+      b.startsWith(a.endsWith(path.sep) ? a : a + path.sep);
+  };
+  for (const root of roots) {
+    if (preparing) c.outputPlacement(root, protectedRoots);
+    else c.safeDirectory(root);
+    if (protectedRoots.some((input) => overlaps(root, input)) || overlaps(root, marker)) {
+      throw new Error("projection overlaps input, scratch, tool, repository or marker");
+    }
+  }
+  if (overlaps(roots[0], roots[1]) || protectedRoots.some((root) => overlaps(marker, root))) {
+    throw new Error("authoring outputs overlap");
+  }
+  if (preparing) {
+    try { fs.lstatSync(marker); }
+    catch (error) { if (error.code === "ENOENT") return; throw error; }
+    throw new Error("pair marker already exists");
+  }
+}
+
+function verifiedAuthoringCandidate(options) {
+  candidateProducer.verifyCandidate(Object.fromEntries([
+    "candidate", "root", "identity", "manifestDigest", "go", "workParent", "assetScope", "authoringMode"
+  ].map((key) => [key, options[key]])));
+  return c.frozenCandidate(options.root, options.identity, options.manifestDigest, AUTHORING_SCOPE, AUTHORING_MODE);
+}
+
+function productManifest(frozen, product) {
+  const id = frozen.manifest.identity;
+  return { schema_version: 3, status: "CANDIDATE", product, repository: id.repository,
+    tag: product === "agentplugins" ? `agentplugins-v${id.versions[product]}` : `v${id.versions[product]}`,
+    version: id.versions[product], commit: id.commit, engine_revision: id.engine_revision,
+    versions: id.versions, candidate_sha256: frozen.manifest_sha256,
+    authoring_mode: AUTHORING_MODE, asset_scope: AUTHORING_SCOPE,
+    assets: frozen.manifest.products[product].assets, ...FALSE_CLAIMS };
+}
+
+function projectionChecksums(manifest, body) {
+  return Buffer.from([...Object.values(manifest.assets).map((asset) => `${asset.sha256}  ${asset.file}`),
+    `${c.digest(body)}  release-manifest.json`].join("\n") + "\n");
+}
+
+function checkProjections(options, frozen) {
+  const products = {};
+  for (const product of c.PRODUCTS) {
+    const root = options.outputs[product];
+    c.safeDirectory(root);
+    const manifest = productManifest(frozen, product);
+    const body = c.encode(manifest);
+    if (!c.readFile(path.join(root, "release-manifest.json"), 1024 * 1024).equals(body) ||
+        !c.readFile(path.join(root, "checksums.txt"), 64 * 1024).equals(projectionChecksums(manifest, body))) {
+      throw new Error("projection manifest or checksums differ from pinned candidate");
+    }
+    for (const asset of Object.values(manifest.assets)) {
+      const bytes = c.readFile(path.join(root, asset.file));
+      if (bytes.length !== asset.size || c.digest(bytes) !== asset.sha256) throw new Error("projected asset corruption");
+      // Same exact archive digest as the independently inspected frozen input,
+      // including its inner binary identity; no rearchive or subject execution.
+    }
+    const expected = [...Object.values(manifest.assets).map((asset) => asset.file), "release-manifest.json", "checksums.txt"];
+    if (fs.readdirSync(root).sort().join("\n") !== expected.sort().join("\n")) throw new Error("extra or missing projection files");
+    products[product] = { manifest_sha256: c.digest(body), checksums_sha256: c.digest(projectionChecksums(manifest, body)) };
+  }
+  return { schema: "authoring-release-pair/v1", status: "CANDIDATE", identity: frozen.manifest.identity,
+    candidate_sha256: frozen.manifest_sha256, authoring_mode: AUTHORING_MODE,
+    asset_scope: AUTHORING_SCOPE, products, ...FALSE_CLAIMS };
+}
+
+function prepareAuthoringRelease(input) {
+  const options = structuredClone(input);
+  authoringOptions(options, true); // Fail before scratch or output side effects.
+  const frozen = verifiedAuthoringCandidate(options);
+  authoringOptions(options, true);
+  // Reserve both absent roots before any copy. Partial bytes are retained, but
+  // only the separate final pair marker signals complete preparation.
+  for (const product of c.PRODUCTS) fs.mkdirSync(options.outputs[product], { mode: 0o700 });
+  let markerOwned = false;
+  try {
+    for (const product of c.PRODUCTS) {
+      const root = options.outputs[product];
+      const manifest = productManifest(frozen, product);
+      for (const asset of Object.values(manifest.assets)) {
+        const bytes = c.readFile(path.join(options.root, asset.file));
+        if (c.digest(bytes) !== asset.sha256 || bytes.length !== asset.size) throw new Error("candidate changed before projection");
+        fs.writeFileSync(path.join(root, asset.file), bytes, { flag: "wx", mode: 0o444 });
+      }
+      const body = c.encode(manifest);
+      fs.writeFileSync(path.join(root, "release-manifest.json"), body, { flag: "wx", mode: 0o444 });
+      fs.writeFileSync(path.join(root, "checksums.txt"), projectionChecksums(manifest, body), { flag: "wx", mode: 0o444 });
+    }
+    const pair = checkProjections(options, frozen);
+    const fd = fs.openSync(options.pairMarker, "wx", 0o444);
+    markerOwned = true;
+    try { fs.writeFileSync(fd, c.encode(pair)); }
+    catch (error) {
+      try { fs.closeSync(fd); } catch (closeError) { error.closeError = closeError; }
+      throw error;
+    }
+    fs.closeSync(fd);
+    return pair;
+  } catch (error) {
+    if (markerOwned) {
+      try { fs.unlinkSync(options.pairMarker); }
+      catch (cleanupError) { throw new AggregateError([error, cleanupError], "pair marker cleanup failed", { cause: error }); }
+    }
+    throw error;
+  }
+}
+
+function verifyAuthoringRelease(input) {
+  const options = structuredClone(input);
+  authoringOptions(options, false);
+  const frozen = verifiedAuthoringCandidate(options);
+  const pair = checkProjections(options, frozen);
+  if (!c.readFile(options.pairMarker, 1024 * 1024).equals(c.encode(pair))) throw new Error("pair success marker mismatch");
+  return { ...pair, consistency_verified: true };
+}
+
+module.exports = { prepareAuthoringRelease, verifyAuthoringRelease };

--- a/npm/agentplugins/scripts/release-assets.js
+++ b/npm/agentplugins/scripts/release-assets.js
@@ -174,8 +174,25 @@ function verifyRelease(assetRoot, tag, commit, options = {}) {
   };
 }
 
+// Load the opt-in v3 adapter only for authoring operations. Historical callers
+// may still distribute this standalone v1/v2 script without candidate tooling.
+function prepareAuthoringRelease(options) {
+  return require("./authoring-release").prepareAuthoringRelease(options);
+}
+
+function verifyAuthoringRelease(options) {
+  return require("./authoring-release").verifyAuthoringRelease(options);
+}
+
 function main() {
   const [command, rootArg, tag, commit, policy] = process.argv.slice(2);
+  if (["prepare-authoring", "verify-authoring"].includes(command)) {
+    if (process.argv.length !== 4 || !path.isAbsolute(rootArg || "")) throw new Error("authoring operation requires one absolute options JSON path");
+    const options = JSON.parse(require("./dual-authoring-candidate").readFile(rootArg, 1024 * 1024));
+    const result = command === "prepare-authoring" ? prepareAuthoringRelease(options) : verifyAuthoringRelease(options);
+    process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+    return;
+  }
   if (!command || !rootArg || !tag || !commit) {
     throw new Error("usage: release-assets.js <prepare|verify> <asset-root> <tag> <commit> [allow-legacy-v1]");
   }
@@ -197,4 +214,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { PRODUCER_REPOSITORY, expectedAssets, prepareRelease, verifyRelease };
+module.exports = { PRODUCER_REPOSITORY, expectedAssets, prepareRelease, verifyRelease, prepareAuthoringRelease, verifyAuthoringRelease };

--- a/npm/agentplugins/test/authoring-release-producer.test.js
+++ b/npm/agentplugins/test/authoring-release-producer.test.js
@@ -1,0 +1,292 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const cp = require("node:child_process");
+const nodeTest = require("node:test");
+// Historical v2 detached packages do not adopt this repository-native producer.
+const test = (name, fn) => nodeTest(name, { skip: process.env.AGENTPLUGINS_STAGED_TEST_CHILD === "1" }, fn);
+const c = require("../scripts/dual-authoring-candidate");
+const release = require("../scripts/release-assets");
+
+const MODE = "release-cli-contract-v1";
+const SCOPE = "six-platform-pair";
+const ID = { repository: c.REPOSITORY, commit: "a".repeat(40), engine_revision: "a".repeat(40),
+  versions: { agentplugins: "0.1.54", "plugin-kit-ai": "2.0.0" } };
+
+// Structural fixtures, not native acceptance. The trusted-tool stub returns
+// embedded fixture records only for env/version; any compile or subject launch
+// is a hard failure. Real verifier/path/archive/projection code runs unchanged.
+function fixture() {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "authoring-producer-"));
+  const root = path.join(sandbox, "candidate");
+  const workParent = path.join(sandbox, "work");
+  const tools = path.join(sandbox, "tools");
+  for (const dir of [root, workParent, tools]) fs.mkdirSync(dir);
+  const go = path.join(tools, "structural-go");
+  fs.writeFileSync(go, `#!${process.execPath}
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(path.join(sandbox, "calls.jsonl"))}, JSON.stringify(args) + '\\n');
+if (JSON.stringify(args) === JSON.stringify(['env', '-json', 'GOVERSION', 'GOHOSTOS', 'GOHOSTARCH'])) {
+  console.log(JSON.stringify({ GOVERSION: 'go1.25.13', GOHOSTOS: 'linux', GOHOSTARCH: 'amd64' }));
+} else if (args.length === 4 && args.slice(0, 3).join(' ') === 'version -m -json') {
+  const stat = fs.statSync(args[3]);
+  if (stat.mode & 0o111) throw Error('subject executable permission');
+  process.stdout.write(fs.readFileSync(args[3]));
+} else throw Error('compile or unexpected tool invocation forbidden');
+`, { mode: 0o755 });
+  const manifest = { schema: c.SCHEMA, status: "CANDIDATE", identity: structuredClone(ID), asset_scope: SCOPE,
+    build: { method: "controlled-git-archive-go-build/v1", go_version: "go1.25.13", go_sha256: c.digest(c.readFile(go)),
+      source_archive_sha256: "c".repeat(64), authoring_mode: MODE }, products: {}, release_eligible: false };
+  for (const product of c.PRODUCTS) {
+    const assets = {};
+    manifest.products[product] = { version: ID.versions[product], assets };
+    for (const target of c.TARGETS) {
+      const [GOOS, GOARCH] = target.split("-");
+      const binary = c.encode({ GoVersion: "go1.25.13", Path: `github.com/777genius/plugin-kit-ai/cli/cmd/${product}`,
+        Settings: Object.entries({ GOOS, GOARCH, CGO_ENABLED: "0", "-buildmode": "exe", "-compiler": "gc",
+          "-ldflags": c.linkerFlags(product, ID, MODE) }).map(([Key, Value]) => ({ Key, Value })) });
+      const file = c.assetName(product, ID.versions[product], target);
+      const name = c.executableName(product, target);
+      const body = product === "plugin-kit-ai" ? c.archive(binary, name) : binary;
+      fs.writeFileSync(path.join(root, file), body, { mode: 0o444 });
+      assets[target] = { file, ...c.metadata(body), binary: { file: name, ...c.metadata(binary) } };
+    }
+  }
+  const options = { candidate: true, root, identity: structuredClone(ID), manifestDigest: "", go, workParent,
+    assetScope: SCOPE, authoringMode: MODE,
+    outputs: { agentplugins: path.join(sandbox, "agentplugins"), "plugin-kit-ai": path.join(sandbox, "plugin-kit-ai") },
+    pairMarker: path.join(sandbox, "pair-prepared.json") };
+  const save = () => {
+    fs.writeFileSync(path.join(root, "candidate.json"), c.encode(manifest));
+    options.manifestDigest = c.digest(c.encode(manifest));
+  };
+  save();
+  return { sandbox, manifest, options, save };
+}
+
+function noOutput(f) {
+  assert.equal(fs.existsSync(f.options.pairMarker), false);
+  for (const root of Object.values(f.options.outputs)) assert.equal(fs.existsSync(root), false);
+}
+
+function rewriteBinary(f, product, change) {
+  const asset = f.manifest.products[product].assets["linux-amd64"];
+  const file = path.join(f.options.root, asset.file);
+  const before = fs.readFileSync(file);
+  const info = JSON.parse(product === "plugin-kit-ai" ? c.unpack(before, asset.binary.file) : before);
+  change(info);
+  const binary = c.encode(info);
+  const body = product === "plugin-kit-ai" ? c.archive(binary, asset.binary.file) : binary;
+  fs.chmodSync(file, 0o644);
+  fs.writeFileSync(file, body);
+  Object.assign(asset, c.metadata(body));
+  Object.assign(asset.binary, c.metadata(binary));
+  f.save();
+}
+
+test("v3 prepares and verifies exactly both pinned products without compilation or execution", () => {
+  const f = fixture();
+  const candidateBefore = Object.fromEntries(fs.readdirSync(f.options.root).map((name) => [name, c.digest(c.readFile(path.join(f.options.root, name)))]));
+  const prepared = release.prepareAuthoringRelease(f.options);
+  const verified = release.verifyAuthoringRelease(f.options);
+  assert.equal(verified.consistency_verified, true);
+  assert.deepEqual(prepared, JSON.parse(fs.readFileSync(f.options.pairMarker)));
+  for (const claims of [prepared, verified]) for (const flag of ["release_eligible", "platform_acceptance", "attested"]) assert.equal(claims[flag], false);
+  for (const product of c.PRODUCTS) {
+    const root = f.options.outputs[product];
+    const manifest = JSON.parse(fs.readFileSync(path.join(root, "release-manifest.json")));
+    assert.equal(manifest.schema_version, 3);
+    assert.equal(manifest.product, product);
+    assert.equal(manifest.repository, c.REPOSITORY);
+    assert.equal(manifest.commit, ID.commit);
+    assert.equal(manifest.engine_revision, ID.commit);
+    assert.deepEqual(manifest.versions, ID.versions);
+    assert.equal(manifest.candidate_sha256, f.options.manifestDigest);
+    assert.equal(manifest.tag, product === "agentplugins" ? "agentplugins-v0.1.54" : "v2.0.0");
+    assert.equal(manifest.authoring_mode, MODE);
+    assert.equal(manifest.status, "CANDIDATE");
+    assert.deepEqual(Object.keys(manifest.assets), c.TARGETS);
+    assert.equal(fs.readdirSync(root).length, 8);
+    for (const asset of Object.values(manifest.assets)) {
+      assert.deepEqual(c.readFile(path.join(root, asset.file)), c.readFile(path.join(f.options.root, asset.file)));
+      assert.notEqual(fs.statSync(path.join(root, asset.file)).ino, fs.statSync(path.join(f.options.root, asset.file)).ino);
+      assert.equal(asset.binary.sha256, f.manifest.products[product].assets[Object.keys(manifest.assets).find((k) => manifest.assets[k] === asset)].binary.sha256);
+    }
+  }
+  for (const [name, digest] of Object.entries(candidateBefore)) assert.equal(c.digest(c.readFile(path.join(f.options.root, name))), digest);
+  const calls = fs.readFileSync(path.join(f.sandbox, "calls.jsonl"), "utf8").trim().split("\n").map(JSON.parse);
+  assert.equal(calls.filter((args) => args[0] === "version").length, 24);
+  assert.equal(calls.filter((args) => args[0] === "env").length, 2);
+  assert.throws(() => release.verifyRelease(f.options.outputs.agentplugins, "agentplugins-v0.1.54", ID.commit), /schema/);
+});
+
+const invalidCandidates = {
+  "missing product": (f) => { delete f.manifest.products["plugin-kit-ai"]; },
+  "missing target": (f) => { delete f.manifest.products.agentplugins.assets["darwin-arm64"]; },
+  "Linux-only": (f) => { f.manifest.asset_scope = "linux-amd64-pair"; },
+  "vertical mode": (f) => { f.manifest.build.authoring_mode = "vertical-slice-v1"; },
+  "empty engine": (f) => { f.manifest.identity.engine_revision = ""; },
+  "unversioned engine": (f) => { f.manifest.identity.engine_revision = "unversioned"; },
+  "stale engine": (f) => { f.manifest.identity.engine_revision = "b".repeat(40); },
+  "stale source and engine": (f) => { f.manifest.identity.commit = f.manifest.identity.engine_revision = "b".repeat(40); },
+  "historical repository": (f) => { f.manifest.identity.repository = "777genius/plugin-kit-ai"; },
+  "version swap": (f) => { f.manifest.identity.versions = { agentplugins: "2.0.0", "plugin-kit-ai": "0.1.54" }; },
+  "product swap": (f) => { [f.manifest.products.agentplugins, f.manifest.products["plugin-kit-ai"]] = [f.manifest.products["plugin-kit-ai"], f.manifest.products.agentplugins]; },
+  "asset corruption": (f) => { const file = path.join(f.options.root, f.manifest.products["plugin-kit-ai"].assets["linux-amd64"].file); fs.chmodSync(file, 0o644); fs.writeFileSync(file, "corrupt"); },
+  "inner binary digest": (f) => { f.manifest.products["plugin-kit-ai"].assets["linux-amd64"].binary.sha256 = "d".repeat(64); },
+  "extra file": (f) => { fs.writeFileSync(path.join(f.options.root, "unrelated"), "preserve"); },
+  "approval flag": (f) => { f.manifest.release_eligible = true; }
+};
+for (const [name, mutate] of Object.entries(invalidCandidates)) test(`reject candidate ${name} before outputs`, () => {
+  const f = fixture(); mutate(f); f.save();
+  assert.throws(() => release.prepareAuthoringRelease(f.options));
+  noOutput(f);
+});
+
+test("wrong or missing independent pin and invalid caller identity fail closed", () => {
+  for (const change of [
+    (o) => { o.manifestDigest = "d".repeat(64); }, (o) => { o.manifestDigest = ""; },
+    (o) => { o.identity.repository = "777genius/plugin-kit-ai"; },
+    (o) => { o.identity.versions["plugin-kit-ai"] = "2.0.1"; },
+    (o) => { o.identity.commit = o.identity.engine_revision = "0".repeat(40); },
+    (o) => { o.authoringMode = "vertical-slice-v1"; }, (o) => { delete o.authoringMode; },
+    (o) => { o.assetScope = "linux-amd64-pair"; }, (o) => { o.candidate = false; }
+  ]) {
+    const f = fixture(); change(f.options);
+    assert.throws(() => release.prepareAuthoringRelease(f.options)); noOutput(f);
+  }
+});
+
+for (const product of c.PRODUCTS) test(`independent byte inspection rejects repinned ${product} inner identity`, () => {
+  for (const change of [
+    (info) => { info.Path = info.Path.replace(`/cmd/${product}`, "/cmd/other-product"); },
+    (info) => { info.Settings.at(-1).Value = c.linkerFlags(product, { ...ID, commit: "b".repeat(40) }, MODE); },
+    (info) => { info.Settings.at(-1).Value = c.linkerFlags(product, ID); },
+    (info) => { info.Settings.at(-1).Value = c.linkerFlags(product, { ...ID, versions: { ...ID.versions, [product]: "9.9.9" } }, MODE); }
+  ]) {
+    const f = fixture(); rewriteBinary(f, product, change);
+    assert.throws(() => release.prepareAuthoringRelease(f.options), /embedded Go/); noOutput(f);
+  }
+});
+
+test("absent external disjoint output policy rejects alias, overlap, existing and symlink paths", () => {
+  for (const kind of ["same", "nested", "case", "candidate", "scratch", "repo", "root-scratch", "existing", "symlink", "marker", "marker-existing"]) {
+    const f = fixture();
+    const original = f.options.outputs.agentplugins;
+    if (kind === "same") f.options.outputs["plugin-kit-ai"] = original;
+    if (kind === "nested") f.options.outputs["plugin-kit-ai"] = path.join(original, "nested");
+    if (kind === "case") f.options.outputs["plugin-kit-ai"] = original.replace(/agentplugins$/, "AGENTPLUGINS");
+    if (kind === "candidate") f.options.outputs.agentplugins = path.join(f.options.root, "out");
+    if (kind === "scratch") f.options.outputs.agentplugins = path.join(f.options.workParent, "out");
+    if (kind === "repo") f.options.outputs.agentplugins = path.resolve(__dirname, "../out");
+    if (kind === "root-scratch") f.options.workParent = path.parse(f.sandbox).root;
+    if (kind === "existing") { fs.mkdirSync(original); fs.writeFileSync(path.join(original, "unrelated"), "preserve"); }
+    if (kind === "symlink") { const link = path.join(f.sandbox, "link"); fs.symlinkSync(f.options.workParent, link); f.options.outputs.agentplugins = path.join(link, "out"); }
+    if (kind === "marker") f.options.pairMarker = path.join(original, "pair.json");
+    if (kind === "marker-existing") fs.writeFileSync(f.options.pairMarker, "unrelated");
+    assert.throws(() => release.prepareAuthoringRelease(f.options));
+    assert.equal(fs.existsSync(path.join(f.sandbox, "calls.jsonl")), false, "placement must fail before tool/scratch effects");
+    if (kind === "existing") assert.equal(fs.readFileSync(path.join(original, "unrelated"), "utf8"), "preserve");
+    if (kind === "marker-existing") assert.equal(fs.readFileSync(f.options.pairMarker, "utf8"), "unrelated");
+  }
+});
+
+test("verification rejects mutated outputs, missing pair marker, links and metadata/claim substitution", () => {
+  const f = fixture(); release.prepareAuthoringRelease(f.options);
+  const root = f.options.outputs.agentplugins;
+  const files = Object.values(f.options.outputs).flatMap((dir) => fs.readdirSync(dir).map((name) => path.join(dir, name)));
+  for (const file of [...files, f.options.pairMarker]) {
+    const body = fs.readFileSync(file);
+    fs.chmodSync(file, 0o644);
+    fs.writeFileSync(file, "corrupt");
+    assert.throws(() => release.verifyAuthoringRelease(f.options));
+    fs.writeFileSync(file, body);
+  }
+  const heldMarker = path.join(f.sandbox, "held-marker");
+  fs.renameSync(f.options.pairMarker, heldMarker);
+  assert.throws(() => release.verifyAuthoringRelease(f.options), /ENOENT/);
+  fs.renameSync(heldMarker, f.options.pairMarker);
+  const manifestFile = path.join(root, "release-manifest.json");
+  const original = fs.readFileSync(manifestFile);
+  for (const change of [
+    (v) => { v.product = "plugin-kit-ai"; }, (v) => { v.attested = true; },
+    (v) => { v.repository = "777genius/plugin-kit-ai"; }, (v) => { v.engine_revision = "b".repeat(40); }
+  ]) {
+    const value = JSON.parse(original); change(value); fs.writeFileSync(manifestFile, c.encode(value));
+    assert.throws(() => release.verifyAuthoringRelease(f.options), /manifest/);
+  }
+  fs.writeFileSync(manifestFile, original);
+  for (const link of [false, true]) {
+    const held = path.join(f.sandbox, link ? "held-symbolic" : "held-hard");
+    fs.renameSync(manifestFile, held);
+    if (link) fs.symlinkSync(held, manifestFile); else fs.linkSync(held, manifestFile);
+    assert.throws(() => release.verifyAuthoringRelease(f.options), /unaliased/);
+    fs.unlinkSync(manifestFile); fs.renameSync(held, manifestFile);
+  }
+  fs.writeFileSync(path.join(root, "unrelated"), "preserve");
+  assert.throws(() => release.verifyAuthoringRelease(f.options), /extra/);
+  assert.equal(fs.readFileSync(path.join(root, "unrelated"), "utf8"), "preserve");
+});
+
+for (const fault of ["second-product", "corrupt-copy", "marker-write", "marker-close"]) test(`partial ${fault} never leaves pair success`, (t) => {
+  const f = fixture();
+  const write = fs.writeFileSync;
+  let markerFd;
+  const open = fs.openSync;
+  t.mock.method(fs, "openSync", function(file, ...rest) {
+    const fd = open.call(this, file, ...rest);
+    if (file === f.options.pairMarker) markerFd = fd;
+    return fd;
+  });
+  t.mock.method(fs, "writeFileSync", function(file, body, ...rest) {
+    if (fault === "second-product" && typeof file === "string" && file.startsWith(f.options.outputs["plugin-kit-ai"] + path.sep)) throw Error("copy failure");
+    if (fault === "marker-write" && file === markerFd) { write.call(this, file, "partial"); throw Error("marker failure"); }
+    if (fault === "corrupt-copy" && typeof file === "string" && file.startsWith(f.options.outputs["plugin-kit-ai"] + path.sep)) body = Buffer.from("corrupt");
+    return write.call(this, file, body, ...rest);
+  });
+  const close = fs.closeSync;
+  t.mock.method(fs, "closeSync", function(fd) {
+    const result = close.call(this, fd);
+    if (fault === "marker-close" && fd === markerFd) throw Error("close failure");
+    return result;
+  });
+  assert.throws(() => release.prepareAuthoringRelease(f.options));
+  assert.equal(fs.existsSync(f.options.pairMarker), false);
+  assert.equal(fs.readdirSync(f.options.outputs.agentplugins).length, 8, "first product remains inspectable");
+});
+
+test("explicit CLI prepare-authoring and verify-authoring use the pinned options contract", () => {
+  const f = fixture();
+  const script = path.resolve(__dirname, "../scripts/release-assets.js");
+  const config = path.join(f.sandbox, "options.json");
+  fs.writeFileSync(config, c.encode(f.options));
+  for (const command of ["prepare-authoring", "verify-authoring"]) {
+    const result = cp.spawnSync(process.execPath, [script, command, config], { encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout).attested, false);
+  }
+  for (const args of [["verify-authoring"], ["verify-authoring", "relative"], ["verify-authoring", config, "extra"]]) {
+    const result = cp.spawnSync(process.execPath, [script, ...args], { encoding: "utf8" });
+    assert.equal(result.status, 1); assert.match(result.stderr, /absolute options/);
+  }
+});
+
+// Existing publication scripts can still copy just release-assets.js.
+test("historical standalone v1/v2 script does not require the authoring adapter", () => {
+  const f = fixture();
+  const standalone = path.join(f.sandbox, "legacy-release-assets.js");
+  fs.copyFileSync(path.resolve(__dirname, "../scripts/release-assets.js"), standalone);
+  const legacy = require(standalone);
+  const assets = path.join(f.sandbox, "historical");
+  fs.mkdirSync(assets);
+  for (const file of Object.values(legacy.expectedAssets("0.1.23"))) fs.writeFileSync(path.join(assets, file), file);
+  legacy.prepareRelease(assets, "agentplugins-v0.1.23", ID.commit);
+  const verified = legacy.verifyRelease(assets, "agentplugins-v0.1.23", ID.commit);
+  assert.equal(verified.repository, "777genius/plugin-kit-ai");
+  assert.equal(verified.manifest_schema, 2);
+  assert.equal(verified.gate_eligible, true); // Historical contract, not authoring approval.
+});


### PR DESCRIPTION
The public native release producer still builds a single product with version-only metadata. Connect it to the existing frozen dual-authoring candidate so both product projections retain one exact source and engine revision, without rebuilding their assets.

Add explicit prepare-authoring/verify-authoring operations and schema-v3 product manifests. The new paired-preparation workflow route has read-only contents access and cannot enter the existing draft, attestation, promotion or downstream publication jobs. The legacy GoReleaser route rejects standard-first major-two requests before effects. Historical v1/v2 asset APIs and the default binary-only route remain.

Stacked on #169 (692cae54b7ba8ea43ed9500087bf98caf0dd92c7), reusing the candidate producer from #165. Six files, 805 changed lines including tests; no command-factory, platform, public-consumer, dependency or legacy implementation changes.

Validation on 3e3386f45390e9ca0864a638536624dfc969b124:
- New structural adapter tests: 27 passed, no skips; candidate/marker tests: 28 passed, no skips.
- Focused Go release/workflow contracts passed: agentplugins 11 top-level tests plus 27 subtests; plugin-kit 12 top-level tests plus 55 subtests.
- Historical focused staging: 9 passed, 1 explicitly skipped. The complete detached aggregate was blocked by the provider's localhost policy and is unproven; this is not a full aggregate pass.
- Patch/source/artifact hashes and whitespace checks passed. Independent exact-commit review accepted the implementation; all nine checks on that earlier SHA passed.
- The initial dispatch exposed invalid runner.temp use in job-level env. Fix adc8e5e5cb5184ed4ab5483eb255d0d34a52c2e2 moves cache paths to their consuming steps. A new regression fails against the old workflow; all five focused workflow checks pass after the fix. Independent review accepted the exact successor.

Actual preparation on adc8e5e5cb5184ed4ab5483eb255d0d34a52c2e2:
- [GitHub run 34181500484](https://github.com/777genius/universal-agent-plugins/actions/runs/34181500484) completed successfully. Only paired-preparation executed; all five binary-only/publication jobs were skipped.
- Artifact 10039199828 contains both products across six targets (12 assets). Downloaded ZIP SHA-256: d4fbe75840cb5c30c827b85517f2be30f896cd904bcb28bffa3a0e8415df744a. Its 19-entry closure, both manifests/checksums, candidate binding and all outer/inner binary hashes were independently checked by the coordinator.
- Candidate manifest SHA-256: da432fc4a5525e26b6c2c18ce5afd75a3cb00a488330605601408cb288b519e4. Source and engine metadata both bind adc8e5e5; versions are agentplugins 0.1.54 and plugin-kit-ai 2.0.0. These are preparation inputs, not published versions.
- Independent exact-adc8 artifact review accepted its bounded scope: all 12 embedded product/target/engine identities verified; both actual Linux-amd64 binaries completed Skill, remote MCP and Node stdio MCP static authoring journeys. 153 native invocations covered 48 expected successes, 103 expected exit-2 rejections and two expected destination-collision refusals; all 42 retired command paths rejected directly and with help. Traces recorded zero network syscalls and zero child-program executions. Reviewer report SHA-256: 4d580728fda67281bd97815f65fa4937101a265eaf9fb064810be08fd6100fef.
- This evidence does not qualify other platforms or public launchers. Installer dry-run was not executed because its production scanner assessment is outside the offline scope. No npm/PyPI/Homebrew lifecycle, signatures or publication acceptance is inferred.
- Current successor CI has two failed Windows authoring jobs; the other seven checks passed. This PR is not ready to merge or publish.


This prepares CANDIDATE outputs only: release_eligible, platform_acceptance and attested remain false. It does not publish packages/tags, adopt public npm/PyPI/Homebrew consumers, resolve main integration conflicts, or complete Phase 6 or the full authoring plan.
