### PR TITLE
feat(cli): add semantic colors and explicit color controls

### DIFF
--- a/.github/workflows/terminal-ui.yml
+++ b/.github/workflows/terminal-ui.yml
@@ -54,6 +54,14 @@ jobs:
         run: |
           python3 -m unittest discover -s scripts/terminal-ui -p 'test_*.py'
           python3 scripts/terminal-ui/harness.py --binary "$RUNNER_TEMP/agentplugins.exe" --scanner-archive "$RUNNER_TEMP/scanner/${{ matrix.archive }}" --artifacts "$RUNNER_TEMP/terminal-evidence" --timeout 15
+      - name: Unix selection combinations (synthetic client and scanner protocols)
+        if: runner.os != 'Windows'
+        run: |
+          python3 scripts/terminal-ui/selection_matrix.py --build-go "$(command -v go)" --artifacts "$RUNNER_TEMP/selection-evidence" --timeout 15 > "$RUNNER_TEMP/selection-matrix.log" 2>&1 || { tail -c 6000 "$RUNNER_TEMP/selection-matrix.log"; exit 1; }
+      - name: Unix full plugin matrix (19 cases, synthetic client and scanner protocols)
+        if: ${{ !cancelled() && runner.os != 'Windows' && steps.build.outcome == 'success' }}
+        run: |
+          python3 scripts/terminal-ui/plugin_matrix.py --binary "$RUNNER_TEMP/agentplugins.exe" --artifacts "$RUNNER_TEMP/plugin-evidence" --timeout 15 > "$RUNNER_TEMP/plugin-matrix.log" 2>&1 || { tail -c 6000 "$RUNNER_TEMP/plugin-matrix.log"; exit 1; }
       - name: Unix npm inherited terminal routes
         if: runner.os != 'Windows'
         run: python3 scripts/terminal-ui/harness.py --binary "$RUNNER_TEMP/agentplugins.exe" --scanner-archive "$RUNNER_TEMP/scanner/${{ matrix.archive }}" --npm-launcher --case escape --case json-tty --case json-explicit --artifacts "$RUNNER_TEMP/npm-terminal-evidence" --timeout 15
@@ -71,7 +79,7 @@ jobs:
         shell: pwsh
         run: |
           $shellPath = (Get-Command pwsh -CommandType Application).Source
-          python scripts/terminal-ui/windows_conpty.py --binary "$env:RUNNER_TEMP/agentplugins.exe" --scanner-archive "$env:RUNNER_TEMP/scanner/${{ matrix.archive }}" --powershell "$shellPath" --case default-no --case ctrl-c --artifacts "$env:RUNNER_TEMP/powershell-terminal-evidence" --timeout 15
+          python scripts/terminal-ui/windows_conpty.py --binary "$env:RUNNER_TEMP/agentplugins.exe" --scanner-archive "$env:RUNNER_TEMP/scanner/${{ matrix.archive }}" --powershell "$shellPath" --case default-no --case no --case yes-lifecycle --case ctrl-c --case confirm-ctrl-c --case eof --case resize --artifacts "$env:RUNNER_TEMP/powershell-terminal-evidence" --timeout 15
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
       # Keep the broad gate required, including when a console case fails.
       # Run it after console proof so legacy fixture failures cannot hide ConPTY.
@@ -84,6 +92,10 @@ jobs:
         with:
           name: terminal-${{ matrix.target }}
           path: |
+            ${{ runner.temp }}/selection-evidence
+            ${{ runner.temp }}/selection-matrix.log
+            ${{ runner.temp }}/plugin-evidence
+            ${{ runner.temp }}/plugin-matrix.log
             ${{ runner.temp }}/terminal-evidence
             ${{ runner.temp }}/npm-terminal-evidence
             ${{ runner.temp }}/windows-fault-evidence

--- a/cli/plugin-kit-ai/TERMINAL_PROMPTS.md
+++ b/cli/plugin-kit-ai/TERMINAL_PROMPTS.md
@@ -7,8 +7,8 @@ The install answer defaults to **No**, including when only one client is found.
 JSON and redirected stdin require explicit targets and never read prompt input.
 Security overrides and activation/authentication attestations remain separate.
 
-Use `--plain` for screen readers or line-oriented interaction without terminal
-controls. Plain selection uses comma-separated numbers; Enter selects the shown
+Use `--plain` for screen readers or line-oriented interaction without cursor
+controls. Color is independent: add `--color=never` for output without escapes. Plain selection uses comma-separated numbers; Enter selects the shown
 defaults. Confirm with a complete `y` or `yes` line. EOF, including an unfinished
 `y`, is an error, not consent. Answers are bounded to 4096 bytes.
 
@@ -22,8 +22,29 @@ screen, mouse interaction, focus reporting or separate TTY is opened.
 Rich mode requires actual terminal files on stdin, stdout and stderr, a known
 non-dumb TERM, and an initial output size of at least 40 columns by 10 rows.
 Otherwise Plain uses the visible output stream. If both outputs are redirected,
-a required question fails without reading. `--no-color` and nonempty `NO_COLOR`
-disable colors independently of rich controls. Use `--plain` for no escapes.
+a required question fails without reading.
+
+`--color=auto|never|always` defaults to `auto`. Auto checks each output stream
+separately: redirected files/pipes and `TERM=dumb` receive no color. A nonempty
+`NO_COLOR` (including `0` or whitespace) disables color unless an explicit color
+flag is present. Explicit `--color=auto` still checks the destination and TERM;
+`--color=always` forces color for human output, including redirected output.
+`--no-color` aliases `--color=never`. Repeated identical choices are accepted;
+contradictory explicit choices are rejected in either order, before command
+execution. `--no-color=false` is rejected; use `--color=auto` instead.
+
+Success uses green, warnings yellow, errors red, labels cyan, and secondary text
+muted gray. Colons and values remain ordinary. Colors supplement the wording;
+they are never required to understand status or consent. Selected human add,
+plan, result, installation status and binding rows use these roles. Help remains
+unstyled. JSON output, help and errors in JSON mode contain no ANSI, even with
+`--color=always`. Rich prompts with `--color=never` retain cursor controls;
+`--plain --color=never` disables both color and cursor controls.
+
+These are implementation semantics, not native terminal release qualification.
+The older terminal evidence harness assumes that Plain always has no escapes;
+its Plain/tiny/redirect checks need an explicit `--color=never` when qualifying
+cursor-free output. Colored Plain needs separate semantic assertions.
 
 Windows currently selects Plain. Native console/ConPTY qualification is pending;
 cross-compilation is not terminal evidence. Its line-reader cancellation uses a

--- a/cli/plugin-kit-ai/cmd/agentplugins/main.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins/main.go
@@ -86,7 +86,7 @@ func main() {
 		return
 	}
 	if err := run(); err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, "agentplugins:", err)
+		_, _ = fmt.Fprintln(os.Stderr, "agentplugins:", agentpluginscli.ErrorText(os.Args[1:], os.Stderr, err))
 		os.Exit(1)
 	}
 }

