### PR TITLE
feat(npm): prepare shared public authoring launchers

### DIFF
--- a/npm/agentplugins/bin/agentplugins.js
+++ b/npm/agentplugins/bin/agentplugins.js
@@ -15,7 +15,8 @@ async function main() {
     process.exitCode = 1;
     return;
   }
-  const childEnvironment = { ...process.env };
+  const childEnvironment = resolved.publicAuthoring
+    ? require("../lib/public-authoring").childEnvironment() : { ...process.env };
   delete childEnvironment.AGENTPLUGINS_INTERNAL_PROOF_MODE;
   delete childEnvironment.AGENTPLUGINS_INTERNAL_PROOF_BINARY;
   const child = spawn(resolved.binaryPath, process.argv.slice(2), { stdio: "inherit", env: childEnvironment });

--- a/npm/agentplugins/lib/bootstrap.js
+++ b/npm/agentplugins/lib/bootstrap.js
@@ -125,6 +125,11 @@ async function verifyLocalProofAsset(file, expected) {
 
 async function ensureBinary(options = {}) {
   const packageRoot = options.packageRoot || path.resolve(__dirname, "..");
+  // lstat detects dangling descriptors too; malformed new metadata never falls back.
+  try {
+    fs.lstatSync(path.join(packageRoot, "public-release.json"));
+    return require("./public-authoring").ensureBinary("agentplugins", { ...options, packageRoot });
+  } catch (error) { if (error.code !== "ENOENT") throw error; }
   const platformInfo = detectPlatform(options.platform, options.arch);
   const release = loadRelease(packageRoot, platformInfo);
   const root = options.cacheRoot || cacheRoot(options.environment, options.platform);

--- a/npm/agentplugins/lib/public-authoring.js
+++ b/npm/agentplugins/lib/public-authoring.js
@@ -1,0 +1,211 @@
+"use strict";
+
+// Package consistency, not a signature verifier. The future protected public
+// stager must authenticate the signed pair before emitting a binding. Preparation
+// emits null. No runtime environment/CLI option can qualify a preparation pack.
+const fsp = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const c = require("../scripts/dual-authoring-candidate");
+const v = require("./verifier");
+const SCHEMA = "dual-authoring-public-npm/v1";
+const MODE = "release-cli-contract-v1";
+const SCOPE = "six-platform-pair";
+const PACKAGES = Object.freeze({ agentplugins: "universal-agent-plugins", "plugin-kit-ai": "plugin-kit-ai" });
+const hash = x => typeof x === "string" && /^[0-9a-f]{64}$/.test(x);
+const inside = (a, b) => a === b || a.startsWith(b + path.sep);
+const equal = (a, b) => c.encode(a).equals(c.encode(b));
+
+function json(file) {
+  const bytes = c.readFile(file, 1024 * 1024);
+  const value = JSON.parse(bytes);
+  if (!bytes.equals(c.encode(value))) throw new Error("noncanonical public JSON");
+  return { bytes, value };
+}
+function pin(value) {
+  if (!hash(value.sha256) || !Number.isSafeInteger(value.size) || value.size <= 0 || value.size > 128 * 1024 * 1024) {
+    throw new Error("invalid bounded public asset/binary pin");
+  }
+}
+
+function qualification(descriptor) {
+  const q = descriptor.qualification;
+  if (q === null) throw new Error("public authoring is not qualified: preparation package");
+  // This is the normalized package binding specified for authenticated staging,
+  // NOT an encoding/parser for the still-unavailable signed promotion record.
+  // B owns verification of exact native subjects, checksums, manifests, candidate,
+  // workflow/source, immutable public tags and all required qualification lanes.
+  c.keys(q, ["identity", "candidate_sha256", "manifest_sha256", "signed_subject"], "qualification binding");
+  c.keys(q.manifest_sha256, c.PRODUCTS, "qualified pair manifests");
+  c.keys(q.signed_subject, ["sha256", "workflow", "source"], "signed qualification subject");
+  if (!equal(q.identity, descriptor.identity) || q.candidate_sha256 !== descriptor.candidate_sha256 ||
+      !Object.values(q.manifest_sha256).every(hash) ||
+      q.manifest_sha256[descriptor.product] !== descriptor.release_manifest_sha256 ||
+      !hash(q.signed_subject.sha256) || q.signed_subject.source !== descriptor.identity.commit ||
+      typeof q.signed_subject.workflow !== "string" ||
+      !/^777genius\/universal-agent-plugins\/\.github\/workflows\/[a-z0-9-]+\.yml$/.test(q.signed_subject.workflow)) {
+    throw new Error("public qualification binding mismatch");
+  }
+}
+
+function loadRelease(product, packageRoot, target) {
+  if (!Object.hasOwn(PACKAGES, product) || !c.TARGETS.includes(target)) throw new Error("unsupported public product/target");
+  c.safeDirectory(packageRoot);
+  const { value: d, bytes: descriptorBytes } = json(path.join(packageRoot, "public-release.json"));
+  c.keys(d, ["schema", "product", "npm_package", "identity", "authoring_mode", "asset_scope",
+    "candidate_sha256", "release_manifest_sha256", "qualification"], "public release");
+  c.identity(d.identity);
+  if (d.schema !== SCHEMA || d.product !== product || d.npm_package !== PACKAGES[product] ||
+      /^0{40}$/.test(d.identity.commit) || d.identity.versions["plugin-kit-ai"] !== "2.0.0" ||
+      d.authoring_mode !== MODE || d.asset_scope !== SCOPE || !hash(d.candidate_sha256) || !hash(d.release_manifest_sha256)) {
+    throw new Error("public release identity mismatch");
+  }
+  const { value: pkg } = json(path.join(packageRoot, "package.json"));
+  c.keys(pkg, ["name", "version", "description", "license", "homepage", "repository", "bugs", "keywords",
+    "engines", "publishConfig", "files", "bin", "scripts", "private", ...(product === "agentplugins" ? ["os", "cpu"] : [])], "public package");
+  const closure = ["LICENSE", "README.md", "package.json", `bin/${product}.js`, "bin/package.json", "lib/package.json",
+    "lib/platform.js", "lib/verifier.js", "lib/public-authoring.js", "scripts/package.json", "scripts/dual-authoring-candidate.js",
+    product === "agentplugins" ? "lib/bootstrap.js" : "lib/install.js", "public-release.json", "release-manifest.json"];
+  if (typeof pkg.private !== "boolean" || !Array.isArray(pkg.files) || !equal(pkg.files, closure.sort())) {
+    throw new Error("public package closure mismatch");
+  }
+  c.keys(pkg.bin, [product], "public npm bin");
+  c.keys(pkg.engines, ["node"], "public npm engines");
+  const scripts = product === "agentplugins" ? { test: "node --test" } : { postinstall: "node ./lib/install.js" };
+  if (pkg.name !== PACKAGES[product] || pkg.version !== d.identity.versions[product] ||
+      pkg.bin[product] !== `bin/${product}.js` || pkg.engines.node !== (product === "agentplugins" ? ">=22" : ">=18") ||
+      !equal(pkg.scripts, scripts)) throw new Error("public npm package binding mismatch");
+  const { value: m, bytes } = json(path.join(packageRoot, "release-manifest.json"));
+  c.keys(m, ["schema_version", "status", "product", "repository", "tag", "version", "commit", "engine_revision",
+    "versions", "candidate_sha256", "authoring_mode", "asset_scope", "assets", "release_eligible", "platform_acceptance", "attested"], "producer projection");
+  if (c.digest(bytes) !== d.release_manifest_sha256 || m.schema_version !== 3 || m.status !== "CANDIDATE" ||
+      m.product !== product || m.repository !== c.REPOSITORY || m.version !== pkg.version ||
+      m.tag !== (product === "agentplugins" ? `agentplugins-v${pkg.version}` : `v${pkg.version}`) ||
+      m.commit !== d.identity.commit || m.engine_revision !== d.identity.engine_revision || !equal(m.versions, d.identity.versions) ||
+      m.candidate_sha256 !== d.candidate_sha256 || m.authoring_mode !== MODE || m.asset_scope !== SCOPE ||
+      m.release_eligible !== false || m.platform_acceptance !== false || m.attested !== false) {
+    throw new Error("public producer projection mismatch");
+  }
+  c.keys(m.assets, c.TARGETS, "six public targets");
+  const seen = new Set();
+  for (const key of c.TARGETS) {
+    const a = m.assets[key];
+    c.keys(a, ["file", "sha256", "size", "binary"], "public asset");
+    c.keys(a.binary, ["file", "sha256", "size"], "public binary");
+    pin(a); pin(a.binary);
+    if (a.file !== c.assetName(product, pkg.version, key) || a.binary.file !== c.executableName(product, key) ||
+        (product === "agentplugins" && (a.sha256 !== a.binary.sha256 || a.size !== a.binary.size)) || seen.has(a.binary.sha256)) {
+      throw new Error("public asset filename/raw pin/uniqueness mismatch");
+    }
+    seen.add(a.binary.sha256);
+  }
+  qualification(d); // Always before effects, including warm cache lookup.
+  return { descriptor: d, manifest: m, asset: m.assets[target], version: pkg.version,
+    binding: c.digest(descriptorBytes), tag: m.tag };
+}
+
+function cachePath(root, product, target, release) {
+  return path.join(root, "public-authoring-v1", MODE, release.descriptor.identity.commit,
+    release.descriptor.candidate_sha256, product, release.version, target, release.asset.binary.sha256, release.asset.binary.file);
+}
+
+// Create only missing directories; never chmod an existing historical cache.
+// PR167 validates every ancestor before the next child can be created.
+async function namespace(root, io) {
+  if (typeof root !== "string" || !path.isAbsolute(root) || path.resolve(root) !== root ||
+      root.includes("\0") || root.split(/[\\/]/).includes("..")) throw new Error("unsafe public cache root");
+  let current = path.parse(root).root;
+  for (const part of root.slice(current.length).split(path.sep).filter(Boolean)) {
+    current = path.join(current, part);
+    try { await io.mkdir(current, { mode: 0o700 }); }
+    catch (e) { if (e.code !== "EEXIST") throw e; }
+    const stat = await io.lstat(current);
+    const uid = typeof process.geteuid === "function" ? process.geteuid() : null;
+    if (!stat.isDirectory() || stat.isSymbolicLink() ||
+        (uid !== null && stat.uid !== uid && stat.uid !== 0) ||
+        (process.platform !== "win32" && (stat.mode & 0o022) && !(stat.mode & 0o1000))) {
+      throw new Error("public cache requires safe ancestors");
+    }
+  }
+  const owned = path.join(root, "public-authoring-v1");
+  try { await io.mkdir(owned, { mode: 0o700 }); }
+  catch (e) { if (e.code !== "EEXIST") throw e; }
+  await v.privateDirectory(owned, owned, io);
+  return owned;
+}
+
+function childEnvironment(environment = process.env) {
+  return Object.fromEntries(Object.entries(environment).filter(([key]) =>
+    !/^(AGENTPLUGINS_INTERNAL_PROOF_|UAP_PRIVATE_NPM_|UAP_PUBLIC_AUTHORING_|PLUGIN_KIT_AI_(VERSION|REPOSITORY|RELEASE_BASE_URL)$|NODE_OPTIONS$)/.test(key)));
+}
+
+async function ensureBinary(product, options = {}) {
+  const platform = require("./platform").detectPlatform(options.platform, options.arch);
+  const target = `${platform.osName}-${platform.archName}`;
+  if (options.target !== undefined && options.target !== target) throw new Error("unexpected public native target");
+  const packageRoot = options.packageRoot || path.resolve(__dirname, "..");
+  v.cancelled(options.signal);
+  const release = loadRelease(product, packageRoot, target);
+  // No historical repository/version/cache override is consulted on this path.
+  const root = options.cacheRoot || path.join(os.homedir(), ".cache", "universal-agent-plugins");
+  if (inside(root, packageRoot) || inside(packageRoot, root)) throw new Error("public cache overlaps package");
+  const io = options.io || fsp;
+  const owned = await namespace(root, io);
+  const binaryPath = cachePath(root, product, target, release);
+  await v.privateDirectory(owned, path.dirname(binaryPath), io);
+  const lockRoot = path.join(owned, ".locks");
+  await v.privateDirectory(owned, lockRoot, io);
+  const settings = { io, signal: options.signal, strict: true, osName: platform.osName };
+  const directoryPins = await Promise.all([owned, path.dirname(binaryPath)].map(async name => [name, await io.lstat(name)]));
+  const unchangedDirectories = async () => {
+    await v.privateDirectory(owned, path.dirname(binaryPath), io);
+    for (const [name, pin] of directoryPins) {
+      const named = await io.lstat(name);
+      if (named.dev !== pin.dev || named.ino !== pin.ino) throw new Error("public cache directory replaced");
+    }
+  };
+  const unlock = await v.acquireLock(binaryPath, { ...options.lockOptions, io, signal: options.signal, lockRoot });
+  let primary, result, temporary, temporaryStat, downloadStat;
+  const errors = [];
+  try {
+    await unchangedDirectories();
+    const hit = await v.strictCachedBinary(binaryPath, release.asset.binary, settings);
+    if (!hit) {
+      temporary = await io.mkdtemp(path.join(owned, ".download-"));
+      temporaryStat = await io.lstat(temporary);
+      await v.privateDirectory(owned, temporary, io);
+      const file = path.join(temporary, "asset");
+      await v.downloadFile(`https://github.com/${c.REPOSITORY}/releases/download/${release.tag}/${release.asset.file}`,
+        file, release.asset, { request: options.request, signal: options.signal, onOpen: stat => { downloadStat = stat; } });
+      v.cancelled(options.signal);
+      const bytes = c.readFile(file);
+      if (bytes.length !== release.asset.size || c.digest(bytes) !== release.asset.sha256) throw new Error("outer public asset mismatch");
+      const binary = product === "plugin-kit-ai" ? c.unpack(bytes, release.asset.binary.file) : bytes;
+      if (binary.length !== release.asset.binary.size || c.digest(binary) !== release.asset.binary.sha256) throw new Error("inner public binary mismatch");
+      await unchangedDirectories();
+      await v.commitVerifiedBinary(binary, binaryPath, release.asset.binary, settings);
+    }
+    v.cancelled(options.signal);
+    // A concurrent metadata edit cannot turn this operation into a warm bypass.
+    if (loadRelease(product, packageRoot, target).binding !== release.binding) throw new Error("public release changed during acquisition");
+    await unchangedDirectories();
+    result = { binaryPath, version: release.version, tag: release.tag, product, cacheHit: hit,
+      publicAuthoring: true, repository: c.REPOSITORY };
+  } catch (e) { primary = e; }
+  if (temporary) {
+    try {
+      const named = await io.lstat(temporary);
+      if (named.ino !== temporaryStat.ino || named.dev !== temporaryStat.dev || !named.isDirectory()) throw new Error("download directory replaced");
+      if (downloadStat) {
+        const file = path.join(temporary, "asset"), namedFile = await io.lstat(file);
+        if (!namedFile.isFile() || namedFile.nlink !== 1 || namedFile.ino !== downloadStat.ino || namedFile.dev !== downloadStat.dev) throw new Error("download cleanup identity changed");
+        await io.unlink(file);
+      }
+      await io.rmdir(temporary);
+    } catch (e) { errors.push(e); }
+  }
+  await unlock().catch(e => errors.push(e));
+  if (primary || errors.length) throw v.failures(primary, errors);
+  return result;
+}
+module.exports = { SCHEMA, MODE, SCOPE, PACKAGES, loadRelease, cachePath, ensureBinary, childEnvironment };

--- a/npm/agentplugins/lib/verifier.js
+++ b/npm/agentplugins/lib/verifier.js
@@ -87,7 +87,12 @@ async function downloadFile(value, destination, expected, options = {}, redirect
       : requestApprovedTarget(target, requestOptions);
     request.setTimeout(DOWNLOAD_TIMEOUT_MS, () => request.destroy(new Error("binary download timed out")));
     let streamFailure;
-    request.once("error", error => streamFailure ? streamFailure(error) : reject(error));
+    let delegated = false;
+    request.once("error", error => {
+      // A superseded request may still fail while its response drains. Only
+      // the descendant owns completion, including waiting for output close.
+      if (!delegated) streamFailure ? streamFailure(error) : reject(error);
+    });
     abort = () => request.destroy(new Error("binary acquisition cancelled"));
     options.signal?.addEventListener("abort", abort, { once: true });
     if (options.signal?.aborted) { abort(); return; }
@@ -100,6 +105,7 @@ async function downloadFile(value, destination, expected, options = {}, redirect
         }
         try {
           const next = new URL(response.headers.location, target.url).toString();
+          delegated = true;
           downloadFile(next, destination, expected, options, redirects - 1).then(resolve, reject);
         } catch (error) { reject(error); }
         return;

--- a/npm/agentplugins/lib/verifier.js
+++ b/npm/agentplugins/lib/verifier.js
@@ -73,6 +73,8 @@ function requestApprovedTarget(target, requestOptions) {
 
 async function downloadFile(value, destination, expected, options = {}, redirects = MAX_REDIRECTS) {
   const target = validateDownloadURL(value);
+  cancelled(options.signal);
+  let abort;
   await new Promise((resolve, reject) => {
     const requestOptions = {
       headers: {
@@ -86,6 +88,9 @@ async function downloadFile(value, destination, expected, options = {}, redirect
     request.setTimeout(DOWNLOAD_TIMEOUT_MS, () => request.destroy(new Error("binary download timed out")));
     let streamFailure;
     request.once("error", error => streamFailure ? streamFailure(error) : reject(error));
+    abort = () => request.destroy(new Error("binary acquisition cancelled"));
+    options.signal?.addEventListener("abort", abort, { once: true });
+    if (options.signal?.aborted) { abort(); return; }
     request.once("response", (response) => {
       if ([301, 302, 303, 307, 308].includes(response.statusCode) && response.headers.location) {
         response.resume();
@@ -125,6 +130,11 @@ async function downloadFile(value, destination, expected, options = {}, redirect
         output.destroy();
       };
       streamFailure = fail;
+      // The operation owner can retain the actual opened identity even when a
+      // partial download fails. Never infer ownership from a later pathname.
+      output.once("open", fd => {
+        try { options.onOpen?.(fs.fstatSync(fd)); } catch (error) { fail(error); }
+      });
       let ended = false;
       response.once("end", () => { ended = true; });
       response.once("close", () => { if (!ended) fail(new Error("binary download response closed before completion")); });
@@ -161,7 +171,7 @@ async function downloadFile(value, destination, expected, options = {}, redirect
         resolve();
       });
     });
-  });
+  }).finally(() => { if (abort) options.signal?.removeEventListener("abort", abort); });
 }
 
 function cancelled(signal) {

--- a/npm/agentplugins/scripts/authoring-release.js
+++ b/npm/agentplugins/scripts/authoring-release.js
@@ -1,0 +1,151 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+// Schema v3 is an explicit projection of one sealed native pair. Historical
+// consumers continue to require v2; consistency is never publication approval.
+const c = require("./dual-authoring-candidate");
+const candidateProducer = require("./stage-dual-authoring-candidate");
+const AUTHORING_MODE = "release-cli-contract-v1";
+const AUTHORING_SCOPE = "six-platform-pair";
+const FALSE_CLAIMS = { release_eligible: false, platform_acceptance: false, attested: false };
+
+function authoringOptions(options, preparing) {
+  c.keys(options, ["candidate", "root", "identity", "manifestDigest", "go", "workParent",
+    "assetScope", "authoringMode", "outputs", "pairMarker"], "authoring release options");
+  c.identity(options.identity);
+  c.keys(options.outputs, c.PRODUCTS, "product outputs");
+  if (options.candidate !== true || options.authoringMode !== AUTHORING_MODE ||
+      options.assetScope !== AUTHORING_SCOPE || options.identity.versions["plugin-kit-ai"] !== "2.0.0" ||
+      /^0{40}$/.test(options.identity.commit)) throw new Error("explicit first-cut release pair required");
+  if (typeof options.go !== "string" || !path.isAbsolute(options.go)) throw new Error("absolute trusted Go tool required");
+  const protectedRoots = [options.root, options.workParent, path.dirname(options.go), path.resolve(__dirname, "../../..")];
+  protectedRoots.forEach(c.safeDirectory);
+  const roots = c.PRODUCTS.map((product) => options.outputs[product]);
+  const marker = options.pairMarker;
+  if (typeof marker !== "string" || !path.isAbsolute(marker) || path.resolve(marker) !== marker ||
+      !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(path.basename(marker))) throw new Error("unsafe pair marker path");
+  c.safeDirectory(path.dirname(marker));
+  // Case-fold too: these outputs must remain disjoint on every target filesystem.
+  const overlaps = (a, b) => {
+    a = a.toLowerCase(); b = b.toLowerCase();
+    return a === b || a.startsWith(b.endsWith(path.sep) ? b : b + path.sep) ||
+      b.startsWith(a.endsWith(path.sep) ? a : a + path.sep);
+  };
+  for (const root of roots) {
+    if (preparing) c.outputPlacement(root, protectedRoots);
+    else c.safeDirectory(root);
+    if (protectedRoots.some((input) => overlaps(root, input)) || overlaps(root, marker)) {
+      throw new Error("projection overlaps input, scratch, tool, repository or marker");
+    }
+  }
+  if (overlaps(roots[0], roots[1]) || protectedRoots.some((root) => overlaps(marker, root))) {
+    throw new Error("authoring outputs overlap");
+  }
+  if (preparing) {
+    try { fs.lstatSync(marker); }
+    catch (error) { if (error.code === "ENOENT") return; throw error; }
+    throw new Error("pair marker already exists");
+  }
+}
+
+function verifiedAuthoringCandidate(options) {
+  candidateProducer.verifyCandidate(Object.fromEntries([
+    "candidate", "root", "identity", "manifestDigest", "go", "workParent", "assetScope", "authoringMode"
+  ].map((key) => [key, options[key]])));
+  return c.frozenCandidate(options.root, options.identity, options.manifestDigest, AUTHORING_SCOPE, AUTHORING_MODE);
+}
+
+function productManifest(frozen, product) {
+  const id = frozen.manifest.identity;
+  return { schema_version: 3, status: "CANDIDATE", product, repository: id.repository,
+    tag: product === "agentplugins" ? `agentplugins-v${id.versions[product]}` : `v${id.versions[product]}`,
+    version: id.versions[product], commit: id.commit, engine_revision: id.engine_revision,
+    versions: id.versions, candidate_sha256: frozen.manifest_sha256,
+    authoring_mode: AUTHORING_MODE, asset_scope: AUTHORING_SCOPE,
+    assets: frozen.manifest.products[product].assets, ...FALSE_CLAIMS };
+}
+
+function projectionChecksums(manifest, body) {
+  return Buffer.from([...Object.values(manifest.assets).map((asset) => `${asset.sha256}  ${asset.file}`),
+    `${c.digest(body)}  release-manifest.json`].join("\n") + "\n");
+}
+
+function checkProjections(options, frozen) {
+  const products = {};
+  for (const product of c.PRODUCTS) {
+    const root = options.outputs[product];
+    c.safeDirectory(root);
+    const manifest = productManifest(frozen, product);
+    const body = c.encode(manifest);
+    if (!c.readFile(path.join(root, "release-manifest.json"), 1024 * 1024).equals(body) ||
+        !c.readFile(path.join(root, "checksums.txt"), 64 * 1024).equals(projectionChecksums(manifest, body))) {
+      throw new Error("projection manifest or checksums differ from pinned candidate");
+    }
+    for (const asset of Object.values(manifest.assets)) {
+      const bytes = c.readFile(path.join(root, asset.file));
+      if (bytes.length !== asset.size || c.digest(bytes) !== asset.sha256) throw new Error("projected asset corruption");
+      // Same exact archive digest as the independently inspected frozen input,
+      // including its inner binary identity; no rearchive or subject execution.
+    }
+    const expected = [...Object.values(manifest.assets).map((asset) => asset.file), "release-manifest.json", "checksums.txt"];
+    if (fs.readdirSync(root).sort().join("\n") !== expected.sort().join("\n")) throw new Error("extra or missing projection files");
+    products[product] = { manifest_sha256: c.digest(body), checksums_sha256: c.digest(projectionChecksums(manifest, body)) };
+  }
+  return { schema: "authoring-release-pair/v1", status: "CANDIDATE", identity: frozen.manifest.identity,
+    candidate_sha256: frozen.manifest_sha256, authoring_mode: AUTHORING_MODE,
+    asset_scope: AUTHORING_SCOPE, products, ...FALSE_CLAIMS };
+}
+
+function prepareAuthoringRelease(input) {
+  const options = structuredClone(input);
+  authoringOptions(options, true); // Fail before scratch or output side effects.
+  const frozen = verifiedAuthoringCandidate(options);
+  authoringOptions(options, true);
+  // Reserve both absent roots before any copy. Partial bytes are retained, but
+  // only the separate final pair marker signals complete preparation.
+  for (const product of c.PRODUCTS) fs.mkdirSync(options.outputs[product], { mode: 0o700 });
+  let markerOwned = false;
+  try {
+    for (const product of c.PRODUCTS) {
+      const root = options.outputs[product];
+      const manifest = productManifest(frozen, product);
+      for (const asset of Object.values(manifest.assets)) {
+        const bytes = c.readFile(path.join(options.root, asset.file));
+        if (c.digest(bytes) !== asset.sha256 || bytes.length !== asset.size) throw new Error("candidate changed before projection");
+        fs.writeFileSync(path.join(root, asset.file), bytes, { flag: "wx", mode: 0o444 });
+      }
+      const body = c.encode(manifest);
+      fs.writeFileSync(path.join(root, "release-manifest.json"), body, { flag: "wx", mode: 0o444 });
+      fs.writeFileSync(path.join(root, "checksums.txt"), projectionChecksums(manifest, body), { flag: "wx", mode: 0o444 });
+    }
+    const pair = checkProjections(options, frozen);
+    const fd = fs.openSync(options.pairMarker, "wx", 0o444);
+    markerOwned = true;
+    try { fs.writeFileSync(fd, c.encode(pair)); }
+    catch (error) {
+      try { fs.closeSync(fd); } catch (closeError) { error.closeError = closeError; }
+      throw error;
+    }
+    fs.closeSync(fd);
+    return pair;
+  } catch (error) {
+    if (markerOwned) {
+      try { fs.unlinkSync(options.pairMarker); }
+      catch (cleanupError) { throw new AggregateError([error, cleanupError], "pair marker cleanup failed", { cause: error }); }
+    }
+    throw error;
+  }
+}
+
+function verifyAuthoringRelease(input) {
+  const options = structuredClone(input);
+  authoringOptions(options, false);
+  const frozen = verifiedAuthoringCandidate(options);
+  const pair = checkProjections(options, frozen);
+  if (!c.readFile(options.pairMarker, 1024 * 1024).equals(c.encode(pair))) throw new Error("pair success marker mismatch");
+  return { ...pair, consistency_verified: true };
+}
+
+module.exports = { prepareAuthoringRelease, verifyAuthoringRelease };

--- a/npm/agentplugins/scripts/release-assets.js
+++ b/npm/agentplugins/scripts/release-assets.js
@@ -174,8 +174,25 @@ function verifyRelease(assetRoot, tag, commit, options = {}) {
   };
 }
 
+// Load the opt-in v3 adapter only for authoring operations. Historical callers
+// may still distribute this standalone v1/v2 script without candidate tooling.
+function prepareAuthoringRelease(options) {
+  return require("./authoring-release").prepareAuthoringRelease(options);
+}
+
+function verifyAuthoringRelease(options) {
+  return require("./authoring-release").verifyAuthoringRelease(options);
+}
+
 function main() {
   const [command, rootArg, tag, commit, policy] = process.argv.slice(2);
+  if (["prepare-authoring", "verify-authoring"].includes(command)) {
+    if (process.argv.length !== 4 || !path.isAbsolute(rootArg || "")) throw new Error("authoring operation requires one absolute options JSON path");
+    const options = JSON.parse(require("./dual-authoring-candidate").readFile(rootArg, 1024 * 1024));
+    const result = command === "prepare-authoring" ? prepareAuthoringRelease(options) : verifyAuthoringRelease(options);
+    process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+    return;
+  }
   if (!command || !rootArg || !tag || !commit) {
     throw new Error("usage: release-assets.js <prepare|verify> <asset-root> <tag> <commit> [allow-legacy-v1]");
   }
@@ -197,4 +214,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { PRODUCER_REPOSITORY, expectedAssets, prepareRelease, verifyRelease };
+module.exports = { PRODUCER_REPOSITORY, expectedAssets, prepareRelease, verifyRelease, prepareAuthoringRelease, verifyAuthoringRelease };

--- a/npm/agentplugins/scripts/stage-authoring-npm.js
+++ b/npm/agentplugins/scripts/stage-authoring-npm.js
@@ -119,10 +119,12 @@ function prepare(options) {
   packing.completeRecord(options.output, record);
   return record;
 }
+// Public blob verification re-enters this module while the CLI is preparing.
+module.exports = { prepare, packageFiles, ALLOWLIST, COMMON };
+
 if (require.main === module) {
   try {
     if (process.argv.length !== 4 || process.argv[2] !== "--prepare" || !path.isAbsolute(process.argv[3])) throw new Error("usage: stage-authoring-npm.js --prepare <absolute-options.json>");
     process.stdout.write(c.encode(prepare(JSON.parse(c.readFile(process.argv[3], 1024 * 1024)))));
   } catch (e) { process.stderr.write(`public npm preparation: ${e.message}\n`); process.exitCode = 1; }
 }
-module.exports = { prepare, packageFiles, ALLOWLIST, COMMON };

--- a/npm/agentplugins/scripts/stage-authoring-npm.js
+++ b/npm/agentplugins/scripts/stage-authoring-npm.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+"use strict";
+
+// Preparation only. B must authenticate real signed promotion inputs before it
+// can introduce public staging. This entrypoint never generates qualification.
+const fs = require("node:fs");
+const path = require("node:path");
+const c = require("./dual-authoring-candidate");
+const adapter = require("./authoring-release");
+const packing = require("./stage-dual-authoring-npm");
+const runtime = require("../lib/public-authoring");
+const PREFIX = "npm/agentplugins/";
+const COMMON = Object.freeze(["lib/verifier.js", "lib/public-authoring.js", "scripts/dual-authoring-candidate.js"]);
+const ownFiles = product => ["LICENSE", "README.md", "package.json", `bin/${product}.js`, "lib/platform.js",
+  product === "agentplugins" ? "lib/bootstrap.js" : "lib/install.js"];
+const ALLOWLIST = Object.freeze([...new Set([...COMMON.map(n => PREFIX + n),
+  ...c.PRODUCTS.flatMap(p => ownFiles(p).map(n => `npm/${p}/${n}`)),
+  ...["stage-authoring-npm.js", "stage-dual-authoring-npm.js", "stage-dual-authoring-candidate.js",
+    "authoring-release.js"].map(n => PREFIX + "scripts/" + n)])]);
+const write = (file, bytes, mode = 0o644) => {
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(file, bytes, { flag: "wx", mode });
+  fs.chmodSync(file, mode);
+};
+
+function packageFiles(product, source, manifestBytes, candidate) {
+  if (!c.PRODUCTS.includes(product)) throw new Error("unknown fixed public package");
+  const base = JSON.parse(source[`npm/${product}/package.json`].bytes);
+  const files = Object.fromEntries(ownFiles(product).filter(n => n !== "package.json").map(n => [n, source[`npm/${product}/${n}`].bytes]));
+  for (const name of COMMON) files[name] = source[PREFIX + name].bytes;
+  for (const dir of ["bin", "lib", "scripts"]) files[`${dir}/package.json`] = c.encode({ type: "commonjs" });
+  files["release-manifest.json"] = manifestBytes;
+  files["public-release.json"] = c.encode({ schema: runtime.SCHEMA, product, npm_package: runtime.PACKAGES[product],
+    identity: candidate.identity, authoring_mode: runtime.MODE, asset_scope: runtime.SCOPE,
+    candidate_sha256: candidate.manifestDigest, release_manifest_sha256: c.digest(manifestBytes), qualification: null });
+  // Preserve scripts and engines exactly, including kit postinstall. These are
+  // private preparation packs of the real public launcher, never private shims.
+  files["package.json"] = c.encode({ ...base, version: candidate.identity.versions[product], private: true,
+    files: [...Object.keys(files), "package.json"].sort() });
+  return files;
+}
+
+function pinFile(file, expected, maximum = 1024 * 1024) {
+  if (typeof expected !== "string" || !/^[0-9a-f]{64}$/.test(expected)) throw new Error("independent preparation digest required");
+  const bytes = c.readFile(file, maximum);
+  if (c.digest(bytes) !== expected) throw new Error("preparation input digest mismatch");
+  return bytes;
+}
+
+function pins(options) {
+  const { candidate, projectionPins, pairMarkerDigest } = options;
+  c.keys(projectionPins, c.PRODUCTS, "projection pins");
+  const bodies = {};
+  for (const p of c.PRODUCTS) {
+    c.keys(projectionPins[p], ["manifest_sha256", "checksums_sha256"], "projection digests");
+    bodies[p] = pinFile(path.join(candidate.outputs[p], "release-manifest.json"), projectionPins[p].manifest_sha256);
+    pinFile(path.join(candidate.outputs[p], "checksums.txt"), projectionPins[p].checksums_sha256, 64 * 1024);
+  }
+  pinFile(candidate.pairMarker, pairMarkerDigest);
+  pinFile(path.join(candidate.root, "candidate.json"), candidate.manifestDigest);
+  return bodies;
+}
+
+function prepare(options) {
+  c.keys(options, ["candidate", "repo", "node", "npm", "output", "projectionPins", "pairMarkerDigest"], "public preparation options");
+  const candidate = options.candidate;
+  if (candidate.authoringMode !== runtime.MODE || candidate.assetScope !== runtime.SCOPE) throw new Error("public preparation requires full release pair");
+  c.identity(candidate.identity);
+  const roots = [options.repo, candidate.root, candidate.workParent, ...Object.values(candidate.outputs), path.dirname(candidate.pairMarker)];
+  roots.forEach(c.safeDirectory);
+  for (const key of ["node", "npm"]) {
+    if (!path.isAbsolute(options[key])) throw new Error("absolute trusted tool required");
+    c.readFile(options[key]);
+  }
+  c.outputPlacement(options.output, [...roots, path.dirname(options.node), path.dirname(options.npm)]);
+  const before = pins(options);
+  // Requires real Go build-info verification of the pinned frozen candidate and
+  // exact projections, without executing assets or claiming platform acceptance.
+  adapter.verifyAuthoringRelease(candidate);
+  const context = packing.npmContext(candidate.workParent);
+  context.env.PATH = "/usr/local/bin:/usr/bin:/bin"; // mandatory guarded tools
+  const source = packing.blobs(options.repo, candidate.identity.commit, context.env, "public");
+  fs.mkdirSync(options.output, { mode: 0o700 });
+  const snapshot = path.join(options.output, "projection-snapshot");
+  fs.mkdirSync(snapshot, { mode: 0o700 });
+  const outputs = {};
+  for (const p of c.PRODUCTS) {
+    const dest = outputs[p] = path.join(snapshot, p);
+    fs.mkdirSync(dest, { mode: 0o700 });
+    for (const name of fs.readdirSync(candidate.outputs[p])) write(path.join(dest, name), c.readFile(path.join(candidate.outputs[p], name)), 0o444);
+  }
+  const pairMarker = path.join(snapshot, "pair.json");
+  write(pairMarker, pinFile(candidate.pairMarker, options.pairMarkerDigest), 0o444);
+  const copied = { ...candidate, outputs, pairMarker };
+  adapter.verifyAuthoringRelease(copied);
+  pins({ ...options, candidate: copied });
+  const packs = {}, generated = {}, closures = {};
+  for (const p of c.PRODUCTS) {
+    const files = closures[p] = packageFiles(p, source, before[p], candidate);
+    const root = path.join(options.output, p);
+    fs.mkdirSync(root, { mode: 0o700 });
+    for (const [name, bytes] of Object.entries(files)) write(path.join(root, name), bytes, name === `bin/${p}.js` ? 0o755 : 0o644);
+    generated[p] = Object.fromEntries(Object.entries(files).map(([n, b]) => [n, c.digest(b)]));
+    packs[p] = packing.packPackage(p, files, root, { ...options, identity: candidate.identity }, context);
+  }
+  for (const name of COMMON) if (!closures.agentplugins[name].equals(closures["plugin-kit-ai"][name])) throw new Error("public shared closure differs");
+  const after = pins(options);
+  for (const p of c.PRODUCTS) {
+    if (!before[p].equals(after[p])) throw new Error("projection changed during packing");
+    pinFile(path.join(options.output, packs[p].file), packs[p].sha256, 128 * 1024 * 1024);
+  }
+  adapter.verifyAuthoringRelease(copied);
+  const record = { schema: "dual-authoring-public-preparation/v1", identity: candidate.identity,
+    candidate_sha256: candidate.manifestDigest, projection_pins: options.projectionPins, pair_marker_sha256: options.pairMarkerDigest,
+    wrapper_blobs: Object.fromEntries(Object.entries(source).map(([n, { bytes, ...pin }]) => [n, pin])),
+    generated, packs, tools: Object.fromEntries(["node", "npm"].map(k => [k, { path: options[k], sha256: c.digest(c.readFile(options[k])) }])),
+    qualification: null, release_eligible: false, platform_acceptance: false, attested: false };
+  packing.blobs(options.repo, candidate.identity.commit, context.env, "public");
+  packing.completeRecord(options.output, record);
+  return record;
+}
+if (require.main === module) {
+  try {
+    if (process.argv.length !== 4 || process.argv[2] !== "--prepare" || !path.isAbsolute(process.argv[3])) throw new Error("usage: stage-authoring-npm.js --prepare <absolute-options.json>");
+    process.stdout.write(c.encode(prepare(JSON.parse(c.readFile(process.argv[3], 1024 * 1024)))));
+  } catch (e) { process.stderr.write(`public npm preparation: ${e.message}\n`); process.exitCode = 1; }
+}
+module.exports = { prepare, packageFiles, ALLOWLIST, COMMON };

--- a/npm/agentplugins/scripts/stage-dual-authoring-npm.js
+++ b/npm/agentplugins/scripts/stage-dual-authoring-npm.js
@@ -38,13 +38,15 @@ function npmContext(workParent) {
   return context;
 }
 
-function blobs(repo, commit, env) {
+function blobs(repo, commit, env, closure = "private") {
+  if (!["private", "public"].includes(closure)) throw new Error("unknown fixed npm closure");
+  const allowlist = closure === "private" ? ALLOWLIST : require("./stage-authoring-npm").ALLOWLIST;
   c.safeDirectory(repo);
   if (run("/usr/bin/git", ["rev-parse", "HEAD"], env, repo).toString().trim() !== commit) {
     throw new Error("expected source must equal checkout HEAD");
   }
   const result = {};
-  for (const name of ALLOWLIST) {
+  for (const name of allowlist) {
     const entry = run("/usr/bin/git", ["ls-tree", "-z", commit, "--", name], env, repo).toString();
     const match = /^(100644|100755) blob ([0-9a-f]{40})\t([^\0]+)\0$/.exec(entry);
     if (!match || match[3] !== name) throw new Error(`required regular Git blob missing: ${name}`);
@@ -54,7 +56,8 @@ function blobs(repo, commit, env) {
   // The code doing verification/generation must itself be this committed code.
   // A dirty caller may not manufacture an exact-source claim using old blobs.
   for (const name of ["scripts/stage-dual-authoring-npm.js", "scripts/stage-dual-authoring-candidate.js",
-    "scripts/dual-authoring-candidate.js"]) {
+    "scripts/dual-authoring-candidate.js", ...(closure === "public" ?
+      ["scripts/stage-authoring-npm.js", "scripts/authoring-release.js", "lib/public-authoring.js"] : [])]) {
     if (!c.readFile(path.resolve(__dirname, "..", name)).equals(result[PREFIX + name].bytes)) {
       throw new Error(`executing stager differs from committed source: ${name}`);
     }
@@ -102,6 +105,20 @@ function verifyPack(tarball, files, destination, env) {
   }
 }
 
+
+// One exact pack algorithm for both fixed closures; private defaults are intact.
+function packPackage(product, files, root, options, context) {
+    const result = JSON.parse(run(options.node, [options.npm, "pack", "--ignore-scripts", "--offline", "--json",
+      "--pack-destination", options.output], context.env, root));
+    const filename = `${PACKAGES[product]}-${options.identity.versions[product]}.tgz`;
+    if (result.length !== 1 || result[0].filename !== filename) throw new Error("unexpected npm pack result");
+    const tarball = path.join(options.output, filename), bytes = c.readFile(tarball);
+    verifyPack(tarball, files, path.join(context.root, product), context.env);
+    const integrity = "sha512-" + crypto.createHash("sha512").update(bytes).digest("base64");
+    if (result[0].integrity !== integrity) throw new Error("npm integrity differs from actual pack");
+    return { file: filename, ...c.metadata(bytes), integrity };
+}
+
 function stagePair(options) {
   c.keys(options, ["candidate", "repo", "root", "identity", "manifestDigest", "assetScope", "authoringMode",
     "go", "workParent", "output", "node", "npm"], "private npm options");
@@ -145,15 +162,7 @@ function stagePair(options) {
     const files = packageFiles(product, source, manifestBytes, options); packFiles[product] = files;
     generated[product] = Object.fromEntries(Object.entries(files).map(([n, b]) => [n, c.digest(b)]));
     for (const [name, bytes] of Object.entries(files)) write(path.join(root, name), bytes, /^bin\/[^/]+\.js$/.test(name) ? 0o755 : 0o644);
-    const result = JSON.parse(run(options.node, [options.npm, "pack", "--ignore-scripts", "--offline", "--json",
-      "--pack-destination", options.output], context.env, root));
-    const filename = `${PACKAGES[product]}-${options.identity.versions[product]}.tgz`;
-    if (result.length !== 1 || result[0].filename !== filename) throw new Error("unexpected npm pack result");
-    const tarball = path.join(options.output, filename), bytes = c.readFile(tarball);
-    verifyPack(tarball, files, path.join(context.root, product), context.env);
-    const integrity = "sha512-" + crypto.createHash("sha512").update(bytes).digest("base64");
-    if (result[0].integrity !== integrity) throw new Error("npm integrity differs from actual pack");
-    packs[product] = { file: filename, ...c.metadata(bytes), integrity };
+    packs[product] = packPackage(product, files, root, options, context);
   }
   for (const name of [...COMMON, "candidate.json"]) {
     if (!packFiles.agentplugins[name].equals(packFiles["plugin-kit-ai"][name])) throw new Error("shared pack bytes differ");
@@ -166,10 +175,15 @@ function stagePair(options) {
     candidate_sha256: options.manifestDigest, asset_scope: options.assetScope, authoring_mode: MODE,
     wrapper_blobs: Object.fromEntries(Object.entries(source).map(([n, { bytes, ...pin }]) => [n, pin])),
     generated, packs, tools, evidence: context.root, release_eligible: false, platform_acceptance: false, attested: false };
+  completeRecord(options.output, record);
+  return record;
+}
+
+function completeRecord(output, record) {
   // Complete the bytes before exclusive publication. Never remove a collision.
-  const temporary = path.join(options.output, "completion.pending.json");
+  const temporary = path.join(output, "completion.pending.json");
   write(temporary, c.encode(record), 0o444);
-  const marker = path.join(options.output, "completion.json");
+  const marker = path.join(output, "completion.json");
   fs.linkSync(temporary, marker);
   try { fs.unlinkSync(temporary); } catch (error) {
     try {
@@ -179,7 +193,6 @@ function stagePair(options) {
     } catch (cleanup) { throw new AggregateError([error, cleanup], "completion cleanup uncertainty"); }
     throw error;
   }
-  return record;
 }
 
 if (require.main === module) {
@@ -188,4 +201,4 @@ if (require.main === module) {
     process.stdout.write(c.encode(stagePair(JSON.parse(c.readFile(process.argv[3], 1024 * 1024)))));
   } catch (error) { process.stderr.write(`private npm pair: ${error.message}\n`); process.exitCode = 1; }
 }
-module.exports = { stagePair, verifyPack, npmContext, blobs, packageFiles, ALLOWLIST, COMMON, MODE, PACKAGES };
+module.exports = { completeRecord, packPackage, stagePair, verifyPack, npmContext, blobs, packageFiles, ALLOWLIST, COMMON, MODE, PACKAGES };

--- a/npm/agentplugins/test/authoring-release-producer.test.js
+++ b/npm/agentplugins/test/authoring-release-producer.test.js
@@ -1,0 +1,292 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const cp = require("node:child_process");
+const nodeTest = require("node:test");
+// Historical v2 detached packages do not adopt this repository-native producer.
+const test = (name, fn) => nodeTest(name, { skip: process.env.AGENTPLUGINS_STAGED_TEST_CHILD === "1" }, fn);
+const c = require("../scripts/dual-authoring-candidate");
+const release = require("../scripts/release-assets");
+
+const MODE = "release-cli-contract-v1";
+const SCOPE = "six-platform-pair";
+const ID = { repository: c.REPOSITORY, commit: "a".repeat(40), engine_revision: "a".repeat(40),
+  versions: { agentplugins: "0.1.54", "plugin-kit-ai": "2.0.0" } };
+
+// Structural fixtures, not native acceptance. The trusted-tool stub returns
+// embedded fixture records only for env/version; any compile or subject launch
+// is a hard failure. Real verifier/path/archive/projection code runs unchanged.
+function fixture() {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "authoring-producer-"));
+  const root = path.join(sandbox, "candidate");
+  const workParent = path.join(sandbox, "work");
+  const tools = path.join(sandbox, "tools");
+  for (const dir of [root, workParent, tools]) fs.mkdirSync(dir);
+  const go = path.join(tools, "structural-go");
+  fs.writeFileSync(go, `#!${process.execPath}
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(path.join(sandbox, "calls.jsonl"))}, JSON.stringify(args) + '\\n');
+if (JSON.stringify(args) === JSON.stringify(['env', '-json', 'GOVERSION', 'GOHOSTOS', 'GOHOSTARCH'])) {
+  console.log(JSON.stringify({ GOVERSION: 'go1.25.13', GOHOSTOS: 'linux', GOHOSTARCH: 'amd64' }));
+} else if (args.length === 4 && args.slice(0, 3).join(' ') === 'version -m -json') {
+  const stat = fs.statSync(args[3]);
+  if (stat.mode & 0o111) throw Error('subject executable permission');
+  process.stdout.write(fs.readFileSync(args[3]));
+} else throw Error('compile or unexpected tool invocation forbidden');
+`, { mode: 0o755 });
+  const manifest = { schema: c.SCHEMA, status: "CANDIDATE", identity: structuredClone(ID), asset_scope: SCOPE,
+    build: { method: "controlled-git-archive-go-build/v1", go_version: "go1.25.13", go_sha256: c.digest(c.readFile(go)),
+      source_archive_sha256: "c".repeat(64), authoring_mode: MODE }, products: {}, release_eligible: false };
+  for (const product of c.PRODUCTS) {
+    const assets = {};
+    manifest.products[product] = { version: ID.versions[product], assets };
+    for (const target of c.TARGETS) {
+      const [GOOS, GOARCH] = target.split("-");
+      const binary = c.encode({ GoVersion: "go1.25.13", Path: `github.com/777genius/plugin-kit-ai/cli/cmd/${product}`,
+        Settings: Object.entries({ GOOS, GOARCH, CGO_ENABLED: "0", "-buildmode": "exe", "-compiler": "gc",
+          "-ldflags": c.linkerFlags(product, ID, MODE) }).map(([Key, Value]) => ({ Key, Value })) });
+      const file = c.assetName(product, ID.versions[product], target);
+      const name = c.executableName(product, target);
+      const body = product === "plugin-kit-ai" ? c.archive(binary, name) : binary;
+      fs.writeFileSync(path.join(root, file), body, { mode: 0o444 });
+      assets[target] = { file, ...c.metadata(body), binary: { file: name, ...c.metadata(binary) } };
+    }
+  }
+  const options = { candidate: true, root, identity: structuredClone(ID), manifestDigest: "", go, workParent,
+    assetScope: SCOPE, authoringMode: MODE,
+    outputs: { agentplugins: path.join(sandbox, "agentplugins"), "plugin-kit-ai": path.join(sandbox, "plugin-kit-ai") },
+    pairMarker: path.join(sandbox, "pair-prepared.json") };
+  const save = () => {
+    fs.writeFileSync(path.join(root, "candidate.json"), c.encode(manifest));
+    options.manifestDigest = c.digest(c.encode(manifest));
+  };
+  save();
+  return { sandbox, manifest, options, save };
+}
+
+function noOutput(f) {
+  assert.equal(fs.existsSync(f.options.pairMarker), false);
+  for (const root of Object.values(f.options.outputs)) assert.equal(fs.existsSync(root), false);
+}
+
+function rewriteBinary(f, product, change) {
+  const asset = f.manifest.products[product].assets["linux-amd64"];
+  const file = path.join(f.options.root, asset.file);
+  const before = fs.readFileSync(file);
+  const info = JSON.parse(product === "plugin-kit-ai" ? c.unpack(before, asset.binary.file) : before);
+  change(info);
+  const binary = c.encode(info);
+  const body = product === "plugin-kit-ai" ? c.archive(binary, asset.binary.file) : binary;
+  fs.chmodSync(file, 0o644);
+  fs.writeFileSync(file, body);
+  Object.assign(asset, c.metadata(body));
+  Object.assign(asset.binary, c.metadata(binary));
+  f.save();
+}
+
+test("v3 prepares and verifies exactly both pinned products without compilation or execution", () => {
+  const f = fixture();
+  const candidateBefore = Object.fromEntries(fs.readdirSync(f.options.root).map((name) => [name, c.digest(c.readFile(path.join(f.options.root, name)))]));
+  const prepared = release.prepareAuthoringRelease(f.options);
+  const verified = release.verifyAuthoringRelease(f.options);
+  assert.equal(verified.consistency_verified, true);
+  assert.deepEqual(prepared, JSON.parse(fs.readFileSync(f.options.pairMarker)));
+  for (const claims of [prepared, verified]) for (const flag of ["release_eligible", "platform_acceptance", "attested"]) assert.equal(claims[flag], false);
+  for (const product of c.PRODUCTS) {
+    const root = f.options.outputs[product];
+    const manifest = JSON.parse(fs.readFileSync(path.join(root, "release-manifest.json")));
+    assert.equal(manifest.schema_version, 3);
+    assert.equal(manifest.product, product);
+    assert.equal(manifest.repository, c.REPOSITORY);
+    assert.equal(manifest.commit, ID.commit);
+    assert.equal(manifest.engine_revision, ID.commit);
+    assert.deepEqual(manifest.versions, ID.versions);
+    assert.equal(manifest.candidate_sha256, f.options.manifestDigest);
+    assert.equal(manifest.tag, product === "agentplugins" ? "agentplugins-v0.1.54" : "v2.0.0");
+    assert.equal(manifest.authoring_mode, MODE);
+    assert.equal(manifest.status, "CANDIDATE");
+    assert.deepEqual(Object.keys(manifest.assets), c.TARGETS);
+    assert.equal(fs.readdirSync(root).length, 8);
+    for (const asset of Object.values(manifest.assets)) {
+      assert.deepEqual(c.readFile(path.join(root, asset.file)), c.readFile(path.join(f.options.root, asset.file)));
+      assert.notEqual(fs.statSync(path.join(root, asset.file)).ino, fs.statSync(path.join(f.options.root, asset.file)).ino);
+      assert.equal(asset.binary.sha256, f.manifest.products[product].assets[Object.keys(manifest.assets).find((k) => manifest.assets[k] === asset)].binary.sha256);
+    }
+  }
+  for (const [name, digest] of Object.entries(candidateBefore)) assert.equal(c.digest(c.readFile(path.join(f.options.root, name))), digest);
+  const calls = fs.readFileSync(path.join(f.sandbox, "calls.jsonl"), "utf8").trim().split("\n").map(JSON.parse);
+  assert.equal(calls.filter((args) => args[0] === "version").length, 24);
+  assert.equal(calls.filter((args) => args[0] === "env").length, 2);
+  assert.throws(() => release.verifyRelease(f.options.outputs.agentplugins, "agentplugins-v0.1.54", ID.commit), /schema/);
+});
+
+const invalidCandidates = {
+  "missing product": (f) => { delete f.manifest.products["plugin-kit-ai"]; },
+  "missing target": (f) => { delete f.manifest.products.agentplugins.assets["darwin-arm64"]; },
+  "Linux-only": (f) => { f.manifest.asset_scope = "linux-amd64-pair"; },
+  "vertical mode": (f) => { f.manifest.build.authoring_mode = "vertical-slice-v1"; },
+  "empty engine": (f) => { f.manifest.identity.engine_revision = ""; },
+  "unversioned engine": (f) => { f.manifest.identity.engine_revision = "unversioned"; },
+  "stale engine": (f) => { f.manifest.identity.engine_revision = "b".repeat(40); },
+  "stale source and engine": (f) => { f.manifest.identity.commit = f.manifest.identity.engine_revision = "b".repeat(40); },
+  "historical repository": (f) => { f.manifest.identity.repository = "777genius/plugin-kit-ai"; },
+  "version swap": (f) => { f.manifest.identity.versions = { agentplugins: "2.0.0", "plugin-kit-ai": "0.1.54" }; },
+  "product swap": (f) => { [f.manifest.products.agentplugins, f.manifest.products["plugin-kit-ai"]] = [f.manifest.products["plugin-kit-ai"], f.manifest.products.agentplugins]; },
+  "asset corruption": (f) => { const file = path.join(f.options.root, f.manifest.products["plugin-kit-ai"].assets["linux-amd64"].file); fs.chmodSync(file, 0o644); fs.writeFileSync(file, "corrupt"); },
+  "inner binary digest": (f) => { f.manifest.products["plugin-kit-ai"].assets["linux-amd64"].binary.sha256 = "d".repeat(64); },
+  "extra file": (f) => { fs.writeFileSync(path.join(f.options.root, "unrelated"), "preserve"); },
+  "approval flag": (f) => { f.manifest.release_eligible = true; }
+};
+for (const [name, mutate] of Object.entries(invalidCandidates)) test(`reject candidate ${name} before outputs`, () => {
+  const f = fixture(); mutate(f); f.save();
+  assert.throws(() => release.prepareAuthoringRelease(f.options));
+  noOutput(f);
+});
+
+test("wrong or missing independent pin and invalid caller identity fail closed", () => {
+  for (const change of [
+    (o) => { o.manifestDigest = "d".repeat(64); }, (o) => { o.manifestDigest = ""; },
+    (o) => { o.identity.repository = "777genius/plugin-kit-ai"; },
+    (o) => { o.identity.versions["plugin-kit-ai"] = "2.0.1"; },
+    (o) => { o.identity.commit = o.identity.engine_revision = "0".repeat(40); },
+    (o) => { o.authoringMode = "vertical-slice-v1"; }, (o) => { delete o.authoringMode; },
+    (o) => { o.assetScope = "linux-amd64-pair"; }, (o) => { o.candidate = false; }
+  ]) {
+    const f = fixture(); change(f.options);
+    assert.throws(() => release.prepareAuthoringRelease(f.options)); noOutput(f);
+  }
+});
+
+for (const product of c.PRODUCTS) test(`independent byte inspection rejects repinned ${product} inner identity`, () => {
+  for (const change of [
+    (info) => { info.Path = info.Path.replace(`/cmd/${product}`, "/cmd/other-product"); },
+    (info) => { info.Settings.at(-1).Value = c.linkerFlags(product, { ...ID, commit: "b".repeat(40) }, MODE); },
+    (info) => { info.Settings.at(-1).Value = c.linkerFlags(product, ID); },
+    (info) => { info.Settings.at(-1).Value = c.linkerFlags(product, { ...ID, versions: { ...ID.versions, [product]: "9.9.9" } }, MODE); }
+  ]) {
+    const f = fixture(); rewriteBinary(f, product, change);
+    assert.throws(() => release.prepareAuthoringRelease(f.options), /embedded Go/); noOutput(f);
+  }
+});
+
+test("absent external disjoint output policy rejects alias, overlap, existing and symlink paths", () => {
+  for (const kind of ["same", "nested", "case", "candidate", "scratch", "repo", "root-scratch", "existing", "symlink", "marker", "marker-existing"]) {
+    const f = fixture();
+    const original = f.options.outputs.agentplugins;
+    if (kind === "same") f.options.outputs["plugin-kit-ai"] = original;
+    if (kind === "nested") f.options.outputs["plugin-kit-ai"] = path.join(original, "nested");
+    if (kind === "case") f.options.outputs["plugin-kit-ai"] = original.replace(/agentplugins$/, "AGENTPLUGINS");
+    if (kind === "candidate") f.options.outputs.agentplugins = path.join(f.options.root, "out");
+    if (kind === "scratch") f.options.outputs.agentplugins = path.join(f.options.workParent, "out");
+    if (kind === "repo") f.options.outputs.agentplugins = path.resolve(__dirname, "../out");
+    if (kind === "root-scratch") f.options.workParent = path.parse(f.sandbox).root;
+    if (kind === "existing") { fs.mkdirSync(original); fs.writeFileSync(path.join(original, "unrelated"), "preserve"); }
+    if (kind === "symlink") { const link = path.join(f.sandbox, "link"); fs.symlinkSync(f.options.workParent, link); f.options.outputs.agentplugins = path.join(link, "out"); }
+    if (kind === "marker") f.options.pairMarker = path.join(original, "pair.json");
+    if (kind === "marker-existing") fs.writeFileSync(f.options.pairMarker, "unrelated");
+    assert.throws(() => release.prepareAuthoringRelease(f.options));
+    assert.equal(fs.existsSync(path.join(f.sandbox, "calls.jsonl")), false, "placement must fail before tool/scratch effects");
+    if (kind === "existing") assert.equal(fs.readFileSync(path.join(original, "unrelated"), "utf8"), "preserve");
+    if (kind === "marker-existing") assert.equal(fs.readFileSync(f.options.pairMarker, "utf8"), "unrelated");
+  }
+});
+
+test("verification rejects mutated outputs, missing pair marker, links and metadata/claim substitution", () => {
+  const f = fixture(); release.prepareAuthoringRelease(f.options);
+  const root = f.options.outputs.agentplugins;
+  const files = Object.values(f.options.outputs).flatMap((dir) => fs.readdirSync(dir).map((name) => path.join(dir, name)));
+  for (const file of [...files, f.options.pairMarker]) {
+    const body = fs.readFileSync(file);
+    fs.chmodSync(file, 0o644);
+    fs.writeFileSync(file, "corrupt");
+    assert.throws(() => release.verifyAuthoringRelease(f.options));
+    fs.writeFileSync(file, body);
+  }
+  const heldMarker = path.join(f.sandbox, "held-marker");
+  fs.renameSync(f.options.pairMarker, heldMarker);
+  assert.throws(() => release.verifyAuthoringRelease(f.options), /ENOENT/);
+  fs.renameSync(heldMarker, f.options.pairMarker);
+  const manifestFile = path.join(root, "release-manifest.json");
+  const original = fs.readFileSync(manifestFile);
+  for (const change of [
+    (v) => { v.product = "plugin-kit-ai"; }, (v) => { v.attested = true; },
+    (v) => { v.repository = "777genius/plugin-kit-ai"; }, (v) => { v.engine_revision = "b".repeat(40); }
+  ]) {
+    const value = JSON.parse(original); change(value); fs.writeFileSync(manifestFile, c.encode(value));
+    assert.throws(() => release.verifyAuthoringRelease(f.options), /manifest/);
+  }
+  fs.writeFileSync(manifestFile, original);
+  for (const link of [false, true]) {
+    const held = path.join(f.sandbox, link ? "held-symbolic" : "held-hard");
+    fs.renameSync(manifestFile, held);
+    if (link) fs.symlinkSync(held, manifestFile); else fs.linkSync(held, manifestFile);
+    assert.throws(() => release.verifyAuthoringRelease(f.options), /unaliased/);
+    fs.unlinkSync(manifestFile); fs.renameSync(held, manifestFile);
+  }
+  fs.writeFileSync(path.join(root, "unrelated"), "preserve");
+  assert.throws(() => release.verifyAuthoringRelease(f.options), /extra/);
+  assert.equal(fs.readFileSync(path.join(root, "unrelated"), "utf8"), "preserve");
+});
+
+for (const fault of ["second-product", "corrupt-copy", "marker-write", "marker-close"]) test(`partial ${fault} never leaves pair success`, (t) => {
+  const f = fixture();
+  const write = fs.writeFileSync;
+  let markerFd;
+  const open = fs.openSync;
+  t.mock.method(fs, "openSync", function(file, ...rest) {
+    const fd = open.call(this, file, ...rest);
+    if (file === f.options.pairMarker) markerFd = fd;
+    return fd;
+  });
+  t.mock.method(fs, "writeFileSync", function(file, body, ...rest) {
+    if (fault === "second-product" && typeof file === "string" && file.startsWith(f.options.outputs["plugin-kit-ai"] + path.sep)) throw Error("copy failure");
+    if (fault === "marker-write" && file === markerFd) { write.call(this, file, "partial"); throw Error("marker failure"); }
+    if (fault === "corrupt-copy" && typeof file === "string" && file.startsWith(f.options.outputs["plugin-kit-ai"] + path.sep)) body = Buffer.from("corrupt");
+    return write.call(this, file, body, ...rest);
+  });
+  const close = fs.closeSync;
+  t.mock.method(fs, "closeSync", function(fd) {
+    const result = close.call(this, fd);
+    if (fault === "marker-close" && fd === markerFd) throw Error("close failure");
+    return result;
+  });
+  assert.throws(() => release.prepareAuthoringRelease(f.options));
+  assert.equal(fs.existsSync(f.options.pairMarker), false);
+  assert.equal(fs.readdirSync(f.options.outputs.agentplugins).length, 8, "first product remains inspectable");
+});
+
+test("explicit CLI prepare-authoring and verify-authoring use the pinned options contract", () => {
+  const f = fixture();
+  const script = path.resolve(__dirname, "../scripts/release-assets.js");
+  const config = path.join(f.sandbox, "options.json");
+  fs.writeFileSync(config, c.encode(f.options));
+  for (const command of ["prepare-authoring", "verify-authoring"]) {
+    const result = cp.spawnSync(process.execPath, [script, command, config], { encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout).attested, false);
+  }
+  for (const args of [["verify-authoring"], ["verify-authoring", "relative"], ["verify-authoring", config, "extra"]]) {
+    const result = cp.spawnSync(process.execPath, [script, ...args], { encoding: "utf8" });
+    assert.equal(result.status, 1); assert.match(result.stderr, /absolute options/);
+  }
+});
+
+// Existing publication scripts can still copy just release-assets.js.
+test("historical standalone v1/v2 script does not require the authoring adapter", () => {
+  const f = fixture();
+  const standalone = path.join(f.sandbox, "legacy-release-assets.js");
+  fs.copyFileSync(path.resolve(__dirname, "../scripts/release-assets.js"), standalone);
+  const legacy = require(standalone);
+  const assets = path.join(f.sandbox, "historical");
+  fs.mkdirSync(assets);
+  for (const file of Object.values(legacy.expectedAssets("0.1.23"))) fs.writeFileSync(path.join(assets, file), file);
+  legacy.prepareRelease(assets, "agentplugins-v0.1.23", ID.commit);
+  const verified = legacy.verifyRelease(assets, "agentplugins-v0.1.23", ID.commit);
+  assert.equal(verified.repository, "777genius/plugin-kit-ai");
+  assert.equal(verified.manifest_schema, 2);
+  assert.equal(verified.gate_eligible, true); // Historical contract, not authoring approval.
+});

--- a/npm/agentplugins/test/public-authoring-native.test.js
+++ b/npm/agentplugins/test/public-authoring-native.test.js
@@ -1,0 +1,188 @@
+"use strict";
+
+// Dedicated lane: missing configuration is a failure, never a skipped acceptance.
+// Run only after the coordinator commits/integrates A and freezes native assets
+// from THAT exact source. Synthetic package binding proves fixture execution,
+// not authenticated native promotion, npm signatures or public eligibility.
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const crypto = require("node:crypto");
+const test = require("node:test");
+const c = require("../scripts/dual-authoring-candidate");
+const adapter = require("../scripts/authoring-release");
+const packing = require("../scripts/stage-dual-authoring-npm");
+const stager = require("../scripts/stage-authoring-npm");
+const { preload, run, ok, environment } = require("./public-authoring-pack.test");
+
+function tree(root) {
+  const result = {};
+  function walk(dir) {
+    for (const name of fs.readdirSync(dir).sort()) {
+      const file = path.join(dir, name), stat = fs.lstatSync(file);
+      assert.ok(!stat.isSymbolicLink(), "project aliases forbidden");
+      if (stat.isDirectory()) walk(file);
+      else result[path.relative(root, file)] = c.digest(c.readFile(file));
+    }
+  }
+  walk(root); return result;
+}
+
+test("PUBLIC NATIVE: exact integrated packs, both actual bins, static parity and lifecycle", () => {
+  const config = process.env.UAP_PUBLIC_AUTHORING_NATIVE_CONFIG;
+  assert.ok(config && path.isAbsolute(config), "required UAP_PUBLIC_AUTHORING_NATIVE_CONFIG: exact integrated assets remain a coordinator gate");
+  const cfg = JSON.parse(c.readFile(config, 1024 * 1024));
+  c.keys(cfg, ["prepare", "completionDigest", "evidenceOutput"], "public native fixture config");
+  const o = cfg.prepare, candidate = o.candidate;
+  const platform = require("../lib/platform").detectPlatform();
+  const target = platform.key;
+  c.outputPlacement(cfg.evidenceOutput, [o.repo, o.output, candidate.root, candidate.workParent]);
+  const context = packing.npmContext(candidate.workParent);
+  const env = { ...context.env, PATH: `${path.dirname(o.node)}:/usr/local/bin:/usr/bin:/bin` };
+  const source = packing.blobs(o.repo, candidate.identity.commit, env, "public");
+  adapter.verifyAuthoringRelease(candidate);
+  const completion = c.readFile(path.join(o.output, "completion.json"));
+  assert.equal(c.digest(completion), cfg.completionDigest);
+  const record = JSON.parse(completion);
+  assert.deepEqual(record.identity, candidate.identity);
+  assert.equal(record.candidate_sha256, candidate.manifestDigest);
+  assert.equal(record.pair_marker_sha256, o.pairMarkerDigest);
+  assert.equal(c.digest(c.readFile(candidate.pairMarker)), o.pairMarkerDigest);
+  assert.deepEqual(record.projection_pins, o.projectionPins);
+  assert.equal(record.qualification, null);
+  for (const claim of ["release_eligible", "platform_acceptance", "attested"]) assert.equal(record[claim], false);
+  assert.deepEqual(record.wrapper_blobs, Object.fromEntries(Object.entries(source).map(([n, { bytes, ...pin }]) => [n, pin])));
+  fs.mkdirSync(cfg.evidenceOutput, { mode: 0o700 });
+  const bodies = {}, tarballs = {}, invocations = [], reports = {}, trees = {};
+  const integrity = bytes => "sha512-" + crypto.createHash("sha512").update(bytes).digest("base64");
+  for (const p of c.PRODUCTS) {
+    const manifestBytes = c.readFile(path.join(candidate.outputs[p], "release-manifest.json"));
+    assert.equal(c.digest(manifestBytes), o.projectionPins[p].manifest_sha256);
+    assert.equal(c.digest(c.readFile(path.join(candidate.outputs[p], "checksums.txt"))), o.projectionPins[p].checksums_sha256);
+    const files = stager.packageFiles(p, source, manifestBytes, candidate);
+    assert.deepEqual(record.generated[p], Object.fromEntries(Object.entries(files).map(([n, b]) => [n, c.digest(b)])));
+    const pin = record.packs[p], tarball = path.join(o.output, pin.file), bytes = c.readFile(tarball);
+    assert.equal(c.digest(bytes), pin.sha256); assert.equal(bytes.length, pin.size); assert.equal(integrity(bytes), pin.integrity);
+    const extract = path.join(context.root, `preparation-${p}`);
+    packing.verifyPack(tarball, files, extract, env);
+    const root = path.join(extract, "package");
+    // Prove unchanged ordinary preparation rejects, then assemble separately
+    // labelled synthetic packs. No source_sha rewriting or altered public code.
+    const denied = run(o.node, [path.join(root, `bin/${p}.js`), "version"], env, context.root);
+    assert.equal(denied.status, 1); assert.match(denied.stderr, /not qualified/); assert.equal(denied.stdout, "");
+    const d = JSON.parse(files["public-release.json"]);
+    d.qualification = { identity: candidate.identity, candidate_sha256: candidate.manifestDigest,
+      manifest_sha256: Object.fromEntries(c.PRODUCTS.map(p => [p, o.projectionPins[p].manifest_sha256])),
+      signed_subject: { sha256: c.digest(Buffer.from("synthetic fixture only")),
+        workflow: `${c.REPOSITORY}/.github/workflows/fixture-only.yml`, source: candidate.identity.commit } };
+    files["public-release.json"] = c.encode(d);
+    fs.writeFileSync(path.join(root, "public-release.json"), files["public-release.json"]);
+    const output = path.join(cfg.evidenceOutput, p); fs.mkdirSync(output);
+    const packed = packing.packPackage(p, files, root, { ...o, output, identity: candidate.identity },
+      { env, root: fs.mkdtempSync(path.join(context.root, "synthetic-pack-")) });
+    tarballs[p] = path.join(output, packed.file);
+    const m = JSON.parse(manifestBytes), a = m.assets[target];
+    const body = c.readFile(path.join(candidate.outputs[p], a.file));
+    assert.equal(c.digest(body), a.sha256);
+    bodies[`https://github.com/${c.REPOSITORY}/releases/download/${m.tag}/${a.file}`] = body;
+  }
+  const loader = path.join(context.root, "transport.cjs"), log = path.join(cfg.evidenceOutput, "downloads.log");
+  preload(loader, bodies, log);
+  // Separate prefixes and homes prove neither native product needs its peer.
+  for (const p of c.PRODUCTS) {
+    const prefix = path.join(context.root, `${p} independent prefix`);
+    const independent = environment({ ...context, env }, prefix, path.join(context.root, `${p} independent home`));
+    ok(run(o.node, [o.npm, "install", "--global", "--prefix", prefix, "--offline", "--ignore-scripts", "--no-audit", "--no-fund", tarballs[p]], independent, context.root));
+    const packageRoot = path.join(prefix, "lib/node_modules", p === "agentplugins" ? "universal-agent-plugins" : p);
+    const controlled = { ...independent, NODE_OPTIONS: `--require=${JSON.stringify(loader)}`, PATH: "/absent-peer-binary-path" };
+    if (p === "plugin-kit-ai") assert.equal(ok(run(o.node, [path.join(packageRoot, "lib/install.js")], controlled, context.root)), "");
+    const version = JSON.parse(ok(run(o.node, [path.join(packageRoot, `bin/${p}.js`), "version", "--format=json"], controlled, context.root)));
+    assert.equal(version.data[p === "agentplugins" ? "version" : "product_version"], candidate.identity.versions[p]);
+    assert.deepEqual(fs.readdirSync(path.join(prefix, "lib/node_modules")), [p === "agentplugins" ? "universal-agent-plugins" : p]);
+  }
+  const prefix = path.join(context.root, "shared prefix ü"), home = path.join(context.root, "consumer home ü");
+  const consumer = environment({ ...context, env }, prefix, home);
+  for (const p of c.PRODUCTS) ok(run(o.node, [o.npm, "install", "--global", "--prefix", prefix, "--offline", "--ignore-scripts", "--no-audit", "--no-fund", tarballs[p]], consumer, context.root));
+  const client = path.join(home, ".codex"), installer = path.join(context.root, "installer-state");
+  fs.mkdirSync(client); fs.mkdirSync(installer);
+  fs.writeFileSync(path.join(client, "config.toml"), "# isolated synthetic target\n");
+  const transportEnv = { ...consumer, CODEX_HOME: client, AGENTPLUGINS_HOME: installer,
+    NODE_OPTIONS: `--require=${JSON.stringify(loader)}` };
+  const bin = p => path.join(prefix, "lib/node_modules", p === "agentplugins" ? "universal-agent-plugins" : p, `bin/${p}.js`);
+  const projects = Object.fromEntries(c.PRODUCTS.map(p => {
+    const root = path.join(context.root, `${p} projects ü`); fs.mkdirSync(root); return [p, root];
+  }));
+  function invoke(p, argv, status = 0, json = true) {
+    const r = run(o.node, [bin(p), ...argv], { ...transportEnv, PATH: "/absent-peer-binary-path" }, projects[p]);
+    invocations.push({ product: p, argv, status: r.status, signal: r.signal, stdout: r.stdout, stderr: r.stderr });
+    fs.writeFileSync(path.join(cfg.evidenceOutput, "invocations.json"), c.encode(invocations));
+    assert.equal(r.status, status, r.stdout + r.stderr); assert.equal(r.stderr, "");
+    return json ? JSON.parse(r.stdout) : r.stdout;
+  }
+  function author(p, argv, status = 0, compare = true) {
+    const r = invoke(p, [...(p === "agentplugins" ? ["author"] : []), ...argv, "--format=json"], status);
+    assert.equal(r.schema_version, 1); assert.equal(r.data.revision, candidate.identity.commit);
+    assert.equal(r.data.engine, "standard-first-slice/1");
+    assert.equal(r.result, status === 0 ? "success" : "failure");
+    const normalized = JSON.parse(JSON.stringify(r).split(projects[p]).join("<project>"));
+    delete normalized.data.product; delete normalized.data.product_version;
+    if (normalized.data.help) normalized.data.help.use = normalized.data.help.use.replace(/^agentplugins author|^plugin-kit-ai/, "<author>");
+    if (compare) reports[p].push(normalized);
+    return r.data;
+  }
+  ok(run(o.node, [path.resolve(bin("plugin-kit-ai"), "../../lib/install.js")], transportEnv, context.root));
+  for (const p of c.PRODUCTS) {
+    reports[p] = []; trees[p] = [];
+    const version = invoke(p, ["version", "--format=json"]);
+    assert.equal(version.data[p === "agentplugins" ? "version" : "product_version"], candidate.identity.versions[p]);
+    assert.ok(invoke(p, ["--help"], 0, false).length);
+    author(p, ["version"]);
+    const help = author(p, ["--help"]);
+    for (const name of ["dev", "bootstrap", "normalize", "import", "export", "publish"]) {
+      assert.ok(!JSON.stringify(help).includes(`"${name}"`), `deferred ${name} absent`);
+    }
+    for (const lane of ["skill", "mcp-remote", "mcp-stdio"]) {
+      const extra = lane === "mcp-remote" ? ["--url=https://docs.example.com/mcp"] : lane === "mcp-stdio" ? ["--runtime=node"] : [];
+      assert.equal(author(p, ["init", lane, `--template=${lane}`, ...extra]).committed, true);
+      const project = path.join(projects[p], lane);
+      for (const command of ["validate", "inspect", "test"]) {
+        const d = author(p, [command, project]);
+        assert.equal(d.runtime_evidence.status, "not_evaluated"); assert.ok(d.identity.tree_digest);
+      }
+      trees[p].push(tree(project));
+    }
+  }
+  assert.deepEqual(fs.readdirSync(installer), [], "authoring never creates installer state");
+  assert.equal(fs.readFileSync(path.join(client, "config.toml"), "utf8"), "# isolated synthetic target\n");
+  assert.deepEqual(reports.agentplugins, reports["plugin-kit-ai"]);
+  assert.deepEqual(trees.agentplugins, trees["plugin-kit-ai"]);
+  const before = tree(projects["plugin-kit-ai"]);
+  const retired = invoke("plugin-kit-ai", ["update", "--all", "--format=json"], 2);
+  assert.equal(retired.data.error.code, "v1_operation_unavailable");
+  assert.deepEqual(tree(projects["plugin-kit-ai"]), before);
+  // Installer dry-run uses an explicitly isolated synthetic client root/home.
+  const dry = invoke("agentplugins", ["add", path.join(projects.agentplugins, "skill"), "--target=codex", "--dry-run", "--format=json"]);
+  assert.ok(dry); assert.deepEqual(tree(projects["plugin-kit-ai"]), before);
+  const runtime = require("../lib/public-authoring");
+  for (const p of c.PRODUCTS) {
+    const packageRoot = path.resolve(bin(p), "../..");
+    const release = runtime.loadRelease(p, packageRoot, target);
+    const cached = runtime.cachePath(path.join(home, ".cache", "universal-agent-plugins"), p, target, release);
+    fs.writeFileSync(cached, "corrupt fixture cache");
+    ok(run(o.node, [bin(p), "version", "--format=json"], transportEnv, projects[p]));
+    assert.equal(c.digest(c.readFile(cached)), release.asset.binary.sha256);
+  }
+  const offline = path.join(context.root, "offline.cjs"); preload(offline, {}, log, true);
+  const offlineEnv = { ...transportEnv, NODE_OPTIONS: `--require=${JSON.stringify(offline)}` };
+  for (const p of c.PRODUCTS) ok(run(o.node, [bin(p), "version", "--format=json"], offlineEnv, projects[p]));
+  const peerBytes = fs.readFileSync(bin("plugin-kit-ai"));
+  ok(run(o.node, [o.npm, "uninstall", "--global", "--prefix", prefix, "--offline", "--ignore-scripts", "universal-agent-plugins"], consumer, context.root));
+  assert.deepEqual(fs.readFileSync(bin("plugin-kit-ai")), peerBytes);
+  ok(run(o.node, [bin("plugin-kit-ai"), "version"], offlineEnv, projects["plugin-kit-ai"]));
+  ok(run(o.node, [o.npm, "install", "--global", "--prefix", prefix, "--offline", "--ignore-scripts", tarballs.agentplugins], consumer, context.root));
+  ok(run(o.node, [bin("agentplugins"), "version"], offlineEnv, projects.agentplugins));
+  assert.deepEqual(tree(projects["plugin-kit-ai"]), before);
+  assert.equal(fs.readFileSync(log, "utf8").trim().split("\n").length, 6, "independent/shared cold and corruption recovery downloads per product; warm is offline");
+  fs.writeFileSync(path.join(cfg.evidenceOutput, "result.json"), c.encode({ source: candidate.identity.commit,
+    fixture_acquisition_execution: true, signed_promotion: false, public_eligible: false, runtime_evidence: "not_evaluated" }));
+});

--- a/npm/agentplugins/test/public-authoring-pack.test.js
+++ b/npm/agentplugins/test/public-authoring-pack.test.js
@@ -56,7 +56,70 @@ function environment(context, prefix, home) {
     npm_config_prefix: prefix };
 }
 
+function mainDiffersFromHead(head) {
+  const name = "npm/agentplugins/scripts/stage-authoring-npm.js";
+  return !fs.readFileSync(path.join(REPO, name)).equals(
+    cp.execFileSync("/usr/bin/git", ["show", `${head}:${name}`], { cwd: REPO }));
+}
+
 if (require.main === module) {
+  test("fresh --prepare CLI reaches the real public blob closure and source guards", () => {
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), "public-cli-"));
+    const head = cp.execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: REPO, encoding: "utf8" }).trim();
+    const root = path.join(parent, "candidate"), workParent = path.join(parent, "work");
+    const projections = path.join(parent, "projections"), outputs = {}, projectionPins = {};
+    for (const dir of [root, workParent, projections]) fs.mkdirSync(dir);
+    const body = Buffer.from("synthetic CLI boundary fixture\n"), digest = c.digest(body);
+    for (const p of c.PRODUCTS) {
+      outputs[p] = path.join(projections, p); fs.mkdirSync(outputs[p]);
+      for (const name of ["release-manifest.json", "checksums.txt"]) fs.writeFileSync(path.join(outputs[p], name), body);
+      projectionPins[p] = { manifest_sha256: digest, checksums_sha256: digest };
+    }
+    const pairMarker = path.join(projections, "pair.json");
+    fs.writeFileSync(pairMarker, body); fs.writeFileSync(path.join(root, "candidate.json"), body);
+    const options = { candidate: { root, workParent, outputs, pairMarker, manifestDigest: digest,
+      authoringMode: "release-cli-contract-v1", assetScope: "six-platform-pair",
+      identity: { repository: c.REPOSITORY, commit: head, engine_revision: head,
+        versions: { agentplugins: "0.1.99", "plugin-kit-ai": "2.0.0" } } },
+      repo: REPO, node: NODE, npm: NPM, output: path.join(parent, "output"), projectionPins, pairMarkerDigest: digest };
+    const optionsFile = path.join(parent, "options.json"), loader = path.join(parent, "boundary.cjs");
+    fs.writeFileSync(optionsFile, c.encode(options));
+    // Only expensive candidate verification is stubbed. Do not preload the main:
+    // the fresh process must execute its require.main branch before re-entry.
+    // Stop after the real blobs call, before any projection copy or npm packing.
+    fs.writeFileSync(loader, `"use strict";
+const assert = require("node:assert/strict");
+const adapter = require(${JSON.stringify(require.resolve("../scripts/authoring-release"))});
+const packing = require(${JSON.stringify(require.resolve("../scripts/stage-dual-authoring-npm"))});
+assert.equal(require.cache[${JSON.stringify(require.resolve("../scripts/stage-authoring-npm"))}], undefined);
+let verified = false;
+adapter.verifyAuthoringRelease = () => { verified = true; };
+const blobs = packing.blobs;
+packing.blobs = (...args) => {
+  assert.equal(verified, true);
+  assert.equal(args[3], "public");
+  const source = blobs(...args);
+  assert.ok(source["npm/agentplugins/scripts/stage-authoring-npm.js"]);
+  throw new Error("fixture: public closure verified; stopped before packing");
+};
+`);
+    const expected = mainDiffersFromHead(head)
+      ? "executing stager differs from committed source: scripts/stage-authoring-npm.js"
+      : "fixture: public closure verified; stopped before packing";
+    const env = { PATH: "/usr/local/bin:/usr/bin:/bin", HOME: parent, GIT_CONFIG_NOSYSTEM: "1", GIT_CONFIG_GLOBAL: "/dev/null" };
+    const invoke = () => run(NODE, ["--require", loader, path.join(REPO, "npm/agentplugins/scripts/stage-authoring-npm.js"), "--prepare", optionsFile], env, parent);
+    const result = invoke();
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, "");
+    assert.equal(result.stderr, `public npm preparation: ${expected}\n`);
+    assert.equal(fs.existsSync(options.output), false);
+    options.candidate.identity.commit = options.candidate.identity.engine_revision = "0".repeat(40);
+    fs.writeFileSync(optionsFile, c.encode(options));
+    const wrongHead = invoke();
+    assert.equal(wrongHead.status, 1);
+    assert.equal(wrongHead.stderr, "public npm preparation: expected source must equal checkout HEAD\n");
+    assert.equal(fs.existsSync(options.output), false);
+  });
   test("both real public packs install independently and together; public bins and kit postinstall use shared acquisition", () => {
     const parent = fs.mkdtempSync(path.join(os.tmpdir(), "public pack ü "));
     const context = packing.npmContext(parent);
@@ -142,6 +205,8 @@ if (require.main === module) {
     // the real closure loads; in the writer's dirty tree it must fail closed.
     const tracked = cp.spawnSync("/usr/bin/git", ["cat-file", "-e", `${head}:npm/agentplugins/scripts/stage-authoring-npm.js`], { cwd: REPO });
     if (tracked.status !== 0) assert.throws(() => packing.blobs(REPO, head, context.env, "public"), /missing|differs/);
+    else if (mainDiffersFromHead(head)) assert.throws(() => packing.blobs(REPO, head, context.env, "public"),
+      { message: "executing stager differs from committed source: scripts/stage-authoring-npm.js" });
     else assert.deepEqual(Object.keys(packing.blobs(REPO, head, context.env, "public")).sort(), [...stager.ALLOWLIST].sort());
     assert.throws(() => packing.blobs(REPO, "0".repeat(40), context.env, "public"), /HEAD/);
     assert.throws(() => packing.blobs(REPO, head, context.env, "arbitrary"), /fixed/);

--- a/npm/agentplugins/test/public-authoring-pack.test.js
+++ b/npm/agentplugins/test/public-authoring-pack.test.js
@@ -1,0 +1,167 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
+const cp = require("node:child_process");
+const test = require("node:test");
+const c = require("../scripts/dual-authoring-candidate");
+const packing = require("../scripts/stage-dual-authoring-npm");
+const stager = require("../scripts/stage-authoring-npm");
+const { fixture, REPO } = require("./public-authoring.test");
+const NODE = process.execPath;
+const NPM = path.resolve(path.dirname(NODE), "../lib/node_modules/npm/bin/npm-cli.js");
+
+// External, transport-only preload. Runtime/metadata/cache/bin modules remain
+// the real packed code. The native child cannot inherit this preload.
+function preload(file, bodies, log, offline = false) {
+  fs.writeFileSync(file, `"use strict";
+const fs = require("node:fs"), https = require("node:https");
+const { EventEmitter } = require("node:events");
+const { PassThrough } = require("node:stream");
+const bodies = ${JSON.stringify(Object.fromEntries(Object.entries(bodies).map(([n, b]) => [n, b.toString("base64")]))) };
+https.get = options => {
+  const req = new EventEmitter();
+  req.setTimeout = () => req;
+  req.destroy = e => req.emit("error", e);
+  process.nextTick(() => {
+    const url = "https://" + options.hostname + options.path;
+    fs.appendFileSync(${JSON.stringify(log)}, url + "\\n");
+    if (${offline} || options.hostname !== "github.com" || !bodies[url]) return req.emit("error", new Error("fixture denied transport"));
+    const res = new PassThrough(); res.statusCode = 200; res.headers = {};
+    req.emit("response", res); res.end(Buffer.from(bodies[url], "base64"));
+  }); return req;
+};
+`);
+}
+function run(exe, args, env, cwd) {
+  return cp.spawnSync(exe, args, { env, cwd, encoding: "utf8", timeout: 30000, maxBuffer: 8 * 1024 * 1024 });
+}
+function ok(result) { assert.equal(result.status, 0, result.stderr || result.stdout); return result.stdout; }
+function packageBytes(root) {
+  const files = {};
+  function walk(dir) {
+    for (const name of fs.readdirSync(dir)) {
+      const file = path.join(dir, name), relative = path.relative(root, file);
+      if (fs.lstatSync(file).isDirectory()) walk(file);
+      else files[relative] = fs.readFileSync(file);
+    }
+  }
+  walk(root); return files;
+}
+function environment(context, prefix, home) {
+  fs.mkdirSync(home, { recursive: true, mode: 0o700 });
+  return { ...context.env, HOME: home, USERPROFILE: home, PATH: `${path.dirname(NODE)}:/usr/local/bin:/usr/bin:/bin`,
+    npm_config_prefix: prefix };
+}
+
+if (require.main === module) {
+  test("both real public packs install independently and together; public bins and kit postinstall use shared acquisition", () => {
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), "public pack ü "));
+    const context = packing.npmContext(parent);
+    context.env.PATH = `${path.dirname(NODE)}:/usr/local/bin:/usr/bin:/bin`;
+    const fixtures = {}, packs = {}, bodies = {};
+    for (const p of c.PRODUCTS) {
+      const f = fixtures[p] = fixture(p, (product, target) => Buffer.from(`#!${NODE}\n// ${product} ${target}\n` +
+        'if (process.argv[2] === "signal") process.kill(process.pid, "SIGTERM");\n' +
+        'else if (process.argv[2] === "exit") process.exit(23);\n' +
+        'else console.log(JSON.stringify({argv:process.argv.slice(2),cwd:process.cwd(),preload:process.env.NODE_OPTIONS||null,proof:process.env.AGENTPLUGINS_INTERNAL_PROOF_BINARY||null}));\n'), parent);
+      f.qualify();
+      const files = packageBytes(f.packageRoot);
+      const result = packing.packPackage(p, files, f.packageRoot, { node: NODE, npm: NPM, output: parent, identity: f.identity },
+        { ...context, root: fs.mkdtempSync(path.join(parent, "verify-")) });
+      packs[p] = path.join(parent, result.file);
+      for (const [n, b] of Object.entries(f.bodies)) bodies[`https://github.com/${c.REPOSITORY}/releases/download/${f.manifest.tag}/${n}`] = b;
+    }
+    for (const n of stager.COMMON) assert.deepEqual(fs.readFileSync(path.join(fixtures.agentplugins.packageRoot, n)), fs.readFileSync(path.join(fixtures["plugin-kit-ai"].packageRoot, n)));
+    const loader = path.join(parent, "transport.cjs"), log = path.join(parent, "transport.log");
+    preload(loader, bodies, log);
+    const prefixes = [path.join(parent, "agent only"), path.join(parent, "kit only"), path.join(parent, "shared ü")];
+    for (const [i, prefix] of prefixes.entries()) {
+      const products = i === 0 ? ["agentplugins"] : i === 1 ? ["plugin-kit-ai"] : c.PRODUCTS;
+      const home = path.join(parent, `home-${i}`), project = path.join(parent, `project-${i}`);
+      fs.mkdirSync(project); fs.writeFileSync(path.join(project, "unchanged"), "sentinel");
+      const env = environment(context, prefix, home);
+      for (const p of products) ok(run(NODE, [NPM, "install", "--global", "--prefix", prefix, "--offline", "--ignore-scripts", "--no-audit", "--no-fund", packs[p]], env, project));
+      const childEnv = { ...env, NODE_OPTIONS: `--require=${JSON.stringify(loader)}`, AGENTPLUGINS_INTERNAL_PROOF_BINARY: "/nonexistent", PLUGIN_KIT_AI_VERSION: "v9.0.0" };
+      for (const p of products) {
+        const installed = path.join(prefix, "lib/node_modules", p === "agentplugins" ? "universal-agent-plugins" : p);
+        if (p === "plugin-kit-ai") {
+          const post = run(NODE, [path.join(installed, "lib/install.js")], childEnv, project);
+          assert.equal(ok(post), "", "postinstall shared path is quiet");
+        }
+        const bin = path.join(installed, `bin/${p}.js`), args = ["space arg", "ü", "$(touch forbidden)", "a;b", "--format", "json"];
+        const result = JSON.parse(ok(run(NODE, [bin, ...args], childEnv, project)));
+        assert.deepEqual(result, { argv: args, cwd: project, preload: null, proof: null });
+        assert.equal(run(NODE, [bin, "exit"], childEnv, project).status, 23);
+        assert.equal(run(NODE, [bin, "signal"], childEnv, project).signal, "SIGTERM");
+        // Exercise npm's actual installed shim too, not just a source bin.
+        assert.deepEqual(JSON.parse(ok(run(path.join(prefix, "bin", p), args, childEnv, project))).argv, args);
+      }
+      const lines = fs.readFileSync(log, "utf8").trim().split("\n");
+      for (const line of lines) assert.ok(bodies[line]);
+      const offlineLoader = path.join(parent, `offline-${i}.cjs`); preload(offlineLoader, {}, log, true);
+      for (const p of products) ok(run(path.join(prefix, "bin", p), ["warm"], { ...childEnv, NODE_OPTIONS: `--require=${JSON.stringify(offlineLoader)}` }, project));
+      assert.equal(fs.readFileSync(path.join(project, "unchanged"), "utf8"), "sentinel");
+      assert.deepEqual(fs.readdirSync(project), ["unchanged"]);
+      if (i === 2) {
+        const before = fs.readFileSync(path.join(prefix, "bin/plugin-kit-ai"));
+        ok(run(NODE, [NPM, "uninstall", "--global", "--prefix", prefix, "--offline", "--ignore-scripts", "universal-agent-plugins"], env, project));
+        assert.deepEqual(fs.readFileSync(path.join(prefix, "bin/plugin-kit-ai")), before);
+        ok(run(path.join(prefix, "bin/plugin-kit-ai"), ["peer"], { ...childEnv, NODE_OPTIONS: `--require=${JSON.stringify(offlineLoader)}` }, project));
+        ok(run(NODE, [NPM, "install", "--global", "--prefix", prefix, "--offline", "--ignore-scripts", packs.agentplugins], env, project));
+        ok(run(path.join(prefix, "bin/agentplugins"), ["reinstalled"], { ...childEnv, NODE_OPTIONS: `--require=${JSON.stringify(offlineLoader)}` }, project));
+      }
+    }
+  });
+  test("actual public bins reject preparation, unsupported versions and legacy v2 override before effects", () => {
+    for (const p of c.PRODUCTS) {
+      const f = fixture(p);
+      const env = { PATH: `${path.dirname(NODE)}:/usr/local/bin:/usr/bin:/bin`, HOME: f.root,
+        UAP_PUBLIC_AUTHORING_VERIFIED: "true", PLUGIN_KIT_AI_VERSION: "v1.2.4" };
+      const result = run(NODE, [path.join(f.packageRoot, `bin/${p}.js`), "--verified", "--format", "json"], env, f.root);
+      assert.equal(result.status, 1); assert.equal(result.stdout, ""); assert.match(result.stderr, /not qualified/);
+      assert.equal(result.stderr.includes("Fallbacks:"), false);
+      assert.equal(fs.existsSync(path.join(f.root, ".cache")), false);
+      if (p === "plugin-kit-ai") {
+        fs.unlinkSync(path.join(f.packageRoot, "public-release.json"));
+        assert.match(run(NODE, [path.join(f.packageRoot, "lib/install.js")], env, f.root).stderr, /requires public-release/);
+        const pkgFile = path.join(f.packageRoot, "package.json"), pkg = JSON.parse(fs.readFileSync(pkgFile));
+        pkg.version = "1.2.4"; fs.writeFileSync(pkgFile, c.encode(pkg));
+        assert.match(run(NODE, [path.join(f.packageRoot, "lib/install.js")], { ...env, PLUGIN_KIT_AI_VERSION: "v2.0.0" }, f.root).stderr, /legacy wrapper cannot/);
+      }
+    }
+  });
+  test("public preparation cannot accept a CLI qualification boolean or substitute working source blobs", () => {
+    assert.throws(() => stager.prepare({ verified: true }), /unexpected or missing fields/);
+    const head = cp.execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: REPO, encoding: "utf8" }).trim();
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "public blob-"));
+    const context = packing.npmContext(root);
+    // This gate is deliberately postcommit-sensitive. On a committed successor
+    // the real closure loads; in the writer's dirty tree it must fail closed.
+    const tracked = cp.spawnSync("/usr/bin/git", ["cat-file", "-e", `${head}:npm/agentplugins/scripts/stage-authoring-npm.js`], { cwd: REPO });
+    if (tracked.status !== 0) assert.throws(() => packing.blobs(REPO, head, context.env, "public"), /missing|differs/);
+    else assert.deepEqual(Object.keys(packing.blobs(REPO, head, context.env, "public")).sort(), [...stager.ALLOWLIST].sort());
+    assert.throws(() => packing.blobs(REPO, "0".repeat(40), context.env, "public"), /HEAD/);
+    assert.throws(() => packing.blobs(REPO, head, context.env, "arbitrary"), /fixed/);
+  });
+}
+module.exports = { preload, run, ok, packageBytes, environment };
+
+if (require.main === module) test("shared completion helper preserves a collision and rolls back an uncertain marker", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "public completion-"));
+  fs.writeFileSync(path.join(root, "completion.json"), "unrelated");
+  assert.throws(() => packing.completeRecord(root, { fixture: true }), /EEXIST/);
+  assert.equal(fs.readFileSync(path.join(root, "completion.json"), "utf8"), "unrelated");
+  const second = fs.mkdtempSync(path.join(os.tmpdir(), "public completion-"));
+  const unlink = fs.unlinkSync;
+  fs.unlinkSync = file => {
+    if (file === path.join(second, "completion.pending.json")) throw new Error("injected marker cleanup failure");
+    return unlink(file);
+  };
+  try { assert.throws(() => packing.completeRecord(second, { fixture: true }), /marker cleanup failure/); }
+  finally { fs.unlinkSync = unlink; }
+  assert.equal(fs.existsSync(path.join(second, "completion.json")), false);
+  assert.equal(fs.readFileSync(path.join(second, "completion.pending.json"), "utf8"), c.encode({ fixture: true }).toString());
+});

