### PR TITLE
fix(cli): show actionable add and lifecycle recovery guidance

### DIFF
--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -20,7 +20,15 @@ func newAddCommand(app App, opts *options) *cobra.Command {
 		Use:     "add <name-or-source>",
 		Aliases: []string{"install"},
 		Short:   "Plan and install one Agent Plugins 1.0 package for one or more clients",
-		Args:    cobra.ExactArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.ExactArgs(1)(cmd, args); err != nil {
+				if len(args) == 0 && opts.format != "json" {
+					return fmt.Errorf("%w\nProvide a plugin name or source, for example:\n  agentplugins add ./my-plugin\nSee agentplugins add --help", err)
+				}
+				return err
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateCommonOptions(opts); err != nil {
 				return err
@@ -504,8 +512,16 @@ func renderAddResultErrorWithSecurity(writer io.Writer, format string, envelope 
 			}
 			return renderHumanPlan(writer, envelope, result)
 		}
-		_, err := fmt.Fprintf(writer, "Add: %s\n", failure)
-		return err
+		if _, err := fmt.Fprintf(writer, "Add: %s\n", failure); err != nil {
+			return err
+		}
+		// Lifecycle recovery is useful after a failed phase, but must not imply
+		// that a rolled-back or uncertain transaction left a usable installation.
+		if failure == "activation_failed" || failure == "authentication_failed" || failure == "verification_failed" {
+			_, err := fmt.Fprintf(writer, "Next: %s\n", nextLocalLifecycleAction(result))
+			return err
+		}
+		return nil
 	}
 	if dryRun {
 		return renderHumanPlan(writer, envelope, result)

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_guidance_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_guidance_test.go
@@ -1,0 +1,104 @@
+package agentpluginscli
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/usecase"
+)
+
+func TestAddMissingSourceGuidance(t *testing.T) {
+	for _, terminal := range []bool{false, true} {
+		for _, name := range []string{"add", "install"} {
+			for _, format := range []string{"human", "json"} {
+				var output bytes.Buffer
+				cmd := NewRoot(App{Terminal: terminal, Input: strings.NewReader(""), Output: &output, ErrorOutput: &output})
+				cmd.SetArgs([]string{name, "--format", format})
+				err := cmd.Execute()
+				if err == nil {
+					t.Fatal("missing source accepted")
+				}
+				if format == "json" {
+					if err.Error() != "accepts 1 arg(s), received 0" {
+						t.Fatalf("JSON error changed: %v", err)
+					}
+				} else {
+					for _, want := range []string{"Provide a plugin name or source", "agentplugins add ./my-plugin", "agentplugins add --help"} {
+						if !strings.Contains(err.Error(), want) {
+							t.Fatalf("missing %q: %v", want, err)
+						}
+					}
+				}
+				if output.Len() != 0 {
+					t.Fatalf("argument validation wrote output: %q", output.String())
+				}
+			}
+		}
+	}
+}
+
+func TestAddFailedLifecycleRecoveryGuidance(t *testing.T) {
+	for _, phase := range []string{"activation_failed", "authentication_failed", "verification_failed"} {
+		for _, mutated := range []bool{false, true} {
+			result := usecase.AddResult{Mutated: mutated}
+			result.Activation.LocalActions = []string{"Recover using /private/client/settings, then rerun add."}
+			result.Activation.UserActions = []string{"Recover in the selected client, then rerun add."}
+			switch phase {
+			case "activation_failed":
+				result.Activation.Activation = domain.ActivationFailed
+			case "authentication_failed":
+				result.Activation.Authentication = domain.AuthenticationFailed
+			case "verification_failed":
+				result.Activation.Verification = domain.VerificationFailed
+			}
+			var human, public bytes.Buffer
+			if err := renderAddResult(&human, "human", domain.PackageEnvelope{}, result, false); err != nil {
+				t.Fatal(err)
+			}
+			if human.String() != "Add: "+phase+"\nNext: "+result.Activation.LocalActions[0]+"\n" {
+				t.Fatalf("human result: %q", human.String())
+			}
+			if err := renderAddResult(&public, "json", domain.PackageEnvelope{}, result, false); err != nil {
+				t.Fatal(err)
+			}
+			assertOutputEnvelopeResult(t, public.Bytes(), "add", outputResultFailure)
+			if strings.Contains(public.String(), "/private/") || !strings.Contains(public.String(), result.Activation.UserActions[0]) {
+				t.Fatalf("public recovery contract: %s", public.String())
+			}
+		}
+	}
+}
+
+func TestAddRecoveryDoesNotOverrideTransactionFailures(t *testing.T) {
+	for _, phase := range []usecase.GroupTargetPhase{usecase.GroupTargetManagedRolledBack, usecase.GroupTargetManagedUnknown, usecase.GroupTargetExternalFailed, usecase.GroupTargetExternalPartial} {
+		result := usecase.AddResult{Mutated: true, GroupPhase: phase, Activation: domain.ActivationOutcome{Activation: domain.ActivationFailed, LocalActions: []string{"Enable the prepared plugin."}}}
+		var output bytes.Buffer
+		if err := renderAddResult(&output, "human", domain.PackageEnvelope{}, result, false); err != nil {
+			t.Fatal(err)
+		}
+		if output.String() != "Add: "+string(phase)+"\n" {
+			t.Fatalf("transaction recovery implied usable install: %q", output.String())
+		}
+	}
+}
+
+type recoveryFailWriter struct{ writes int }
+
+func (w *recoveryFailWriter) Write(p []byte) (int, error) {
+	w.writes++
+	if w.writes > 1 {
+		return 0, io.ErrClosedPipe
+	}
+	return len(p), nil
+}
+func TestAddRecoveryPropagatesWriterFailure(t *testing.T) {
+	result := usecase.AddResult{Activation: domain.ActivationOutcome{Activation: domain.ActivationFailed}}
+	err := renderAddResult(&recoveryFailWriter{}, "human", domain.PackageEnvelope{}, result, false)
+	if !errors.Is(err, io.ErrClosedPipe) {
+		t.Fatalf("writer error lost: %v", err)
+	}
+}


### PR DESCRIPTION
Makes `agentplugins add` without a source explain what to provide and show a copyable local-source example. Failed activation, authentication and verification now display the existing recovery action instead of only a failure label.

JSON-mode argument errors, public/private action separation, transaction-failure precedence and exit codes are preserved. No adapter or lifecycle mutation behavior changes.

Validation:
- 48 before/after captures at 80/120 columns, including real main CLI PTY/no-TTY cases and explicitly simulated renderer outcomes. No native clients were launched for this UX test.
- 43 focused test cases passed on hosted Linux; four new regression tests also passed locally.
- Independent hosted Astra review approved exact patch SHA256 20868f91b623e5750aef7785fc18e32c34cd996d4d0e97c7b823af675ca1154a.
- `git diff --check` passes.

Renderer simulations do not establish real provider runtime, OAuth, or cancellation during mutation. No redesign or new dependencies.
