### PR TITLE
fix(release): deliver terminal dependency license notices

### DIFF
--- a/.github/workflows/agentplugins-npm-publish.yml
+++ b/.github/workflows/agentplugins-npm-publish.yml
@@ -58,7 +58,7 @@ jobs:
           git merge-base --is-ancestor "${commit}" refs/remotes/origin/main
           release_json="$(gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" --json isDraft,isPrerelease,tagName,assets)"
           version="${TAG#agentplugins-v}"
-          expected_names="agentplugins_${version}_darwin_amd64 agentplugins_${version}_darwin_arm64 agentplugins_${version}_linux_amd64 agentplugins_${version}_linux_arm64 agentplugins_${version}_windows_amd64.exe agentplugins_${version}_windows_arm64.exe checksums.txt release-manifest.json"
+          expected_names="THIRD_PARTY_NOTICES.txt agentplugins_${version}_darwin_amd64 agentplugins_${version}_darwin_arm64 agentplugins_${version}_linux_amd64 agentplugins_${version}_linux_arm64 agentplugins_${version}_windows_amd64.exe agentplugins_${version}_windows_arm64.exe checksums.txt release-manifest.json"
           actual_names="$(jq -r '.assets[].name' <<<"${release_json}" | sort | tr '\n' ' ' | sed 's/ $//')"
           expected_sorted="$(printf '%s\n' ${expected_names} | sort | tr '\n' ' ' | sed 's/ $//')"
           jq -e --arg tag "${TAG}" '.isDraft == false and .isPrerelease == false and .tagName == $tag' <<<"${release_json}" >/dev/null
@@ -66,7 +66,7 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/release-assets"
           gh release download "${TAG}" --repo "${GITHUB_REPOSITORY}" --dir "${RUNNER_TEMP}/release-assets"
           node npm/agentplugins/scripts/release-assets.js verify "${RUNNER_TEMP}/release-assets" "${TAG}" "${commit}" > "${RUNNER_TEMP}/verified-release.json"
-          for asset in "${RUNNER_TEMP}"/release-assets/agentplugins_* "${RUNNER_TEMP}/release-assets/checksums.txt" "${RUNNER_TEMP}/release-assets/release-manifest.json"; do
+          for asset in "${RUNNER_TEMP}"/release-assets/agentplugins_* "${RUNNER_TEMP}/release-assets/checksums.txt" "${RUNNER_TEMP}/release-assets/release-manifest.json" "${RUNNER_TEMP}/release-assets/THIRD_PARTY_NOTICES.txt"; do
             gh attestation verify "${asset}" --repo "${GITHUB_REPOSITORY}" --signer-workflow "github.com/${GITHUB_REPOSITORY}/.github/workflows/agentplugins-release.yml" --source-digest "${commit}"
           done
       - name: Stage and pack the exact npm facade

--- a/.github/workflows/agentplugins-platform-proof.yml
+++ b/.github/workflows/agentplugins-platform-proof.yml
@@ -202,7 +202,11 @@ jobs:
           fi
           node proof-tools/npm/agentplugins/scripts/release-assets.js verify \
             "${assets}" "${TAG}" "${commit}" "${policy[@]}" > "${RUNNER_TEMP}/verified-release.json"
-          for asset in "${assets}"/agentplugins_* "${assets}/checksums.txt" "${assets}/release-manifest.json"; do
+          attested_assets=("${assets}"/agentplugins_* "${assets}/checksums.txt" "${assets}/release-manifest.json")
+          if [[ -f "${assets}/THIRD_PARTY_NOTICES.txt" ]]; then
+            attested_assets+=("${assets}/THIRD_PARTY_NOTICES.txt")
+          fi
+          for asset in "${attested_assets[@]}"; do
             gh attestation verify "${asset}" \
               --repo "${GITHUB_REPOSITORY}" \
               --signer-workflow "github.com/${GITHUB_REPOSITORY}/.github/workflows/agentplugins-release.yml" \
@@ -244,6 +248,9 @@ jobs:
             mkdir -p "${proof_bundle}/release-assets"
             cp "${assets}"/agentplugins_* "${assets}/checksums.txt" "${assets}/release-manifest.json" \
               "${proof_bundle}/release-assets/"