--- a/npm/agentplugins/test/public-authoring.test.js
+++ b/npm/agentplugins/test/public-authoring.test.js
@@ -1,0 +1,266 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const { EventEmitter } = require("node:events");
+const { PassThrough } = require("node:stream");
+const test = require("node:test");
+const c = require("../scripts/dual-authoring-candidate");
+const publicAPI = require("../lib/public-authoring");
+const stager = require("../scripts/stage-authoring-npm");
+const v = require("../lib/verifier");
+const REPO = path.resolve(__dirname, "../../..");
+
+// Synthetic package binding only. This fixture does not claim signed promotion,
+// current qualification, or bytes built from this writer's uncommitted source.
+function fixture(product, binaryFor = (p, t) => Buffer.from(`fixture ${p} ${t}\n`), parent = os.tmpdir()) {
+  const root = fs.mkdtempSync(path.join(parent, "public fixture ü "));
+  const packageRoot = path.join(root, product), cacheRoot = path.join(root, "cache");
+  fs.mkdirSync(packageRoot, { mode: 0o700 });
+  fs.mkdirSync(cacheRoot, { mode: 0o700 });
+  const identity = { repository: c.REPOSITORY, commit: "1".repeat(40), engine_revision: "1".repeat(40),
+    versions: { agentplugins: "0.1.99", "plugin-kit-ai": "2.0.0" } };
+  const candidate = { identity, manifestDigest: "2".repeat(64) };
+  const assets = {}, bodies = {};
+  for (const t of c.TARGETS) {
+    const binary = binaryFor(product, t), name = c.executableName(product, t);
+    const body = product === "plugin-kit-ai" ? c.archive(binary, name) : binary;
+    const file = c.assetName(product, identity.versions[product], t);
+    assets[t] = { file, ...c.metadata(body), binary: { file: name, ...c.metadata(binary) } };
+    bodies[file] = body;
+  }
+  const manifest = { schema_version: 3, status: "CANDIDATE", product, repository: c.REPOSITORY,
+    tag: product === "agentplugins" ? "agentplugins-v0.1.99" : "v2.0.0", version: identity.versions[product],
+    commit: identity.commit, engine_revision: identity.engine_revision, versions: identity.versions,
+    candidate_sha256: candidate.manifestDigest, authoring_mode: publicAPI.MODE, asset_scope: publicAPI.SCOPE,
+    assets, release_eligible: false, platform_acceptance: false, attested: false };
+  const source = Object.fromEntries(stager.ALLOWLIST.map(n => [n, { bytes: fs.readFileSync(path.join(REPO, n)) }]));
+  const files = stager.packageFiles(product, source, c.encode(manifest), candidate);
+  for (const [n, bytes] of Object.entries(files)) {
+    const file = path.join(packageRoot, n);
+    fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(file, bytes, { mode: n.startsWith("bin/") && n.endsWith(".js") ? 0o755 : 0o644 });
+  }
+  const descriptor = JSON.parse(files["public-release.json"]);
+  const qualify = () => {
+    descriptor.qualification = { identity, candidate_sha256: candidate.manifestDigest,
+      manifest_sha256: { agentplugins: "3".repeat(64), "plugin-kit-ai": "4".repeat(64), [product]: c.digest(c.encode(manifest)) },
+      signed_subject: { sha256: "5".repeat(64), workflow: `${c.REPOSITORY}/.github/workflows/fixture-only.yml`, source: identity.commit } };
+    save();
+  };
+  const save = () => {
+    fs.writeFileSync(path.join(packageRoot, "public-release.json"), c.encode(descriptor));
+    fs.writeFileSync(path.join(packageRoot, "release-manifest.json"), c.encode(manifest));
+  };
+  return { root, packageRoot, cacheRoot, descriptor, manifest, bodies, files, identity, qualify, save };
+}
+function transport(f, seen = [], alter = res => res) {
+  return (url, options) => {
+    seen.push(url.toString());
+    assert.deepEqual(Object.keys(options.headers).sort(), ["Accept", "User-Agent"]);
+    assert.equal(url.hostname, "github.com");
+    assert.equal(url.pathname, `/${c.REPOSITORY}/releases/download/${f.manifest.tag}/${path.basename(url.pathname)}`);
+    const req = new EventEmitter();
+    req.destroy = e => req.emit("error", e);
+    req.setTimeout = (ms, fn) => { assert.equal(ms, 30000); req.timeout = fn; };
+    process.nextTick(() => {
+      const res = new PassThrough(); res.statusCode = 200; res.headers = {};
+      const body = f.bodies[path.basename(url.pathname)];
+      assert.ok(body, "selected product only");
+      alter(res, req, body);
+      if (!req.done) { req.emit("response", res); res.end(body); }
+    });
+    return req;
+  };
+}
+function options(f, extra = {}) { return { packageRoot: f.packageRoot, cacheRoot: f.cacheRoot, request: transport(f), ...extra }; }
+const target = `${process.platform === "win32" ? "windows" : process.platform}-${process.arch === "x64" ? "amd64" : process.arch}`;
+
+if (require.main === module) {
+  for (const p of c.PRODUCTS) {
+    test(`${p}: preparation and forged bypass reject before any cache/download effect`, async () => {
+      const f = fixture(p);
+      const before = fs.readdirSync(f.cacheRoot);
+      let requests = 0;
+      process.env.UAP_PUBLIC_AUTHORING_VERIFIED = "true";
+      try {
+        await assert.rejects(publicAPI.ensureBinary(p, options(f, { verified: true, request: () => { requests++; } })), /not qualified/);
+        assert.equal(requests, 0); assert.deepEqual(fs.readdirSync(f.cacheRoot), before);
+      } finally { delete process.env.UAP_PUBLIC_AUTHORING_VERIFIED; }
+    });
+    test(`${p}: cold, offline warm, corrupt recovery and isolation`, async () => {
+      const f = fixture(p); f.qualify(); const seen = [];
+      const cold = await publicAPI.ensureBinary(p, options(f, { request: transport(f, seen) }));
+      assert.equal(cold.cacheHit, false); assert.equal(seen.length, 1);
+      assert.ok(cold.binaryPath.includes(`/public-authoring-v1/${publicAPI.MODE}/${f.identity.commit}/`));
+      const warm = await publicAPI.ensureBinary(p, options(f, { request: () => assert.fail("warm network") }));
+      assert.equal(warm.cacheHit, true); assert.equal(warm.binaryPath, cold.binaryPath);
+      assert.equal(fs.statSync(cold.binaryPath).mode & 0o777, 0o755);
+      fs.writeFileSync(cold.binaryPath, "corrupt");
+      assert.equal((await publicAPI.ensureBinary(p, options(f))).cacheHit, false);
+      assert.equal(c.digest(fs.readFileSync(cold.binaryPath)), f.manifest.assets[target].binary.sha256);
+      f.descriptor.qualification = null; f.save();
+      await assert.rejects(publicAPI.ensureBinary(p, options(f)), /not qualified/);
+      assert.deepEqual(fs.readdirSync(path.join(f.cacheRoot, "public-authoring-v1")).sort(), [".locks", publicAPI.MODE].sort());
+    });
+    const mutations = [
+      ["product", f => { f.descriptor.product = "peer"; }],
+      ["npm", f => { f.descriptor.npm_package = "peer"; }],
+      ["repo", f => { f.descriptor.identity.repository = "owner/other"; }],
+      ["zero source", f => { f.descriptor.identity.commit = "0".repeat(40); }],
+      ["engine", f => { f.manifest.engine_revision = "a".repeat(40); }],
+      ["peer version", f => { f.manifest.versions = { ...f.manifest.versions, [p === "agentplugins" ? "plugin-kit-ai" : "agentplugins"]: "9.0.0" }; }],
+      ["tag", f => { f.manifest.tag = "latest"; }],
+      ["mode", f => { f.manifest.authoring_mode = "vertical-slice-v1"; }],
+      ["scope", f => { f.manifest.asset_scope = "linux-amd64-pair"; }],
+      ["claim", f => { f.manifest.attested = true; }],
+      ["status", f => { f.manifest.status = "RELEASE"; }],
+      ["missing target", f => { delete f.manifest.assets["windows-arm64"]; }],
+      ["unsafe name", f => { f.manifest.assets[target].file = "../binary"; }],
+      ["unsafe inner name", f => { f.manifest.assets[target].binary.file = "peer"; }],
+      ["unbounded size", f => { f.manifest.assets[target].size = 2 ** 30; }],
+      ["extra field", f => { f.manifest.extra = true; }],
+      ["stale proof", f => { f.descriptor.qualification.signed_subject.source = "a".repeat(40); }],
+      ["forged proof", f => { f.descriptor.qualification = true; }],
+      ["missing proof", f => { delete f.descriptor.qualification; }],
+      ["wrong subject", f => { f.descriptor.qualification.signed_subject.sha256 = "bad"; }]
+    ];
+    for (const [label, mutate] of mutations) test(`${p}: ${label} rejects warm and cold`, async () => {
+      for (const warm of [false, true]) {
+        const f = fixture(p); f.qualify();
+        if (warm) await publicAPI.ensureBinary(p, options(f));
+        mutate(f);
+        // Recomputing the descriptor's manifest digest cannot repair a stale
+        // independently bound proof or invalid producer metadata.
+        f.descriptor.release_manifest_sha256 = c.digest(c.encode(f.manifest)); f.save();
+        await assert.rejects(publicAPI.ensureBinary(p, options(f, { request: () => assert.fail("invalid metadata downloaded") })));
+      }
+    });
+    test(`${p}: canonical JSON, package binding and unsafe metadata files`, async () => {
+      for (const name of ["public-release.json", "release-manifest.json", "package.json"]) {
+        for (const change of [b => Buffer.from(b.toString().replace("{", '{"duplicate":1,"duplicate":2,')),
+          b => Buffer.concat([b, Buffer.from([0xff])]), b => Buffer.from(b.toString().trim())]) {
+          const f = fixture(p); f.qualify(); const file = path.join(f.packageRoot, name);
+          fs.writeFileSync(file, change(fs.readFileSync(file)));
+          await assert.rejects(publicAPI.ensureBinary(p, options(f)));
+        }
+      }
+      for (const field of ["name", "bin", "version", "engines", "scripts"]) {
+        const f = fixture(p); f.qualify(); const file = path.join(f.packageRoot, "package.json");
+        const pkg = JSON.parse(fs.readFileSync(file)); pkg[field] = "invalid"; fs.writeFileSync(file, c.encode(pkg));
+        await assert.rejects(publicAPI.ensureBinary(p, options(f)));
+      }
+    });
+    test(`${p}: strict cache aliases, parents, overlap and finite lock wait`, async () => {
+      for (const alias of ["symlink", "hardlink", "directory"]) {
+        const f = fixture(p); f.qualify(); const resolved = await publicAPI.ensureBinary(p, options(f));
+        const backup = path.join(f.root, "unrelated"); fs.renameSync(resolved.binaryPath, backup);
+        if (alias === "symlink") fs.symlinkSync(backup, resolved.binaryPath);
+        if (alias === "hardlink") fs.linkSync(backup, resolved.binaryPath);
+        if (alias === "directory") fs.mkdirSync(resolved.binaryPath);
+        await assert.rejects(publicAPI.ensureBinary(p, options(f)), /unsafe/);
+        assert.equal(c.digest(fs.readFileSync(backup)), f.manifest.assets[target].binary.sha256);
+      }
+      const f = fixture(p); f.qualify();
+      await assert.rejects(publicAPI.ensureBinary(p, options(f, { cacheRoot: f.packageRoot })), /overlaps/);
+      const alias = path.join(f.root, "alias"); fs.symlinkSync(f.cacheRoot, alias);
+      await assert.rejects(publicAPI.ensureBinary(p, options(f, { cacheRoot: alias })), /safe ancestors/);
+      const cold = await publicAPI.ensureBinary(p, options(f));
+      const lockRoot = path.join(f.cacheRoot, "public-authoring-v1", ".locks");
+      const unlock = await v.acquireLock(cold.binaryPath, { lockRoot });
+      try { await assert.rejects(publicAPI.ensureBinary(p, options(f, { lockOptions: { timeoutMs: 2, pollMs: 1 } })), /timed out/); }
+      finally { await unlock(); }
+      fs.chmodSync(path.dirname(cold.binaryPath), 0o755);
+      await assert.rejects(publicAPI.ensureBinary(p, options(f)), /mode-0700/);
+    });
+    test(`${p}: concurrent cold callers serialize one download and cancellation is effect-free`, async () => {
+      const f = fixture(p); f.qualify(); const seen = [];
+      const results = await Promise.all([1, 2, 3].map(() => publicAPI.ensureBinary(p, options(f, { request: transport(f, seen) }))));
+      assert.equal(seen.length, 1); assert.equal(results.filter(r => !r.cacheHit).length, 1);
+      const controller = new AbortController(); controller.abort();
+      await assert.rejects(publicAPI.ensureBinary(p, options(f, { signal: controller.signal })), /cancelled/);
+      await assert.rejects(publicAPI.ensureBinary(p, options(f, { arch: "mips" })), /arch/);
+      await assert.rejects(publicAPI.ensureBinary(p, options(f, { target: "unrecognized" })), /target/);
+    });
+    test(`${p}: real downloader faults never publish or leave operation files`, async () => {
+      for (const kind of ["digest", "overflow", "truncated", "redirect", "timeout"]) {
+        const f = fixture(p); f.qualify();
+        const request = transport(f, [], (res, req, body) => {
+          req.done = true;
+          if (kind === "timeout") return req.timeout();
+          if (kind === "redirect") { res.statusCode = 302; res.headers.location = "https://unapproved.invalid/binary"; }
+          req.emit("response", res);
+          res.end(kind === "digest" ? Buffer.alloc(body.length) : kind === "overflow" ? Buffer.concat([body, body]) : body.subarray(1));
+        });
+        await assert.rejects(publicAPI.ensureBinary(p, options(f, { request })));
+        const namespace = path.join(f.cacheRoot, "public-authoring-v1");
+        assert.equal(fs.readdirSync(namespace).some(n => n.startsWith(".download-")), false);
+        assert.deepEqual(fs.readdirSync(path.join(namespace, ".locks")), []);
+      }
+    });
+  }
+  test("kit outer-valid inner-invalid archive fails without cache publication", async () => {
+    for (const unsafe of [false, true]) {
+      const f = fixture("plugin-kit-ai");
+      const a = f.manifest.assets[target];
+      const body = unsafe ? Buffer.from("not gzip") : c.archive(Buffer.from("wrong inner bytes"), a.binary.file);
+      Object.assign(a, c.metadata(body)); f.bodies[a.file] = body;
+      f.descriptor.release_manifest_sha256 = c.digest(c.encode(f.manifest)); f.qualify();
+      await assert.rejects(publicAPI.ensureBinary("plugin-kit-ai", options(f)));
+    }
+  });
+  test("cleanup and rename failure surface uncertainty; previous bytes survive", async () => {
+    const f = fixture("agentplugins"); f.qualify();
+    const cold = await publicAPI.ensureBinary("agentplugins", options(f)); fs.writeFileSync(cold.binaryPath, "old");
+    const io = { ...fsp, rename: async (a, b) => {
+      if (path.basename(a).startsWith(".agentplugins-staging-")) throw new Error("injected publication failure");
+      return fsp.rename(a, b);
+    } };
+    await assert.rejects(publicAPI.ensureBinary("agentplugins", options(f, { io })), /publication failure/);
+    assert.equal(fs.readFileSync(cold.binaryPath, "utf8"), "old");
+    const cleanup = { ...fsp, unlink: async file => {
+      if (path.basename(file) === "asset") throw new Error("injected cleanup failure");
+      return fsp.unlink(file);
+    } };
+    await assert.rejects(publicAPI.ensureBinary("agentplugins", options(f, { io: cleanup })), /cleanup\/rollback uncertainty/);
+  });
+  test("new child environment strips private/test controls and retains ordinary user argv environment", () => {
+    const env = publicAPI.childEnvironment({ NODE_OPTIONS: "preload", AGENTPLUGINS_INTERNAL_PROOF_BINARY: "private",
+      UAP_PUBLIC_AUTHORING_NATIVE_CONFIG: "fixture", PLUGIN_KIT_AI_VERSION: "v9", KEEP: "yes" });
+    assert.deepEqual(env, { KEEP: "yes" });
+  });
+}
+module.exports = { fixture, transport, options, target, REPO };
+
+if (require.main === module) {
+  test("public acquisition detects parent replacement during download and preserves unrelated data", async () => {
+    const f = fixture("agentplugins"); f.qualify();
+    const release = publicAPI.loadRelease("agentplugins", f.packageRoot, target);
+    const parent = path.dirname(publicAPI.cachePath(f.cacheRoot, "agentplugins", target, release));
+    const request = transport(f, [], () => {
+      fs.renameSync(parent, parent + "-retained"); fs.mkdirSync(parent, { mode: 0o700 });
+      fs.writeFileSync(path.join(parent, "unrelated"), "preserved");
+    });
+    await assert.rejects(publicAPI.ensureBinary("agentplugins", options(f, { request })), /directory replaced/);
+    assert.equal(fs.readFileSync(path.join(parent, "unrelated"), "utf8"), "preserved");
+  });
+  test("canonical kit archive rejects traversal, links, extra members and oversized expansion", async () => {
+    const zlib = require("node:zlib");
+    for (const kind of ["traversal", "symlink", "hardlink", "extra", "padding", "bomb"]) {
+      const f = fixture("plugin-kit-ai"); const a = f.manifest.assets[target];
+      let tar = zlib.gunzipSync(f.bodies[a.file]);
+      if (kind === "traversal") tar.write("../plugin-kit-ai\0", 0);
+      if (kind === "symlink") tar[156] = 50;
+      if (kind === "hardlink") tar[156] = 49;
+      if (kind === "extra") tar = Buffer.concat([tar, tar]);
+      if (kind === "padding") tar[tar.length - 1] = 1;
+      if (kind === "bomb") tar.write("77777777777\0", 124);
+      const body = zlib.gzipSync(tar); Object.assign(a, c.metadata(body)); f.bodies[a.file] = body;
+      f.descriptor.release_manifest_sha256 = c.digest(c.encode(f.manifest)); f.qualify();
+      await assert.rejects(publicAPI.ensureBinary("plugin-kit-ai", options(f)));
+    }
+  });
+}