--- a/cli/plugin-kit-ai/go.mod
+++ b/cli/plugin-kit-ai/go.mod
@@ -14,6 +14,7 @@ require (
 	charm.land/bubbles/v2 v2.0.0
 	charm.land/bubbletea/v2 v2.0.2
 	charm.land/huh/v2 v2.0.3
+	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/777genius/plugin-kit-ai/install/integrationctl v0.0.0
 	github.com/777genius/plugin-kit-ai/plugininstall v0.0.0
 	github.com/777genius/plugin-kit-ai/sdk v0.0.0
@@ -34,7 +35,6 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/catppuccin/go v0.2.0 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260205113103-524a6607adb8 // indirect
-	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/exp/ordered v0.1.0 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/777genius/plugin-kit-ai/cli/internal/agentpluginscli/prompt"
 	"github.com/777genius/plugin-kit-ai/cli/internal/promptio"
+	"github.com/777genius/plugin-kit-ai/cli/internal/terminaltheme"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/ports"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/usecase"
@@ -464,26 +465,26 @@ func renderHumanPlan(writer io.Writer, envelope domain.PackageEnvelope, result u
 	result = withOpenCodeRuntimeNotice(result)
 	checked := &planWriter{writer: writer}
 	writer = checked
-	_, _ = fmt.Fprintf(writer, "Plugin: %s %s\n", prompt.SafeText(string(envelope.Manifest.Name)), prompt.SafeText(string(envelope.Manifest.Version)))
-	_, _ = fmt.Fprintf(writer, "Target: %s\n", prompt.SafeText(string(result.Plan.ClientID)))
-	_, _ = fmt.Fprintf(writer, "Package: %s\n", prompt.SafeText(string(result.Plan.PackageMode)))
-	_, _ = fmt.Fprintf(writer, "Result: %s\n", prompt.SafeText(string(result.Plan.Status)))
-	_, _ = fmt.Fprintf(writer, "Authentication: %s\n", prompt.SafeText(string(result.Plan.Authentication)))
-	_, _ = fmt.Fprintf(writer, "Verification: %s\n", prompt.SafeText(string(result.Plan.Verification)))
+	_, _ = fmt.Fprintf(writer, "%s: %s %s\n", terminaltheme.For(writer).Text(terminaltheme.Label, "Plugin"), prompt.SafeText(string(envelope.Manifest.Name)), prompt.SafeText(string(envelope.Manifest.Version)))
+	_, _ = fmt.Fprintf(writer, "%s: %s\n", terminaltheme.For(writer).Text(terminaltheme.Label, "Target"), prompt.SafeText(string(result.Plan.ClientID)))
+	_, _ = fmt.Fprintf(writer, "%s: %s\n", terminaltheme.For(writer).Text(terminaltheme.Label, "Package"), prompt.SafeText(string(result.Plan.PackageMode)))
+	_, _ = fmt.Fprintf(writer, "%s: %s\n", terminaltheme.For(writer).Text(terminaltheme.Label, "Result"), prompt.SafeText(string(result.Plan.Status)))
+	_, _ = fmt.Fprintf(writer, "%s: %s\n", terminaltheme.For(writer).Text(terminaltheme.Label, "Authentication"), prompt.SafeText(string(result.Plan.Authentication)))
+	_, _ = fmt.Fprintf(writer, "%s: %s\n", terminaltheme.For(writer).Text(terminaltheme.Label, "Verification"), prompt.SafeText(string(result.Plan.Verification)))
 	for _, component := range result.Plan.Components {
 		_, _ = fmt.Fprintf(writer, "  - %s %s: %s\n", prompt.SafeText(string(component.Kind)), prompt.SafeText(string(component.Name)), prompt.SafeText(string(component.Support)))
 	}
 	for _, diagnostic := range result.Plan.Diagnostics {
-		_, _ = fmt.Fprintf(writer, "  Warning: %s: %s\n", prompt.SafeText(string(diagnostic.Code)), prompt.SafeText(string(diagnostic.Message)))
+		_, _ = fmt.Fprintf(writer, "  %s: %s: %s\n", terminaltheme.For(writer).Text(terminaltheme.Warning, "Warning"), prompt.SafeText(string(diagnostic.Code)), prompt.SafeText(string(diagnostic.Message)))
 	}
 	for _, warning := range result.Plan.Warnings {
-		_, _ = fmt.Fprintf(writer, "  Warning: %s\n", prompt.SafeText(string(warning)))
+		_, _ = fmt.Fprintf(writer, "  %s: %s\n", terminaltheme.For(writer).Text(terminaltheme.Warning, "Warning"), prompt.SafeText(string(warning)))
 	}
 	for _, action := range result.Plan.UserActions {
-		_, _ = fmt.Fprintf(writer, "  Planned action: %s\n", prompt.SafeText(string(action)))
+		_, _ = fmt.Fprintf(writer, "  %s: %s\n", terminaltheme.For(writer).Text(terminaltheme.Label, "Planned action"), prompt.SafeText(string(action)))
 	}
 	for _, action := range result.Plan.LocalActions {
-		_, _ = fmt.Fprintf(writer, "  Planned action: %s\n", prompt.SafeText(string(action)))
+		_, _ = fmt.Fprintf(writer, "  %s: %s\n", terminaltheme.For(writer).Text(terminaltheme.Label, "Planned action"), prompt.SafeText(string(action)))
 	}
 	return checked.err
 }
@@ -509,18 +510,18 @@ func renderAddResultErrorWithSecurity(writer io.Writer, format string, envelope 
 	}
 	if failure := addFailureStatus(result, commandErr); failure != "" {
 		if result.Plan.Status == domain.PlanUnsupported {
-			if _, err := fmt.Fprintf(writer, "Add: %s\n", failure); err != nil {
+			if _, err := fmt.Fprintf(writer, "%s: %s\n", terminaltheme.For(writer).Text(terminaltheme.Error, "Add"), failure); err != nil {
 				return err
 			}
 			return renderHumanPlan(writer, envelope, result)
 		}
-		if _, err := fmt.Fprintf(writer, "Add: %s\n", failure); err != nil {
+		if _, err := fmt.Fprintf(writer, "%s: %s\n", terminaltheme.For(writer).Text(terminaltheme.Error, "Add"), failure); err != nil {
 			return err
 		}
 		// Lifecycle recovery is useful after a failed phase, but must not imply
 		// that a rolled-back or uncertain transaction left a usable installation.
 		if failure == "activation_failed" || failure == "authentication_failed" || failure == "verification_failed" {
-			_, err := fmt.Fprintf(writer, "Next: %s\n", nextLocalLifecycleAction(result))
+			_, err := fmt.Fprintf(writer, "%s: %s\n", terminaltheme.For(writer).Text(terminaltheme.Label, "Next"), nextLocalLifecycleAction(result))
 			return err
 		}
 		return nil
@@ -532,17 +533,17 @@ func renderAddResultErrorWithSecurity(writer io.Writer, format string, envelope 
 		return err
 	}
 	if result.NoChange {
-		_, _ = fmt.Fprintln(writer, "Already installed and lifecycle verification is complete. No changes made.")
+		_, _ = fmt.Fprintln(writer, terminaltheme.For(writer).Text(terminaltheme.Muted, "Already installed and lifecycle verification is complete. No changes made."))
 		return nil
 	}
 	if result.Mutated && fullyInstalled(result.Activation) {
 		if result.Activation.ActivationAttested || result.Activation.AuthenticationAttested {
-			_, _ = fmt.Fprintln(writer, "Lifecycle is user-attested for the explicitly confirmed phase; it was not observed from the client.")
+			_, _ = fmt.Fprintln(writer, terminaltheme.For(writer).Text(terminaltheme.Warning, "Lifecycle is user-attested for the explicitly confirmed phase; it was not observed from the client."))
 		} else {
 			if result.Plan.ClientID == domain.ClientOpenCode && len(domain.SelectedMCPNames(result.Plan)) > 0 {
-				_, _ = fmt.Fprintln(writer, "OpenCode MCP configuration installed and verified.")
+				_, _ = fmt.Fprintln(writer, terminaltheme.For(writer).Text(terminaltheme.Success, "OpenCode MCP configuration installed and verified."))
 			} else {
-				_, _ = fmt.Fprintln(writer, "Installed and verified for the selected client.")
+				_, _ = fmt.Fprintln(writer, terminaltheme.For(writer).Text(terminaltheme.Success, "Installed and verified for the selected client."))
 			}
 		}
 		return nil
@@ -550,18 +551,18 @@ func renderAddResultErrorWithSecurity(writer io.Writer, format string, envelope 
 	if result.Mutated {
 		if result.Activation.Authentication == domain.AuthenticationPending {
 			if result.Activation.Activation == domain.ActivationActive {
-				_, _ = fmt.Fprintln(writer, "Package materialized and client activation completed. Authentication is pending.")
+				_, _ = fmt.Fprintln(writer, terminaltheme.For(writer).Text(terminaltheme.Warning, "Package materialized and client activation completed. Authentication is pending."))
 			} else {
-				_, _ = fmt.Fprintln(writer, "Package prepared. Authentication and client activation are pending.")
+				_, _ = fmt.Fprintln(writer, terminaltheme.For(writer).Text(terminaltheme.Warning, "Package prepared. Authentication and client activation are pending."))
 			}
 		} else if result.Activation.Authentication == domain.AuthenticationNotChecked && result.Activation.Activation == domain.ActivationActive {
-			_, _ = fmt.Fprintln(writer, "Package materialized and client activation verified. Authentication requirements have not been checked.")
+			_, _ = fmt.Fprintln(writer, terminaltheme.For(writer).Text(terminaltheme.Warning, "Package materialized and client activation verified. Authentication requirements have not been checked."))
 		} else {
-			_, _ = fmt.Fprintln(writer, "Package prepared. Activation is not complete yet.")
+			_, _ = fmt.Fprintln(writer, terminaltheme.For(writer).Text(terminaltheme.Warning, "Package prepared. Activation is not complete yet."))
 		}
 	}
 	if action := nextLocalLifecycleAction(result); action != "" && !fullyInstalled(result.Activation) {
-		_, _ = fmt.Fprintf(writer, "Next: %s\n", action)
+		_, _ = fmt.Fprintf(writer, "%s: %s\n", terminaltheme.For(writer).Text(terminaltheme.Label, "Next"), action)
 	}
 	return nil
 }

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_group_rendering_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_group_rendering_test.go
@@ -1,0 +1,53 @@
+package agentpluginscli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+func TestSharedGroupHumanReviewIdentifiesLogicalTargets(t *testing.T) {
+	for _, order := range [][]domain.ClientID{{domain.ClientCopilot, domain.ClientVSCode}, {domain.ClientVSCode, domain.ClientCopilot}} {
+		t.Run(string(order[0]), func(t *testing.T) {
+			first, second := fixtureClient(t, order[0]), fixtureClient(t, order[1])
+			if first.ClientID == domain.ClientCopilot {
+				first.ExecutablePath = "/test/bin/copilot"
+			} else {
+				second.ExecutablePath = "/test/bin/copilot"
+			}
+			f := newCLIFixture(t, []domain.DetectedClient{first, second})
+			out, _, err := f.executeInput(true, "\nn\n", "add", writeCLIPlugin(t))
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, target := range []string{"copilot", "vscode"} {
+				if strings.Count(out, "Target: "+target+"\n") != 1 {
+					t.Fatalf("selected target missing or repeated: %s", out)
+				}
+			}
+			if !strings.Contains(out, "Uses shared physical binding owned by ") ||
+				strings.Count(out, "Authentication: not_checked") != 2 || !strings.Contains(out, "Installation not applied") {
+				t.Fatal(out)
+			}
+			state, err := f.store.Load()
+			if err != nil || len(state.Installations) != 0 {
+				t.Fatalf("declined review mutated state: %+v, %v", state, err)
+			}
+		})
+	}
+}
+
+func TestGroupCollisionErrorIncludesSelectedTargetContext(t *testing.T) {
+	f := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor), fixtureClient(t, domain.ClientKiro)})
+	f.app.Lifecycle.NativeObserver = selectiveNativeObserver{foreign: domain.ClientCursor}
+	_, _, err := f.execute(false, "add", writeCLIPlugin(t), "--target", "cursor,kiro")
+	if err == nil || !strings.Contains(err.Error(), "selected targets: [cursor kiro]") ||
+		!strings.Contains(err.Error(), "unmanaged") || !strings.Contains(err.Error(), "no target was changed") {
+		t.Fatalf("collision error: %v", err)
+	}
+	state, loadErr := f.store.Load()
+	if loadErr != nil || len(state.Installations) != 0 {
+		t.Fatalf("collision mutated state: %+v, %v", state, loadErr)
+	}
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
@@ -148,13 +148,13 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 	if err != nil {
 		combined.Status, combined.Failed, combined.Succeeded = "preflight_failed", len(inputs), 0
 		_ = renderAddMultiResult(cmd, opts, combined, loaded.envelope)
-		return fmt.Errorf("group preflight failed; no target was changed: %w%s", err, addGroupNextAction(combined.Targets))
+		return fmt.Errorf("group preflight failed; no target was changed (selected targets: %v): %w%s", targets, err, addGroupNextAction(combined.Targets))
 	}
 	if opts.dryRun {
 		return renderAddMultiResult(cmd, opts, combined, loaded.envelope)
 	}
 	if needsInstallConfirmation {
-		accepted, err := confirmInstall(ctx, cmd, app, loaded, planned.Targets)
+		accepted, err := confirmInstall(ctx, cmd, app, loaded, humanAddGroupPlans(combined.Targets))
 		if err != nil {
 			return err
 		}
@@ -194,7 +194,7 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 		if applied.Phase == usecase.GroupPhasePlanned && !applied.Mutated {
 			combined.Status, combined.Failed, combined.Succeeded = "preflight_failed", len(inputs), 0
 			_ = renderAddMultiResult(cmd, opts, combined, loaded.envelope)
-			return fmt.Errorf("group apply preflight failed; no target was changed: %w%s", err, addGroupNextAction(combined.Targets))
+			return fmt.Errorf("group apply preflight failed; no target was changed (selected targets: %v): %w%s", targets, err, addGroupNextAction(combined.Targets))
 		}
 		combined.Status = groupFailureStatus(applied.Phase)
 		combined.Failed = len(inputs) - combined.Succeeded
@@ -391,6 +391,24 @@ func addResultTargets(results []addTargetResult) string {
 		values[index] = result.Target
 	}
 	return strings.Join(values, ",")
+}
+
+// The group result describes physical delivery. Review must also identify the
+// selected logical surface when Copilot and VS Code share that delivery.
+// Copy the presentation data so JSON, apply inputs and persisted IDs keep their
+// physical ownership semantics.
+func humanAddGroupPlans(targets []addTargetResult) []usecase.AddResult {
+	results := make([]usecase.AddResult, len(targets))
+	for index, target := range targets {
+		result := target.Output.Result
+		if target.Target != string(result.Plan.ClientID) {
+			result.Plan.LocalActions = append(append([]string(nil), result.Plan.LocalActions...),
+				fmt.Sprintf("Uses shared physical binding owned by %s", result.Plan.ClientID))
+			result.Plan.ClientID = domain.ClientID(target.Target)
+		}
+		results[index] = result
+	}
+	return results
 }
 
 func addGroupNextAction(targets []addTargetResult) string {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/app.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/app.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/777genius/plugin-kit-ai/cli/internal/agentpluginscli/prompt"
+	"github.com/777genius/plugin-kit-ai/cli/internal/terminaltheme"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/directoryv1"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/discoveryv1"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/statemigration"
@@ -63,11 +64,11 @@ type App struct {
 }
 
 type options struct {
+	color               terminaltheme.Policy
 	target              string
 	scope               string
 	dryRun              bool
 	format              string
-	noColor             bool
 	plain               bool
 	externalUninstalled bool
 	purgeData           bool

--- a/cli/plugin-kit-ai/internal/agentpluginscli/binding.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/binding.go
@@ -7,7 +7,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/777genius/plugin-kit-ai/cli/internal/agentpluginscli/prompt"
 	"github.com/777genius/plugin-kit-ai/cli/internal/promptio"
+	"github.com/777genius/plugin-kit-ai/cli/internal/terminaltheme"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/usecase"
 	"github.com/spf13/cobra"
@@ -137,15 +139,15 @@ func renderBindingChange(writer io.Writer, format, commandName string, result us
 		}
 	}
 	if !result.Plan.CanApply {
-		_, _ = fmt.Fprintln(writer, "Blocked. Remove every listed target and native object first.")
+		_, _ = fmt.Fprintln(writer, terminaltheme.For(writer).Text(terminaltheme.Error, "Blocked. Remove every listed target and native object first."))
 		return nil
 	}
 	if result.NoChange {
-		_, _ = fmt.Fprintln(writer, "Binding already matches. No changes made.")
+		_, _ = fmt.Fprintln(writer, terminaltheme.For(writer).Text(terminaltheme.Muted, "Binding already matches. No changes made."))
 		return nil
 	}
 	if result.Mutated {
-		_, _ = fmt.Fprintln(writer, "Binding updated. Reinstall targets explicitly with agentplugins add.")
+		_, _ = fmt.Fprintln(writer, terminaltheme.For(writer).Text(terminaltheme.Success, "Binding updated. Reinstall targets explicitly with agentplugins add."))
 	}
 	return nil
 }
@@ -153,18 +155,18 @@ func renderBindingChange(writer io.Writer, format, commandName string, result us
 func renderHumanBindingPlan(writer io.Writer, plan usecase.BindingChangePlan) error {
 	checked := &planWriter{writer: writer}
 	writer = checked
-	_, _ = fmt.Fprintf(writer, "Plugin: %s -> %s\n", plan.OldName, plan.NewName)
-	_, _ = fmt.Fprintf(writer, "Format: %s -> %s\n", plan.OldFormat.FormatID, plan.NewFormat.FormatID)
-	_, _ = fmt.Fprintf(writer, "Schema: %s -> %s\n", plan.OldFormat.SchemaURI, plan.NewFormat.SchemaURI)
-	_, _ = fmt.Fprintf(writer, "Source: %s -> %s\n", provenanceLabel(plan.OldSource), provenanceLabel(plan.NewSource))
-	_, _ = fmt.Fprintf(writer, "Components: %s -> %s\n", componentInventoryLabel(plan.OldComponents), componentInventoryLabel(plan.NewComponents))
-	_, _ = fmt.Fprintf(writer, "Native objects: %d\n", plan.NativeObjectCount)
-	_, _ = fmt.Fprintln(writer, "PLUGIN_DATA: not transferred")
+	_, _ = fmt.Fprintf(writer, "%s: %s -> %s\n", terminaltheme.For(writer).Text(terminaltheme.Label, "Plugin"), prompt.SafeText(string(plan.OldName)), prompt.SafeText(string(plan.NewName)))
+	_, _ = fmt.Fprintf(writer, "%s: %s -> %s\n", terminaltheme.For(writer).Text(terminaltheme.Label, "Format"), prompt.SafeText(string(plan.OldFormat.FormatID)), prompt.SafeText(string(plan.NewFormat.FormatID)))
+	_, _ = fmt.Fprintf(writer, "%s: %s -> %s\n", terminaltheme.For(writer).Text(terminaltheme.Label, "Schema"), prompt.SafeText(string(plan.OldFormat.SchemaURI)), prompt.SafeText(string(plan.NewFormat.SchemaURI)))
+	_, _ = fmt.Fprintf(writer, "%s: %s -> %s\n", terminaltheme.For(writer).Text(terminaltheme.Label, "Source"), prompt.SafeText(string(provenanceLabel(plan.OldSource))), prompt.SafeText(string(provenanceLabel(plan.NewSource))))
+	_, _ = fmt.Fprintf(writer, "%s: %s -> %s\n", terminaltheme.For(writer).Text(terminaltheme.Label, "Components"), prompt.SafeText(string(componentInventoryLabel(plan.OldComponents))), prompt.SafeText(string(componentInventoryLabel(plan.NewComponents))))
+	_, _ = fmt.Fprintf(writer, "%s: %d\n", terminaltheme.For(writer).Text(terminaltheme.Label, "Native objects"), plan.NativeObjectCount)
+	_, _ = fmt.Fprintln(writer, terminaltheme.For(writer).Text(terminaltheme.Label, "PLUGIN_DATA")+": not transferred")
 	for _, target := range plan.Targets {
-		_, _ = fmt.Fprintf(writer, "  %s/%s: %s\n", target.ClientID, target.Scope, target.Decision)
+		_, _ = fmt.Fprintf(writer, "  %s/%s: %s\n", prompt.SafeText(string(target.ClientID)), prompt.SafeText(string(target.Scope)), prompt.SafeText(string(target.Decision)))
 	}
 	for _, blocker := range plan.Blockers {
-		_, _ = fmt.Fprintf(writer, "  Blocker: %s\n", blocker)
+		_, _ = fmt.Fprintf(writer, "  %s: %s\n", terminaltheme.For(writer).Text(terminaltheme.Error, "Blocker"), prompt.SafeText(blocker))
 	}
 	return checked.err
 }

--- a/cli/plugin-kit-ai/internal/agentpluginscli/color_error.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/color_error.go
@@ -1,0 +1,23 @@
+package agentpluginscli
+
+import (
+	"io"
+
+	"github.com/777genius/plugin-kit-ai/cli/internal/agentpluginscli/prompt"
+	"github.com/777genius/plugin-kit-ai/cli/internal/terminaltheme"
+)
+
+// ErrorText uses the same flag parser without executing a command or touching state.
+// Malformed flags and unknown commands deliberately keep their diagnostic unstyled.
+func ErrorText(args []string, output io.Writer, err error) string {
+	text := prompt.SafeText(err.Error())
+	root := NewRoot(App{ErrorOutput: output})
+	cmd, remaining, findErr := root.Find(args)
+	if findErr != nil {
+		return text
+	}
+	if cmd.ParseFlags(remaining) != nil {
+		return text
+	}
+	return terminaltheme.For(root.ErrOrStderr()).Text(terminaltheme.Error, text)
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/color_error.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/color_error.go
@@ -2,15 +2,17 @@ package agentpluginscli
 
 import (
 	"io"
+	"strings"
+	"unicode"
 
-	"github.com/777genius/plugin-kit-ai/cli/internal/agentpluginscli/prompt"
 	"github.com/777genius/plugin-kit-ai/cli/internal/terminaltheme"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // ErrorText uses the same flag parser without executing a command or touching state.
 // Malformed flags and unknown commands deliberately keep their diagnostic unstyled.
 func ErrorText(args []string, output io.Writer, err error) string {
-	text := prompt.SafeText(err.Error())
+	text := safeDiagnosticText(err.Error())
 	root := NewRoot(App{ErrorOutput: output})
 	cmd, remaining, findErr := root.Find(args)
 	if findErr != nil {
@@ -20,4 +22,19 @@ func ErrorText(args []string, output io.Writer, err error) string {
 		return text
 	}
 	return terminaltheme.For(root.ErrOrStderr()).Text(terminaltheme.Error, text)
+}
+
+// Diagnostics can contain multiline examples and trailing recovery guidance.
+// Strip escapes per line so an unterminated sequence cannot consume later lines.
+func safeDiagnosticText(text string) string {
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		lines[i] = strings.Map(func(r rune) rune {
+			if unicode.IsControl(r) || unicode.In(r, unicode.Cf) {
+				return -1
+			}
+			return r
+		}, ansi.Strip(line))
+	}
+	return strings.Join(lines, "\n")
 }

--- a/cli/plugin-kit-ai/internal/agentpluginscli/color_error_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/color_error_test.go
@@ -1,0 +1,65 @@
+package agentpluginscli
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/cli/internal/terminaltheme"
+)
+
+func TestErrorTextMissingAddArguments(t *testing.T) {
+	for _, format := range []string{"human", "json"} {
+		t.Run(format, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			args := []string{"add", "--format=" + format, "--color=always"}
+			root := NewRoot(App{Output: &stdout, ErrorOutput: &stderr})
+			root.SetArgs(args)
+			err := root.Execute()
+			if err == nil {
+				t.Fatal("expected argument error")
+			}
+			want := "accepts 1 arg(s), received 0"
+			if format == "human" {
+				want += "\nProvide a plugin name or source, for example:\n  agentplugins add ./my-plugin\nSee agentplugins add --help"
+				want = (terminaltheme.Theme{Enabled: true}).Text(terminaltheme.Error, want)
+			}
+			if got := ErrorText(args, &stderr, err); got != want {
+				t.Fatalf("diagnostic = %q; want %q", got, want)
+			}
+			if stdout.Len() != 0 {
+				t.Fatal("argument error wrote to stdout")
+			}
+		})
+	}
+}
+
+func TestErrorTextLongWrappedGuidance(t *testing.T) {
+	err := fmt.Errorf("resolve package: %w\nSee agentplugins add --help", errors.New(strings.Repeat("package detail 界 ", 80)))
+	for _, flags := range [][]string{{"--color=never"}, {"--color=always", "--format=json"}, {"--unknown"}} {
+		if got := ErrorText(append([]string{"add"}, flags...), io.Discard, err); got != err.Error() {
+			t.Fatalf("long diagnostic changed: got %d bytes, want %d", len(got), len(err.Error()))
+		}
+	}
+}
+
+func TestErrorTextHostileMultiline(t *testing.T) {
+	for _, tc := range []struct{ name, input, want string }{
+		{"safe", "failure\n\n  example 界\nSee --help", "failure\n\n  example 界\nSee --help"},
+		{"ANSI OSC CR", "\x1b[31mfailure\x1b[0m\r\n\x1b]52;c;payload\aexample\x1b]8;;https://evil.example\x1b\\ link\x1b]8;;\x1b\\\nSee\x00\x7f\u0085\u202e --help", "failure\nexample link\nSee --help"},
+		{"unterminated OSC", "failure\x1b]52;c;payload\nSee --help", "failure\nSee --help"},
+		{"CR overwrite", "failure\roverwrite\b\t\nSee --help", "failureoverwrite\nSee --help"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, mode := range []string{"never", "always"} {
+				want := (terminaltheme.Theme{Enabled: mode == "always"}).Text(terminaltheme.Error, tc.want)
+				if got := ErrorText([]string{"add", "--color=" + mode}, io.Discard, errors.New(tc.input)); got != want {
+					t.Fatalf("%s diagnostic = %q; want %q", mode, got, want)
+				}
+			}
+		})
+	}
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/color_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/color_test.go
@@ -63,7 +63,7 @@ func TestJSONHelpAndErrorsHaveNoANSI(t *testing.T) {
 			t.Fatalf("ANSI: %q", out.String())
 		}
 	}
-	if got := ErrorText([]string{"add", "--color=always"}, io.Discard, errors.New("fixture\x1b[31m\nerror")); !strings.HasPrefix(got, "\x1b[31m") || strings.Contains(got, "\n") {
+	if got := ErrorText([]string{"add", "--color=always"}, io.Discard, errors.New("fixture\x1b[31m\nerror")); !strings.HasPrefix(got, "\x1b[31m") || !strings.Contains(got, "\n") {
 		t.Fatalf("error: %q", got)
 	}
 }

--- a/cli/plugin-kit-ai/internal/agentpluginscli/color_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/color_test.go
@@ -1,0 +1,139 @@
+package agentpluginscli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/cli/internal/agentpluginscli/prompt"
+	"github.com/777genius/plugin-kit-ai/cli/internal/terminaltheme"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/usecase"
+)
+
+func TestColorFlagsBeforeMutation(t *testing.T) {
+	for _, flags := range [][]string{{"--color=wrong"}, {"--color=always", "--no-color"}, {"--no-color", "--color=always"}, {"--color=never", "--color=auto"}, {"--no-color=false"}} {
+		f := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+		_, _, err := f.execute(false, append([]string{"add", writeCLIPlugin(t), "--target=cursor"}, flags...)...)
+		if err == nil {
+			t.Fatalf("accepted %v", flags)
+		}
+		state, _ := f.store.Load()
+		if len(state.Installations) != 0 {
+			t.Fatal("mutated state")
+		}
+	}
+}
+func TestColorCLIOutput(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	for _, tc := range []struct {
+		flags []string
+		want  bool
+	}{
+		{[]string{"--color=always"}, true}, {[]string{"--plain", "--color=always"}, true},
+		{[]string{"--color=never", "--no-color"}, false}, {[]string{"--color=always", "--color=always"}, true},
+		{nil, false}, {[]string{"--color=auto"}, false}, {[]string{"--color=always", "--format=json"}, false},
+	} {
+		f := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCursor)})
+		out, stderr, err := f.execute(false, append([]string{"add", writeCLIPlugin(t), "--target=cursor", "--dry-run"}, tc.flags...)...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(out, "\x1b[") != tc.want {
+			t.Fatalf("flags %v color mismatch: %.150q", tc.flags, out)
+		}
+		if !tc.want && strings.Contains(stderr, "\x1b") {
+			t.Fatal("ANSI stderr")
+		}
+	}
+}
+func TestJSONHelpAndErrorsHaveNoANSI(t *testing.T) {
+	for _, args := range [][]string{{"--color=always", "--format=json", "--help"}, {"add", "--color=always", "--format=json"}, {"add", "--color=always", "--unknown", "--format=json"}} {
+		var out bytes.Buffer
+		root := NewRoot(App{Output: &out, ErrorOutput: &out})
+		root.SetArgs(args)
+		err := root.Execute()
+		if err != nil {
+			out.WriteString(ErrorText(args, &out, err))
+		}
+		if strings.Contains(out.String(), "\x1b") {
+			t.Fatalf("ANSI: %q", out.String())
+		}
+	}
+	if got := ErrorText([]string{"add", "--color=always"}, io.Discard, errors.New("fixture\x1b[31m\nerror")); !strings.HasPrefix(got, "\x1b[31m") || strings.Contains(got, "\n") {
+		t.Fatalf("error: %q", got)
+	}
+}
+func TestColoredPlanShortWritePreventsConsent(t *testing.T) {
+	format := "human"
+	policy := terminaltheme.Policy{Mode: "always", Explicit: true}
+	cmd := NewRoot(App{})
+	app := App{reviewOutput: terminaltheme.Wrap(shortPromptWriter{}, &policy, &format), Prompter: fakePrompter{confirmFn: func() (prompt.ConfirmationResult, error) {
+		t.Fatal("consent after failed output")
+		return prompt.ConfirmationResult{}, nil
+	}}}
+	accepted, err := confirmInstall(context.Background(), cmd, app, loadedPackage{}, []usecase.AddResult{{}})
+	if accepted || !errors.Is(err, io.ErrShortWrite) {
+		t.Fatal(accepted, err)
+	}
+}
+func TestColoredPlanValuesAndBindingSanitation(t *testing.T) {
+	var out bytes.Buffer
+	format := "human"
+	p := terminaltheme.Policy{Mode: "always", Explicit: true}
+	w := terminaltheme.Wrap(&out, &p, &format)
+	result := usecase.AddResult{Plan: domain.DeliveryPlan{ClientID: "cursor", Warnings: []string{"synthetic warning"}}}
+	if err := renderHumanPlan(w, domain.PackageEnvelope{}, result); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "\x1b[36mTarget\x1b[m: cursor\n") || !strings.Contains(out.String(), "\x1b[33mWarning\x1b[m: synthetic warning") {
+		t.Fatalf("%q", out.String())
+	}
+	out.Reset()
+	if err := renderHumanBindingPlan(w, usecase.BindingChangePlan{Blockers: []string{"fixture\x1b\nforged"}}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "\x1b[31mBlocker\x1b[m: fixtureforged\n") {
+		t.Fatalf("%q", out.String())
+	}
+}
+
+// Verbose execution is a deterministic presentation demo using only in-memory data.
+func TestSemanticColorDemo(t *testing.T) {
+	for _, mode := range []string{"always", "never"} {
+		t.Run(mode, func(t *testing.T) {
+			var out bytes.Buffer
+			format := "human"
+			policy := terminaltheme.Policy{Mode: mode, Explicit: true}
+			w := terminaltheme.Wrap(&out, &policy, &format)
+			result := usecase.AddResult{Plan: domain.DeliveryPlan{ClientID: "cursor", Warnings: []string{"Synthetic review warning; no real scanner was run."}}}
+			if err := renderHumanPlan(w, domain.PackageEnvelope{}, result); err != nil {
+				t.Fatal(err)
+			}
+			if err := renderBindingChange(w, "human", "rebind", usecase.BindingChangeResult{}, false); err != nil {
+				t.Fatal(err)
+			}
+			out.WriteString(terminaltheme.For(w).Text(terminaltheme.Success, "Synthetic success") + "\n")
+			out.WriteString(terminaltheme.For(w).Text(terminaltheme.Muted, "Synthetic secondary detail") + "\n")
+			out.WriteString(ErrorText([]string{"add", "--color=" + mode}, &out, errors.New("synthetic helpful error: choose --target=cursor")) + "\n")
+			if strings.Contains(out.String(), "\x1b[") != (mode == "always") {
+				t.Fatal("demo policy mismatch")
+			}
+			t.Log("Synthetic presentation only; no mutation, profile, authentication or agent launch.\n" + out.String())
+		})
+	}
+}
+
+func TestNoColorTypedFlagCompatibility(t *testing.T) {
+	root := NewRoot(App{})
+	if err := root.ParseFlags([]string{"--no-color"}); err != nil {
+		t.Fatal(err)
+	}
+	value, err := root.PersistentFlags().GetBool("no-color")
+	if err != nil || !value {
+		t.Fatal("inherited typed bool adapter lost --no-color", value, err)
+	}
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/prompts.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/prompts.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/777genius/plugin-kit-ai/cli/internal/agentpluginscli/prompt"
+	"github.com/777genius/plugin-kit-ai/cli/internal/terminaltheme"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/usecase"
 	"github.com/spf13/cobra"
 )
@@ -18,7 +19,7 @@ func withPrompter(cmd *cobra.Command, app App, opts *options) (App, error) {
 		return app, prompt.ErrPromptUnavailable
 	}
 	var err error
