### PR TITLE
docs(installer): connect setup compatibility and support

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ well-formed; it does not prove runtime, OAuth, or activation in every client.
 The CLI prints installed, prepared, activation required, and authentication
 pending as separate outcomes.
 
+See the [client compatibility evidence](https://777genius.github.io/universal-agent-plugins/docs/en/reference/client-compatibility.html)
+for tested client versions, platforms, and release-specific limitations.
+
 For Codex, declared MCP SSE is unsupported; stdio and Streamable HTTP retain
 their existing adapter support. Valid SSE components are excluded from Codex
 delivery without invalidating the package. See [transport evidence and lifecycle

--- a/docs/NATIVE_INSTALL.md
+++ b/docs/NATIVE_INSTALL.md
@@ -96,3 +96,15 @@ The npm facade remains available for users who prefer `npx`:
 ```bash
 npx universal-agent-plugins add context7
 ```
+
+## After installation
+
+If `agentplugins` is not found, add the installation directory to `PATH` as
+printed by the installer, or invoke the binary by its full path. The one-shot
+Unix command above already invokes the installed binary by its full path.
+
+Follow the CLI's activation or sign-in instructions, then start a new agent
+session. Installation does not by itself prove activation or plugin runtime.
+See the [client compatibility evidence](https://777genius.github.io/universal-agent-plugins/docs/en/reference/client-compatibility.html)
+for tested versions and platform limitations, or [installer support](./SUPPORT.md#universal-agent-plugins-installer)
+if you need help.

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,6 +1,20 @@
 # Support And Compatibility Policy
 
-This document defines the approved public contract for `plugin-kit-ai` after the `v1.0.0` release.
+## Universal Agent Plugins installer
+
+For `agentplugins`, start with [native CLI installation](./NATIVE_INSTALL.md)
+and the [client compatibility evidence](https://777genius.github.io/universal-agent-plugins/docs/en/reference/client-compatibility.html).
+The matrix identifies tested installer/client versions and platforms;
+package validity, installation, activation, runtime and OAuth are separate layers.
+
+For help, [open a question or bug report](https://github.com/777genius/universal-agent-plugins/issues/new/choose)
+with your OS/architecture, installer and client versions, the command used, and
+the diagnostic output. Remove secrets and private paths before sharing output.
+Use the [security reporting process](../SECURITY.md) for vulnerabilities.
+
+## Historical plugin-kit-ai v1 policy
+
+The remaining sections define the approved public contract for `plugin-kit-ai` after the `v1.0.0` release.
 
 ## Recommended Production Lanes
 

--- a/website/source/en/guide/quickstart.md
+++ b/website/source/en/guide/quickstart.md
@@ -34,6 +34,8 @@ Compatibility is package-specific. Schema validation does not prove runtime, OAu
 
 [Client compatibility (English)](https://github.com/777genius/universal-agent-plugins#supported-clients)
 
+[Tested client versions and platform limitations](/en/reference/client-compatibility)
+
 ## Build plugins {#build-plugins}
 
 <a id="recommended-default"></a>

--- a/website/source/ru/guide/quickstart.md
+++ b/website/source/ru/guide/quickstart.md
@@ -28,6 +28,8 @@ npx universal-agent-plugins add context7
 
 [Инструкция по установке](https://github.com/777genius/universal-agent-plugins#quick-start)
 
+[Проверенные версии клиентов и ограничения платформ](/ru/reference/client-compatibility)
+
 Версии проверены 2026-09-07: universal-agent-plugins 0.1.53 (npm), plugin-kit-ai 1.2.4 (npm/PyPI), стабильный релиз GitHub agentplugins-v0.1.53.
 
 Совместимость зависит от пакета. Проверка схемы не доказывает работу, OAuth или активацию. Codex не поддерживает заявленный MCP SSE; поддержка stdio и Streamable HTTP сохраняется в существующих адаптерах.


### PR DESCRIPTION
Connects the installer setup flow to released client compatibility evidence and installer-specific help. Adds PATH recovery guidance without changing installation commands, and separates the installer support entry from the preserved historical authoring policy.

Validation: independent hosted Astra review approved exact patch 993d357c; static links and command preservation checked; both public English/Russian compatibility URLs return HTTP 200; git diff --check passes. No installers or native clients executed for documentation validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added links to client compatibility evidence, including tested versions, supported platforms, and release-specific limitations.
  - Expanded native CLI installation guidance with post-installation steps, activation and sign-in instructions, troubleshooting for unavailable commands, and runtime verification notes.
  - Updated support documentation with guidance for the Universal Agent Plugins installer, compatibility resources, and security reporting.
  - Added compatibility references to English and Russian quickstart guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->