--- a/npm/agentplugins/test/verifier.test.js
+++ b/npm/agentplugins/test/verifier.test.js
@@ -158,3 +158,27 @@ test("hash and original facade cache helpers remain canonical", async () => {
   fs.unlinkSync(file); assert.equal(await v.validCachedBinary(file, PIN.sha256), false);
   assert.equal(typeof fsp.open, "function");
 });
+
+test("download owner receives opened inode on partial failure, and cancellation closes output", async () => {
+  const file = destination(), controller = new AbortController();
+  let opened;
+  await assert.rejects(v.downloadFile(URL, file, PIN, {
+    signal: controller.signal,
+    onOpen: stat => { opened = stat; controller.abort(); },
+    request: transport((res, req) => { req.emit("response", res); res.write(BODY.subarray(0, 2)); })
+  }), /cancelled/);
+  assert.ok(opened);
+  const named = fs.lstatSync(file);
+  assert.equal(named.ino, opened.ino); assert.equal(named.dev, opened.dev);
+  fs.unlinkSync(file); assert.equal(fs.existsSync(file), false);
+});
+
+test("download open observer failure settles after close without hiding its owned inode", async () => {
+  const file = destination(); let opened;
+  await assert.rejects(v.downloadFile(URL, file, PIN, {
+    onOpen: stat => { opened = stat; throw new Error("injected owner observation failure"); },
+    request: transport((res, req) => { req.emit("response", res); res.end(BODY); })
+  }), /owner observation failure/);
+  assert.equal(fs.lstatSync(file).ino, opened.ino);
+  fs.unlinkSync(file);
+});