+            if [[ -f "${assets}/THIRD_PARTY_NOTICES.txt" ]]; then
+              cp "${assets}/THIRD_PARTY_NOTICES.txt" "${proof_bundle}/release-assets/"
+            fi
           fi
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:

--- a/.github/workflows/agentplugins-release.yml
+++ b/.github/workflows/agentplugins-release.yml
@@ -258,7 +258,7 @@ jobs:
             gh release download "${TAG}" --repo "${GITHUB_REPOSITORY}" --dir "${existing}"
             node "${GITHUB_WORKSPACE}/npm/agentplugins/scripts/release-assets.js" \
               verify "${existing}" "${TAG}" "${FROZEN_COMMIT}"
-            for asset in agentplugins_* checksums.txt release-manifest.json; do
+            for asset in agentplugins_* checksums.txt release-manifest.json THIRD_PARTY_NOTICES.txt; do
               cmp -- "${asset}" "${existing}/${asset}" || {
                 echo "existing draft asset differs from the frozen build: ${asset}" >&2
                 exit 1
@@ -274,6 +274,7 @@ jobs:
             ${{ runner.temp }}/agentplugins-assets/agentplugins_*
             ${{ runner.temp }}/agentplugins-assets/checksums.txt
             ${{ runner.temp }}/agentplugins-assets/release-manifest.json
+            ${{ runner.temp }}/agentplugins-assets/THIRD_PARTY_NOTICES.txt
       - name: Create non-public immutable draft
         if: ${{ steps.draft.outputs.existing != 'true' }}
         env:
@@ -292,10 +293,11 @@ jobs:
             echo "release ${TAG} appeared concurrently; refusing to overwrite immutable assets" >&2
             exit 1
           fi
-          gh release create "${TAG}" agentplugins_* checksums.txt release-manifest.json \
+          gh release create "${TAG}" agentplugins_* checksums.txt release-manifest.json THIRD_PARTY_NOTICES.txt \
             --repo "${GITHUB_REPOSITORY}" --verify-tag \
             --target "${{ needs.validate.outputs.commit }}" --draft \
-            --title "Agentplugins ${TAG#agentplugins-v}" --generate-notes
+            --title "Agentplugins ${TAG#agentplugins-v}" --generate-notes \
+            --notes "Native downloads: retain the companion THIRD_PARTY_NOTICES.txt with the binary and include it when redistributing."
       - name: Share frozen draft assets with the read-only proof workflow
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:
@@ -304,6 +306,7 @@ jobs:
             ${{ runner.temp }}/agentplugins-assets/agentplugins_*
             ${{ runner.temp }}/agentplugins-assets/checksums.txt
             ${{ runner.temp }}/agentplugins-assets/release-manifest.json
+            ${{ runner.temp }}/agentplugins-assets/THIRD_PARTY_NOTICES.txt
           if-no-files-found: error
           retention-days: 7
 
@@ -368,8 +371,9 @@ jobs:
           mkdir -p "${assets}"
           gh release download "${TAG}" --repo "${GITHUB_REPOSITORY}" --dir "${assets}"
           node npm/agentplugins/scripts/release-assets.js verify "${assets}" "${TAG}" "${FROZEN_COMMIT}"
+          cmp -- npm/agentplugins/THIRD_PARTY_NOTICES.txt "${assets}/THIRD_PARTY_NOTICES.txt"
           test "$(sha256sum "${assets}/checksums.txt" | cut -d ' ' -f 1)" = "${EXPECTED_ASSET_SET_DIGEST}"
-          for asset in "${assets}"/agentplugins_* "${assets}/checksums.txt" "${assets}/release-manifest.json"; do
+          for asset in "${assets}"/agentplugins_* "${assets}/checksums.txt" "${assets}/release-manifest.json" "${assets}/THIRD_PARTY_NOTICES.txt"; do
             gh attestation verify "${asset}" \
               --repo "${GITHUB_REPOSITORY}" \
               --signer-workflow "github.com/${GITHUB_REPOSITORY}/.github/workflows/agentplugins-release.yml" \

--- a/docs/agentplugins-release.md
+++ b/docs/agentplugins-release.md
@@ -73,6 +73,31 @@ Proof` with `--ref <exact-tag>` and `allow_legacy_manifest=true`. The workflow
 must already exist at that tag, and its source SHA must equal the audited tag
 commit; current `main` is never allowed to impersonate a historical harness.
 
+## Third-party notice delivery
+
+New release preparation copies `npm/agentplugins/THIRD_PARTY_NOTICES.txt` into
+an identically named companion release asset. It is included in `checksums.txt`,
+attested, compared on draft reuse, and reverified before promotion. The six raw
+binary filenames, bytes, download URLs, and schema-v2 binary manifest stay the
+same. The checksum list gains one notice entry. Historical releases without the
+companion remain readable; this does not qualify their notice delivery.
+
+The npm file list includes the complete notice text even with pack scripts
+disabled. Its checked-in copy must match
+`cli/plugin-kit-ai/THIRD_PARTY_NOTICES.txt`; the npm tests enforce this in the
+source tree. When updating production dependency notices, copy the canonical
+file to the npm package too. Staging checks it against the verified companion.
+The npm tarball still contains no native binaries.
+
+Native users must download and retain `THIRD_PARTY_NOTICES.txt` from the same
+release alongside their binary, and include it when redistributing. Release
+notes state this requirement. Raw-binary bootstrap and atomic installation do
+not fetch the companion automatically. Homebrew and other downstream packagers
+must arrange notice delivery themselves; this change does not prove that they
+do. Companion availability does not guarantee delivery to a user who downloads
+only a binary. The existing notice inventory covers the terminal integration;
+this packaging change is not an audit of every historical dependency license.
+
 ## Homebrew tap
 
 Homebrew synchronization is owned by

--- a/npm/agentplugins/README.md
+++ b/npm/agentplugins/README.md
@@ -103,6 +103,10 @@ versioned Go binary for macOS, Linux, or Windows, verifies its embedded SHA-256,
 and caches it locally. Native release tests cover x64 and arm64 on all three
 operating systems.
 
+Third-party license text is included in `THIRD_PARTY_NOTICES.txt` in this npm
+package. For direct native downloads, retain the companion notice file from
+the same release with the binary, including when redistributing.
+
 - [Source and documentation](https://github.com/777genius/universal-agent-plugins)
 - [Browse the plugin catalog](https://777genius.github.io/universal-agent-plugins/plugins/)
 - [Client E2E evidence](https://github.com/777genius/universal-agent-plugins/blob/main/docs/AGENTPLUGINS_CLIENT_E2E.md)

--- a/npm/agentplugins/THIRD_PARTY_NOTICES.txt
+++ b/npm/agentplugins/THIRD_PARTY_NOTICES.txt
@@ -1,0 +1,631 @@
+Third-party notices for modules added or upgraded by the terminal prompt integration.
+Generated from the linked agentplugins production graph. Existing project notices still apply.
+
+=== charm.land/bubbles/v2 v2.0.0 ===
+LICENSE
+MIT License
+
+Copyright (c) 2020-2026 Charmbracelet, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+=== charm.land/bubbletea/v2 v2.0.2 ===
+LICENSE
+MIT License
+
+Copyright (c) 2020-2026 Charmbracelet, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+=== charm.land/huh/v2 v2.0.3 ===
+LICENSE
+MIT License
+
+Copyright (c) 2023–2026 Charm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+=== charm.land/lipgloss/v2 v2.0.1 ===
+LICENSE
+MIT License
+
+Copyright (c) 2021-2026 Charmbracelet, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+=== github.com/atotto/clipboard v0.1.4 ===
+LICENSE
+Copyright (c) 2013 Ato Araki. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of @atotto. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+=== github.com/catppuccin/go v0.2.0 ===
+LICENSE
+MIT License
+
+Copyright (c) 2021 Catppuccin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+=== github.com/charmbracelet/colorprofile v0.4.2 ===
+LICENSE
+MIT License
+
+Copyright (c) 2020-2024 Charmbracelet, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+=== github.com/charmbracelet/ultraviolet v0.0.0-20260205113103-524a6607adb8 ===
+LICENSE
+MIT License
+
+Copyright (c) 2025 Charmbracelet, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+=== github.com/charmbracelet/x/ansi v0.11.6 ===
+LICENSE
+MIT License
+
+Copyright (c) 2023 Charmbracelet, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+=== github.com/charmbracelet/x/exp/ordered v0.1.0 ===
+LICENSE
+MIT License
+
+Copyright (c) 2023 Charmbracelet, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+=== github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 ===
+LICENSE
+MIT License
+
+Copyright (c) 2023 Charmbracelet, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+=== github.com/charmbracelet/x/term v0.2.2 ===
+LICENSE
+MIT License
+
+Copyright (c) 2023 Charmbracelet, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+=== github.com/charmbracelet/x/termios v0.1.1 ===
+LICENSE
+MIT License
+
+Copyright (c) 2023 Charmbracelet, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+=== github.com/charmbracelet/x/windows v0.2.2 ===
+LICENSE
+MIT License
+
+Copyright (c) 2023 Charmbracelet, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+=== github.com/clipperhouse/displaywidth v0.11.0 ===
+LICENSE
+MIT License
+
+Copyright (c) 2025 Matt Sherman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+=== github.com/clipperhouse/uax29/v2 v2.7.0 ===
+LICENSE
+MIT License
+
+Copyright (c) 2020 Matt Sherman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+=== github.com/dustin/go-humanize v1.0.1 ===
+LICENSE
+Copyright (c) 2005-2008  Dustin Sallings <dustin@spy.net>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+<http://www.opensource.org/licenses/mit-license.php>
+
+
+=== github.com/lucasb-eyer/go-colorful v1.3.0 ===
+LICENSE
+Copyright (c) 2013 Lucas Beyer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+=== github.com/mattn/go-runewidth v0.0.20 ===
+LICENSE
+The MIT License (MIT)
+
+Copyright (c) 2016 Yasuhiro Matsumoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+=== github.com/mitchellh/hashstructure/v2 v2.0.2 ===
+LICENSE
+The MIT License (MIT)
+
+Copyright (c) 2016 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+=== github.com/muesli/cancelreader v0.2.2 ===
+LICENSE
+MIT License
+
+Copyright (c) 2022 Erik Geiser and Christian Muehlhaeuser
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+=== github.com/rivo/uniseg v0.4.7 ===
+LICENSE.txt
+MIT License
+
+Copyright (c) 2019 Oliver Kuederle
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+=== github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e ===
+LICENSE
+The MIT License (MIT)
+
+Copyright (c) 2016 Anmol Sethi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+=== golang.org/x/sync v0.22.0 ===
+LICENSE
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+=== golang.org/x/sys v0.42.0 ===
+LICENSE
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/npm/agentplugins/package.json
+++ b/npm/agentplugins/package.json
@@ -45,6 +45,7 @@
   },
   "files": [
     "LICENSE",
+    "THIRD_PARTY_NOTICES.txt",
     "README.md",
     "assets.json",
     "bin",

--- a/npm/agentplugins/scripts/release-assets.js
+++ b/npm/agentplugins/scripts/release-assets.js
@@ -8,6 +8,7 @@ const path = require("node:path");
 const VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 const COMMIT = /^[0-9a-f]{40}$/;
 const DIGEST = /^[0-9a-f]{64}$/;
+const NOTICES = "THIRD_PARTY_NOTICES.txt";
 const PRODUCER_REPOSITORY = "777genius/plugin-kit-ai";
 const TARGETS = [
   ["darwin-amd64", "darwin", "amd64", ""],
@@ -69,8 +70,15 @@ function assetMetadata(assetRoot, version) {
   return assets;
 }
 
+// Historical releases have no companion notices; new preparation always adds them.
+function noticeFiles(assetRoot) {
+  if (!fs.readdirSync(assetRoot).includes(NOTICES)) return [];
+  regularUnaliasedFile(path.join(assetRoot, NOTICES), "release notices");
+  return [NOTICES];
+}
+
 function writeChecksums(assetRoot, assets) {
-  const names = [...Object.values(assets).map((asset) => asset.file), "release-manifest.json"];
+  const names = [...Object.values(assets).map((asset) => asset.file), "release-manifest.json", ...noticeFiles(assetRoot)];
   const body = names.map((file) => `${sha256(path.join(assetRoot, file))}  ${file}`).join("\n") + "\n";
   fs.writeFileSync(path.join(assetRoot, "checksums.txt"), body);
 }
@@ -83,6 +91,11 @@ function prepareRelease(assetRoot, tag, commit) {
     assets: assetMetadata(assetRoot, identity.version)
   };
   fs.writeFileSync(path.join(assetRoot, "release-manifest.json"), JSON.stringify(manifest, null, 2) + "\n");
+  const noticeSource = path.resolve(__dirname, "..", NOTICES);
+  regularUnaliasedFile(noticeSource, "packaged notices");
+  const noticeTarget = path.join(assetRoot, NOTICES);
+  if (fs.readdirSync(assetRoot).includes(NOTICES)) regularUnaliasedFile(noticeTarget, "release notices");
+  fs.copyFileSync(noticeSource, noticeTarget);
   writeChecksums(assetRoot, manifest.assets);
   return manifest;
 }
@@ -104,7 +117,7 @@ function parseChecksums(assetRoot) {
 function verifyChecksums(assetRoot, expectedNames) {
   const entries = parseChecksums(assetRoot);
   if (entries.size !== expectedNames.length || expectedNames.some((name) => !entries.has(name))) {
-    throw new Error("checksums.txt does not name exactly the six binaries and release manifest");
+    throw new Error("checksums.txt does not name exactly the six binaries, release manifest, and any companion notices");
   }
   for (const name of expectedNames) {
     if (entries.get(name) !== sha256(path.join(assetRoot, name))) {
@@ -124,12 +137,12 @@ function verifyRelease(assetRoot, tag, commit, options = {}) {
     throw new Error("release manifest identity does not match the exact tag and commit");
   }
   const computed = assetMetadata(assetRoot, identity.version);
-  const names = [...Object.values(computed).map((asset) => asset.file), "release-manifest.json"];
+  const names = [...Object.values(computed).map((asset) => asset.file), "release-manifest.json", ...noticeFiles(assetRoot)];
   verifyChecksums(assetRoot, names);
   const expectedFiles = [...names, "checksums.txt"].sort();
   const actualFiles = fs.readdirSync(assetRoot).sort();
   if (actualFiles.join("\n") !== expectedFiles.join("\n")) {
-    throw new Error("release directory must contain exactly the six binaries, checksums, and manifest");
+    throw new Error("release directory must contain exactly the six binaries, checksums, manifest, and any companion notices");
   }
 
   if (manifest.schema_version === 1 && options.allowLegacyManifest === true) {
@@ -170,6 +183,7 @@ function verifyRelease(assetRoot, tag, commit, options = {}) {
     assets: computed,
     manifest_schema: 2,
     manifest_sha256: sha256(manifestPath),
+    notices: noticeFiles(assetRoot).map((file) => ({ file, sha256: sha256(path.join(assetRoot, file)) })),
     gate_eligible: true
   };
 }

--- a/npm/agentplugins/scripts/stage-release.js
+++ b/npm/agentplugins/scripts/stage-release.js
@@ -305,7 +305,8 @@ function snapshotRelease(assetRoot, release, version, commit, options) {
     const names = [
       ...Object.values(release.assets).map((asset) => asset.file),
       "release-manifest.json",
-      "checksums.txt"
+      "checksums.txt",
+      ...(release.notices || []).map((notice) => notice.file)
     ];
     for (const name of names) {
       fs.copyFileSync(path.join(assetRoot, name), path.join(snapshotRoot, name), fs.constants.COPYFILE_EXCL);
@@ -334,10 +335,22 @@ function stage(packageRoot, assetRoot, version, commit, options = {}) {
   const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
   const packageName = validatePackageMetadata(pkg);
   const loadedEvidence = loadEvidence(options.evidenceRoot);
+  const notice = initialRelease.notices?.[0];
+  let noticeBody;
+  if (notice) {
+    const source = path.resolve(__dirname, "..", notice.file);
+    requireSafeStagingFile(source, "packaged notices");
+    noticeBody = fs.readFileSync(source);
+    if (crypto.createHash("sha256").update(noticeBody).digest("hex") !== notice.sha256) {
+      throw new Error("packaged notices do not match the verified release notices");
+    }
+    requireSafeStagingFile(path.join(packageRoot, notice.file), "staged notices", true);
+  }
   if (options.afterInitialReleaseVerification) options.afterInitialReleaseVerification();
   const release = snapshotRelease(assetRoot, initialRelease, version, commit, options);
   if (JSON.stringify(release.assets) !== JSON.stringify(initialRelease.assets) ||
-      release.manifest_sha256 !== initialRelease.manifest_sha256) {
+      release.manifest_sha256 !== initialRelease.manifest_sha256 ||
+      JSON.stringify(release.notices) !== JSON.stringify(initialRelease.notices)) {
     throw new Error("release directory changed during staging");
   }
   if (options.afterReleaseSnapshotVerification) options.afterReleaseSnapshotVerification();
@@ -367,6 +380,7 @@ function stage(packageRoot, assetRoot, version, commit, options = {}) {
     assets
   };
   pkg.version = version;
+  if (noticeBody) fs.writeFileSync(path.join(packageRoot, notice.file), noticeBody);
   writeEvidence(packageRoot, loadedEvidence);
   fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
   fs.writeFileSync(path.join(packageRoot, "assets.json"), JSON.stringify(manifest, null, 2) + "\n");

--- a/npm/agentplugins/test/notices.test.js
+++ b/npm/agentplugins/test/notices.test.js
@@ -1,0 +1,63 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const { expectedAssets, prepareRelease, verifyRelease } = require("../scripts/release-assets");
+
+const packageRoot = path.resolve(__dirname, "..");
+const noticeName = "THIRD_PARTY_NOTICES.txt";
+const notices = fs.readFileSync(path.join(packageRoot, noticeName));
+const digest = (body) => crypto.createHash("sha256").update(body).digest("hex");
+
+function temporaryRoot(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "agentplugins-notices-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+test("npm notice copy matches the canonical production notices", (t) => {
+  const canonical = path.resolve(packageRoot, "../../cli/plugin-kit-ai", noticeName);
+  if (!fs.existsSync(canonical)) return t.skip("detached npm package has no source tree");
+  assert.deepEqual(notices, fs.readFileSync(canonical));
+});
+
+test("offline npm tarball includes complete notices even with scripts disabled", (t) => {
+  const root = temporaryRoot(t);
+  const staged = path.join(root, "package");
+  fs.cpSync(packageRoot, staged, { recursive: true });
+  const result = JSON.parse(execFileSync(process.platform === "win32" ? "npm.cmd" : "npm", [
+    "pack", "--offline", "--ignore-scripts", "--json", "--pack-destination", root
+  ], { cwd: staged, encoding: "utf8", shell: process.platform === "win32",
+    env: { ...process.env, npm_config_cache: path.join(root, "cache") } }));
+  assert.ok(result[0].files.some((entry) => entry.path === noticeName));
+  const packed = execFileSync("tar", ["-xOf", path.join(root, result[0].filename), `package/${noticeName}`]);
+  assert.deepEqual(packed, notices);
+});
+
+test("release packaging preserves all six binary bytes and verifies companion notices", (t) => {
+  const root = temporaryRoot(t);
+  const version = "0.1.99";
+  const tag = `agentplugins-v${version}`;
+  const commit = "a".repeat(40);
+  const bodies = Object.fromEntries(Object.values(expectedAssets(version)).map((file) => [file, Buffer.from(`fixture-${file}\n`)]));
+  for (const [file, body] of Object.entries(bodies)) fs.writeFileSync(path.join(root, file), body);
+  const manifest = prepareRelease(root, tag, commit);
+  assert.equal(manifest.schema_version, 2);
+  assert.equal(Object.keys(manifest.assets).length, 6);
+  for (const [file, body] of Object.entries(bodies)) assert.deepEqual(fs.readFileSync(path.join(root, file)), body);
+  assert.deepEqual(fs.readFileSync(path.join(root, noticeName)), notices);
+  assert.deepEqual(verifyRelease(root, tag, commit).notices, [{ file: noticeName, sha256: digest(notices) }]);
+  fs.appendFileSync(path.join(root, noticeName), "tampered");
+  assert.throws(() => verifyRelease(root, tag, commit), /checksum mismatch/);
+  fs.unlinkSync(path.join(root, noticeName));
+  assert.throws(() => verifyRelease(root, tag, commit), /checksums.txt/);
+  // Historical schema-v2 releases retain their original eight-file contract.
+  const checksums = path.join(root, "checksums.txt");
+  fs.writeFileSync(checksums, fs.readFileSync(checksums, "utf8").split("\n").filter((line) => !line.endsWith(`  ${noticeName}`)).join("\n"));
+  assert.deepEqual(verifyRelease(root, tag, commit).notices, []);
+});

--- a/npm/agentplugins/test/stage-release.test.js
+++ b/npm/agentplugins/test/stage-release.test.js
@@ -169,6 +169,10 @@ test("release staging embeds every exact platform asset hash", async (t) => {
   const evidenceRoot = await fixtureEvidence(root);
   const manifest = stage(packageRoot, assetsRoot, version, COMMIT, { evidenceRoot });
   assert.equal(manifest.version, version);
+  assert.deepEqual(
+    await fsp.readFile(path.join(packageRoot, "THIRD_PARTY_NOTICES.txt")),
+    await fsp.readFile(path.join(assetsRoot, "THIRD_PARTY_NOTICES.txt"))
+  );
   assert.equal(manifest.npm_package, "universal-agent-plugins");
   assert.equal(manifest.producer.repository, "777genius/plugin-kit-ai");
   assert.equal(manifest.producer.commit, COMMIT);
@@ -199,6 +203,15 @@ test("release staging embeds every exact platform asset hash", async (t) => {
     await fsp.readFile(path.join(packageRoot, "test/evidence-root/AGENTPLUGINS_CLIENT_E2E.md"), "utf8"),
     await fsp.readFile(path.join(evidenceRoot, "AGENTPLUGINS_CLIENT_E2E.md"), "utf8")
   );
+  // A rechecksummed companion from a different source must not reach npm.
+  const noticeFile = path.join(assetsRoot, "THIRD_PARTY_NOTICES.txt");
+  await fsp.writeFile(noticeFile, "different source notices\n");
+  const noticeHash = crypto.createHash("sha256").update(await fsp.readFile(noticeFile)).digest("hex");
+  const checksumsFile = path.join(assetsRoot, "checksums.txt");
+  await fsp.writeFile(checksumsFile, (await fsp.readFile(checksumsFile, "utf8")).replace(
+    /^[0-9a-f]{64}  THIRD_PARTY_NOTICES\.txt$/m, `${noticeHash}  THIRD_PARTY_NOTICES.txt`
+  ));
+  assert.throws(() => stage(packageRoot, assetsRoot, version, COMMIT, { evidenceRoot }), /packaged notices do not match/);
 });
 
 test("staged package tests are hermetic to repository layout and caller cwd", {
@@ -473,6 +486,7 @@ test("legacy manifests are audit-only and never gate eligible", async (t) => {
     await fsp.writeFile(path.join(root, expectedAssetName(version, info)), `${info.key}\n`);
   }
   const { assets } = prepareRelease(root, `agentplugins-v${version}`, COMMIT);
+  await fsp.rm(path.join(root, "THIRD_PARTY_NOTICES.txt"));
   await fsp.writeFile(path.join(root, "release-manifest.json"), JSON.stringify({
     schema_version: 1,
     tag: `agentplugins-v${version}`,


### PR DESCRIPTION
Terminal UI dependencies require license notices to accompany distribution. This change includes canonical notices in npm packages and adds a checksummed, attested companion to native release assets without changing binary names or the manifest format.

Stacked on #205. No release is published by this PR. Raw native downloads require retaining the companion notice file.

Validation: 19 focused packaging tests, six native builds and offline prepare/verify/stage/pack checks, and release contract tests passed. All applicable checks on the current PR head passed. Independent review approved the unchanged notice-delivery scope with no outstanding findings.