-	app.Prompter, app.reviewOutput, err = app.PromptFactory(cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(), opts.plain, opts.noColor)
+	app.Prompter, app.reviewOutput, err = app.PromptFactory(cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(), opts.plain, !terminaltheme.For(visiblePromptWriter(cmd)).Enabled)
 	return app, err
 }
 func reviewWriter(cmd *cobra.Command, app App) io.Writer {
@@ -35,16 +36,16 @@ func confirmInstall(ctx context.Context, cmd *cobra.Command, app App, loaded loa
 		return false, prompt.ErrPromptUnavailable
 	}
 	writer := &planWriter{writer: reviewWriter(cmd, app)}
-	if _, err := fmt.Fprintf(writer, "Source: %s\nScope: user\n", prompt.SafeText(publicPackageSource(loaded.envelope.Source))); err != nil {
+	if _, err := fmt.Fprintf(writer, "%s: %s\n%s: user\n", terminaltheme.For(writer).Text(terminaltheme.Label, "Source"), prompt.SafeText(publicPackageSource(loaded.envelope.Source)), terminaltheme.For(writer).Text(terminaltheme.Label, "Scope")); err != nil {
 		return false, err
 	}
 	if loaded.envelope.Source.ResolvedRevision != "" {
-		if _, err := fmt.Fprintln(writer, "Revision: "+prompt.SafeText(loaded.envelope.Source.ResolvedRevision)); err != nil {
+		if _, err := fmt.Fprintln(writer, terminaltheme.For(writer).Text(terminaltheme.Label, "Revision")+": "+prompt.SafeText(loaded.envelope.Source.ResolvedRevision)); err != nil {
 			return false, err
 		}
 	}
 	if loaded.envelope.TreeDigest != "" {
-		if _, err := fmt.Fprintln(writer, "Tree: "+prompt.SafeText(loaded.envelope.TreeDigest)); err != nil {
+		if _, err := fmt.Fprintln(writer, terminaltheme.For(writer).Text(terminaltheme.Label, "Tree")+": "+prompt.SafeText(loaded.envelope.TreeDigest)); err != nil {
 			return false, err
 		}
 	}
@@ -83,3 +84,11 @@ func (w *planWriter) Write(p []byte) (int, error) {
 	}
 	return len(p), nil
 }
+
+func visiblePromptWriter(cmd *cobra.Command) io.Writer {
+	if terminaltheme.IsTerminal(cmd.OutOrStdout()) {
+		return cmd.OutOrStdout()
+	}
+	return cmd.ErrOrStderr()
+}
+func (w *planWriter) SemanticTheme() terminaltheme.Theme { return terminaltheme.For(w.writer) }

--- a/cli/plugin-kit-ai/internal/agentpluginscli/read.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/read.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/777genius/plugin-kit-ai/cli/internal/agentpluginscli/prompt"
+	"github.com/777genius/plugin-kit-ai/cli/internal/terminaltheme"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/adapters/dirswap"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 	clientplanner "github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/planner"
@@ -241,22 +243,22 @@ func runDoctor(ctx context.Context, cmd *cobra.Command, app App, opts *options, 
 		return writeJSONOutput(cmd.OutOrStdout(), "doctor", report)
 	}
 	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "agentplugins doctor (read-only)")
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Tool version: %s\n", report.ToolVersion)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s: %s\n", terminaltheme.For(cmd.OutOrStdout()).Text(terminaltheme.Label, "Tool version"), report.ToolVersion)
 	for _, client := range clients {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s: %s\n", client.DisplayName, client.Status)
 	}
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Tracked installations: %d\n", report.InstallationCount)
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Open recovery operations: %d\n", report.OpenOperationCount)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s: %d\n", terminaltheme.For(cmd.OutOrStdout()).Text(terminaltheme.Label, "Tracked installations"), report.InstallationCount)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s: %d\n", terminaltheme.For(cmd.OutOrStdout()).Text(terminaltheme.Label, "Open recovery operations"), report.OpenOperationCount)
 	for _, finding := range report.Findings {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  [%s] %s: %s\n", finding.Status, finding.Code, finding.Message)
 		if finding.InstallationID != "" {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "    Installation: %s (%s)\n", finding.InstallationName, finding.InstallationID)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "    %s: %s (%s)\n", terminaltheme.For(cmd.OutOrStdout()).Text(terminaltheme.Label, "Installation"), finding.InstallationName, finding.InstallationID)
 		}
 		if finding.ClientID != "" {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "    Client: %s\n", finding.ClientID)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "    %s: %s\n", terminaltheme.For(cmd.OutOrStdout()).Text(terminaltheme.Label, "Client"), finding.ClientID)
 		}
 		if finding.RecoveryAction != "" {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "    Recovery: %s\n", finding.RecoveryAction)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "    %s: %s\n", terminaltheme.For(cmd.OutOrStdout()).Text(terminaltheme.Label, "Recovery"), finding.RecoveryAction)
 		}
 	}
 	if report.Installation != nil {
@@ -614,7 +616,7 @@ func selectInstallation(state domain.StateFileV2, selector string) (domain.Insta
 
 func renderInstallationList(writer io.Writer, installations []publicInstallation) error {
 	if len(installations) == 0 {
-		_, _ = fmt.Fprintln(writer, "No Agent Plugins installations are tracked.")
+		_, _ = fmt.Fprintln(writer, terminaltheme.For(writer).Text(terminaltheme.Muted, "No Agent Plugins installations are tracked."))
 		return nil
 	}
 	for _, installation := range installations {
@@ -627,10 +629,10 @@ func renderInstallationList(writer io.Writer, installations []publicInstallation
 
 func renderInstallation(writer io.Writer, installation publicInstallation) error {
 	_, _ = fmt.Fprintf(writer, "%s %s (%s)\n", installation.Name, installation.Version, installation.InstallationID)
-	_, _ = fmt.Fprintf(writer, "  Source: %s\n", installation.Source)
+	_, _ = fmt.Fprintf(writer, "  %s: %s\n", terminaltheme.For(writer).Text(terminaltheme.Label, "Source"), installation.Source)
 	for _, client := range installation.Clients {
 		_, _ = fmt.Fprintf(writer, "  %s: materialization=%s activation=%s auth=%s verification=%s\n",
-			client.ClientID, client.Materialization, client.Activation, client.Authentication, client.Verification)
+			terminaltheme.For(writer).Text(terminaltheme.Label, prompt.SafeText(string(client.ClientID))), client.Materialization, client.Activation, client.Authentication, client.Verification)
 		if client.ReceiptReconciled != nil && client.NativeDiscoveryReconciled != nil {
 			_, _ = fmt.Fprintf(writer, "    native_identity=%s receipt_reconciled=%t native_discovery_reconciled=%t client_version=%s\n",
 				client.NativeIdentityState, *client.ReceiptReconciled, *client.NativeDiscoveryReconciled, client.ClientVersion)
@@ -638,7 +640,7 @@ func renderInstallation(writer io.Writer, installation publicInstallation) error
 	}
 	if installation.Directory != nil {
 		value := installation.Directory
-		_, _ = fmt.Fprintf(writer, "  Directory: recorded=%s@%s release=%d current=%s@%s release=%d\n",
+		_, _ = fmt.Fprintf(writer, "  %s: recorded=%s@%s release=%d current=%s@%s release=%d\n", terminaltheme.For(writer).Text(terminaltheme.Label, "Directory"),
 			value.RecordedDistribution, value.RecordedRevision, value.RecordedReleaseSequence,
 			value.CurrentDistribution, value.CurrentRevision, value.CurrentReleaseSequence)
 	}
@@ -646,9 +648,9 @@ func renderInstallation(writer io.Writer, installation publicInstallation) error
 		_, _ = fmt.Fprintf(writer, "  Mixed version: true\n  Convergence: %s\n", installation.ConvergenceAction)
 	}
 	for _, warning := range installation.Warnings {
-		_, _ = fmt.Fprintf(writer, "  WARNING [%s]: %s\n", warning.Code, warning.Message)
+		_, _ = fmt.Fprintf(writer, "  %s [%s]: %s\n", terminaltheme.For(writer).Text(terminaltheme.Warning, "WARNING"), warning.Code, warning.Message)
 		if warning.Action != "" {
-			_, _ = fmt.Fprintf(writer, "    Action: %s\n", warning.Action)
+			_, _ = fmt.Fprintf(writer, "    %s: %s\n", terminaltheme.For(writer).Text(terminaltheme.Label, "Action"), warning.Action)
 		}
 	}
 	return nil

--- a/cli/plugin-kit-ai/internal/agentpluginscli/root.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/root.go
@@ -3,6 +3,7 @@ package agentpluginscli
 import (
 	"fmt"
 
+	"github.com/777genius/plugin-kit-ai/cli/internal/terminaltheme"
 	"github.com/spf13/cobra"
 )
 
@@ -15,6 +16,8 @@ func NewRoot(app App) *cobra.Command {
 		SilenceErrors: true,
 	}
 	root.SetIn(app.input())
+	app.Output = terminaltheme.Wrap(app.output(), &opts.color, &opts.format)
+	app.ErrorOutput = terminaltheme.Wrap(app.errorOutput(), &opts.color, &opts.format)
 	root.SetOut(app.output())
 	root.SetErr(app.errorOutput())
 	flags := root.PersistentFlags()
@@ -22,8 +25,10 @@ func NewRoot(app App) *cobra.Command {
 	flags.StringVar(&opts.scope, "scope", "user", "installation scope (user only in this release)")
 	flags.BoolVar(&opts.dryRun, "dry-run", false, "show the exact plan without changes")
 	flags.StringVar(&opts.format, "format", "human", "output format: human or json")
-	flags.BoolVar(&opts.plain, "plain", false, "use accessible line prompts without terminal controls")
-	flags.BoolVar(&opts.noColor, "no-color", false, "disable color output")
+	flags.BoolVar(&opts.plain, "plain", false, "use accessible line prompts (independent of color)")
+	flags.Var(&opts.color, "color", "human output color: auto, never, always")
+	flags.Var(terminaltheme.NoColorFlag{Policy: &opts.color}, "no-color", "alias for --color=never")
+	flags.Lookup("no-color").NoOptDefVal = "true"
 	flags.BoolVar(&opts.acceptSecurityRisk, "accept-security-risk", false, "continue despite blocking automated security findings")
 	flags.BoolVar(&opts.securityDetails, "security-details", false, "show every automated security finding in human output")
 

--- a/cli/plugin-kit-ai/internal/promptio/line_darwin.go
+++ b/cli/plugin-kit-ai/internal/promptio/line_darwin.go
@@ -34,7 +34,7 @@ func readUnixTerminalLine(ctx context.Context, reader io.Reader, f *os.File) (li
 		return "", fmt.Errorf("reprocess prompt input: %w", e)
 	}
 	defer func() {
-		if e := unix.IoctlSetTermios(int(f.Fd()), unix.TIOCSETA, attrs); e != nil {
+		if e := restoreTerminal(int(f.Fd()), attrs); e != nil {
 			line = ""
 			err = fmt.Errorf("restore prompt terminal: %w", e)
 		}

--- a/cli/plugin-kit-ai/internal/promptio/terminal_darwin.go
+++ b/cli/plugin-kit-ai/internal/promptio/terminal_darwin.go
@@ -1,0 +1,51 @@
+//go:build darwin
+
+package promptio
+
+import "golang.org/x/sys/unix"
+
+// SnapshotTerminal returns a restore callback for the current terminal state.
+// Call it after this owner's input readers and cancellation callbacks have joined.
+func SnapshotTerminal(fd int) (func() error, error) {
+	attrs, err := unix.IoctlGetTermios(fd, unix.TIOCGETA)
+	if err != nil {
+		return nil, err
+	}
+	return func() error { return restoreTerminal(fd, attrs) }, nil
+}
+
+func restoreTerminal(fd int, attrs *unix.Termios) error {
+	initial := *attrs
+	if attrs.Lflag&(unix.ICANON|unix.PENDIN) == unix.ICANON {
+		current, err := unix.IoctlGetTermios(fd, unix.TIOCGETA)
+		if err != nil {
+			return err
+		}
+		if current.Lflag&unix.ICANON == 0 {
+			// TIOCSETA wakes kqueue readers before installing ICANON. Their
+			// ttnread can clear the kernel's PENDIN under the old raw settings,
+			// leaving even newline-terminated input in the raw queue. Include
+			// PENDIN in the requested flags so canonical replay remains due
+			// after the new settings are installed.
+			initial.Lflag |= unix.PENDIN
+		}
+	}
+	if err := unix.IoctlSetTermios(fd, unix.TIOCSETA, &initial); err != nil {
+		return err
+	}
+	if attrs.Lflag&unix.PENDIN != 0 {
+		return nil
+	}
+	// Darwin can retain PENDIN across TIOCSETA. FIONREAD lets the line
+	// discipline reprocess pending input and clear that transient flag without
+	// dequeuing any bytes into userspace. Do not do this when PENDIN was set in
+	// the caller's snapshot: that pending work belongs to the next owner.
+	// FIONREAD = _IOR('f', 127, int), not exported by x/sys on Darwin.
+	if _, err := unix.IoctlGetInt(fd, 0x4004667f); err != nil {
+		return err
+	}
+	// Replay can change other flags (ttyecho clears FLUSHO). Restore the
+	// snapshot again now that PENDIN is clear. ICANON already matches, so this
+	// TIOCSETA does not schedule another replay.
+	return unix.IoctlSetTermios(fd, unix.TIOCSETA, attrs)
+}

--- a/cli/plugin-kit-ai/internal/promptio/terminal_other.go
+++ b/cli/plugin-kit-ai/internal/promptio/terminal_other.go
@@ -1,0 +1,15 @@
+//go:build !darwin
+
+package promptio
+
+import "golang.org/x/term"
+
+// SnapshotTerminal returns a restore callback for the current terminal state.
+// Call it after this owner's input readers and cancellation callbacks have joined.
+func SnapshotTerminal(fd int) (func() error, error) {
+	state, err := term.GetState(fd)
+	if err != nil {
+		return nil, err
+	}
+	return func() error { return term.Restore(fd, state) }, nil
+}

--- a/cli/plugin-kit-ai/internal/terminalprompts/color_linux_test.go
+++ b/cli/plugin-kit-ai/internal/terminalprompts/color_linux_test.go
@@ -1,0 +1,61 @@
+//go:build linux
+
+package terminalprompts
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/cli/internal/terminaltheme"
+	"golang.org/x/sys/unix"
+)
+
+func TestColorPerStreamAndVisiblePrompt(t *testing.T) {
+	t.Setenv("TERM", "xterm-256color")
+	t.Setenv("NO_COLOR", "")
+	master, err := os.OpenFile("/dev/ptmx", os.O_RDWR|unix.O_NOCTTY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer master.Close()
+	if err := unix.IoctlSetPointerInt(int(master.Fd()), unix.TIOCSPTLCK, 0); err != nil {
+		t.Fatal(err)
+	}
+	n, err := unix.IoctlGetInt(int(master.Fd()), unix.TIOCGPTN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	slave, err := os.OpenFile(fmt.Sprintf("/dev/pts/%d", n), os.O_RDWR|unix.O_NOCTTY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer slave.Close()
+	if err := unix.IoctlSetWinsize(int(slave.Fd()), unix.TIOCSWINSZ, &unix.Winsize{Row: 30, Col: 100}); err != nil {
+		t.Fatal(err)
+	}
+	var redirected bytes.Buffer
+	format := "human"
+	policy := terminaltheme.Policy{}
+	stdout := terminaltheme.Wrap(&redirected, &policy, &format)
+	stderr := terminaltheme.Wrap(slave, &policy, &format)
+	if terminaltheme.For(stdout).Enabled || !terminaltheme.For(stderr).Enabled {
+		t.Fatal("streams share detection")
+	}
+	p, visible, err := New(slave, stdout, stderr, false, !terminaltheme.For(stderr).Enabled)
+	if err != nil || visible != stderr {
+		t.Fatal("lost visible review stream", err)
+	}
+	plain, ok := p.(PlainPrompter)
+	if !ok || !terminaltheme.For(plain.Output).Enabled {
+		t.Fatal("redirected stdout must retain colored plain stderr")
+	}
+	policy.Mode = "never"
+	policy.Explicit = true
+	p, visible, err = New(slave, stderr, stderr, false, !terminaltheme.For(stderr).Enabled)
+	rich, ok := p.(HuhPrompter)
+	if err != nil || !ok || !rich.NoColor || visible != stderr {
+		t.Fatal("never must preserve rich interaction", err)
+	}
+}

--- a/cli/plugin-kit-ai/internal/terminalprompts/color_test.go
+++ b/cli/plugin-kit-ai/internal/terminalprompts/color_test.go
@@ -1,0 +1,51 @@
+package terminalprompts
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/777genius/plugin-kit-ai/cli/internal/agentpluginscli/prompt"
+	"github.com/777genius/plugin-kit-ai/cli/internal/terminaltheme"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+func TestPlainColoredAndRichNever(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	var out strings.Builder
+	format := "human"
+	policy := terminaltheme.Policy{Mode: "always", Explicit: true}
+	p := PlainPrompter{Input: strings.NewReader("yes\n"), Output: terminaltheme.Wrap(&out, &policy, &format)}
+	result, err := p.Confirm(context.Background(), prompt.ConfirmationRequest{Title: "Apply fixture?"})
+	if err != nil || !result.Accepted || !strings.Contains(out.String(), "\x1b[36mApply fixture?\x1b[m") {
+		t.Fatal(result, err, out.String())
+	}
+	out.Reset()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	result, err = (HuhPrompter{Input: strings.NewReader("\r"), Output: &out, NoColor: true}).Confirm(ctx, prompt.ConfirmationRequest{Title: "Apply fixture?"})
+	if err != nil || result.Accepted {
+		t.Fatal(result, err)
+	}
+	if regexp.MustCompile(`\x1b\[[0-9;]*m`).MatchString(out.String()) {
+		t.Fatalf("SGR in color-disabled rich prompt: %q", out.String())
+	}
+}
+
+func TestSyntheticColorSelectionDemo(t *testing.T) {
+	var out strings.Builder
+	format := "human"
+	policy := terminaltheme.Policy{Mode: "always", Explicit: true}
+	p := PlainPrompter{Input: strings.NewReader("1\n"), Output: terminaltheme.Wrap(&out, &policy, &format)}
+	request := prompt.TargetSelectionRequest{Choices: []prompt.TargetChoice{{ID: "cursor", Label: "Synthetic Cursor"}, {ID: "codex", Label: "Synthetic Codex"}}, DefaultIDs: []domain.ClientID{"cursor", "codex"}, SkippedLabels: []string{"Synthetic unsupported client"}}
+	selected, err := p.SelectTargets(context.Background(), request)
+	if err != nil || len(selected.IDs) != 1 || selected.IDs[0] != "cursor" {
+		t.Fatal(selected, err)
+	}
+	if !strings.Contains(out.String(), "\x1b[33mSkipped") || !strings.Contains(out.String(), "\x1b[36mChoose") {
+		t.Fatal("missing semantic selection colors")
+	}
+	t.Log("Synthetic selection; input is the in-memory line 1, not a live terminal session.\n" + out.String())
+}

--- a/cli/plugin-kit-ai/internal/terminalprompts/consent.go
+++ b/cli/plugin-kit-ai/internal/terminalprompts/consent.go
@@ -1,0 +1,127 @@
+package terminalprompts
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"golang.org/x/term"
+)
+
+// confirmationInput establishes a new consent boundary BEFORE displaying the
+// question. Snapshot only the terminal bytes already queued, never flush the
+// terminal or drain until empty: input arriving after the snapshot belongs to
+// the new question. Scripted non-terminal readers keep their answer contract.
+func confirmationInput(ctx context.Context, input io.Reader) (keys []byte, err error) {
+	f, ok := input.(*os.File)
+	if !ok || !term.IsTerminal(int(f.Fd())) {
+		return nil, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	// Canonical mode can hide an incomplete queued line (notably a lone Space).
+	// This short, synchronous ownership interval has no competing form reader.
+	state, err := term.MakeRaw(int(f.Fd()))
+	if err != nil {
+		return nil, fmt.Errorf("prepare consent boundary: %w", err)
+	}
+	defer func() {
+		if e := term.Restore(int(f.Fd()), state); e != nil {
+			keys, err = nil, fmt.Errorf("restore consent boundary: %w", e)
+		}
+	}()
+	n, err := queuedInputBytes(f)
+	if err != nil {
+		return nil, fmt.Errorf("inspect consent boundary: %w", err)
+	}
+	queued, submitted, err := readQueuedInput(ctx, f, n)
+	if err != nil {
+		return nil, fmt.Errorf("read consent boundary: %w", err)
+	}
+	keys = queuedConfirmationKeys(queued)
+	// A raw submission gate ends this owner's stale answer even if the event
+	// decoder ignores it (for example ESC CR is Alt+Enter). Resolve default No
+	// before the live form can read the untouched suffix for the next owner.
+	if submitted && len(keys) == 0 {
+		keys = []byte{'\r'}
+	}
+	return keys, nil
+}
+
+func readQueuedInput(ctx context.Context, input io.Reader, n int) ([]byte, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	// Reuse the handoff parser: even within the snapshot, stop at the first
+	// non-pasted submission and leave the next owner's answer in the terminal.
+	r := newSubmissionReader(ctx, input)
+	defer r.finish()
+	queued := make([]byte, 0, n)
+	var b [1]byte
+	for len(queued) < n {
+		count, err := r.Read(b[:])
+		if e := ctx.Err(); e != nil {
+			return nil, false, e
+		}
+		if err != nil {
+			return nil, false, err
+		}
+		if count == 0 {
+			return nil, false, io.ErrNoProgress
+		}
+		queued = append(queued, b[0])
+		// Read is synchronous; there is no second reader accessing this gate.
+		if r.gate != nil {
+			return queued, true, nil
+		}
+	}
+	return queued, false, nil
+}
+
+// Old keys may decline or cancel, but cannot choose Yes. Decode with the same
+// event decoder as Bubble Tea, including enhanced keyboard encodings. Paste is
+// ignored as a whole; an unfinished paste fails closed rather than interpreting
+// its later suffix as fresh consent. The live form still parses all fresh input.
+func queuedConfirmationKeys(queued []byte) []byte {
+	var decoder uv.EventDecoder
+	for len(queued) > 0 {
+		// The decoder treats ESC+[ alone as Alt+[. At this boundary it may be
+		// the beginning of a paste, whose later bytes must not become consent.
+		if bytes.Equal(queued, []byte("\x1b[")) {
+			return []byte{3}
+		}
+		n, event := decoder.Decode(queued)
+		if n <= 0 {
+			return []byte{3}
+		}
+		queued = queued[n:]
+		switch event := event.(type) {
+		case uv.PasteStartEvent:
+			end := bytes.Index(queued, []byte("\x1b[201~"))
+			if end < 0 {
+				return []byte{3}
+			}
+			queued = queued[end+len("\x1b[201~"):]
+		case uv.UnknownEvent, uv.UnknownCsiEvent, uv.UnknownSs3Event,
+			uv.UnknownOscEvent, uv.UnknownDcsEvent, uv.UnknownSosEvent,
+			uv.UnknownPmEvent, uv.UnknownApcEvent:
+			return []byte{3}
+		case uv.KeyPressEvent:
+			switch event.String() {
+			case "enter":
+				return []byte{'\r'}
+			case "esc":
+				return []byte{27}
+			case "ctrl+c":
+				return []byte{3}
+			case "ctrl+d":
+				return []byte{4}
+			}
+		}
+	}
+	return nil
+}

--- a/cli/plugin-kit-ai/internal/terminalprompts/consent_bsd.go
+++ b/cli/plugin-kit-ai/internal/terminalprompts/consent_bsd.go
@@ -1,0 +1,14 @@
+//go:build darwin || freebsd || openbsd || netbsd || dragonfly
+
+package terminalprompts
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func queuedInputBytes(f *os.File) (int, error) {
+	// FIONREAD = _IOR('f', 127, int), not exported by x/sys on BSD systems.
+	return unix.IoctlGetInt(int(f.Fd()), 0x4004667f)
+}

--- a/cli/plugin-kit-ai/internal/terminalprompts/consent_darwin_test.go
+++ b/cli/plugin-kit-ai/internal/terminalprompts/consent_darwin_test.go
@@ -1,0 +1,109 @@
+//go:build darwin
+
+package terminalprompts
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const consentGetTermios = unix.TIOCGETA
+
+func consentPTY(t *testing.T) (*os.File, *os.File) {
+	t.Helper()
+	master, slave := darwinHandoffPTY(t)
+	if err := unix.IoctlSetWinsize(int(slave.Fd()), unix.TIOCSWINSZ, &unix.Winsize{Row: 30, Col: 100}); err != nil {
+		t.Fatal(err)
+	}
+	return master, slave
+}
+
+// Unlike os.OpenFile, a blocking inherited descriptor wrapped by os.NewFile
+// does not register the slave with Go's kqueue poller. Snapshot the untouched
+// kernel defaults, as the native Python openpty CLI harness does, and also
+// exercise both values of Darwin's transient PENDIN flag. Never reset attributes
+// between selection, confirmation and the plain owner.
+func TestDarwinConsentInheritedPTY(t *testing.T) {
+	for _, flags := range []string{"kernel-defaults", "pendin-set", "pendin-clear"} {
+		t.Run(flags, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestDarwinConsentInheritedPTYChild$", "-test.v")
+			root := t.TempDir()
+			cmd.Env = []string{"HOME=" + root, "USERPROFILE=" + root,
+				"XDG_CONFIG_HOME=" + root, "XDG_DATA_HOME=" + root, "XDG_CACHE_HOME=" + root,
+				"TMPDIR=" + root, "DARWIN_CONSENT_FLAGS=" + flags}
+			out, err := cmd.CombinedOutput()
+			t.Logf("%s", out)
+			if err != nil {
+				t.Fatalf("native inherited PTY: %v (deadline: %v)", err, ctx.Err())
+			}
+		})
+	}
+}
+
+func TestDarwinConsentInheritedPTYChild(t *testing.T) {
+	flags := os.Getenv("DARWIN_CONSENT_FLAGS")
+	if flags == "" {
+		return
+	}
+	testConsentPTYBoundary(t, func(t *testing.T) (*os.File, *os.File) {
+		master, err := os.OpenFile("/dev/ptmx", os.O_RDWR|unix.O_NOCTTY|unix.O_NONBLOCK, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { master.Close() })
+		var name [128]byte
+		_, _, errno := unix.Syscall(unix.SYS_IOCTL, master.Fd(), unix.TIOCPTYGNAME, uintptr(unsafe.Pointer(&name[0])))
+		if errno != 0 {
+			t.Fatal(errno)
+		}
+		for _, op := range []uint{unix.TIOCPTYGRANT, unix.TIOCPTYUNLK} {
+			if err := unix.IoctlSetInt(int(master.Fd()), op, 0); err != nil {
+				t.Fatal(err)
+			}
+		}
+		path := strings.TrimRight(string(name[:]), "\x00")
+		fd, err := unix.Open(path, unix.O_RDWR|unix.O_NOCTTY, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		slave := os.NewFile(uintptr(fd), path)
+		t.Cleanup(func() { slave.Close() })
+		if flags != "kernel-defaults" {
+			attrs, err := unix.IoctlGetTermios(fd, unix.TIOCGETA)
+			if err != nil {
+				t.Fatal(err)
+			}
+			switch flags {
+			case "pendin-set":
+				attrs.Lflag |= unix.PENDIN
+			case "pendin-clear":
+				attrs.Lflag &^= unix.PENDIN
+			default:
+				t.Fatalf("unknown initial flags %q", flags)
+			}
+			if err := unix.IoctlSetTermios(fd, unix.TIOCSETA, attrs); err != nil {
+				t.Fatal(err)
+			}
+			actual, err := unix.IoctlGetTermios(fd, unix.TIOCGETA)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if actual.Lflag&unix.PENDIN != attrs.Lflag&unix.PENDIN {
+				t.Fatalf("initial PENDIN not established: got %+v want %+v", actual, attrs)
+			}
+		}
+		if err := unix.IoctlSetWinsize(fd, unix.TIOCSWINSZ, &unix.Winsize{Row: 30, Col: 100}); err != nil {
+			t.Fatal(err)
+		}
+		return master, slave
+	})
+}

--- a/cli/plugin-kit-ai/internal/terminalprompts/consent_linux.go
+++ b/cli/plugin-kit-ai/internal/terminalprompts/consent_linux.go
@@ -1,0 +1,11 @@
+package terminalprompts
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func queuedInputBytes(f *os.File) (int, error) {
+	return unix.IoctlGetInt(int(f.Fd()), unix.TIOCINQ)
+}

--- a/cli/plugin-kit-ai/internal/terminalprompts/consent_linux_test.go
+++ b/cli/plugin-kit-ai/internal/terminalprompts/consent_linux_test.go
@@ -1,0 +1,38 @@
+//go:build linux
+
+package terminalprompts
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+const consentGetTermios = unix.TCGETS
+
+func consentPTY(t *testing.T) (*os.File, *os.File) {
+	t.Helper()
+	master, err := os.OpenFile("/dev/ptmx", os.O_RDWR|unix.O_NOCTTY|unix.O_NONBLOCK, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { master.Close() })
+	if err := unix.IoctlSetPointerInt(int(master.Fd()), unix.TIOCSPTLCK, 0); err != nil {
+		t.Fatal(err)
+	}
+	number, err := unix.IoctlGetInt(int(master.Fd()), unix.TIOCGPTN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	slave, err := os.OpenFile(fmt.Sprintf("/dev/pts/%d", number), os.O_RDWR|unix.O_NOCTTY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { slave.Close() })
+	if err := unix.IoctlSetWinsize(int(slave.Fd()), unix.TIOCSWINSZ, &unix.Winsize{Row: 30, Col: 100}); err != nil {
+		t.Fatal(err)
+	}
+	return master, slave
+}

--- a/cli/plugin-kit-ai/internal/terminalprompts/consent_other.go
+++ b/cli/plugin-kit-ai/internal/terminalprompts/consent_other.go
@@ -1,0 +1,13 @@
+//go:build !linux && !darwin && !freebsd && !openbsd && !netbsd && !dragonfly
+
+package terminalprompts
+
+import (
+	"os"
+
+	"github.com/777genius/plugin-kit-ai/cli/internal/agentpluginscli/prompt"
+)
+
+func queuedInputBytes(*os.File) (int, error) {
+	return 0, prompt.ErrPromptUnavailable
+}

--- a/cli/plugin-kit-ai/internal/terminalprompts/consent_pty_test.go
+++ b/cli/plugin-kit-ai/internal/terminalprompts/consent_pty_test.go
@@ -1,0 +1,157 @@
+//go:build linux || darwin
+
+package terminalprompts
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/777genius/plugin-kit-ai/cli/internal/agentpluginscli/prompt"
+	"github.com/777genius/plugin-kit-ai/cli/internal/promptio"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"golang.org/x/sys/unix"
+)
+
+// The controller writes one actual PTY batch at the selection frame. There is
+// no delay between that submission and the queued confirmation keys.
+func TestConsentPTYBoundary(t *testing.T) {
+	testConsentPTYBoundary(t, consentPTY)
+}
+
+func testConsentPTYBoundary(t *testing.T, openPTY func(*testing.T) (*os.File, *os.File)) {
+	t.Setenv("TERM", "xterm-256color")
+	for _, tc := range []struct {
+		name, selection, confirmation, remaining string
+		accepted                                 bool
+		wantErr                                  error
+	}{
+		{name: "queued-space-enter", selection: "\r \r"},
+		{name: "queued-alt-enter-space-enter", selection: "\r\x1b\r \r"},
+		{name: "queued-alt-enter-left-enter", selection: "\r\x1b\r\x1b[D\r"},
+		{name: "queued-alt-enter-enhanced-space-enter", selection: "\r\x1b\r\x1b[32u\r"},
+		{name: "queued-space-alt-enter-space-enter", selection: "\r \x1b\r \r"},
+		{name: "queued-alt-enter-next-owner", selection: "\r\x1b\rnext-owner\n", remaining: "next-owner"},
+		{name: "queued-double-escape-enter", selection: "\r\x1b\x1b\r \r"},
+		{name: "queued-incomplete-csi-enter", selection: "\r\x1b[32;\r \r", wantErr: prompt.ErrPromptCanceled},
+		{name: "queued-enters", selection: "\r\r"},
+		{name: "queued-yes", selection: "\ry\r"},
+		{name: "queued-left", selection: "\r\x1b[D\r"},
+		{name: "queued-right", selection: "\r\x1b[C\r"},
+		{name: "queued-enhanced-space", selection: "\r\x1b[32u\r"},
+		{name: "queued-space-fresh-enter", selection: "\r ", confirmation: "\r"},
+		{name: "queued-space-fresh-consent", selection: "\r ", confirmation: " \r", accepted: true},
+		{name: "queued-paste-fresh-consent", selection: "\r\x1b[200~ \ry\n\x1b[201~", confirmation: " \r", accepted: true},
+		{name: "incomplete-paste", selection: "\r\x1b[200~ \r", wantErr: prompt.ErrPromptCanceled},
+		{name: "queued-escape", selection: "\r\x1b", wantErr: prompt.ErrPromptCanceled},
+		{name: "queued-ctrl-c", selection: "\r\x03", wantErr: prompt.ErrPromptCanceled},
+		{name: "queued-ctrl-d", selection: "\r\x04", wantErr: prompt.ErrPromptCanceled},
+		{name: "fresh-space-enter", selection: "\r", confirmation: " \r", accepted: true},
+		{name: "fresh-left-enter", selection: "\r", confirmation: "\x1b[D\r", accepted: true},
+		{name: "fresh-paste-default-no", selection: "\r", confirmation: "\x1b[200~ \ry\n\x1b[201~\r"},
+		{name: "fresh-default-no", selection: "\r", confirmation: "\r"},
+		{name: "fresh-escape", selection: "\r", confirmation: "\x1b", wantErr: prompt.ErrPromptCanceled},
+		{name: "fresh-ctrl-c", selection: "\r", confirmation: "\x03", wantErr: prompt.ErrPromptCanceled},
+		{name: "fresh-ctrl-d", selection: "\r", confirmation: "\x04", wantErr: prompt.ErrPromptCanceled},
+		{name: "stale-next-owner", selection: "\r \rnext-owner\n", remaining: "next-owner"},
+		{name: "fresh-next-owner", selection: "\r", confirmation: " \rnext-owner\n", accepted: true, remaining: "next-owner"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			master, slave := openPTY(t)
+			before, err := unix.IoctlGetTermios(int(slave.Fd()), consentGetTermios)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("initial terminal: %+v", before)
+			drained := make(chan []byte, 1)
+			go func() {
+				var output bytes.Buffer
+				var buf [4096]byte
+				selectionSent, confirmationSent := false, false
+				for {
+					n, err := master.Read(buf[:])
+					output.Write(buf[:n])
+					if !selectionSent && bytes.Contains(output.Bytes(), []byte("Choose targets")) {
+						selectionSent = true
+						if n, e := io.WriteString(master, tc.selection); e != nil || n != len(tc.selection) {
+							t.Errorf("selection write=%d %v", n, e)
+						}
+					}
+					if selectionSent && !confirmationSent && tc.confirmation != "" && bytes.Contains(output.Bytes(), []byte("Yes")) {
+						confirmationSent = true
+						if n, e := io.WriteString(master, tc.confirmation); e != nil || n != len(tc.confirmation) {
+							t.Errorf("confirmation write=%d %v", n, e)
+						}
+					}
+					if err != nil {
+						drained <- output.Bytes()
+						return
+					}
+				}
+			}()
+			defer func() {
+				slave.Close()
+				master.Close()
+				select {
+				case <-drained:
+				case <-time.After(time.Second):
+					t.Error("controller did not join")
+				}
+			}()
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			p := HuhPrompter{Input: slave, Output: slave, NoColor: true}
+			_, err = p.SelectTargets(ctx, prompt.TargetSelectionRequest{Choices: []prompt.TargetChoice{{ID: "cursor", Label: "Fixture"}}, DefaultIDs: []domain.ClientID{"cursor"}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			selected, selectErr := unix.IoctlGetTermios(int(slave.Fd()), consentGetTermios)
+			if selectErr != nil {
+				t.Fatal(selectErr)
+			}
+			if *selected != *before {
+				t.Errorf("selection changed terminal: got %+v want %+v", selected, before)
+			}
+			result, err := p.Confirm(ctx, prompt.ConfirmationRequest{Title: "Apply fixture?"})
+			after, restoreErr := unix.IoctlGetTermios(int(slave.Fd()), consentGetTermios)
+			if restoreErr != nil {
+				t.Fatal(restoreErr)
+			}
+			if *after != *before {
+				t.Errorf("confirmation changed terminal: got %+v want %+v", after, before)
+			}
+			if tc.remaining != "" {
+				line, e := promptio.ReadLine(ctx, slave)
+				if e != nil || line != tc.remaining {
+					t.Errorf("next owner: %q %v", line, e)
+				}
+				afterLine, e := unix.IoctlGetTermios(int(slave.Fd()), consentGetTermios)
+				if e != nil {
+					t.Fatal(e)
+				}
+				if *afterLine != *before {
+					t.Errorf("plain handoff changed terminal: got %+v want %+v", afterLine, before)
+				}
+			}
+			slave.Close()
+			var output []byte
+			select {
+			case output = <-drained:
+			case <-ctx.Done():
+				t.Fatal("output did not drain")
+			}
+			drained <- output
+			t.Logf("selection batch=%x separate confirmation=%x accepted=%v error=%v\n%s", tc.selection, tc.confirmation, result.Accepted, err, output)
+			if !errors.Is(err, tc.wantErr) || result.Accepted != tc.accepted {
+				t.Fatalf("confirmation=%+v %v; want accepted=%v", result, err, tc.accepted)
+			}
+			if bytes.LastIndex(output, []byte("\x1b[?25h")) <= bytes.LastIndex(output, []byte("\x1b[?25l")) {
+				t.Error("cursor not restored")
+			}
+		})
+	}
+}

--- a/cli/plugin-kit-ai/internal/terminalprompts/consent_test.go
+++ b/cli/plugin-kit-ai/internal/terminalprompts/consent_test.go
@@ -1,0 +1,65 @@
+package terminalprompts
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// The count is captured before the new question. Extra input is already
+// readable by the time the snapshot is consumed; it must remain untouched.
+func TestConsentSnapshotDoesNotDrainLaterInput(t *testing.T) {
+	for _, tc := range []struct {
+		input        string
+		n            int
+		queued, rest string
+		submitted    bool
+	}{
+		{" \r", 1, " ", "\r", false},
+		{"\x1b[D \r", 3, "\x1b[D", " \r", false},
+		{" \rnext\n", 8, " \r", "next\n", true},
+		{"\x1b[200~ \r\x1b[201~ \rnext\n", 21, "\x1b[200~ \r\x1b[201~ \r", "next\n", true},
+		{"\x1b\r \r", 4, "\x1b\r", " \r", true},
+		{" \r", 0, "", " \r", false},
+	} {
+		t.Run(tc.queued, func(t *testing.T) {
+			input := strings.NewReader(tc.input)
+			queued, submitted, err := readQueuedInput(context.Background(), input, tc.n)
+			if err != nil || string(queued) != tc.queued || submitted != tc.submitted {
+				t.Fatalf("snapshot=%q submitted=%v %v", queued, submitted, err)
+			}
+			rest, err := io.ReadAll(input)
+			if err != nil || string(rest) != tc.rest {
+				t.Fatalf("later input=%q %v", rest, err)
+			}
+		})
+	}
+}
+
+func TestConsentSnapshotCancellationAndEOF(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	input := strings.NewReader(" \r")
+	if _, _, err := readQueuedInput(ctx, input, 2); !errors.Is(err, context.Canceled) || input.Len() != 2 {
+		t.Fatalf("canceled snapshot consumed input: %v", err)
+	}
+	if _, _, err := readQueuedInput(context.Background(), strings.NewReader(" "), 2); !errors.Is(err, io.EOF) {
+		t.Fatalf("snapshot EOF=%v", err)
+	}
+}
+
+func TestQueuedConfirmationKeysCannotChooseYes(t *testing.T) {
+	for _, tc := range []struct{ input, want string }{
+		{" \r", "\r"}, {"y\r", "\r"}, {"\x1b[D\r", "\r"},
+		{"\x1b[32u\x1b[13u", "\r"}, {"\x1b[1;1D\r", "\r"},
+		{" ", ""}, {"\x1b[200~ \ry\x03\x1b[201~", ""},
+		{"\x1b[200~ \r", "\x03"}, {"\x1b[32;", "\x03"}, {"\x1b[", "\x03"},
+		{"\x1b", "\x1b"}, {"\x03", "\x03"}, {"\x04", "\x04"},
+	} {
+		if got := string(queuedConfirmationKeys([]byte(tc.input))); got != tc.want {
+			t.Errorf("keys(%q)=%q; want %q", tc.input, got, tc.want)
+		}
+	}
+}

--- a/cli/plugin-kit-ai/internal/terminalprompts/handoff_darwin_test.go
+++ b/cli/plugin-kit-ai/internal/terminalprompts/handoff_darwin_test.go
@@ -140,7 +140,7 @@ func TestDarwinInputHandoffChild(t *testing.T) {
 // Darwin's ptmx ioctls avoid adding a test dependency to the module graph.
 func darwinHandoffPTY(t *testing.T) (*os.File, *os.File) {
 	t.Helper()
-	master, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	master, err := os.OpenFile("/dev/ptmx", os.O_RDWR|unix.O_NOCTTY|unix.O_NONBLOCK, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/plugin-kit-ai/internal/terminalprompts/huh.go
+++ b/cli/plugin-kit-ai/internal/terminalprompts/huh.go
@@ -1,6 +1,7 @@
 package terminalprompts
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -17,6 +18,7 @@ import (
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 	"github.com/charmbracelet/colorprofile"
 	"github.com/muesli/cancelreader"
+	"golang.org/x/term"
 )
 
 type HuhPrompter struct {
@@ -46,16 +48,36 @@ func (p HuhPrompter) SelectTargets(ctx context.Context, r prompt.TargetSelection
 		}
 	}
 	field := huh.NewMultiSelect[domain.ClientID]().Title("Choose targets (all selected by default)").Options(choices...).Height(len(choices) + 2).Value(&ids).Filterable(false).Validate(func(v []domain.ClientID) error { _, err := prompt.ValidateSelection(r, v); return err })
-	if err := p.run(ctx, huh.NewForm(huh.NewGroup(field)), func() bool { _, err := prompt.ValidateSelection(r, ids); return err == nil }); err != nil {
+	if err := p.run(ctx, huh.NewForm(huh.NewGroup(field)), formInput{canSubmit: func() bool { _, err := prompt.ValidateSelection(r, ids); return err == nil }}); err != nil {
 		return prompt.TargetSelectionResult{}, err
 	}
 	return prompt.ValidateSelection(r, ids)
 }
-func (p HuhPrompter) Confirm(ctx context.Context, r prompt.ConfirmationRequest) (prompt.ConfirmationResult, error) {
+func (p HuhPrompter) Confirm(ctx context.Context, r prompt.ConfirmationRequest) (result prompt.ConfirmationResult, err error) {
 	if p.Input == nil || p.Output == nil {
 		return prompt.ConfirmationResult{}, prompt.ErrPromptUnavailable
 	}
 	if err := ctx.Err(); err != nil {
+		return prompt.ConfirmationResult{}, err
+	}
+	// This owner includes consent inspection and the form. The form snapshots
+	// the terminal only after inspection, so its restore cannot preserve flags
+	// changed at that earlier boundary. Restore the caller's snapshot after all
+	// form readers and cancellation callbacks have joined, including error exits.
+	if f, ok := p.Input.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
+		restore, e := promptio.SnapshotTerminal(int(f.Fd()))
+		if e != nil {
+			return prompt.ConfirmationResult{}, fmt.Errorf("snapshot confirmation terminal: %w", e)
+		}
+		defer func() {
+			if e := restore(); e != nil {
+				result = prompt.ConfirmationResult{}
+				err = fmt.Errorf("restore confirmation terminal: %w", e)
+			}
+		}()
+	}
+	queued, err := confirmationInput(ctx, p.Input)
+	if err != nil {
 		return prompt.ConfirmationResult{}, err
 	}
 	if err := promptio.WriteText(p.Output, fmt.Sprintf("%s (No by default; arrows/Space choose, Enter submits)\n", prompt.SafeText(r.Title))); err != nil {
@@ -68,7 +90,7 @@ func (p HuhPrompter) Confirm(ctx context.Context, r prompt.ConfirmationRequest) 
 		}
 	}
 	field := huh.NewConfirm().Title(prompt.SafeText(r.Title)).Affirmative("Yes").Negative("No").Value(&accepted)
-	if err := p.run(ctx, huh.NewForm(huh.NewGroup(field))); err != nil {
+	if err := p.run(ctx, huh.NewForm(huh.NewGroup(field)), formInput{queued: queued}); err != nil {
 		return prompt.ConfirmationResult{}, err
 	}
 	return prompt.ConfirmationResult{Accepted: accepted}, nil
@@ -84,7 +106,17 @@ func promptKeyMap() *huh.KeyMap {
 	km.Confirm.Reject = key.NewBinding(key.WithDisabled())
 	return km
 }
-func (p HuhPrompter) run(ctx context.Context, form *huh.Form, canSubmit ...func() bool) (err error) {
+
+type formInput struct {
+	canSubmit func() bool
+	queued    []byte
+}
+
+func (p HuhPrompter) run(ctx context.Context, form *huh.Form, configs ...formInput) (err error) {
+	var config formInput
+	if len(configs) > 0 {
+		config = configs[0]
+	}
 	if err = ctx.Err(); err != nil {
 		return err
 	}
@@ -106,6 +138,9 @@ func (p HuhPrompter) run(ctx context.Context, form *huh.Form, canSubmit ...func(
 			return fmt.Errorf("prepare terminal input: %w", err)
 		}
 		source = owned
+	}
+	if len(config.queued) > 0 {
+		source = io.MultiReader(bytes.NewReader(config.queued), source)
 	}
 	handoff := newSubmissionReader(runCtx, source)
 	defer handoff.finish()
@@ -136,12 +171,20 @@ func (p HuhPrompter) run(ctx context.Context, form *huh.Form, canSubmit ...func(
 	if f, ok := p.Input.(*os.File); ok {
 		input = &formFileReader{formReader: reader, file: f}
 	}
+	var resizeErr error
 	options := []tea.ProgramOption{tea.WithInput(input), tea.WithOutput(output), tea.WithoutSignalHandler(), tea.WithFilter(func(_ tea.Model, msg tea.Msg) tea.Msg {
+		filtered, err := formWindowSize(p.Output, msg)
+		if err != nil {
+			resizeErr = err
+			cancel()
+			return nil
+		}
+		msg = filtered
 		switch m := msg.(type) {
 		case tea.QuitMsg, tea.InterruptMsg:
 			finishInput()
 		case tea.KeyPressMsg:
-			if m.String() == "enter" && len(canSubmit) > 0 && !canSubmit[0]() {
+			if m.String() == "enter" && config.canSubmit != nil && !config.canSubmit() {
 				handoff.reject()
 			}
 		}
@@ -167,6 +210,9 @@ func (p HuhPrompter) run(ctx context.Context, form *huh.Form, canSubmit ...func(
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
+	if resizeErr != nil {
+		return fmt.Errorf("query terminal size: %w", resizeErr)
+	}
 	if inputErr := reader.Err(); inputErr != nil {
 		if errors.Is(inputErr, io.EOF) {
 			return prompt.ErrPromptInputClosed
@@ -180,6 +226,26 @@ func (p HuhPrompter) run(ctx context.Context, form *huh.Form, canSubmit ...func(
 		return fmt.Errorf("terminal prompt: %w", err)
 	}
 	return nil
+}
+
+// Bubble Tea v2.0.2 handles RequestWindowSize with an unjoined checkResize
+// goroutine, which can call the inherited output's Fd after the form returns
+// and its owner closes it. Resolve that command in the event loop instead.
+// The library still owns initial sizing and its joined SIGWINCH listener.
+// Do not cache Fd: that would leave late ioctls targeting a reused descriptor.
+func formWindowSize(output io.Writer, msg tea.Msg) (tea.Msg, error) {
+	if msg != tea.RequestWindowSize() {
+		return msg, nil
+	}
+	f, ok := output.(*os.File)
+	if !ok || !term.IsTerminal(int(f.Fd())) {
+		return nil, nil // Like Bubble Tea, no size query for nonterminal output.
+	}
+	width, height, err := term.GetSize(int(f.Fd()))
+	if err != nil {
+		return nil, err
+	}
+	return tea.WindowSizeMsg{Width: width, Height: height}, nil
 }
 
 type formWriter struct {

--- a/cli/plugin-kit-ai/internal/terminalprompts/huh.go
+++ b/cli/plugin-kit-ai/internal/terminalprompts/huh.go
@@ -13,6 +13,7 @@ import (
 	"charm.land/huh/v2"
 	"github.com/777genius/plugin-kit-ai/cli/internal/agentpluginscli/prompt"
 	"github.com/777genius/plugin-kit-ai/cli/internal/promptio"
+	"github.com/777genius/plugin-kit-ai/cli/internal/terminaltheme"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 	"github.com/charmbracelet/colorprofile"
 	"github.com/muesli/cancelreader"
@@ -40,7 +41,7 @@ func (p HuhPrompter) SelectTargets(ctx context.Context, r prompt.TargetSelection
 		choices = append(choices, huh.NewOption(prompt.SafeText(c.Label)+" ("+prompt.SafeText(string(c.ID))+")", c.ID))
 	}
 	for _, label := range r.SkippedLabels {
-		if err := promptio.WriteText(p.Output, "Skipped installed clients that this package cannot install together: "+prompt.SafeText(label)+"\n"); err != nil {
+		if err := promptio.WriteText(p.Output, (terminaltheme.Theme{Enabled: !p.NoColor}).Text(terminaltheme.Warning, "Skipped installed clients that this package cannot install together")+": "+prompt.SafeText(label)+"\n"); err != nil {
 			return prompt.TargetSelectionResult{}, err
 		}
 	}
@@ -148,8 +149,10 @@ func (p HuhPrompter) run(ctx context.Context, form *huh.Form, canSubmit ...func(
 	})}
 	if p.NoColor {
 		options = append(options, tea.WithColorProfile(colorprofile.Ascii))
+	} else {
+		options = append(options, tea.WithColorProfile(colorprofile.ANSI))
 	}
-	form.WithAccessible(false).WithInput(input).WithOutput(output).WithKeyMap(promptKeyMap()).WithProgramOptions(options...).WithViewHook(func(v tea.View) tea.View { v.ReportFocus = false; return v })
+	form.WithTheme(huh.ThemeFunc(semanticHuhTheme)).WithAccessible(false).WithInput(input).WithOutput(output).WithKeyMap(promptKeyMap()).WithProgramOptions(options...).WithViewHook(func(v tea.View) tea.View { v.ReportFocus = false; return v })
 	// Huh assumes a nonnil returned model even on initialization failure. Bubble
 	// Tea retains its own panic cleanup; normalize a remaining adapter panic.
 	defer func() {
@@ -269,4 +272,18 @@ func (r *formReader) stop(cancelRead func()) {
 	r.mu.Unlock()
 	cancelRead()
 	r.active.Wait()
+}
+
+func semanticHuhTheme(dark bool) *huh.Styles {
+	t := huh.ThemeBase(dark)
+	for _, f := range []*huh.FieldStyles{&t.Focused, &t.Blurred} {
+		f.Title = f.Title.Foreground(terminaltheme.Color(terminaltheme.Label))
+		f.Description = f.Description.Foreground(terminaltheme.Color(terminaltheme.Muted))
+		f.ErrorIndicator = f.ErrorIndicator.Foreground(terminaltheme.Color(terminaltheme.Error))
+		f.ErrorMessage = f.ErrorMessage.Foreground(terminaltheme.Color(terminaltheme.Error))
+		f.SelectedPrefix = f.SelectedPrefix.Foreground(terminaltheme.Color(terminaltheme.Success))
+		f.MultiSelectSelector = f.MultiSelectSelector.Foreground(terminaltheme.Color(terminaltheme.Label))
+		f.FocusedButton = f.FocusedButton.Foreground(terminaltheme.Color(terminaltheme.Label))
+	}
+	return t
 }

--- a/cli/plugin-kit-ai/internal/terminalprompts/huh_test.go
+++ b/cli/plugin-kit-ai/internal/terminalprompts/huh_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -15,6 +16,27 @@ import (
 	"github.com/777genius/plugin-kit-ai/cli/internal/agentpluginscli/prompt"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 )
+
+func TestFormWindowSizeMessages(t *testing.T) {
+	// Only the size-query command is consumed. In particular, messages carrying
+	// slices must pass through without an interface-comparison panic.
+	for _, msg := range []tea.Msg{nil, tea.QuitMsg{}, tea.WindowSizeMsg{Width: 80, Height: 24}, tea.BatchMsg{}} {
+		got, err := formWindowSize(io.Discard, msg)
+		if err != nil || !reflect.DeepEqual(got, msg) {
+			t.Fatalf("forward %T: got %T, %v", msg, got, err)
+		}
+	}
+	f, err := os.CreateTemp(t.TempDir(), "redirected")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	for _, output := range []io.Writer{io.Discard, f} {
+		if got, err := formWindowSize(output, tea.RequestWindowSize()); err != nil || got != nil {
+			t.Fatalf("nonterminal %T: got %v, %v", output, got, err)
+		}
+	}
+}
 
 // Both implementations must discard values when canceled, closed or unable to
 // show their question. PTY tests separately exercise rich keyboard submission.

--- a/cli/plugin-kit-ai/internal/terminalprompts/mode.go
+++ b/cli/plugin-kit-ai/internal/terminalprompts/mode.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 
 	"github.com/777genius/plugin-kit-ai/cli/internal/agentpluginscli/prompt"
+	"github.com/777genius/plugin-kit-ai/cli/internal/terminaltheme"
 	"golang.org/x/term"
 )
 
@@ -30,10 +31,19 @@ func ResolveMode(c Capabilities, plain bool) Mode {
 	}
 	return Rich
 }
-func terminal(v any) bool { f, ok := v.(*os.File); return ok && term.IsTerminal(int(f.Fd())) }
+func terminal(v any) bool {
+	if w, ok := v.(io.Writer); ok {
+		v = terminaltheme.Unwrap(w)
+	}
+	f, ok := v.(*os.File)
+	return ok && term.IsTerminal(int(f.Fd()))
+}
+
+// New receives the CLI-resolved noColor decision for the visible stream.
+// It must not reapply NO_COLOR after explicit flags have overridden it.
 func New(input io.Reader, output, errorOutput io.Writer, plain, noColor bool) (prompt.Prompter, io.Writer, error) {
 	c := Capabilities{InputTTY: terminal(input), OutputTTY: terminal(output), ErrorTTY: terminal(errorOutput), TERM: os.Getenv("TERM"), GOOS: runtime.GOOS}
-	if f, ok := output.(*os.File); ok {
+	if f, ok := terminaltheme.Unwrap(output).(*os.File); ok {
 		w, h, e := term.GetSize(int(f.Fd()))
 		c.SizeOK = e == nil && w >= 40 && h >= 10
 	}
@@ -46,7 +56,12 @@ func New(input io.Reader, output, errorOutput io.Writer, plain, noColor bool) (p
 		visible = errorOutput
 	}
 	if mode == Rich {
-		return HuhPrompter{Input: input, Output: visible, NoColor: noColor || os.Getenv("NO_COLOR") != ""}, visible, nil
+		return HuhPrompter{Input: input, Output: terminaltheme.Unwrap(visible), NoColor: noColor}, visible, nil
 	}
-	return PlainPrompter{Input: input, Output: visible}, visible, nil
+	policy := &terminaltheme.Policy{Mode: "always", Explicit: true}
+	if noColor {
+		policy.Mode = "never"
+	}
+	format := "human"
+	return PlainPrompter{Input: input, Output: terminaltheme.Wrap(terminaltheme.Unwrap(visible), policy, &format)}, visible, nil
 }

--- a/cli/plugin-kit-ai/internal/terminalprompts/plain.go
+++ b/cli/plugin-kit-ai/internal/terminalprompts/plain.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/777genius/plugin-kit-ai/cli/internal/agentpluginscli/prompt"
 	"github.com/777genius/plugin-kit-ai/cli/internal/promptio"
+	"github.com/777genius/plugin-kit-ai/cli/internal/terminaltheme"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 )
 
@@ -29,7 +30,7 @@ func (p PlainPrompter) SelectTargets(ctx context.Context, r prompt.TargetSelecti
 	}
 	var b strings.Builder
 	if len(r.SkippedLabels) > 0 {
-		b.WriteString("Skipped installed clients that this package cannot install together: ")
+		b.WriteString(terminaltheme.For(p.Output).Text(terminaltheme.Warning, "Skipped installed clients that this package cannot install together") + ": ")
 		for i, s := range r.SkippedLabels {
 			if i > 0 {
 				b.WriteString(", ")
@@ -38,11 +39,11 @@ func (p PlainPrompter) SelectTargets(ctx context.Context, r prompt.TargetSelecti
 		}
 		b.WriteByte('\n')
 	}
-	b.WriteString("Detected supported clients (all selected by default):\n")
+	b.WriteString(terminaltheme.For(p.Output).Text(terminaltheme.Label, "Detected supported clients") + terminaltheme.For(p.Output).Text(terminaltheme.Muted, " (all selected by default)") + ":\n")
 	for i, c := range r.Choices {
 		fmt.Fprintf(&b, "  %d. [x] %s (%s)\n", i+1, prompt.SafeText(c.Label), prompt.SafeText(string(c.ID)))
 	}
-	b.WriteString("Choose targets by number, comma-separated [all]: ")
+	b.WriteString(terminaltheme.For(p.Output).Text(terminaltheme.Label, "Choose targets by number, comma-separated [all]") + ": ")
 	if err := promptio.WriteText(p.Output, b.String()); err != nil {
 		return prompt.TargetSelectionResult{}, fmt.Errorf("write prompt: %w", err)
 	}
@@ -78,7 +79,7 @@ func (p PlainPrompter) Confirm(ctx context.Context, r prompt.ConfirmationRequest
 			return prompt.ConfirmationResult{}, fmt.Errorf("write prompt: %w", err)
 		}
 	}
-	if err := promptio.WriteText(p.Output, fmt.Sprintf("%s [y/N] ", prompt.SafeText(r.Title))); err != nil {
+	if err := promptio.WriteText(p.Output, fmt.Sprintf("%s [y/N] ", terminaltheme.For(p.Output).Text(terminaltheme.Label, prompt.SafeText(r.Title)))); err != nil {
 		return prompt.ConfirmationResult{}, fmt.Errorf("write prompt: %w", err)
 	}
 	line, err := promptio.ReadLine(ctx, p.Input)

--- a/cli/plugin-kit-ai/internal/terminalprompts/resize_linux_test.go
+++ b/cli/plugin-kit-ai/internal/terminalprompts/resize_linux_test.go
@@ -1,0 +1,54 @@
+//go:build linux
+
+package terminalprompts
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"golang.org/x/sys/unix"
+)
+
+func TestFormWindowSizePTY(t *testing.T) {
+	master, err := os.OpenFile("/dev/ptmx", os.O_RDWR|unix.O_NOCTTY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer master.Close()
+	if err := unix.IoctlSetPointerInt(int(master.Fd()), unix.TIOCSPTLCK, 0); err != nil {
+		t.Fatal(err)
+	}
+	number, err := unix.IoctlGetInt(int(master.Fd()), unix.TIOCGPTN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	slave, err := os.OpenFile(fmt.Sprintf("/dev/pts/%d", number), os.O_RDWR|unix.O_NOCTTY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer slave.Close()
+	var messages []tea.Msg
+	want := []tea.WindowSizeMsg{{Width: 100, Height: 30}, {Width: 43, Height: 12}}
+	for _, size := range want {
+		if err := unix.IoctlSetWinsize(int(slave.Fd()), unix.TIOCSWINSZ, &unix.Winsize{Row: uint16(size.Height), Col: uint16(size.Width)}); err != nil {
+			t.Fatal(err)
+		}
+		msg, err := formWindowSize(slave, tea.RequestWindowSize())
+		if err != nil {
+			t.Fatal(err)
+		}
+		messages = append(messages, msg)
+	}
+	// The query has completed before handoff. Bubble Tea receives only the
+	// concrete dimensions, so processing the message cannot touch a closed FD.
+	if err := slave.Close(); err != nil {
+		t.Fatal(err)
+	}
+	for i, msg := range messages {
+		if msg != want[i] {
+			t.Errorf("resize %d: got %#v; want %#v", i, msg, want[i])
+		}
+	}
+}

--- a/cli/plugin-kit-ai/internal/terminalprompts/restore_darwin_test.go
+++ b/cli/plugin-kit-ai/internal/terminalprompts/restore_darwin_test.go
@@ -1,0 +1,150 @@
+//go:build darwin
+
+package terminalprompts
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/777genius/plugin-kit-ai/cli/internal/promptio"
+	"golang.org/x/sys/unix"
+	"golang.org/x/term"
+)
+
+func TestDarwinRestoreQueuedFlags(t *testing.T) {
+	for _, scenario := range []string{"flusho", "flusho-no-echo", "flusho-pendin"} {
+		t.Run(scenario, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestDarwinRestoreQueuedFlagsChild$", "-test.v")
+			cmd.Env = []string{"DARWIN_RESTORE_CASE=" + scenario, "TMPDIR=" + t.TempDir()}
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("PTY restore: %v (deadline: %v)\n%s", err, ctx.Err(), out)
+			}
+		})
+	}
+}
+
+func TestDarwinRestoreQueuedFlagsChild(t *testing.T) {
+	scenario := os.Getenv("DARWIN_RESTORE_CASE")
+	if scenario == "" {
+		return
+	}
+	master, slave := darwinHandoffPTY(t)
+	fd := int(slave.Fd())
+	get := func() unix.Termios {
+		t.Helper()
+		attrs, err := unix.IoctlGetTermios(fd, unix.TIOCGETA)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return *attrs
+	}
+	original := get()
+	// The exact queued LF must complete a canonical record after replay.
+	// Do not inherit a newline-to-CR mapping from the PTY's initial flags.
+	original.Iflag &^= unix.INLCR | unix.IGNCR
+	original.Lflag &^= unix.PENDIN
+	original.Lflag |= unix.FLUSHO
+	if scenario == "flusho-pendin" {
+		original.Lflag |= unix.PENDIN
+	}
+	if scenario == "flusho-no-echo" {
+		original.Lflag &^= unix.ECHO | unix.ECHONL
+	}
+	if err := unix.IoctlSetTermios(fd, unix.TIOCSETA, &original); err != nil {
+		t.Fatal(err)
+	}
+	if got := get(); got != original {
+		t.Fatalf("snapshot setup: got %+v want %+v", got, original)
+	}
+	restore, err := promptio.SnapshotTerminal(fd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := term.MakeRaw(fd); err != nil {
+		t.Fatal(err)
+	}
+	// Keep an explicit reader knote attached across restoration. TIOCSETA's
+	// wakeup can invoke ttnread before it installs the canonical attributes;
+	// the test must exercise that path independently of Go's runtime poller.
+	kq, err := unix.Kqueue()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unix.Close(kq)
+	change := unix.Kevent_t{Ident: uint64(fd), Filter: unix.EVFILT_READ, Flags: unix.EV_ADD | unix.EV_CLEAR}
+	if _, err := unix.Kevent(kq, []unix.Kevent_t{change}, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	const queued = "next owner\n"
+	if _, err := io.WriteString(master, queued); err != nil {
+		t.Fatal(err)
+	}
+	// A kernel readiness event plus an exact raw byte count acknowledges the
+	// whole write without reading it. Raw readiness does not yet prove that a
+	// completed canonical record exists; the post-restore probes below do.
+	const fionread = 0x4004667f
+	deadline := time.Now().Add(time.Second)
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			t.Fatal("raw queue readiness deadline")
+		}
+		var events [1]unix.Kevent_t
+		timeout := unix.NsecToTimespec(remaining.Nanoseconds())
+		count, err := unix.Kevent(kq, nil, events[:], &timeout)
+		if err == unix.EINTR {
+			continue
+		}
+		if err != nil || count != 1 {
+			t.Fatalf("raw queue readiness: %d %v", count, err)
+		}
+		if event := events[0]; event.Ident != uint64(fd) || event.Filter != unix.EVFILT_READ || event.Flags&(unix.EV_ERROR|unix.EV_EOF) != 0 {
+			t.Fatalf("raw queue event: %+v", event)
+		}
+		n, err := unix.IoctlGetInt(fd, fionread)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n == len(queued) {
+			break
+		}
+		if n > len(queued) {
+			t.Fatalf("raw queue: got %d want %d", n, len(queued))
+		}
+	}
+	if err := restore(); err != nil {
+		t.Fatal(err)
+	}
+	if got := get(); got != original {
+		t.Fatalf("restore: got %+v want %+v", got, original)
+	}
+	if original.Lflag&unix.PENDIN == 0 {
+		// Subsequent next-owner probes must neither replay input nor clear FLUSHO.
+		for i := 0; i < 2; i++ {
+			n, err := unix.IoctlGetInt(fd, fionread)
+			if err != nil || n != len(queued) {
+				t.Fatalf("canonical queue probe %d: got %d want %d, error %v; attrs %+v", i, n, len(queued), err, get())
+			}
+			if got := get(); got != original {
+				t.Fatalf("renewed replay: got %+v want %+v", got, original)
+			}
+		}
+	}
+	// With original PENDIN set, the exact-state assertion above requires that
+	// replay remain pending; this read is the next owner's pending work.
+	var buf [64]byte
+	n, err := slave.Read(buf[:])
+	if err != nil || string(buf[:n]) != queued {
+		t.Fatalf("next owner: %q %v", buf[:n], err)
+	}
+	if n, err := unix.IoctlGetInt(fd, fionread); err != nil || n != 0 {
+		t.Fatalf("remaining queue: %d %v", n, err)
+	}
+}

--- a/cli/plugin-kit-ai/internal/terminaltheme/theme.go
+++ b/cli/plugin-kit-ai/internal/terminaltheme/theme.go
@@ -1,0 +1,114 @@
+// Package terminaltheme owns human presentation colors; writers are never rewritten.
+package terminaltheme
+
+import (
+	"fmt"
+	"image/color"
+	"io"
+	"os"
+
+	"github.com/charmbracelet/x/ansi"
+	"golang.org/x/term"
+)
+
+type Policy struct {
+	Mode     string
+	Explicit bool
+}
+
+func (p *Policy) Set(value string) error {
+	if value != "auto" && value != "never" && value != "always" {
+		return fmt.Errorf("--color must be auto, never, or always")
+	}
+	if p.Explicit && p.Mode != value {
+		return fmt.Errorf("contradictory explicit color flags")
+	}
+	p.Mode, p.Explicit = value, true
+	return nil
+}
+func (p *Policy) String() string {
+	if p.Mode == "" {
+		return "auto"
+	}
+	return p.Mode
+}
+func (*Policy) Type() string { return "auto|never|always" }
+
+type NoColorFlag struct{ Policy *Policy }
+
+func (f NoColorFlag) Set(v string) error {
+	if v != "true" {
+		return fmt.Errorf("--no-color only accepts true; use --color=auto to enable detection")
+	}
+	return f.Policy.Set("never")
+}
+func (f NoColorFlag) String() string {
+	if f.Policy.Explicit && f.Policy.Mode == "never" {
+		return "true"
+	}
+	return "false"
+}
+func (f NoColorFlag) Type() string { return "bool" }
+func (p Policy) Enabled(tty bool, terminal, noColor, format string) bool {
+	if format == "json" || p.Mode == "never" {
+		return false
+	}
+	if !p.Explicit && noColor != "" {
+		return false
+	}
+	if p.Mode == "always" {
+		return true
+	}
+	return tty && terminal != "dumb"
+}
+func IsTerminal(w io.Writer) bool {
+	f, ok := Unwrap(w).(*os.File)
+	return ok && term.IsTerminal(int(f.Fd()))
+}
+
+type writer struct {
+	io.Writer
+	policy *Policy
+	format *string
+}
+
+func Wrap(w io.Writer, p *Policy, format *string) io.Writer { return &writer{w, p, format} }
+func Unwrap(w io.Writer) io.Writer {
+	if v, ok := w.(*writer); ok {
+		return v.Writer
+	}
+	return w
+}
+func For(w io.Writer) Theme {
+	if v, ok := w.(interface{ SemanticTheme() Theme }); ok {
+		return v.SemanticTheme()
+	}
+	return Theme{}
+}
+func (w *writer) SemanticTheme() Theme {
+	return Theme{Enabled: w.policy.Enabled(IsTerminal(w.Writer), os.Getenv("TERM"), os.Getenv("NO_COLOR"), *w.format)}
+}
+
+type Role int
+
+const (
+	Success Role = iota
+	Warning
+	Error
+	Label
+	Muted
+)
+
+type Theme struct{ Enabled bool }
+
+func (t Theme) Text(role Role, text string) string {
+	if !t.Enabled || text == "" {
+		return text
+	}
+	return ansi.NewStyle().ForegroundColor(Color(role)).Styled(text)
+}
+
+// Color shares the semantic palette with the existing Huh style adapter.
+func Color(role Role) color.Color {
+	return ansi.BasicColor([]uint8{2, 3, 1, 6, 8}[role])
+}

--- a/cli/plugin-kit-ai/internal/terminaltheme/theme_test.go
+++ b/cli/plugin-kit-ai/internal/terminaltheme/theme_test.go
@@ -1,0 +1,37 @@
+package terminaltheme
+
+import "testing"
+
+func TestPolicy(t *testing.T) {
+	for _, tc := range []struct {
+		name, mode, term, noColor, format string
+		explicit, tty, want               bool
+	}{
+		{name: "auto terminal", tty: true, want: true},
+		{name: "redirect", tty: false},
+		{name: "dumb", tty: true, term: "dumb"},
+		{name: "NO_COLOR nonempty zero", tty: true, noColor: "0"},
+		{name: "NO_COLOR whitespace", tty: true, noColor: " "},
+		{name: "explicit auto overrides env", mode: "auto", explicit: true, tty: true, noColor: "1", want: true},
+		{name: "explicit auto still detects", mode: "auto", explicit: true, noColor: "1"},
+		{name: "always forces", mode: "always", explicit: true, term: "dumb", noColor: "1", want: true},
+		{name: "never", mode: "never", explicit: true, tty: true},
+		{name: "JSON overrides always", mode: "always", explicit: true, tty: true, format: "json"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := (Policy{Mode: tc.mode, Explicit: tc.explicit}).Enabled(tc.tty, tc.term, tc.noColor, tc.format); got != tc.want {
+				t.Fatalf("enabled=%v", got)
+			}
+		})
+	}
+}
+func TestRoles(t *testing.T) {
+	for role, code := range map[Role]string{Success: "32", Warning: "33", Error: "31", Label: "36", Muted: "90"} {
+		if got := (Theme{Enabled: true}).Text(role, "fixture"); got != "\x1b["+code+"mfixture\x1b[m" {
+			t.Fatalf("role %d: %q", role, got)
+		}
+		if got := (Theme{}).Text(role, "fixture"); got != "fixture" {
+			t.Fatal(got)
+		}
+	}
+}

--- a/scripts/terminal-ui/README.md
+++ b/scripts/terminal-ui/README.md
@@ -68,7 +68,7 @@ output before invoking the Unix harness; its hash is recorded in `results.json`.
 | `yes-lifecycle` | Space deselects Codex, arrow moves to Cursor, Enter submits; preflight identity/version visible before Yes; exactly Cursor materializes; plain activation No is consumed and auth is not asked. |
 | `empty` | Space/arrows deselect both; Enter produces inline validation, never defaults back to all; Esc exits 1 without mutation. |
 | `escape`, `ctrl-c`, `ctrl-d`, `confirm-*` | Cancellation at each form exits 1 without mutation and restores terminal. Raw Ctrl+D is a key, not Unix EOF. |
-| `plain`, `dumb`, `term-unset` | Full selection/default-No path without escape sequences; same consent policy. |
+| `plain`, `dumb`, `term-unset` | Full selection/default-No path with explicit `--color=never`, without escape sequences; same consent policy. |
 | `no-color`, `NO_COLOR` | Same keyboard UI, no color SGR; cursor controls are allowed. |
 | `plain-eof`, `plain-partial-eof` | Canonical VEOF at empty selection and partial `y` plus EOF at confirm fail closed; neither equals Enter/Yes. |
 | `stdin-pipe` | Pipe stays open with no data; CLI exits with required-target error without reading it. |
@@ -94,7 +94,7 @@ The inspected Huh keymap uses Space/arrows and Enter for confirmation; `y`/`n`
 are disabled. Yes uses Space then Enter; explicit No moves left then right and
 submits. Normal rich cases wait for the rendered Yes/No/Enter controls, beyond
 the preprinted question. The initially tiny viewport selects Plain under the
-inspected size gate (width < 40 or height < 10), and must emit no ANSI. `queued` deliberately sends two Enters together and
+inspected size gate (width < 40 or height < 10), and, with explicit `--color=never`, must emit no ANSI. `queued` deliberately sends two Enters together and
 requires completion without another key; its queued-input assertion is retained.
 
 Each case saves `terminal.ansi` (raw synthetic capture), `transcript.txt`, semantic
@@ -193,3 +193,17 @@ Each Unix semantic checkpoint saves `.frame.txt` and `.frame.svg` alongside
 `terminal.raw`. SVG files are rendered synthetic transcript images from the
 harness's small Screen model, not native terminal-emulator screenshots; raw
 captures and restoration/state checks remain authoritative.
+
+## Semantic color policy cases
+
+The historical escape-free Plain/tiny/redirect cases explicitly pass
+`--color=never`; Plain selects interaction independently of color. Additional
+real PTY cases `plain-auto`, `plain-always`, `plain-never`, `plain-NO_COLOR`,
+`rich-never`, and `color-stderr-visible` retain the same consent, mutation and
+terminal reuse assertions. They check colored visible labels with reset before
+the colon/value, escape-free Plain suppression, rich controls without SGR, and
+independent redirected stdout / visible stderr policy. `color-pipe-human` forces
+color into redirected human output; `color-pipe-json` requires a single versioned
+JSON envelope and no escapes on either output despite always. `color-error`
+checks red error/reset boundaries; both existing Yes lifecycle cases also require
+yellow warning/reset boundaries while retaining all persisted-state/auth checks.

--- a/scripts/terminal-ui/README.md
+++ b/scripts/terminal-ui/README.md
@@ -207,3 +207,93 @@ color into redirected human output; `color-pipe-json` requires a single versione
 JSON envelope and no escapes on either output despite always. `color-error`
 checks red error/reset boundaries; both existing Yes lifecycle cases also require
 yellow warning/reset boundaries while retaining all persisted-state/auth checks.
+
+## Bounded selection matrix
+
+`selection_matrix.py` owns a separate stdlib lane using the unchanged harness's
+`Fixture`, controlling PTY, status channel and same-PTY restoration probe. Run
+against a frozen native binary with an independently known SHA256; no build or
+agent installation is performed:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover \
+  -s scripts/terminal-ui -p test_selection_matrix.py
+PYTHONDONTWRITEBYTECODE=1 python3 scripts/terminal-ui/selection_matrix.py \
+  --binary /absolute/frozen-agentplugins --binary-sha256 TRUSTED_SHA256 \
+  --artifacts /tmp/new-selection-matrix --timeout 8
+```
+
+Fifteen cases cover Codex-only, Cursor-only and both with default No and explicit
+Yes → activation No; neither with retained empty validation; Escape/Ctrl+C at
+both forms; queued Enter/Enter, Enter/y/Enter and Enter/Space/Enter; and native-ownership rejection.
+Selection paths exercise Up/Down and Space toggle/re-toggle, assert the displayed
+canonical identities, then compare exact plan targets and persisted binding IDs,
+receipt identities and native package paths. Queued cases require exit without
+another key and unchanged state; the controls may disappear before rendering.
+No pre-consent client/project/managed/state/journal mutation is allowed. Cache
+exclusions match the existing harness and are not a whole-filesystem guarantee.
+
+Each case saves raw key bytes in `events.json`, semantic frames with protected
+state hashes, complete before/after protected state, actual CLI exit status,
+restoration/reuse results, and `outcome.json` with source commit/file hashes and
+binary hash. The historical binary's equivalence to the source commit is not
+assumed. The lane normalizes reverse-index only for its small evidence renderer;
+raw PTY bytes remain unchanged. Parser tests are not native E2E evidence.
+
+The fixture adds a minimal `.codex-plugin/plugin.json` identity to the standard
+package. Codex positive installation may still be **blocked**: the native owner
+observer invokes `codex plugin list --json`, which version-only stubs reject with
+97. Positive cases remain failures; they never substitute Cursor or fabricate a
+registry response. The separate ownership case requires CLI exit 1, the native
+identity error, unchanged protected state and terminal reuse. The synthetic
+scanner is UI-only evidence. No real profiles, auth or agents are used.
+
+Linux is the executed platform for this lane. For macOS, use the same invocation
+with a verified native binary in a disposable environment containing only the two
+synthetic clients; the existing persistent PTY owner handles terminal lifetime.
+macOS remains untested until that native run. The existing Windows ConPTY lane
+supports Plain interaction, not this rich arrow/Space matrix; this matrix is
+explicitly **not covered on Windows**. Reuse its persistent ConPTY owner/mode/echo
+probe when adding native Plain subset cases; do not count Linux, WSL, or renderer
+unit tests as Windows PASS. No new framework or dependency is needed.
+
+## Plugin fixture matrix
+
+`plugin_matrix.py` runs 19 cases on native Linux or macOS against a supplied
+binary. Eight package kinds cover empty/skill packages, missing stdio runtime,
+HTTP authentication uncertainty, mixed healthy/skipped components, malformed
+JSON, ignored unsupported components, and native ownership collisions. Keyboard
+cancel/default No, rejection, exact Cursor skill install/removal, and read-only
+JSON plans retain state and terminal restoration assertions.
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 PLUGIN_MATRIX_BINARY=/absolute/frozen-agentplugins \
+  python3 -m unittest discover -s scripts/terminal-ui -p test_plugin_matrix.py
+PYTHONDONTWRITEBYTECODE=1 python3 scripts/terminal-ui/plugin_matrix.py \
+  --binary /absolute/frozen-agentplugins --artifacts /tmp/new-plugin-matrix --timeout 15
+# Focused ten-client selection/default-No and JSON plan check:
+PYTHONDONTWRITEBYTECODE=1 python3 scripts/terminal-ui/plugin_matrix.py \
+  --binary /absolute/frozen-agentplugins --case empty:all-ten \
+  --artifacts /tmp/new-plugin-all-ten --timeout 15
+```
+
+The all-ten case adds seven version-only stubs and synthetic config directories
+for ten logical choices: Codex, Cursor, Copilot, VS Code, Kiro, Claude, Gemini,
+OpenCode, Cline and Windsurf. Paths follow production
+`install/integrationctl/agentplugins/adapters/clientdetect/detector.go`: Cline's
+VS Code globalStorage lives under the fixture's `Library/Application Support`
+on Darwin and XDG config on Linux; OpenCode uses XDG config on both. No host OS
+is overridden and no desktop application is seeded. All paths stay under the
+fresh synthetic HOME. Run on a disposable host without ambient desktop agents,
+as described above; unexpected choices remain failures. ChatGPT has no
+config-only discovery surface and is omitted. Ten logical review/JSON identities
+are required, with the Copilot/VS Code shared physical owner explained; this
+case declines installation and does not prove ten-client runtime operation.
+
+`report.json` records the actual host platform, executed case list, binary and
+source hashes, contract references and limitations. Path-contract tests exercise
+both platform layouts; they do not execute Darwin discovery on Linux. The native
+CI workflow runs the full matrix on Linux and macOS; a local Linux result is
+not a macOS pass. Windows ConPTY is a separate lane. HTTP fixtures use only an
+isolated loopback endpoint and assert zero CLI requests; scanner output remains
+synthetic, with no authentication, security or real-client release qualification.

--- a/scripts/terminal-ui/harness.py
+++ b/scripts/terminal-ui/harness.py
@@ -472,7 +472,9 @@ CASES = ('detection', 'baseline-lifecycle', 'default-no', 'no', 'yes-lifecycle',
          'confirm-ctrl-d', 'confirm-lf-escape', 'plain', 'dumb', 'term-unset', 'no-color', 'NO_COLOR',
          'resize', 'tiny', 'queued', 'paste', 'plain-eof', 'plain-partial-eof',
          'stdin-pipe', 'json', 'json-tty', 'json-explicit', 'stdout-redirect',
-         'stderr-redirect', 'both-redirect')
+         'stderr-redirect', 'both-redirect', 'plain-auto', 'plain-always',
+         'plain-never', 'plain-NO_COLOR', 'rich-never', 'color-stderr-visible',
+         'color-pipe-human', 'color-pipe-json', 'color-error')
 
 
 def run_case(name, binary, root, args):
@@ -493,7 +495,19 @@ def run_case(name, binary, root, args):
             argv = [node, staged['launcher'], *argv[1:]]
         plain = name in ('tiny', 'plain', 'dumb', 'term-unset', 'plain-eof', 'plain-partial-eof',
                          'stdout-redirect', 'stderr-redirect')
+        legacy_plain = plain
+        if legacy_plain: argv += ['--color=never']
+        if name.startswith('plain-') or name == 'color-stderr-visible': plain = True
         if name.startswith('plain'): argv += ['--plain']
+        if name in ('plain-auto', 'color-stderr-visible'): argv += ['--color=auto']
+        if name in ('plain-always', 'color-pipe-human', 'color-pipe-json', 'color-error'):
+            argv += ['--color=always']
+        if name in ('plain-never', 'rich-never'): argv += ['--color=never']
+        if name == 'plain-NO_COLOR': fixture.env['NO_COLOR'] = '1'
+        if name in ('color-pipe-human', 'color-pipe-json'):
+            argv += ['--target=cursor', '--dry-run']
+        if name == 'color-pipe-json': argv += ['--format=json']
+        if name == 'color-error': argv += ['--target=nonexistent', '--dry-run']
         if name == 'dumb': fixture.env['TERM'] = 'dumb'
         if name == 'term-unset': fixture.env.pop('TERM')
         if name == 'no-color': argv += ['--no-color']
@@ -504,10 +518,26 @@ def run_case(name, binary, root, args):
         redirect = {'stdout-redirect': 'stdout', 'stderr-redirect': 'stderr',
                     'both-redirect': 'both', 'json': 'stdout',
                     'json-explicit': 'stdout'}.get(name)
+        if name == 'color-stderr-visible': redirect = 'stdout'
+        if name in ('color-pipe-human', 'color-pipe-json'): redirect = 'both'
         session = Session(argv, fixture, evidence, args.timeout,
                           stdin_pipe=name == 'stdin-pipe', redirect=redirect,
                           rows=6 if name == 'tiny' else 30, cols=32 if name == 'tiny' else 100)
         try:
+            if name in ('color-pipe-human', 'color-pipe-json', 'color-error'):
+                session.finish(1 if name == 'color-error' else 0)
+                fixture.unchanged()
+                if name == 'color-error':
+                    check(re.search(rb'\x1b\[31m[^\x1b]+\x1b\[m', session.raw), 'error role/reset missing')
+                else:
+                    body = (evidence / 'stdout.raw').read_bytes()
+                    stderr = (evidence / 'stderr.raw').read_bytes()
+                    if name == 'color-pipe-json':
+                        check(json.loads(body).get('schema_version') == 1, 'invalid JSON envelope')
+                        check(b'\x1b' not in body + stderr, 'forced color contaminated JSON streams')
+                    else:
+                        check(b'\x1b[36mTarget\x1b[m: cursor' in body, 'label reset/value boundary missing')
+                return
             if name in ('stdin-pipe', 'json', 'json-tty', 'json-explicit', 'both-redirect'):
                 # stdin-pipe is deliberately held OPEN with no bytes. Reading it hangs
                 # and fails the bound; closing first would only prove EOF handling.
@@ -613,10 +643,21 @@ def run_case(name, binary, root, args):
                 if name == 'no': session.send(b'\x1b[D\x1b[C\r')
                 elif name != 'queued': session.send(b'\n' if plain else b'\r')
                 session.finish(); fixture.unchanged()
-            if plain:
+            if legacy_plain or name in ('plain-never', 'plain-NO_COLOR'):
                 check(b'\x1b' not in session.raw, 'plain emitted terminal controls')
+            if name in ('plain-auto', 'plain-always', 'color-stderr-visible'):
+                check(b'\x1b[36mTarget\x1b[m: ' in session.raw, 'visible colored label/reset missing')
+                check(b'\x1b[?25l' not in session.raw, 'Plain unexpectedly entered rich renderer')
+                if name == 'color-stderr-visible':
+                    check(b'\x1b' not in (evidence / 'stdout.raw').read_bytes(), 'redirected auto stdout colored')
+            if name == 'rich-never':
+                check(b'\x1b[?25l' in session.raw, 'never disabled rich interaction')
+                check(not re.search(rb'\x1b\[[0-9;:]*m', session.raw), 'never emitted SGR')
+            if name in ('yes-lifecycle', 'queued-lifecycle'):
+                check(re.search(rb'\x1b\[33m[^\x1b]+\x1b\[m', session.raw), 'warning role/reset missing')
             if name in ('no-color', 'NO_COLOR'):
                 sgr = re.findall(rb'\x1b\[([0-9;:]*)m', session.raw)
+                check(not sgr, 'disabled color emitted SGR')
                 for value in sgr:
                     nums = [int(n) for n in re.split(rb'[;:]', value) if n]
                     check(not any(30 <= n <= 38 or 40 <= n <= 48 or 90 <= n <= 107 for n in nums), 'color SGR emitted')

--- a/scripts/terminal-ui/plugin_matrix.py
+++ b/scripts/terminal-ui/plugin_matrix.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""Bounded real-CLI plugin fixture lane; no build, client launch, or external MCP.
+
+Run with --binary PATH --artifacts NEW_DIRECTORY. Failures stay failures. The
+synthetic scanner inherited from harness is UI evidence, not security evidence.
+Schema/semantics: specregistry/schemas/1.0.0, loader/loader_test.go, and
+providers/native_identity_test.go under install/integrationctl/agentplugins.
+"""
+import argparse
+from contextlib import contextmanager
+import hashlib
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import json
+import os
+import platform
+from pathlib import Path
+import re
+import shutil
+import shlex
+import subprocess
+import tempfile
+import threading
+import time
+
+from harness import Fixture, Session, SELECT, CONFIRM, LIFECYCLE, check, clean, hashes
+
+SCHEMA = 'https://agent-plugins.org/schemas/1.0.0/'
+KINDS = ('empty', 'skill', 'stdio-missing', 'http-auth', 'mixed', 'malformed',
+         'unsupported', 'collision')
+CASES = tuple(f'{kind}:{action}' for kind in KINDS for action in
+              (('reject',) if kind == 'malformed' else
+               ('cancel',) if kind in ('stdio-missing', 'collision') else ('cancel', 'default-no'))
+              ) + ('skill:install', 'stdio-missing:reject', 'mixed:partial-plan',
+                   'collision:reject', 'http-auth:auth-unknown', 'empty:all-ten')
+
+# Expectations follow the existing planner contract, not a stricter invented
+# pre-consent policy. Keep validation, delivery, activation, auth and runtime
+# separate. Original failed case names remain in the audit for traceability.
+AUDIT_MATRIX = {
+    'mixed:reject': {
+        'case': 'mixed:partial-plan', 'classification': 'test assumption',
+        'reason': 'Healthy skills remain deliverable when missing stdio is skipped.',
+        'source': 'install/integrationctl/agentplugins/usecase/component_readiness_test.go:TestMixedAddAndGroupKeepHealthySiblings'},
+    'http-auth:reject': {
+        'case': 'http-auth:auth-unknown', 'classification': 'test assumption',
+        'reason': 'Installation does not authenticate remote MCP; preserve not_checked and make no HTTP request.',
+        'source': 'install/integrationctl/agentplugins/planner/planner_test.go:TestPlannerAuthenticationRequiresAffirmativePerClientCatalogEvidence'},
+    'collision:reject': {
+        'case': 'collision:reject', 'classification': 'human diagnostic bug',
+        'reason': 'Ownership rejection must retain remediation and selected-target context.',
+        'source': 'cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go:runAddManyLoaded'},
+    'empty:all-ten': {
+        'case': 'empty:all-ten', 'classification': 'human display ambiguity',
+        'reason': 'Outer JSON targets are logical IDs; inner plans may share the Copilot physical owner. Show selected identities and explain shared delivery.',
+        'source': 'cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go:TestCopilotAndVSCodeShareOneGroupedPhysicalMutation'},
+}
+
+
+def put(root, relative, body):
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding='utf-8')
+
+
+def package(fixture, kind, endpoint=None):
+    check(kind in KINDS, 'unknown fixture kind')
+    manifest = {'$schema': SCHEMA + 'plugin.schema.json', 'name': 'pty-synthetic',
+                'version': '1.0.0'}
+    put(fixture.package, 'plugin.json', json.dumps(manifest))
+    if kind in ('skill', 'mixed', 'collision'):
+        put(fixture.package, 'skills/guide/SKILL.md',
+            '---\nname: guide\ndescription: Explain the isolated fixture\n---\n'
+            'Read reference.txt and report its fixture marker. Do not run commands.\n')
+        put(fixture.package, 'skills/guide/reference.txt', 'plugin-matrix-fixture-v1\n')
+    if kind in ('stdio-missing', 'mixed', 'http-auth'):
+        server = {'type': 'stdio', 'command': 'uap-fixture-missing-runtime'}
+        if kind == 'http-auth':
+            check(endpoint and endpoint.startswith('http://127.0.0.1:'), 'loopback endpoint required')
+            server = {'type': 'streamable-http', 'url': endpoint}
+        put(fixture.package, 'mcp.json', json.dumps({
+            '$schema': SCHEMA + 'mcp.schema.json', 'mcpServers': {'fixture': server}}))
+    if kind == 'malformed':
+        put(fixture.package, 'plugin.json', '{"name":')
+    if kind == 'unsupported':
+        # Portable loader deliberately ignores these; do not invent hook support.
+        put(fixture.package, 'hooks/hooks.json', '{}\n')
+        put(fixture.package, 'commands/run.md', 'Inert unsupported component.\n')
+    if kind == 'collision':
+        put(fixture.home, '.cursor/plugins/local/foreign/.cursor-plugin/plugin.json',
+            '{"name":"pty-synthetic"}')
+        put(fixture.home, '.cursor/plugins/local/foreign/keep.txt', 'unowned\n')
+    fixture.before = fixture.mutations()
+
+
+@contextmanager
+def local_endpoint(enabled):
+    requests = []
+    if not enabled:
+        yield None, requests
+        return
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            requests.append({'method': self.command, 'path': self.path})
+            self.send_response(401)
+            self.send_header('WWW-Authenticate', 'Bearer realm="isolated-fixture"')
+            self.send_header('Content-Length', '0')
+            self.end_headers()
+        do_GET = do_POST
+        def log_message(self, *args):
+            pass
+    server = HTTPServer(('127.0.0.1', 0), Handler)
+    server.timeout = 1
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f'http://127.0.0.1:{server.server_port}/mcp', requests
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def ten_client_paths(fixture, system):
+    """Synthetic discovery surfaces from clientdetect/detector.go.
+
+    The explicit system argument permits path-contract tests on either host;
+    real runs always use the native system, including the native scanner cache.
+    """
+    check(system in ('Linux', 'Darwin'), 'ten-profile fixture supports Linux and Darwin only')
+    config = Path(fixture.env['XDG_CONFIG_HOME'])
+    editor = (fixture.home / 'Library/Application Support' if system == 'Darwin' else config)
+    paths = (fixture.home / '.copilot', fixture.home / '.kiro',
+             Path(fixture.env['CLAUDE_CONFIG_DIR']),
+             Path(fixture.env['GEMINI_CLI_HOME']) / '.gemini',
+             editor / 'Code/User/globalStorage/saoudrizwan.claude-dev',
+             config / 'opencode', fixture.home / '.codeium/windsurf')
+    for path in paths:
+        check(path.resolve().is_relative_to(fixture.home.resolve()),
+              'discovery path escapes synthetic HOME')
+    return paths
+
+
+def seed_ten_clients(fixture):
+    for path in ten_client_paths(fixture, platform.system()):
+        path.mkdir(parents=True, exist_ok=True)
+    # Claude selection requires its CLI surface, not only its config directory.
+    for name in ('copilot', 'code', 'kiro-cli', 'claude', 'gemini', 'opencode', 'windsurf'):
+        shutil.copy2(fixture.bin / 'cursor', fixture.bin / name)
+    fixture.before = fixture.mutations()
+
+
+def choices(raw):
+    # Only actual checkbox rows, not arbitrary client words in diagnostics.
+    return list(dict.fromkeys(re.findall(r'\[[^\]]*\][^\r\n]*\(([a-z0-9_-]+)\)', clean(raw))))
+
+
+def send(session, keys):
+    session.events.append({'event': 'key', 'hex': keys.hex(), 'offset': len(session.raw),
+                           'elapsed': round(time.monotonic() - session.start, 3)})
+    session.send(keys)
+
+
+def exact_skill(fixture):
+    fixture.installed(['cursor'])
+    state = json.loads((fixture.data / 'state-v2.json').read_text())
+    bindings = list(state['installations'][0]['clients'].values())
+    target = Path(bindings[0]['target_locator'])
+    expected = hashes(fixture.package / 'skills')
+    check(hashes(target / 'skills') == expected, 'installed skill files/bytes differ from source')
+    native = hashes(target)
+    files = {name for name, digest in native.items() if digest != 'directory'}
+    expected_files = {'plugin.json', '.cursor-plugin/plugin.json',
+                      'skills/guide/SKILL.md', 'skills/guide/reference.txt'}
+    check(files == expected_files, f'unexpected native files: {files ^ expected_files}')
+    check(json.loads((target / '.cursor-plugin/plugin.json').read_text()) == {
+        'name': 'pty-synthetic', 'version': '1.0.0', 'skills': './skills/'},
+        'Cursor projected manifest differs from adapter contract')
+    check(json.loads((target / 'plugin.json').read_text()) ==
+          json.loads((fixture.package / 'plugin.json').read_text()), 'portable manifest differs')
+    check(hashes(fixture.home / '.codex') == {}, 'unselected Codex changed')
+    return target
+
+
+def json_plan(fixture, binary, evidence, targets, timeout):
+    # Separate read-only inspection after the actual keyboard consent decision;
+    # this does not bypass selection or authorize installation/activation.
+    argv = [str(binary), 'add', str(fixture.package), '--target=' + ','.join(targets),
+            '--dry-run', '--format=json']
+    (evidence / 'plan-command.json').write_text(json.dumps(argv))
+    result = subprocess.run(argv, cwd=fixture.project, env=fixture.env,
+                            capture_output=True, timeout=timeout)
+    (evidence / 'plan.json').write_bytes(result.stdout)
+    (evidence / 'plan.stderr').write_bytes(result.stderr)
+    check(result.returncode == 0, 'JSON plan failed')
+    fixture.unchanged()
+    data = json.loads(result.stdout)['data']
+    return data.get('targets', [{'target': targets[0], 'output': data}])
+
+
+def check_auth_unknown(plan):
+    check(plan['authentication'] == 'not_checked', 'plan overstated authentication')
+    check(plan['verification'] == 'package_validated', 'plan overstated runtime/installation verification')
+
+
+def run_case(case, binary, evidence, timeout=8):
+    kind, action = case.split(':')
+    check(case in CASES, 'unknown case')
+    evidence.mkdir(parents=True)
+    with tempfile.TemporaryDirectory(prefix='uap-plugin-matrix-') as tmp, local_endpoint(kind == 'http-auth') as (url, requests):
+        fixture = Fixture(tmp)
+        package(fixture, kind, url)
+        if action == 'all-ten':
+            seed_ten_clients(fixture)
+        if url:
+            fixture.env['NO_PROXY'] = '127.0.0.1'
+        shutil.copytree(fixture.package, evidence / 'package')
+        if kind == 'collision':
+            shutil.copytree(fixture.home / '.cursor/plugins/local/foreign', evidence / 'unowned-native')
+        (evidence / 'fixture.json').write_text(json.dumps({
+            'kind': kind, 'action': action, 'package_hashes': hashes(fixture.package),
+            'collision': kind == 'collision', 'scanner': 'synthetic protocol; not security proof',
+            'endpoint': url}, indent=2))
+        session = Session([str(binary), 'add', str(fixture.package)], fixture, evidence, timeout)
+        try:
+            if kind == 'malformed':
+                session.finish(1)
+                check(re.search(r'(?i)(manifest|plugin.json|json)', clean(session.raw)), 'missing manifest diagnostic')
+                check(not re.search(CONFIRM, clean(session.raw)), 'invalid manifest reached consent')
+                fixture.unchanged()
+                return
+            session.wait(SELECT, 'selection')
+            session.wait(r'enter submit', 'choices-ready')
+            skipped = re.findall(r'Skipped installed clients[^\r\n]*', clean(session.raw))
+            (evidence / 'selection.json').write_text(json.dumps({
+                'compatible': choices(session.raw), 'skipped': skipped}, indent=2))
+            check(not skipped, f'unexpected skipped client/reason: {skipped}')
+            if action == 'all-ten':
+                expected = {'codex', 'cursor', 'copilot', 'vscode', 'kiro', 'claude',
+                            'gemini', 'opencode', 'cline', 'windsurf'}
+                offered = set(choices(session.raw))
+                (evidence / 'compatible-list.json').write_text(json.dumps(sorted(offered)))
+                if offered != expected:
+                    send(session, b'\x1b')
+                    session.finish(1)
+                    fixture.unchanged()
+                    raise AssertionError(f'empty package ten-profile compatibility mismatch: missing={sorted(expected - offered)}, extra={sorted(offered - expected)}')
+                offset = len(session.raw)
+                send(session, b'\r')
+                session.wait(CONFIRM, 'all-ten-confirmation', after=offset)
+                session.wait(r'(?s)Yes.*?No.*?enter submit', 'all-ten-controls', after=offset)
+                text = clean(session.raw[offset:])
+                planned = re.findall(r'Target: ([a-z]+)', text)
+                check('pty-synthetic' in text and '1.0.0' in text, 'ten-target plan identity missing')
+                fixture.unchanged()
+                send(session, b'\r')
+                session.finish()
+                fixture.unchanged()
+                check(set(planned) == expected and len(planned) == len(expected),
+                      f'ten-target plan differs from selected identities: {planned}')
+                check('Uses shared physical binding owned by copilot' in text,
+                      'shared physical owner not explained')
+                records = json_plan(fixture, binary, evidence, planned, timeout)
+                check({r['target'] for r in records} == expected and len(records) == 10,
+                      'JSON lost selected logical identities')
+                plans = {r['target']: r['output']['result']['plan'] for r in records}
+                for target, plan in plans.items():
+                    check_auth_unknown(plan)
+                    check(plan['client_id'] == ('copilot' if target == 'vscode' else target),
+                          'unexpected physical plan owner')
+                check(plans['copilot'] == plans['vscode'],
+                      'shared targets have different physical bindings')
+                return
+            check(choices(session.raw) == ['codex', 'cursor'],
+                  f'compatible choices differ: {choices(session.raw)}')
+            fixture.unchanged()
+            if action == 'cancel':
+                send(session, b'\x1b')
+                session.finish(1)
+                fixture.unchanged()
+                return
+            offset = len(session.raw)
+            # Actual Space / Down / Enter: deselect Codex, select only Cursor.
+            send(session, b' \x1b[B\r')
+            if action == 'reject':
+                deadline = time.monotonic() + timeout
+                while session.process.poll() is None and not re.search(CONFIRM, clean(session.raw[offset:])):
+                    check(time.monotonic() < deadline, 'no rejection or consent within bound')
+                    session.pump()
+                if re.search(CONFIRM, clean(session.raw[offset:])):
+                    session.wait(r'(?s)Yes.*?No.*?enter submit', 'unexpected-consent', after=offset)
+                    fixture.unchanged()
+                    send(session, b'\r')
+                    session.finish()
+                    fixture.unchanged()
+                    raise AssertionError(f'{kind}: reached consent instead of fail-closed rejection; default No preserved zero changes')
+                session.finish(1)
+                fixture.unchanged()
+                text = clean(session.raw[offset:]).lower()
+                check('cursor' in text, 'failure omitted selected client identity (Cursor)')
+                pattern = (r'(unmanaged|unowned|collision|ownership)' if kind == 'collision' else
+                           r'(runtime|executable|command).*?(missing|not found|unavailable)|missing.*?(runtime|executable|command)')
+                check(re.search(pattern, text, re.S), 'missing fail-closed diagnostic')
+                check(re.search(r'(install|remove|choose|verify|authenticate)', text), 'missing remediation')
+                check(not re.search(CONFIRM, text), 'unsafe plan reached consent')
+                return
+            session.wait(CONFIRM, 'confirmation', after=offset)
+            session.wait(r'(?s)Yes.*?No.*?enter submit', 'confirmation-ready', after=offset)
+            text = clean(session.raw[offset:])
+            check(all(value in text for value in ('pty-synthetic', '1.0.0', 'Target: cursor', 'Planned action:')),
+                  'full client-specific plan missing before consent')
+            check('Target: codex' not in text, 'unselected target entered plan')
+            fixture.unchanged()
+            if kind in ('skill', 'mixed'):
+                check('skill guide: native' in text, 'skill support decision missing')
+            if kind == 'mixed':
+                check(all(value in text for value in ('mcp_server fixture: unsupported',
+                      'stdio_runtime_unavailable', 'uap-fixture-missing-runtime', 'install it explicitly',
+                      'components_skipped_local_readiness')), 'MCP skipped reason/remediation missing')
+            if kind in ('mixed', 'http-auth'):
+                check('Authentication: not_checked' in text, 'auth uncertainty label lost')
+                check('Verification: package_validated' in text, 'verification overstated')
+                check('Installed and verified' not in text and 'Ready' not in text, 'plan falsely claimed usability')
+            if kind == 'http-auth':
+                check('mcp_server fixture: native' in text, 'HTTP support decision missing')
+                check('Authentication: not_checked' in text, 'HTTP auth status overstated')
+                check(re.search(r'(?i)verify.*authentication', text), 'missing actionable auth guidance')
+            if kind in ('empty', 'unsupported'):
+                check(not re.search(r'  - (skill|mcp_server|hook|command) ', text),
+                      'loader invented portable components')
+            if action in ('default-no', 'partial-plan', 'auth-unknown'):
+                send(session, b'\r')
+                session.finish()
+                fixture.unchanged()
+                if action in ('partial-plan', 'auth-unknown'):
+                    records = json_plan(fixture, binary, evidence, ['cursor'], timeout)
+                    check(len(records) == 1 and records[0]['target'] == 'cursor', 'JSON target mismatch')
+                    plan = records[0]['output']['result']['plan']
+                    check_auth_unknown(plan)
+                    components = {(c['kind'], c['name']): c for c in plan['components']}
+                    mcp = components[('mcp_server', 'fixture')]
+                    if action == 'partial-plan':
+                        check(components[('skill', 'guide')]['support'] == 'native', 'healthy skill lost')
+                        check(mcp['support'] == 'unsupported' and mcp['reason'] == 'stdio_runtime_unavailable',
+                              'missing runtime skip differs from contract')
+                    else:
+                        check(mcp['support'] == 'native', 'HTTP component lost')
+                        check(requests == [], 'installation unexpectedly contacted HTTP endpoint')
+                return
+            send(session, b' \r')
+            session.wait(LIFECYCLE, 'activation')
+            target = exact_skill(fixture)
+            (evidence / 'installed-files.json').write_text(json.dumps(hashes(target), indent=2))
+            send(session, b'n\n')
+            session.finish()
+            check('Have you completed required authentication' not in clean(session.raw), 'No advanced into auth')
+            exact_skill(fixture)
+            # Noninteractive removal is explicitly authorized synthetic cleanup;
+            # add/selection never bypasses the keyboard with --target.
+            remove_argv = [str(binary), 'remove', 'pty-synthetic', '--target=cursor', '--external-uninstalled']
+            (evidence / 'remove-command.json').write_text(json.dumps(remove_argv))
+            result = subprocess.run(remove_argv, cwd=fixture.project, env=fixture.env,
+                                    capture_output=True, timeout=timeout)
+            (evidence / 'remove.stdout').write_bytes(result.stdout)
+            (evidence / 'remove.stderr').write_bytes(result.stderr)
+            check(result.returncode == 0, 'synthetic CLI removal failed')
+            check(not target.exists(), 'CLI removal retained native package')
+            state = json.loads((fixture.data / 'state-v2.json').read_text())
+            check(all(binding.get('materialization') != 'materialized'
+                      for install in state.get('installations', [])
+                      for binding in install.get('clients', {}).values()), 'removal left materialized binding')
+            check(hashes(fixture.home / '.codex') == {}, 'removal changed unselected Codex')
+        finally:
+            session.close()
+            (evidence / 'http-requests.json').write_text(json.dumps(requests))
+            (evidence / 'mutations.json').write_text(json.dumps({
+                'before': fixture.before, 'after': fixture.mutations()}, indent=2))
+            fixture.validate_stubs()
+            if kind == 'http-auth':
+                check(requests == [], 'installation unexpectedly contacted HTTP endpoint')
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--binary', type=Path, required=True)
+    parser.add_argument('--artifacts', type=Path, required=True)
+    parser.add_argument('--case', action='append', choices=CASES)
+    parser.add_argument('--timeout', type=float, default=8)
+    args = parser.parse_args()
+    check(os.name == 'posix', 'coverage gap: rich keyboard ConPTY lane not qualified; use native Windows harness separately')
+    binary = args.binary.resolve(strict=True)
+    args.artifacts.mkdir(parents=True, exist_ok=False)
+    source = Path(__file__).resolve().parents[2]
+    report = {'source_sha': subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=source, text=True).strip(),
+              'binary': str(binary), 'binary_sha256': hashlib.sha256(binary.read_bytes()).hexdigest(),
+              'binary_source_link': 'Supplied binary SHA256 recorded; consult external build receipt for source parity.',
+              'platform': platform.system(),
+              'audit_matrix': AUDIT_MATRIX,
+              'fixture_contracts': {
+                  'manifest': 'install/integrationctl/agentplugins/adapters/specregistry/schemas/1.0.0/plugin.schema.json',
+                  'mcp': 'install/integrationctl/agentplugins/adapters/specregistry/schemas/1.0.0/mcp.schema.json',
+                  'loader': 'install/integrationctl/agentplugins/adapters/loader/loader_test.go',
+                  'projection': 'install/integrationctl/agentplugins/providers/stager_test.go',
+                  'ownership': 'install/integrationctl/agentplugins/providers/native_identity_test.go',
+                  'discovery': 'install/integrationctl/agentplugins/adapters/clientdetect/detector.go'},
+              'gaps': ['Ten-profile empty run uses synthetic native Linux/Darwin discovery paths. ChatGPT is an eleventh client with no config-only surface; omitted.',
+                       'This report covers only the recorded native platform and listed cases; Windows ConPTY is a separate lane.',
+                       'Scanner is synthetic; no security/runtime/client activation qualification.'], 'cases': []}
+    for case in args.case or CASES:
+        entry = {'case': case, 'status': 'pass',
+                 'repro': shlex.join(['python3', str(Path(__file__).resolve()), '--binary', str(binary),
+                                     '--case', case, '--artifacts', '/tmp/uap-plugin-matrix-repro-' + case.replace(':', '-')])}
+        try:
+            run_case(case, binary, args.artifacts / case.replace(':', '-'), args.timeout)
+        except Exception as error:
+            entry.update(status='fail', error=str(error), fix_owner='Unassigned; coordinating owner to triage. Production files outside lane scope.')
+        report['cases'].append(entry)
+        print(f"{entry['status']}: {case}: {entry.get('error', '')}", flush=True)
+    report['evidence_hashes'] = hashes(args.artifacts)
+    report['source_files'] = {name: hashlib.sha256((Path(__file__).parent / name).read_bytes()).hexdigest()
+                              for name in ('plugin_matrix.py', 'test_plugin_matrix.py', 'harness.py', 'pty_owner.py')}
+    (args.artifacts / 'report.json').write_text(json.dumps(report, indent=2))
+    return int(any(case['status'] == 'fail' for case in report['cases']))
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/terminal-ui/selection_matrix.py
+++ b/scripts/terminal-ui/selection_matrix.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Bounded real-keyboard selection matrix; native Unix only, stdlib only."""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+from harness import Fixture, Session, Screen, SELECT, CONFIRM, LIFECYCLE, check, clean, hashes
+
+TARGETS = ('codex', 'cursor')
+SETS = {'codex': ('codex',), 'cursor': ('cursor',), 'both': TARGETS}
+CASES = tuple(f'{s}-{answer}' for s in SETS for answer in ('default-no', 'yes')) + (
+    'neither', 'selection-escape', 'selection-ctrl-c',
+    'confirmation-escape', 'confirmation-ctrl-c', 'queued-enters', 'queued-yes', 'queued-space',
+    'native-ownership', 'selection-eof', 'confirmation-eof', 'confirmation-partial-eof')
+
+
+def digest(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def source_digest(repo):
+    """Hash tracked working-tree bytes, including local changes and deletions."""
+    paths = subprocess.check_output(['git', 'ls-files', '-z'], cwd=repo).split(b'\0')
+    state = hashlib.sha256()
+    for raw in sorted(set(paths) - {b''}):
+        path = repo / os.fsdecode(raw)
+        state.update(raw + b'\0')
+        state.update((digest(path) if path.is_file() else 'missing').encode() + b'\0')
+    return state.hexdigest()
+
+
+def choices(text):
+    return re.findall(r'\[([• ])\][^\n]*?\(([^()]+)\)', text)
+
+
+def plan_ids(text):
+    return re.findall(r'^Target: ([a-z0-9-]+)\s*$', text, re.M)
+
+
+class Keyboard(Session):
+    def frame(self, label):
+        super().frame(label)
+        state = self.fixture.mutations()
+        self.events[-1]['protected_state_sha256'] = hashlib.sha256(
+            json.dumps(state, sort_keys=True).encode()).hexdigest()
+        self.events[-1]['unchanged'] = state == self.fixture.before
+
+    def pump(self, timeout=0.1):
+        super().pump(timeout)
+        # This lane exercises reverse-index away from the top margin. Normalize
+        # only the evidence renderer; PTY input/output bytes stay untouched.
+        screen = Screen(self.screen.rows, self.screen.cols)
+        screen.feed(bytes(self.raw).replace(b'\x1bM', b'\x1b[1A'))
+        self.screen = screen
+
+    def send(self, keys):
+        self.events.append({'event': 'raw-key', 'hex': keys.hex(),
+                            'offset': len(self.raw),
+                            'elapsed': round(time.monotonic() - self.start, 3)})
+        super().send(keys)
+
+    def key(self, keys, label):
+        offset = len(self.raw)
+        self.send(keys)
+        deadline = time.monotonic() + self.timeout
+        while len(self.raw) == offset and time.monotonic() < deadline:
+            self.pump()
+        check(len(self.raw) > offset, f'no keyboard repaint: {label}')
+        self.pump(0.1)
+        self.frame(label)
+
+
+def selected_frame(session, expected):
+    rows = choices(session.screen.snapshot())
+    check([r[1] for r in rows] == list(TARGETS), f'choice order/identities: {rows}')
+    check([r[1] for r in rows if r[0] == '•'] == list(expected),
+          f'displayed selection differs from identities {expected}: {rows}')
+
+
+def installed(fixture, selected):
+    # Keep shared installation checks here: Fixture.installed assumes no active
+    # clients, while this lane verifies synthetic Codex native activation.
+    state = fixture.data / 'state-v2.json'
+    check(state.is_file(), 'no persisted installation state after Yes')
+    body = json.loads(state.read_text())
+    found = set()
+    def walk(value):
+        if isinstance(value, dict):
+            if 'client_id' in value: found.add(value['client_id'])
+            for child in value.values(): walk(child)
+        elif isinstance(value, list):
+            for child in value: walk(child)
+    walk(body)
+    check(found == set(selected), f'persisted clients {found}, expected {set(selected)}')
+    installations = body.get('installations', [])
+    check(len(installations) == 1, 'expected exactly one fresh installation')
+    bindings = installations[0]['clients']
+    check(sorted(b['client_id'] for b in bindings.values()) == sorted(selected),
+          'binding identities differ from selection')
+    locators = []
+    for binding_id, binding in bindings.items():
+        client = binding['client_id']
+        check(binding['materialization'] == 'materialized', 'binding not materialized')
+        check(any(r.get('phase') == 'committed' for r in binding['receipts']), 'missing commit')
+        check(binding.get('authentication') not in ('authenticated', 'not_required'), 'false auth')
+        check(binding.get('activation') == 'active' if client == 'codex' else binding.get('activation') != 'active', 'wrong activation')
+        check(binding['client_binding_id'] == binding_id, 'binding key mismatch')
+        for receipt in binding['receipts']:
+            check(receipt['client_binding_id'] == binding_id, 'receipt identity mismatch')
+            check(receipt['active_path'] == binding['target_locator'], 'receipt path mismatch')
+        target = Path(binding['target_locator']).resolve()
+        check(target.is_relative_to(fixture.root.resolve()), 'target escaped fixture')
+        manifest = target / 'plugin.json'
+        check(manifest.is_file(), 'native package manifest missing')
+        check(json.loads(manifest.read_text())['name'] == 'pty-synthetic',
+              'wrong package materialized')
+        check(manifest.read_bytes() == (fixture.package / 'plugin.json').read_bytes(),
+              'package manifest bytes differ from source')
+        expected_root = fixture.data / 'managed/clients/codex' if client == 'codex' else fixture.home / '.cursor'
+        check(target.is_relative_to(expected_root.resolve()),
+              f'identity/path mismatch: {client}: {target}')
+        if client == 'codex':
+            native = target / '.codex-plugin/plugin.json'
+            check(native.is_file(), 'Codex native identity missing after Yes')
+            check(json.loads(native.read_text())['name'] == 'pty-synthetic', 'wrong Codex identity')
+            # The standard adapter renders native metadata from plugin.json.
+            expected_native = (b'{\n  "description": "Synthetic terminal fixture",\n'
+                               b'  "name": "pty-synthetic",\n  "version": "1.0.0"\n}\n')
+            check(native.read_bytes() == expected_native,
+                  'Codex native manifest bytes differ from expected projection')
+            registry = json.loads((fixture.data / 'synthetic-codex-registry.json').read_text())
+            check(len(registry['installed']) == 1 and registry['installed'][0]['enabled'], 'native registry mismatch')
+        locators.append(str(target))
+    for client in set(TARGETS) - set(selected):
+        check(hashes(fixture.home / ('.' + client)) == {}, f'unselected {client} mutated')
+    check(fixture.mutations() != fixture.before, 'Yes produced no mutation')
+    return {'bindings': bindings, 'package_paths': locators}
+
+
+def prepare_codex_registry(fixture):
+    """Synthetic controlled native registry protocol, not a real Codex executable."""
+    stub = fixture.bin / 'codex'
+    stub.write_text('#!' + sys.executable + '\n' + r'''import json, os, sys
+from pathlib import Path
+args = sys.argv[1:]
+root = Path(os.environ['AGENTPLUGINS_HOME'])
+registry = root / 'synthetic-codex-registry.json'
+with open(os.environ['STUB_LOG'], 'a') as log:
+    log.write(sys.argv[0] + ' ' + ' '.join(args) + '\n')
+state = json.loads(registry.read_text()) if registry.exists() else {}
+if args == ['--version']:
+    print('synthetic 99.0.0')
+elif args == ['plugin', 'list', '--json']:
+    print(json.dumps({'installed': state.get('installed', [])}))
+elif len(args) == 5 and args[:3] == ['plugin', 'marketplace', 'add'] and args[4] == '--json':
+    path = Path(args[3]).resolve()
+    if not path.is_relative_to((root / 'managed/clients/codex').resolve()): sys.exit(97)
+    manifest = path / '.agents/plugins/marketplace.json'
+    body = json.loads(manifest.read_text())
+    state['marketplace'] = body['name']
+    registry.write_text(json.dumps(state))
+    print('{}')
+elif len(args) == 4 and args[:2] == ['plugin', 'add'] and args[3] == '--json':
+    market = state.get('marketplace')
+    if not market or args[2] != 'pty-synthetic@' + market: sys.exit(97)
+    state['installed'] = [dict(pluginId=args[2], name='pty-synthetic', marketplaceName=market,
+                               installed=True, enabled=True)]
+    registry.write_text(json.dumps(state))
+    print('{}')
+else:
+    sys.exit(97)
+''')
+
+
+def run_case(name, binary, evidence, timeout):
+    evidence.mkdir()
+    with tempfile.TemporaryDirectory(prefix='selection-matrix-') as tmp:
+        fixture = Fixture(tmp)
+        native = fixture.package / '.codex-plugin/plugin.json'
+        native.parent.mkdir()
+        native.write_text(json.dumps({'name': 'pty-synthetic', 'version': '1.0.0'}))
+        if name != 'native-ownership': prepare_codex_registry(fixture)
+        eof = name.endswith('eof')
+        argv = [str(binary), 'add', str(fixture.package)] + (['--plain'] if eof else [])
+        session = Keyboard(argv, fixture, evidence, timeout)
+        outcome = {'case': name, 'status': 'failed'}
+        try:
+            session.wait(SELECT, 'selection')
+            if eof:
+                fixture.unchanged()
+                if name != 'selection-eof':
+                    session.send(b'\n')
+                    session.wait(CONFIRM, 'confirmation')
+                    fixture.unchanged()
+                session.send(b'y\x04\x04' if name == 'confirmation-partial-eof' else b'\x04')
+                session.finish(1)
+                fixture.unchanged()
+                outcome['status'] = 'passed'
+                return outcome
+            session.wait(r'enter submit', 'selection-ready')
+            selected_frame(session, TARGETS)
+            fixture.unchanged()
+            if name.startswith('selection-'):
+                session.send(b'\x1b' if name.endswith('escape') else b'\x03')
+                session.finish(1)
+                fixture.unchanged()
+            else:
+                selected = SETS.get(name.split('-')[0], TARGETS)
+                if name == 'neither': selected = ()
+                if name == 'native-ownership': selected = ('codex',)
+                # Every path exercises down/up and a reversible Space toggle.
+                session.key(b' ', 'toggle-off')
+                selected_frame(session, ('cursor',))
+                session.key(b' ', 'toggle-back')
+                selected_frame(session, TARGETS)
+                session.key(b'\x1b[B', 'down')
+                session.key(b'\x1b[A', 'up')
+                if 'codex' not in selected: session.key(b' ', 'codex-off')
+                if 'cursor' not in selected:
+                    session.key(b'\x1b[B', 'cursor-focus')
+                    session.key(b' ', 'cursor-off')
+                selected_frame(session, selected)
+                outcome['selected_ids'] = list(selected)
+                fixture.unchanged()
+                offset = len(session.raw)
+                session.send(b'\r\r' if name == 'queued-enters' else
+                             b'\ry\r' if name == 'queued-yes' else
+                             b'\r \r' if name == 'queued-space' else b'\r')
+                if name == 'neither':
+                    session.wait(r'(?i)(at least one|select one|cannot be empty|must select)',
+                                 'empty-validation')
+                    selected_frame(session, ())
+                    fixture.unchanged()
+                    session.send(b'\x1b'); session.finish(1)
+                    check(not re.search(CONFIRM, clean(session.raw[offset:])), 'empty reached confirmation')
+                    fixture.unchanged()
+                else:
+                    session.wait(CONFIRM, 'confirmation', after=offset)
+                    if name not in ('queued-enters', 'queued-yes', 'queued-space'):
+                        session.wait(r'(?s)Yes.*?No.*?enter submit', 'confirmation-ready', after=offset)
+                    fixture.unchanged()
+                    plan = plan_ids(clean(session.raw[offset:]))
+                    check(plan == list(selected), f'plan targets {plan}, expected {list(selected)}')
+                    check('Plugin: pty-synthetic 1.0.0' in clean(session.raw[offset:]), 'plan identity missing')
+                    session.frame('plan-verified')
+                    if name.startswith('confirmation-'):
+                        session.send(b'\x1b' if name.endswith('escape') else b'\x03')
+                        session.finish(1); fixture.unchanged()
+                    elif name == 'native-ownership':
+                        session.send(b' \r')
+                        session.finish(1)
+                        check('observe native identity for codex' in clean(session.raw),
+                              'native ownership failure diagnostic missing')
+                        fixture.unchanged()
+                    elif name.endswith('-yes') and name != 'queued-yes':
+                        session.send(b' \r')
+                        for index, client in enumerate(selected if len(selected) == 1 else ()):
+                            marker = r'Have you completed required authentication[^\r\n]*\[y/N\]' if client == 'codex' else LIFECYCLE
+                            offset = session.wait(marker, f'lifecycle-{index}', after=offset)
+                            import termios
+                            check(termios.tcgetattr(session.slave) == session.before, 'raw mode at activation')
+                            session.send(b'n\n')
+                        session.finish(0)
+                        check(clean(session.raw).count('Have you completed required authentication') == int(selected == ('codex',)),
+                              'unexpected authentication prompt')
+                        outcome['installation'] = installed(fixture, selected)
+                    else:
+                        if name not in ('queued-enters', 'queued-yes', 'queued-space'): session.send(b'\r')
+                        session.finish(0); fixture.unchanged()
+            outcome['status'] = 'passed'
+        except Exception as exc:
+            outcome['error'] = str(exc)
+            # Preserve actual status and restoration even when a semantic assertion fails.
+            if session.process.poll() is not None and session.restoration is None:
+                try: session.restore_probe()
+                except Exception as restore: outcome['restoration_error'] = str(restore)
+        finally:
+            outcome['unchanged'] = fixture.mutations() == fixture.before
+            (evidence / 'mutations.json').write_text(json.dumps({
+                'before': fixture.before, 'after': fixture.mutations()}, indent=2))
+            session.close()
+            try:
+                if (fixture.root / 'stub.log').exists():
+                    log = (fixture.root / 'stub.log').read_text().splitlines()
+                    check(log and all(line.endswith(' --version') or line.endswith('codex plugin list --json')
+                                      or (name in ('codex-yes', 'both-yes') and ('/codex plugin marketplace add ' in line or '/codex plugin add pty-synthetic@' in line) and line.endswith(' --json'))
+                                      for line in log), 'unexpected native subprocess')
+                else:
+                    fixture.validate_stubs()
+            except Exception as exc:
+                outcome['stub_error'] = str(exc)
+                outcome['status'] = 'failed'
+            log = fixture.root / 'stub.log'
+            if log.exists(): (evidence / 'stub.log').write_bytes(log.read_bytes())
+        return outcome
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--binary', type=Path)
+    parser.add_argument('--build-go', type=Path, help='build exact current source with this Go executable')
+    parser.add_argument('--binary-sha256')
+    parser.add_argument('--artifacts', required=True, type=Path)
+    parser.add_argument('--timeout', type=float, default=8)
+    parser.add_argument('--case', action='append', choices=CASES)
+    args = parser.parse_args()
+    if os.name != 'posix': parser.error('Windows selection matrix NOT COVERED; Unix PTY required')
+    if not 0 < args.timeout <= 30: parser.error('timeout must be in (0, 30]')
+    repo = Path(__file__).resolve().parents[2]
+    source_before = source_digest(repo)
+    if args.build_go:
+        check(args.binary is None and args.binary_sha256 is None, '--build-go excludes supplied binary')
+        args.artifacts.mkdir(parents=True, exist_ok=False)
+        args.binary = args.artifacts.resolve() / 'source-agentplugins'
+        with (args.artifacts / 'build.log').open('wb') as log:
+            subprocess.run([str(args.build_go.resolve()), 'build', '-o', str(args.binary), './cmd/agentplugins'],
+                           cwd=repo / 'cli/plugin-kit-ai', stdout=log, stderr=subprocess.STDOUT, check=True, timeout=180)
+        check(source_digest(repo) == source_before, 'tracked source changed during build')
+        args.binary_sha256 = digest(args.binary)
+    else:
+        check(args.binary is not None and args.binary_sha256, 'supply --build-go or binary and hash')
+        args.artifacts.mkdir(parents=True, exist_ok=False)
+    check(digest(args.binary) == args.binary_sha256, 'binary hash mismatch; build needed if no verified binary')
+    binary = args.artifacts.resolve() / 'frozen-agentplugins'
+    shutil.copyfile(args.binary, binary); binary.chmod(0o700)
+    check(digest(binary) == args.binary_sha256, 'frozen copy hash mismatch')
+    repo = Path(__file__).resolve().parents[2]
+    provenance = {'tracked_worktree_sha256': source_before, 'source_commit': subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=repo, text=True).strip(),
+                  'source_files_sha256': {p.name: digest(p) for p in (
+                      Path(__file__), Path(__file__).with_name('harness.py'),
+                      Path(__file__).with_name('pty_owner.py'))},
+                  'binary_sha256': digest(binary), 'platform': platform.platform(),
+                  'binary_source_equivalence': 'built from current source in this run' if args.build_go else 'not established; supplied binary',
+                  'client_registry': 'synthetic Codex registry and install protocol; version-only Cursor; no real client qualification',
+                  'scanner': 'synthetic protocol stub; UI evidence only',
+                  'windows': 'not covered', 'macos': 'not run' if platform.system() != 'Darwin' else 'native'}
+    results = []
+    for name in args.case or CASES:
+        result = run_case(name, binary, args.artifacts / name, args.timeout)
+        result.update(provenance)
+        (args.artifacts / name / 'outcome.json').write_text(json.dumps(result, indent=2))
+        results.append(result)
+        print(json.dumps({k: result[k] for k in ('case', 'status', 'error') if k in result}), flush=True)
+        (args.artifacts / 'results.json').write_text(json.dumps(results, indent=2))
+    check(source_digest(repo) == source_before, 'tracked source changed during matrix')
+    return int(any(r['status'] != 'passed' for r in results))
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/terminal-ui/test_plugin_matrix.py
+++ b/scripts/terminal-ui/test_plugin_matrix.py
@@ -1,0 +1,132 @@
+"""Fixture validation plus opt-in actual PTY integration (never mocked CLI)."""
+import json
+import http.client
+from urllib.parse import urlsplit
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import plugin_matrix as lane
+
+
+class FixtureValidation(unittest.TestCase):
+    def test_platform_discovery_paths(self):
+        for system, editor in (('Linux', 'config'), ('Darwin', 'Library/Application Support')):
+            with self.subTest(system=system), tempfile.TemporaryDirectory() as tmp:
+                fixture = lane.Fixture(tmp)
+                before = fixture.mutations()
+                paths = lane.ten_client_paths(fixture, system)
+                self.assertEqual({str(p.relative_to(fixture.home)) for p in paths}, {
+                    '.copilot', '.kiro', '.claude', '.gemini/.gemini',
+                    editor + '/Code/User/globalStorage/saoudrizwan.claude-dev',
+                    'config/opencode', '.codeium/windsurf'})
+                self.assertEqual(fixture.mutations(), before)
+                self.assertTrue(all(p.resolve().is_relative_to(fixture.home.resolve()) for p in paths))
+
+    def test_native_seed_preserves_isolation_and_version_only_stubs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = lane.Fixture(tmp)
+            env = dict(fixture.env)
+            with patch.object(lane, 'ten_client_paths', wraps=lane.ten_client_paths) as paths:
+                lane.seed_ten_clients(fixture)
+                paths.assert_called_once_with(fixture, lane.platform.system())
+            self.assertEqual(fixture.env, env)
+            self.assertTrue(all(p.is_dir() for p in lane.ten_client_paths(fixture, lane.platform.system())))
+            self.assertEqual({p.name for p in fixture.bin.iterdir()}, {
+                'codex', 'cursor', 'copilot', 'code', 'kiro-cli', 'claude', 'gemini', 'opencode', 'windsurf'})
+            for stub in fixture.bin.iterdir():
+                self.assertEqual(stub.read_bytes(), (fixture.bin / 'cursor').read_bytes())
+                self.assertTrue(os.access(stub, os.X_OK))
+            fixture.unchanged()
+
+    def test_discovery_rejects_unsupported_platform_and_external_roots(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = lane.Fixture(tmp)
+            with self.assertRaisesRegex(AssertionError, 'Linux and Darwin'):
+                lane.ten_client_paths(fixture, 'Windows')
+            fixture.env['XDG_CONFIG_HOME'] = str(fixture.root / 'outside-home')
+            for system in ('Linux', 'Darwin'):
+                with self.subTest(system=system), self.assertRaisesRegex(AssertionError, 'escapes'):
+                    lane.ten_client_paths(fixture, system)
+
+    def test_standard_fixture_contracts(self):
+        for kind in lane.KINDS:
+            with self.subTest(kind=kind), tempfile.TemporaryDirectory() as tmp:
+                fixture = lane.Fixture(tmp)
+                lane.package(fixture, kind, 'http://127.0.0.1:12345/mcp')
+                if kind == 'malformed':
+                    with self.assertRaises(json.JSONDecodeError):
+                        json.loads((fixture.package / 'plugin.json').read_text())
+                    continue
+                manifest = json.loads((fixture.package / 'plugin.json').read_text())
+                self.assertEqual(manifest['$schema'], lane.SCHEMA + 'plugin.schema.json')
+                self.assertEqual(manifest['name'], 'pty-synthetic')
+                if kind in ('skill', 'mixed', 'collision'):
+                    body = (fixture.package / 'skills/guide/SKILL.md').read_text()
+                    self.assertTrue(body.startswith('---\nname: guide\ndescription: '))
+                    self.assertIn('reference.txt', body)
+                    self.assertTrue((fixture.package / 'skills/guide/reference.txt').is_file())
+                if kind in ('stdio-missing', 'mixed', 'http-auth'):
+                    mcp = json.loads((fixture.package / 'mcp.json').read_text())
+                    server = mcp['mcpServers']['fixture']
+                    if kind == 'http-auth':
+                        self.assertEqual(set(server), {'type', 'url'})
+                    else:
+                        self.assertEqual(server['command'], 'uap-fixture-missing-runtime')
+                        self.assertFalse((fixture.bin / server['command']).exists())
+                fixture.unchanged()
+
+    def test_controlled_endpoint_requires_auth_without_credentials(self):
+        with lane.local_endpoint(True) as (url, requests):
+            parsed = urlsplit(url)
+            connection = http.client.HTTPConnection(parsed.hostname, parsed.port, timeout=2)
+            try:
+                connection.request('POST', parsed.path, body=b'{}')
+                response = connection.getresponse()
+                self.assertEqual(response.status, 401)
+                self.assertIn('Bearer', response.getheader('WWW-Authenticate'))
+                response.read()
+            finally:
+                connection.close()
+            self.assertEqual(requests, [{'method': 'POST', 'path': '/mcp'}])
+
+    def test_case_contract(self):
+        self.assertEqual(len(lane.CASES), 19)
+        self.assertEqual(len(lane.CASES), len(set(lane.CASES)))
+        self.assertIn('empty:all-ten', lane.CASES)
+        self.assertIn('skill:install', lane.CASES)
+        for kind in ('stdio-missing', 'collision', 'malformed'):
+            self.assertIn(kind + ':reject', lane.CASES)
+        self.assertIn('mixed:partial-plan', lane.CASES)
+        self.assertIn('http-auth:auth-unknown', lane.CASES)
+        self.assertNotIn('mixed:reject', lane.CASES)
+        self.assertNotIn('http-auth:reject', lane.CASES)
+
+    def test_auth_uncertainty_does_not_imply_runtime_verification(self):
+        lane.check_auth_unknown({'authentication': 'not_checked', 'verification': 'package_validated'})
+        for auth, verification in (('not_required', 'package_validated'), ('verified', 'package_validated'),
+                                   ('not_checked', 'installed')):
+            with self.subTest(auth=auth, verification=verification), self.assertRaises(AssertionError):
+                lane.check_auth_unknown({'authentication': auth, 'verification': verification})
+
+    def test_choice_parser_rejects_diagnostic_only_client(self):
+        self.assertEqual(lane.choices(b'Warning: cursor (cursor)\n'), [])
+        self.assertEqual(lane.choices('┃ > [•] OpenAI Codex (codex)\r\n┃ [•] Cursor (cursor)'.encode()), ['codex', 'cursor'])
+
+    def test_external_endpoint_refused(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaisesRegex(AssertionError, 'loopback'):
+                lane.package(lane.Fixture(tmp), 'http-auth', 'https://external.example/mcp')
+
+
+@unittest.skipUnless(os.environ.get('PLUGIN_MATRIX_BINARY'), 'set PLUGIN_MATRIX_BINARY for actual PTY')
+class RealPTY(unittest.TestCase):
+    def test_skill_keyboard_lifecycle(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            lane.run_case('skill:install', Path(os.environ['PLUGIN_MATRIX_BINARY']).resolve(), Path(tmp) / 'evidence')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/terminal-ui/test_selection_matrix.py
+++ b/scripts/terminal-ui/test_selection_matrix.py
@@ -1,0 +1,158 @@
+"""Parser/renderer regression tests, not native CLI qualification."""
+import unittest
+import copy
+import json
+import shutil
+import tempfile
+import subprocess
+import os
+from harness import Fixture
+from harness import Screen
+from selection_matrix import CASES, SETS, choices, plan_ids, selected_frame, prepare_codex_registry, installed
+from types import SimpleNamespace
+
+
+class InstallationTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.fixture = Fixture(self.tmp.name)
+        native = self.fixture.package / '.codex-plugin/plugin.json'
+        native.parent.mkdir()
+        native.write_text('{\n  "description": "Synthetic terminal fixture",\n'
+                          '  "name": "pty-synthetic",\n  "version": "1.0.0"\n}\n')
+
+    def materialize(self, selected):
+        fixture = self.fixture
+        self.targets = {}
+        bindings = {}
+        for client in selected:
+            root = (fixture.data / 'managed/clients/codex' if client == 'codex'
+                    else fixture.home / '.cursor')
+            target = root / 'pty-synthetic'
+            shutil.copytree(fixture.package, target)
+            self.targets[client] = target
+            binding_id = client + '-binding'
+            bindings[binding_id] = {
+                'client_id': client, 'client_binding_id': binding_id,
+                'materialization': 'materialized',
+                'activation': 'active' if client == 'codex' else 'unknown',
+                'authentication': 'unknown', 'target_locator': str(target),
+                'receipts': [{'phase': 'committed', 'client_binding_id': binding_id,
+                              'active_path': str(target)}],
+            }
+        self.body = {'installations': [{'clients': bindings}]}
+        self.save_state()
+        (fixture.data / 'synthetic-codex-registry.json').write_text(
+            json.dumps({'installed': [{'enabled': True}]}))
+        installed(fixture, selected)
+
+    def save_state(self):
+        (self.fixture.data / 'state-v2.json').write_text(json.dumps(self.body))
+
+    def test_each_selected_set_accepts_valid_packages(self):
+        # Separate fixture per selection avoids residue from earlier selections.
+        for selected in SETS.values():
+            with self.subTest(selected=selected):
+                with tempfile.TemporaryDirectory() as root:
+                    original = self.fixture
+                    try:
+                        self.fixture = Fixture(root)
+                        shutil.copytree(original.package / '.codex-plugin',
+                                        self.fixture.package / '.codex-plugin')
+                        self.materialize(selected)
+                    finally:
+                        self.fixture = original
+
+    def test_both_rejects_missing_wrong_and_changed_cursor_manifest(self):
+        self.materialize(SETS['both'])
+        manifest = self.targets['cursor'] / 'plugin.json'
+        source = manifest.read_bytes()
+        for corruption, message in (
+                (None, 'native package manifest missing'),
+                (b'{"name": "wrong"}', 'wrong package materialized'),
+                (source + b'\n', 'package manifest bytes differ from source')):
+            with self.subTest(corruption=corruption):
+                if corruption is None:
+                    manifest.unlink()
+                else:
+                    manifest.write_bytes(corruption)
+                with self.assertRaisesRegex(AssertionError, message):
+                    installed(self.fixture, SETS['both'])
+                manifest.write_bytes(source)
+
+    def test_both_rejects_changed_codex_native_bytes(self):
+        self.materialize(SETS['both'])
+        native = self.targets['codex'] / '.codex-plugin/plugin.json'
+        native.write_bytes(native.read_bytes() + b'\n')
+        with self.assertRaisesRegex(AssertionError, 'Codex native manifest bytes'):
+            installed(self.fixture, SETS['both'])
+
+    def test_both_rejects_extra_installation(self):
+        self.materialize(SETS['both'])
+        self.body['installations'].append(copy.deepcopy(self.body['installations'][0]))
+        self.save_state()
+        with self.assertRaisesRegex(AssertionError, 'exactly one fresh installation'):
+            installed(self.fixture, SETS['both'])
+
+    def test_both_rejects_extra_binding(self):
+        self.materialize(SETS['both'])
+        bindings = self.body['installations'][0]['clients']
+        bindings['extra'] = copy.deepcopy(bindings['cursor-binding'])
+        self.save_state()
+        with self.assertRaisesRegex(AssertionError, 'binding identities differ'):
+            installed(self.fixture, SETS['both'])
+
+
+class EvidenceTests(unittest.TestCase):
+    def test_matrix_covers_each_nonempty_set_both_decisions(self):
+        self.assertEqual(set(SETS.values()), {('codex',), ('cursor',), ('codex', 'cursor')})
+        for name in SETS:
+            for decision in ('default-no', 'yes'):
+                self.assertIn(name + '-' + decision, CASES)
+        self.assertIn('neither', CASES)
+
+    @unittest.skipUnless(os.name == 'posix', 'shell client fixture is Unix only')
+    def test_registry_protocol_is_strict_and_read_only(self):
+        with tempfile.TemporaryDirectory() as root:
+            fixture = Fixture(root)
+            prepare_codex_registry(fixture)
+            for argv, code, output in [(['plugin', 'list', '--json'], 0, '{"installed": []}'),
+                                       (['plugin', 'install', 'anything'], 97, ''),
+                                       (['plugin', 'list', '--json', 'extra'], 97, '')]:
+                result = subprocess.run([str(fixture.bin / 'codex'), *argv],
+                                        env=fixture.env, capture_output=True, text=True, timeout=3)
+                self.assertEqual(result.returncode, code)
+                self.assertEqual(result.stdout.strip(), output)
+                fixture.unchanged()
+
+    def test_eof_covers_both_prompts_and_partial_confirmation(self):
+        for name in ('selection-eof', 'confirmation-eof', 'confirmation-partial-eof'):
+            self.assertIn(name, CASES)
+
+    def test_plan_ignores_labels_but_retains_wrong_and_duplicate_ids(self):
+        self.assertEqual(plan_ids('OpenAI Codex (codex)\nTarget: cursor\nTarget: codex\n'),
+                         ['cursor', 'codex'])
+        self.assertEqual(plan_ids('Target: cursor\nTarget: cursor\n'), ['cursor', 'cursor'])
+
+    def test_display_order_and_selection_are_independent_assertions(self):
+        screen = Screen()
+        screen.feed(b'[ ] OpenAI Codex (codex)\r\n')
+        screen.feed('[•] Cursor (cursor)'.encode())
+        session = SimpleNamespace(screen=screen)
+        selected_frame(session, ('cursor',))
+        with self.assertRaises(AssertionError): selected_frame(session, ('codex',))
+        screen = Screen()
+        screen.feed('[•] Cursor (cursor)\r\n[ ] OpenAI Codex (codex)'.encode())
+        with self.assertRaises(AssertionError):
+            selected_frame(SimpleNamespace(screen=screen), ('cursor',))
+
+    def test_reverse_index_redraw_preserves_identity(self):
+        raw = '[•] Codex (codex)\r\n[•] Cursor (cursor)\r\x1bM[ ]'.encode()
+        screen = Screen()
+        screen.feed(raw.replace(b'\x1bM', b'\x1b[1A'))
+        self.assertEqual(choices(screen.snapshot()), [(' ', 'codex'), ('•', 'cursor')])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Human CLI output now uses semantic colors with a shared presentation theme. Users control colors with --color=auto|never|always, --no-color and NO_COLOR; --plain independently controls interaction. JSON stays unstyled. Labels, success, warnings and errors have distinct roles, and diagnostic guidance retains safe line breaks.

Stacked on #206. No release publication.

Validation: focused Go tests and Darwin/Windows cross-builds passed; 42 Linux PTY scenarios, six fault cases and three npm launcher cases passed. Final native Linux amd64, macOS arm64 and Windows amd64 Terminal UI CI passed on 79e9990bcd74af1577b16a48f35ef4fa514007e3: https://github.com/777genius/universal-agent-plugins/actions/runs/34255937345. Independent final review approved with zero actionable findings. Native macOS screenshots require manual handoff because computer-use access to Terminal is denied.