--- a/npm/agentplugins/test/verifier.test.js
+++ b/npm/agentplugins/test/verifier.test.js
@@ -182,3 +182,83 @@ test("download open observer failure settles after close without hiding its owne
   assert.equal(fs.lstatSync(file).ino, opened.ino);
   fs.unlinkSync(file);
 });
+
+for (const scenario of [
+  { redirects: 1, cancel: true },
+  { redirects: 3, cancel: true },
+  { redirects: 3, cancel: true, oldError: true },
+  { redirects: 3, cancel: false, oldError: true }
+]) {
+  test(`redirect chain closes before settlement ${JSON.stringify(scenario)}`, async t => {
+    const file = destination(), controller = new AbortController();
+    const requests = [], responses = [], sockets = [], events = [];
+    let output, opened;
+    const create = fs.createWriteStream;
+    t.mock.method(fs, "createWriteStream", (...args) => {
+      output = create(...args);
+      output.once("close", () => events.push("close"));
+      return output;
+    });
+    const request = (url, options) => {
+      assert.deepEqual(Object.keys(options.headers).sort(), ["Accept", "User-Agent"]);
+      assert.equal(url.hostname, requests.length ? "release-assets.githubusercontent.com" : "github.com");
+      const number = requests.length;
+      let sent = false;
+      const socket = new Duplex({
+        read() {},
+        write(chunk, encoding, callback) {
+          callback();
+          if (sent) return;
+          sent = true;
+          process.nextTick(() => this.push(Buffer.from(number < scenario.redirects
+            ? "HTTP/1.1 302 Found\r\nLocation: https://release-assets.githubusercontent.com/binary\r\nContent-Length: 100\r\nConnection: close\r\n\r\nx"
+            : `HTTP/1.1 200 OK\r\nContent-Length: ${BODY.length}\r\nConnection: close\r\n\r\n${BODY.subarray(0, 1)}`)));
+        }
+      });
+      socket.setTimeout = () => socket;
+      sockets.push(socket);
+      const req = http.get({ hostname: "fixture.invalid", headers: options.headers,
+        createConnection: () => socket });
+      req.once("response", res => responses.push(res));
+      req.on("error", () => events.push(`request-error-${number}`));
+      requests.push(req);
+      return req;
+    };
+    try {
+      const download = v.downloadFile(URL, file, PIN, {
+        request, signal: controller.signal,
+        onOpen: stat => {
+          opened = stat;
+          events.push("open");
+          if (scenario.oldError) requests[0].destroy(new Error("superseded request failed"));
+          // Let the real old ClientRequest error fire while its descendant is open.
+          setImmediate(() => {
+            if (scenario.cancel) controller.abort();
+            else { sockets.at(-1).push(BODY.subarray(1)); sockets.at(-1).push(null); }
+          });
+        }
+      }).then(() => {
+        events.push("resolved");
+        assert.equal(output.closed, true, "output must close before resolution");
+      }, error => {
+        events.push("rejected");
+        assert.equal(output.closed, true, "output must close before rejection");
+        throw error;
+      });
+      if (scenario.cancel) await assert.rejects(download, /cancelled/);
+      else { await download; assert.deepEqual(fs.readFileSync(file), BODY); }
+      assert.equal(requests.length, scenario.redirects + 1);
+      assert.equal(responses.length, requests.length);
+      for (const res of responses.slice(0, -1)) assert.equal(res.complete, false);
+      if (scenario.oldError) assert.ok(events.includes("request-error-0"));
+      assert.ok(events.indexOf("close") < events.indexOf(scenario.cancel ? "rejected" : "resolved"));
+      const named = fs.lstatSync(file);
+      assert.equal(named.ino, opened.ino); assert.equal(named.dev, opened.dev);
+    } finally {
+      controller.abort();
+      for (const req of requests) req.destroy();
+      if (output && !output.closed) await new Promise(resolve => output.once("close", resolve));
+      if (fs.existsSync(file)) fs.unlinkSync(file);
+    }
+  });
+}

--- a/npm/plugin-kit-ai/bin/plugin-kit-ai.js
+++ b/npm/plugin-kit-ai/bin/plugin-kit-ai.js
@@ -17,7 +17,8 @@ async function main() {
   }
 
   const child = spawn(installResult.installedBinary, process.argv.slice(2), {
-    stdio: "inherit"
+    stdio: "inherit",
+    env: installResult.publicAuthoring ? require("../lib/public-authoring").childEnvironment() : process.env
   });
   child.on("error", (err) => {
     process.stderr.write(`plugin-kit-ai npm launcher: ${err.message}\n`);

--- a/npm/plugin-kit-ai/lib/install.js
+++ b/npm/plugin-kit-ai/lib/install.js
@@ -167,6 +167,23 @@ function extractBinaryFromTarGz(archiveBuffer, wantedName) {
 
 async function ensureInstalled(options = {}) {
   const packageRoot = options.packageRoot || path.resolve(__dirname, "..");
+  const packageVersion = readPackageVersion(packageRoot);
+  const major = /^(0|[1-9]\d*)\./.exec(packageVersion);
+  let descriptor = false;
+  try { fs.lstatSync(path.join(packageRoot, "public-release.json")); descriptor = true; }
+  catch (error) { if (error.code !== "ENOENT") throw error; }
+  if (descriptor || (major && Number(major[1]) >= 2)) {
+    try {
+      if (packageVersion !== "2.0.0") throw new Error("unsupported public plugin-kit-ai version");
+      if (!descriptor) throw new Error("plugin-kit-ai major 2 requires public-release.json");
+      const result = await require("./public-authoring").ensureBinary("plugin-kit-ai", { ...options, packageRoot });
+      return { ...result, installedBinary: result.binaryPath };
+    } catch (error) { error.publicAuthoring = true; throw error; }
+  }
+  const rejectLegacyMajor = tag => {
+    if (/^v?(?:[2-9]|[1-9]\d+)\./.test(tag)) throw new Error("legacy wrapper cannot acquire plugin-kit-ai major 2 or later");
+  };
+  rejectLegacyMajor(normalizeTag(process.env.PLUGIN_KIT_AI_VERSION));
   const repository = process.env.PLUGIN_KIT_AI_REPOSITORY || defaultRepository;
   const apiBase = process.env.GITHUB_API_BASE || "https://api.github.com";
   const releaseBase = deriveReleaseBase(apiBase, process.env.PLUGIN_KIT_AI_RELEASE_BASE_URL);
@@ -175,6 +192,7 @@ async function ensureInstalled(options = {}) {
   if (!tag) {
     tag = await latestTag(apiBase, repository);
   }
+  rejectLegacyMajor(tag);
   const version = tag.replace(/^v/, "");
   const assetName = assetNameForVersion(version, platformInfo);
   const vendorDir = path.join(packageRoot, "vendor", tag);
@@ -220,6 +238,7 @@ async function ensureInstalled(options = {}) {
 }
 
 function formatInstallError(err) {
+  if (err.publicAuthoring) return `plugin-kit-ai npm bootstrap: ${err.message}`;
   return [
     `plugin-kit-ai npm bootstrap: ${err.message}`,
     "Fallbacks:",


### PR DESCRIPTION
The public npm launchers cannot consume the engine-bound dual-authoring release. Add one shared acquisition adapter for both fixed products, strict metadata/cache verification, and exact preparation packs containing the actual public launchers.

Preparation packs remain private and unqualified: ordinary launch rejects before effects. Protected public staging, authenticated native qualification and publishing remain the next slice. Preserve historical v1/v2 behavior, package scripts, Node minima and kit postinstall. Reuse existing verifier, canonical archive parser and private packing primitives.

Stacked on #170 (070663efb27f69ecae8609e6b839f86f843efbb0). Reuses three exact producer files from #196 at 3e3386f45390e9ca0864a638536624dfc969b124; no workflow imports. Current diff: 1,690 changed lines, including 462 exact imported lines and the redirect regression fix.

Validation of writer bytes committed as 635e05673242ca6387fc7cfd45cba39eefc94b65:
- 72 focused verifier/public-runtime/public-pack tests passed, no skips. Local fixture tarballs exercised actual public bins, cold/warm cache, postinstall, signals and peer-preserving uninstall/reinstall using structural executables and transport-only fixtures.
- 27 imported structural producer tests passed; focused Go npm package contract passed.
- All source/artifact hashes and patch checks passed. Independent exact-commit review found one P2: cancellation through an incompletely drained redirect can reject before the active destination closes. Reproduced with the real HTTP parser over an in-memory Duplex, without a network listener. Fixed in f68c25d3a02cdc4745c55b67828cbea0ef46d0c9 and accepted by independent exact-commit review: 76 focused tests passed; four regressions fail against the exact parent and pass on the fix, with two supplemental active-error cases passing. 
- Exact-source f68 E2E built all 12 native assets and verified both projections, then failed the actual public preparation CLI: allowlist is not iterable. Main calls prepare before exporting ALLOWLIST, and the public closure reader observes the partially initialized module. No npm packs were produced and public native execution did not run. Terminal artifact SHA256SUMS verification passed. Fixed by 64cba1d3390f3070ddcf9f4246b75bec1f7e15f5: initialize exports before CLI entry. Independent review accepted both files/all 69 changed lines; matching-commit fresh CLI regression and 62 focused tests passed without skips. Actual preparation/native evidence for this successor remains pending; old f68 artifacts are not relabeled. Node 18 remains unproved.
- Current f68 source-acquisition and polyglot smoke passed on both OS lanes. Native checks remain failing; Linux requires the missing packed-native input. Existing #172 mandatory packed wiring and an explicit public evidence intake are being integrated separately, without dropping required coverage.

Synthetic qualification fixtures prove acquisition/execution behavior only, not signatures or publication readiness. No packages/tags were published. This does not complete Phase 6 or the full authoring plan. Main integration, supported-platform checks and subsequent authenticated publishing gates remain.
