### PR TITLE
feat(landing): localize shell and download with EN reference copy

### DIFF
--- a/landing/components/common/AppLogo.vue
+++ b/landing/components/common/AppLogo.vue
@@ -1,15 +1,20 @@
 <script setup lang="ts">
-const localePath = useLocalePath();
-const homePath = computed(() => localePath("/"));
+import { isKnownLocale } from '~/data/i18n';
+import { localizedPath } from '~/utils/localizedRoutes';
+const { t, locale } = useI18n();
+
+const homePath = computed(() =>
+  localizedPath('/', isKnownLocale(locale.value) ? locale.value : 'en'),
+);
 const { asset } = useSite();
 </script>
 
 <template>
-  <NuxtLink :to="homePath" class="app-logo">
+  <NuxtLink :to="homePath" class="app-logo" :aria-label="t('shell.accessibility.home')">
     <img :src="asset('icon.svg')" alt="" class="app-logo__mark" width="36" height="36" >
     <span class="app-logo__copy">
       <span class="app-logo__text">Universal Agent Plugins</span>
-      <span class="app-logo__subtext">multi-agent CLI</span>
+      <span class="app-logo__subtext">{{ t('shell.logo.subtitle') }}</span>
     </span>
   </NuxtLink>
 </template>
@@ -43,7 +48,7 @@ const { asset } = useSite();
 }
 
 .app-logo__text {
-  font-family: "JetBrains Mono", monospace;
+  font-family: 'JetBrains Mono', monospace;
   font-weight: 700;
   font-size: 14px;
   letter-spacing: 0.04em;

--- a/landing/components/common/ThemeToggle.vue
+++ b/landing/components/common/ThemeToggle.vue
@@ -6,7 +6,7 @@ const { isDark, toggleTheme } = useBrowserTheme();
 const { trackThemeToggle } = useAnalytics();
 
 const tooltip = computed(() => isDark.value ? t('theme.light') : t('theme.dark'));
-const ariaLabel = computed(() => t("theme.toggle"));
+const ariaLabel = tooltip;
 
 const onToggle = () => {
   const nextTheme = isDark.value ? "light" : "dark";

--- a/landing/components/layout/AppFooter.vue
+++ b/landing/components/layout/AppFooter.vue
@@ -27,7 +27,7 @@ const githubOwnerUrl = `https://github.com/${githubOwner}`;
           t('footer.github')
         }}</a>
         <span class="app-footer__divider" />
-        <a class="app-footer__link" href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank" rel="noopener noreferrer">Apache 2.0</a>
+        <a class="app-footer__link" :aria-label="t('shell.accessibility.license')" href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank" rel="noopener noreferrer">Apache 2.0</a>
       </div>
     </v-container>
   </footer>

--- a/landing/components/layout/AppHeader.vue
+++ b/landing/components/layout/AppHeader.vue
@@ -28,11 +28,11 @@ const githubUrl = `https://github.com/${config.public.githubRepo}`;
 const homePath = computed(() => localePath('/'));
 const homeHref = computed(() => router.resolve(homePath.value).href);
 
-const navItems = [
-  { id: 'plugins', label: 'Plugins' },
-  { id: 'why', label: 'Why it works' },
-  { id: 'faq', label: 'FAQ' },
-];
+const navItems = computed(() => [
+  { id: 'plugins', label: t('shell.navigation.plugins') },
+  { id: 'why', label: t('shell.navigation.why') },
+  { id: 'faq', label: t('shell.navigation.faq') },
+]);
 
 const normalizePath = (value: string) => (value !== '/' ? value.replace(/\/+$/, '') : '/');
 
@@ -77,14 +77,14 @@ onMounted(() => {
       <div class="app-header__mobile-actions">
         <DialogRoot v-model:open="menuOpen">
           <DialogTrigger as-child>
-            <v-btn :icon="mdiMenu" variant="text" :disabled="!interactiveReady" aria-label="Open navigation menu" />
+            <v-btn :icon="mdiMenu" variant="text" :disabled="!interactiveReady" :aria-label="t('shell.navigation.open')" />
           </DialogTrigger>
           <DialogPortal>
             <DialogOverlay class="mobile-menu-overlay" />
             <DialogContent class="mobile-menu" @escape-key-down="onMobileEscape">
-              <DialogTitle class="sr-only">Navigation menu</DialogTitle>
+              <DialogTitle class="sr-only">{{ t('shell.navigation.title') }}</DialogTitle>
               <DialogDescription class="sr-only">
-                Jump to plugins, product details, frequently asked questions, or GitHub.
+                {{ t('shell.navigation.description') }}
               </DialogDescription>
               <div class="mobile-menu__header">
                 <div @click="menuOpen = false">
@@ -92,7 +92,7 @@ onMounted(() => {
                 </div>
                 <div style="flex: 1" />
                 <DialogClose as-child>
-                  <v-btn :icon="mdiClose" variant="text" aria-label="Close navigation menu" />
+                  <v-btn :icon="mdiClose" variant="text" :aria-label="t('shell.navigation.close')" />
                 </DialogClose>
               </div>
               <hr class="mobile-menu__divider" >
@@ -118,7 +118,7 @@ onMounted(() => {
               </nav>
               <hr class="mobile-menu__divider" >
               <div class="mobile-menu__actions">
-                <span>Appearance</span>
+                <span>{{ t('shell.navigation.appearance') }}</span>
                 <template v-if="interactiveReady">
                   <LanguageSwitcher v-if="publishedLocales.length > 1" compact contain-menu @menu-open="languageMenuOpen = $event" />
                   <ThemeToggle />

--- a/landing/components/registry/ClientStrip.vue
+++ b/landing/components/registry/ClientStrip.vue
@@ -1,19 +1,24 @@
 <script setup lang="ts">
+import { isKnownLocale } from '~/data/i18n';
+import { localizedPath } from '~/utils/localizedRoutes';
 import { clientLandingById } from '~/data/clients';
 
+const { t, locale } = useI18n();
+const clientPath = (slug: string) =>
+  localizedPath(`/agents/${slug}/`, isKnownLocale(locale.value) ? locale.value : 'en');
 const { asset } = useSite();
 </script>
 
 <template>
-  <ul class="client-strip" aria-label="Supported agents">
+  <ul class="client-strip" :aria-label="t('shell.accessibility.supportedAgents')">
     <li v-for="client in clients" :key="client.id">
-      <NuxtLink :to="`/agents/${clientLandingById.get(client.id)?.slug}/`">
+      <NuxtLink :to="clientPath(clientLandingById.get(client.id)!.slug)">
         <span class="client-strip__icon"
           ><img :src="asset(`client-icons/${client.icon}`)" alt="" width="24" height="24"
-        /></span>
+        ></span>
         <span class="client-strip__copy"
           ><strong>{{ client.name }}</strong
-          ><small>{{ client.status }}</small></span
+          ><small>{{ t(`registryUi.clients.${client.id}.status`) }}</small></span
         >
       </NuxtLink>
     </li>

--- a/landing/components/registry/RegistryFaq.vue
+++ b/landing/components/registry/RegistryFaq.vue
@@ -1,20 +1,16 @@
 <script setup lang="ts">
-import { registryFaqItems } from '~/data/registryFaq';
+defineProps<{ items: Array<{ question: string; answer: string }> }>();
+const { t } = useI18n();
 </script>
 
 <template>
-  <section
-    id="faq"
-    class="registry-faq container"
-    aria-labelledby="faq-title"
-    data-scroll-reveal
-  >
+  <section id="faq" class="registry-faq container" aria-labelledby="faq-title" data-scroll-reveal>
     <div class="section-heading section-heading--center">
-      <p class="eyebrow">FAQ</p>
-      <h2 id="faq-title">Common questions</h2>
+      <p class="eyebrow">{{ t('shell.faq.eyebrow') }}</p>
+      <h2 id="faq-title">{{ t('shell.faq.title') }}</h2>
     </div>
     <div class="registry-faq__list">
-      <details v-for="item in registryFaqItems" :key="item.question">
+      <details v-for="item in items" :key="item.question">
         <summary>{{ item.question }}<span aria-hidden="true">+</span></summary>
         <p>{{ item.answer }}</p>
       </details>

--- a/landing/components/registry/RegistryHero.vue
+++ b/landing/components/registry/RegistryHero.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
+import { useInstallPreferencesStore } from '~/stores/installPreferences';
 import type { ClientID, RegistryIndex } from '~/types/registry';
 import { pluginCommands } from '~/utils/commands';
 import { countAtElapsed, PLUGIN_COUNT_ANIMATION_MS } from '~/utils/countAnimation';
 import { catalogVisiblePlugins, groupCatalogPlugins } from '~/utils/filter';
-import { deliveryLabel, expectedDistribution, resolveDistribution } from '~/utils/registry';
+import { expectedDistribution, resolveDistribution } from '~/utils/registry';
 
+const { t, locale } = useI18n();
 const props = defineProps<{ registry: RegistryIndex }>();
 const config = useRuntimeConfig();
 const { current, expired, published } = useDirectoryStatus();
@@ -16,7 +18,7 @@ const displayedPluginCount = ref<number | null>(null);
 const pluginCount = computed(() =>
   displayedPluginCount.value === null
     ? null
-    : new Intl.NumberFormat('en').format(displayedPluginCount.value),
+    : new Intl.NumberFormat(locale.value).format(displayedPluginCount.value),
 );
 const countAnimationCompleted = useState('hero-plugin-count-animated', () => false);
 let countAnimationFrame: number | undefined;
@@ -74,16 +76,34 @@ const demoPlugin = computed(() => {
 const compatibleClients = computed(() =>
   clients.filter((client) => demoPlugin.value.client_support.clients.includes(client.id)),
 );
-const initialTarget =
-  compatibleClients.value.find((client) => client.id === 'cursor')?.id ??
-  compatibleClients.value[0]!.id;
-const selectedTargets = ref<ClientID[]>([initialTarget]);
-const autoDetect = ref(true);
-const autoOption = {
-  label: 'All installed agents (recommended)',
-  summary: 'All installed agents',
-  description: 'Detected when you run the command',
-};
+const preferences = useInstallPreferencesStore();
+const availableTargets = computed(() => compatibleClients.value.map((client) => client.id));
+const selectionIdentity = computed(() => `hero:${demoPlugin.value.install_source}`);
+const choice = computed(() =>
+  preferences.readPackage(selectionIdentity.value, availableTargets.value),
+);
+const selectedTargets = computed<ClientID[]>(() =>
+  choice.value.targetIds.length
+    ? (choice.value.targetIds as ClientID[])
+    : [
+        compatibleClients.value.find((client) => client.id === 'cursor')?.id ??
+          availableTargets.value[0]!,
+      ],
+);
+const autoDetect = computed({
+  get: () => choice.value.autoDetect,
+  set: (value: boolean) =>
+    preferences.selectPackage(
+      selectionIdentity.value,
+      { ...choice.value, targetIds: selectedTargets.value, autoDetect: value },
+      availableTargets.value,
+    ),
+});
+const autoOption = computed(() => ({
+  label: t('shell.hero.autoLabel'),
+  summary: t('shell.hero.autoSummary'),
+  description: t('shell.hero.autoDescription'),
+}));
 
 const targetOptions = computed(() =>
   clients.map((client) => ({
@@ -92,14 +112,16 @@ const targetOptions = computed(() =>
     icon: asset(`client-icons/${client.icon}`),
     disabled: !demoPlugin.value.client_support.clients.includes(client.id),
     description: (() => {
-      if (!published.value) return 'Temporarily unavailable';
-      if (expired.value) return 'Refreshing plugin data';
+      if (!published.value) return t('shell.hero.unavailable');
+      if (expired.value) return t('shell.hero.refreshing');
       const target = expectedDistribution(demoPlugin.value, [client.id])?.targets.find(
         (item) => item.client === client.id,
       );
       if (client.id === 'chatgpt')
-        return target?.app_binding ? 'Finish setup in ChatGPT' : 'Not available';
-      return target ? deliveryLabel(target.delivery) : 'Not available for this plugin';
+        return target?.app_binding ? t('shell.hero.chatgptSetup') : t('shell.hero.notAvailable');
+      return target
+        ? t(`shell.hero.delivery.${target.delivery}`)
+        : t('shell.hero.notAvailableForPlugin');
     })(),
   })),
 );
@@ -113,6 +135,49 @@ const resolution = computed(() =>
     selectedClients.value.map((client) => client.id),
   ),
 );
+// Additive descriptors are supplied by the registry lane. Older/unknown diagnostics
+// remain original text; presentation never parses English to make domain decisions.
+type ShellDiagnostic = {
+  code: string;
+  params?: Record<string, string | number>;
+  reasons?: ShellDiagnostic[];
+};
+function diagnosticText(diagnostic: ShellDiagnostic): string | null {
+  const codes = [
+    'distributionStatus',
+    'releaseStatus',
+    'missingComponents',
+    'unsupportedTargets',
+    'blockingFailure',
+    'missingEvidence',
+    'noReleases',
+    'defaultIneligible',
+  ];
+  const nested = (diagnostic.reasons ?? []).map(diagnosticText);
+  if (nested.some((reason) => reason === null)) return null;
+  const reasons = nested.join(t('shell.hero.diagnostics.reasonSeparator'));
+  if (diagnostic.code === 'reasons') return reasons;
+  if (!codes.includes(diagnostic.code)) return null;
+  const params = { ...diagnostic.params };
+  if (
+    typeof params.status === 'string' &&
+    ['candidate', 'active', 'suspended', 'superseded', 'revoked'].includes(params.status)
+  ) {
+    params.status = t(`shell.hero.diagnostics.status.${params.status}`);
+  }
+  return t(`shell.hero.diagnostics.${diagnostic.code}`, { ...params, reasons });
+}
+const fallbackReason = computed(() => {
+  const diagnostic = (
+    resolution.value as typeof resolution.value & {
+      fallback_diagnostic?: ShellDiagnostic;
+    }
+  ).fallback_diagnostic;
+  return (
+    (diagnostic && diagnosticText(diagnostic)) ??
+    t('shell.hero.sourceReason', { reason: resolution.value.fallback_reason ?? '' })
+  );
+});
 const command = computed(() => {
   if (!current.value || (!autoDetect.value && !resolution.value.distribution)) return '';
   return pluginCommands(
@@ -124,7 +189,12 @@ const command = computed(() => {
 function updateTargets(values: string[]) {
   const allowed = new Set(compatibleClients.value.map((client) => client.id));
   const next = values.filter((value): value is ClientID => allowed.has(value as ClientID));
-  if (next.length) selectedTargets.value = next;
+  if (next.length)
+    preferences.selectPackage(
+      selectionIdentity.value,
+      { ...choice.value, targetIds: next },
+      availableTargets.value,
+    );
 }
 </script>
 
@@ -132,23 +202,32 @@ function updateTargets(values: string[]) {
   <section class="hero-shell">
     <div class="hero container">
       <div class="hero__copy">
-        <h1>One plugin<br /><em>All your agents</em></h1>
+        <h1>
+          {{ t('shell.hero.title') }}<br ><em>{{ t('shell.hero.subtitle') }}</em>
+        </h1>
         <p class="hero__lead">
-          Install, update, repair, and remove Agent Plugins 1.0 across supported AI agents with one
-          command. Let the CLI detect installed agents, or choose exactly where the plugin goes.
+          {{ t('shell.hero.intro') }}
         </p>
         <div class="hero__actions">
           <a class="button button--primary" href="#plugins">
-            Explore
-            <span v-if="pluginCount !== null" class="hero__plugin-count">{{ pluginCount }}</span>
-            plugins <span aria-hidden="true">→</span>
+            <i18n-t
+              v-if="pluginCount !== null"
+              keypath="shell.hero.exploreCount"
+              tag="span"
+              :plural="displayedPluginCount ?? 0"
+            >
+              <template #count
+                ><span class="hero__plugin-count">{{ pluginCount }}</span></template
+              >
+            </i18n-t>
+            <span v-else>{{ t('shell.hero.explore') }}</span> <span aria-hidden="true">→</span>
           </a>
           <a
             class="button button--secondary"
             :href="cliRepositoryUrl"
             target="_blank"
             rel="noreferrer"
-            >Open GitHub</a
+            >{{ t('shell.hero.github') }}</a
           >
         </div>
       </div>
@@ -158,7 +237,7 @@ function updateTargets(values: string[]) {
         <div class="hero__window">
           <div class="hero__window-body">
             <div class="hero-quick-start__header">
-              <h2>Install {{ demoPlugin.display_name }}</h2>
+              <h2>{{ t('shell.hero.install', { name: demoPlugin.display_name }) }}</h2>
               <a href="https://agent-plugins.org/specification" target="_blank" rel="noreferrer"
                 >Agent Plugins 1.0</a
               >
@@ -167,13 +246,14 @@ function updateTargets(values: string[]) {
               <li class="hero-quick-start__step">
                 <span class="hero-quick-start__number">1</span>
                 <span class="hero-quick-start__label"
-                  ><strong>Choose agents</strong><small>One, many, or auto-detect</small></span
+                  ><strong>{{ t('shell.hero.choose') }}</strong
+                  ><small>{{ t('shell.hero.chooseHint') }}</small></span
                 >
                 <AppMultiSelect
                   :model-value="selectedTargets"
                   :auto-selected="autoDetect"
                   :auto-option="autoOption"
-                  label="Choose target agents"
+                  :label="t('shell.accessibility.chooseTargets')"
                   :options="targetOptions"
                   @update:auto-selected="autoDetect = $event"
                   @update:model-value="updateTargets"
@@ -182,30 +262,28 @@ function updateTargets(values: string[]) {
               <li class="hero-quick-start__step">
                 <span class="hero-quick-start__number hero-quick-start__number--run">2</span>
                 <span class="hero-quick-start__label"
-                  ><strong>Copy and run</strong><small>In your terminal</small></span
+                  ><strong>{{ t('shell.hero.run') }}</strong
+                  ><small>{{ t('shell.hero.terminal') }}</small></span
                 >
                 <div class="hero-quick-start__command">
                   <CommandSnippet v-if="command" :command="command" kind="add" inline />
                   <p v-else class="install-panel__notice" role="status">
-                    Plugin data is refreshing. Try again shortly.
+                    {{ t('shell.hero.refreshNotice') }}
                   </p>
                   <a
                     class="hero-quick-start__more-install"
                     href="https://github.com/777genius/universal-agent-plugins#quick-start"
                     target="_blank"
                     rel="noreferrer"
-                    >Other installation methods <span aria-hidden="true">↗</span></a
+                    >{{ t('shell.hero.otherMethods') }} <span aria-hidden="true">↗</span></a
                   >
                 </div>
               </li>
             </ol>
             <div class="hero-quick-start__footer">
-              <p>
-                <span aria-hidden="true">✓</span> One command plans every selected agent before
-                changing files
-              </p>
+              <p><span aria-hidden="true">✓</span> {{ t('shell.hero.planNotice') }}</p>
               <p v-if="!autoDetect && resolution.fallback_reason">
-                {{ resolution.fallback_reason }}
+                {{ fallbackReason }}
               </p>
             </div>
           </div>
@@ -215,11 +293,10 @@ function updateTargets(values: string[]) {
 
     <div class="client-section" aria-labelledby="supported-clients-title">
       <div class="client-section__inner container">
-        <p id="supported-clients-title">Supported clients</p>
+        <p id="supported-clients-title">{{ t('shell.hero.supportedClients') }}</p>
         <ClientStrip />
         <p class="client-section__note">
-          The CLI installs or prepares the native format each client supports. Some clients may ask
-          you to finish activation or sign in.
+          {{ t('shell.hero.clientNote') }}
         </p>
       </div>
     </div>

--- a/landing/components/registry/RegistryWhy.vue
+++ b/landing/components/registry/RegistryWhy.vue
@@ -1,3 +1,7 @@
+<script setup lang="ts">
+const { t } = useI18n();
+</script>
+
 <template>
   <section
     id="why"
@@ -6,63 +10,90 @@
     data-scroll-reveal
   >
     <div class="section-heading section-heading--center">
-      <p class="eyebrow">Why it works</p>
-      <h2 id="why-title">One standard<br />Native delivery</h2>
-      <p>The package stays portable; the installer handles each client's format and lifecycle.</p>
+      <p class="eyebrow">{{ t('shell.why.eyebrow') }}</p>
+      <h2 id="why-title">{{ t('shell.why.title') }}<br >{{ t('shell.why.subtitle') }}</h2>
+      <p>{{ t('shell.why.intro') }}</p>
     </div>
     <div class="registry-benefits__grid">
       <article class="registry-benefits__card">
         <div class="registry-benefits__signature" aria-hidden="true">
           <span class="registry-benefits__number">01</span>
-          <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <svg
+            viewBox="0 0 32 32"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
             <path d="m16 3 11 6v14l-11 6-11-6V9Z M5 9l11 6 11-6 M16 15v14 M10.5 6l11 6v6" />
           </svg>
         </div>
-        <h3>Standard first</h3>
-        <p>
-          Packages are read from Agent Plugins 1.0 <code>plugin.json</code>, without a second
-          install manifest.
-        </p>
+        <h3>{{ t('shell.why.standardTitle') }}</h3>
+        <i18n-t keypath="shell.why.standardDescription" tag="p">
+          <template #manifest><code>plugin.json</code></template>
+        </i18n-t>
       </article>
       <article class="registry-benefits__card">
         <div class="registry-benefits__signature" aria-hidden="true">
           <span class="registry-benefits__number">02</span>
-          <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <svg
+            viewBox="0 0 32 32"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
             <rect x="3" y="12" width="8" height="8" rx="2" />
             <rect x="22" y="3" width="7" height="7" rx="2" />
             <rect x="22" y="22" width="7" height="7" rx="2" />
             <path d="M11 16h5V6.5h6 M16 16v9.5h6 M16 16h12" />
           </svg>
         </div>
-        <h3>Client-aware</h3>
+        <h3>{{ t('shell.why.clientTitle') }}</h3>
         <p>
-          Codex, Cursor, Claude Code, Gemini CLI, OpenCode, and other clients receive the format
-          they support.
+          {{ t('shell.why.clientDescription') }}
         </p>
       </article>
       <article class="registry-benefits__card">
         <div class="registry-benefits__signature" aria-hidden="true">
           <span class="registry-benefits__number">03</span>
-          <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M26 12a11 11 0 0 0-19-4L4 11 M4 5v6h6 M6 20a11 11 0 0 0 19 4l3-3 M28 27v-6h-6 M11 16l3 3 7-7" />
+          <svg
+            viewBox="0 0 32 32"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path
+              d="M26 12a11 11 0 0 0-19-4L4 11 M4 5v6h6 M6 20a11 11 0 0 0 19 4l3-3 M28 27v-6h-6 M11 16l3 3 7-7"
+            />
           </svg>
         </div>
-        <h3>Full lifecycle</h3>
-        <p>Add, inspect, update, repair, switch source, or remove a plugin through the same CLI.</p>
+        <h3>{{ t('shell.why.lifecycleTitle') }}</h3>
+        <p>{{ t('shell.why.lifecycleDescription') }}</p>
       </article>
       <article class="registry-benefits__card">
         <div class="registry-benefits__signature" aria-hidden="true">
           <span class="registry-benefits__number">04</span>
-          <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <svg
+            viewBox="0 0 32 32"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
             <path d="M2 16s5-9 14-9 14 9 14 9-5 9-14 9S2 16 2 16Z" />
             <circle cx="16" cy="16" r="4" />
             <path d="M16 2v2 M16 28v2" />
           </svg>
         </div>
-        <h3>Source visible</h3>
+        <h3>{{ t('shell.why.sourceTitle') }}</h3>
         <p>
-          Reviewed packages and community discovery remain clearly labeled, with their source
-          available before install.
+          {{ t('shell.why.sourceDescription') }}
         </p>
       </article>
     </div>

--- a/landing/components/sections/DownloadSection.vue
+++ b/landing/components/sections/DownloadSection.vue
@@ -1,14 +1,19 @@
 <script setup lang="ts">
+import { isKnownLocale } from '~/data/i18n';
+import { localizedPath } from '~/utils/localizedRoutes';
 import CommandSnippetCard from '~/components/shared/CommandSnippetCard.vue';
 import { clientLandingPages } from '~/data/clients';
 import { applyCliInvocation, getCliInvocation } from '~/utils/cliInvocation';
 
 withDefaults(defineProps<{ headingTag?: 'h1' | 'h2' }>(), { headingTag: 'h2' });
 
-const { content } = useLandingContent();
 const { t, locale } = useI18n();
+const { content } = await useDownloadContent();
+const clientPath = (slug: string) =>
+  localizedPath(`/agents/${slug}/`, isKnownLocale(locale.value) ? locale.value : 'en');
 const { data: releaseData, fallbackUrl } = useReleaseDownloads();
-const { quickstartUrl, supportBoundaryUrl } = useDocsLinks();
+const { quickstartUrl, supportBoundaryUrl, docsLabel, supportBoundaryEnglishFallback } =
+  useDocsLinks();
 
 const releaseVersion = computed(() => {
   const version = releaseData.value?.version;
@@ -211,11 +216,16 @@ const quickstartSteps = computed(() => {
           >
             <div class="download-section__support-main">
               <h4 class="download-section__support-name">
-                <NuxtLink :to="`/agents/${client.slug}/`">{{ client.name }}</NuxtLink>
+                <NuxtLink :to="clientPath(client.slug)">{{ client.name }}</NuxtLink>
               </h4>
-              <span class="download-section__support-status">{{ client.status }}</span>
+              <span class="download-section__support-status">{{
+                t(`registryUi.clients.${client.id}.status`)
+              }}</span>
             </div>
-            <p class="download-section__support-note">{{ client.note }}. {{ client.activation }}</p>
+            <p class="download-section__support-note">
+              {{ t(`registryUi.clients.${client.id}.note`) }}.
+              {{ t(`registryUi.clients.${client.id}.activation`) }}
+            </p>
           </div>
         </div>
 
@@ -225,7 +235,7 @@ const quickstartSteps = computed(() => {
           target="_blank"
           rel="noopener noreferrer"
         >
-          {{ t('download.supportLink') }}
+          {{ docsLabel(t('download.supportLink'), supportBoundaryEnglishFallback) }}
         </a>
       </article>
     </v-container>

--- a/landing/components/shared/CommandSnippetCard.vue
+++ b/landing/components/shared/CommandSnippetCard.vue
@@ -1,16 +1,20 @@
 <script setup lang="ts">
 import { renderHighlightedCommand } from '~/utils/commandHighlight';
 
+const { t } = useI18n();
+
 const props = withDefaults(
   defineProps<{
     label: string;
     command: string;
-    copyLabel: string;
-    copiedLabel: string;
+    copyLabel?: string;
+    copiedLabel?: string;
     accent?: string;
   }>(),
   {
     accent: '#00f0ff',
+    copyLabel: undefined,
+    copiedLabel: undefined,
   },
 );
 
@@ -63,7 +67,9 @@ const copyCommand = async () => {
 };
 
 const commandLines = computed(() => renderHighlightedCommand(props.command));
-const copyStateLabel = computed(() => (copied.value ? props.copiedLabel : props.copyLabel));
+const copyStateLabel = computed(() =>
+  copied.value ? (props.copiedLabel ?? t('download.copied')) : (props.copyLabel ?? t('download.copy')),
+);
 </script>
 
 <template>

--- a/landing/composables/useDocsLinks.ts
+++ b/landing/composables/useDocsLinks.ts
@@ -1,57 +1,25 @@
 import { computed } from 'vue';
-import type { LocaleCode } from '~/data/i18n';
-
-const docsLocalePattern = /\/(en|ru|es|fr|zh)(?=\/|$)/;
-
-const replaceDocsLocale = (url: string, locale: LocaleCode): string => {
-  if (!url) {
-    return url;
-  }
-
-  if (docsLocalePattern.test(url)) {
-    return url.replace(docsLocalePattern, `/${locale}`);
-  }
-
-  return url;
-};
+import { resolveDocsLink, type DocsPageId } from '~/data/docsAvailability';
 
 export const useDocsLinks = () => {
-  const { locale } = useI18n();
+  const { locale, t } = useI18n();
   const config = useRuntimeConfig();
+  const link = (id: DocsPageId, configured?: string) =>
+    computed(() => resolveDocsLink(id, locale.value, configured));
+  const docs = link('home', String(config.public.docsUrl || ''));
+  const quickstart = link('quickstart', String(config.public.quickstartUrl || ''));
+  const supportBoundary = link('supportBoundary');
+  const customLogicGuide = link('customLogicGuide');
+  const docsLabel = (label: string, englishFallback = docs.value.englishFallback) =>
+    englishFallback ? t('shell.docs.englishLabel', { label }) : label;
 
-  const currentLocale = computed<LocaleCode>(() => {
-    const supported = new Set<LocaleCode>(['en', 'ru', 'es', 'fr', 'zh']);
-    return supported.has(locale.value as LocaleCode) ? (locale.value as LocaleCode) : 'en';
-  });
-
-  const docsUrl = computed(() =>
-    replaceDocsLocale(
-      config.public.docsUrl || 'https://777genius.github.io/universal-agent-plugins/docs/en/',
-      currentLocale.value,
-    ),
-  );
-
-  const quickstartUrl = computed(() =>
-    replaceDocsLocale(
-      config.public.quickstartUrl ||
-        'https://777genius.github.io/universal-agent-plugins/docs/en/guide/quickstart.html',
-      currentLocale.value,
-    ),
-  );
-
-  const supportBoundaryUrl = computed(() =>
-    replaceDocsLocale(
-      'https://777genius.github.io/universal-agent-plugins/docs/en/reference/support-boundary.html',
-      currentLocale.value,
-    ),
-  );
-
-  const customLogicGuideUrl = computed(() =>
-    replaceDocsLocale(
-      'https://777genius.github.io/universal-agent-plugins/docs/en/guide/build-custom-plugin-logic.html',
-      currentLocale.value,
-    ),
-  );
-
-  return { docsUrl, quickstartUrl, supportBoundaryUrl, customLogicGuideUrl };
+  return {
+    docsUrl: computed(() => docs.value.url),
+    quickstartUrl: computed(() => quickstart.value.url),
+    supportBoundaryUrl: computed(() => supportBoundary.value.url),
+    customLogicGuideUrl: computed(() => customLogicGuide.value.url),
+    docsLabel,
+    quickstartEnglishFallback: computed(() => quickstart.value.englishFallback),
+    supportBoundaryEnglishFallback: computed(() => supportBoundary.value.englishFallback),
+  };
 };

--- a/landing/composables/useDownloadContent.ts
+++ b/landing/composables/useDownloadContent.ts
@@ -1,0 +1,24 @@
+import { assembleDownloadContent } from '~/data/download';
+import type { DownloadOverlay } from '~/types/download';
+
+// Each overlay is its own lazy chunk. Legacy content and draft languages stay off this path.
+export const useDownloadContent = async () => {
+  const { locale } = useI18n();
+  const load = async (code: string): Promise<DownloadOverlay> => {
+    const language = code === 'ru' || code === 'uk' ? code : 'en';
+    try {
+      return (await import(`../content/download/${language}.json`)).default;
+    } catch (error) {
+      if (language === 'en') throw error;
+      // Emergency fallback only; published overlay completeness is a release gate.
+      return (await import('../content/download/en.json')).default;
+    }
+  };
+  const { data } = await useAsyncData(
+    () => `shell-download-${locale.value}`,
+    () => load(locale.value),
+  );
+  const fallback = await load('en');
+  const content = computed(() => assembleDownloadContent(data.value ?? fallback));
+  return { content };
+};

--- a/landing/composables/useInstallChannelSelection.ts
+++ b/landing/composables/useInstallChannelSelection.ts
@@ -11,6 +11,7 @@ export function useInstallChannelSelection(channels: ComputedRef<InstallChannel[
   const preferences = useInstallPreferencesStore();
   const selectedInstallChannelId = computed(() => preferences.channelId);
   const detectedInstallPlatform = ref<InstallPlatform | null>(null);
+  const detectionComplete = ref(false);
 
   const recommendedChannelId = computed(() => {
     if (detectedInstallPlatform.value) {
@@ -32,15 +33,20 @@ export function useInstallChannelSelection(channels: ComputedRef<InstallChannel[
     );
   });
 
-  watchEffect(() => {
-    const available = channels.value.map((channel) => channel.id);
-    preferences.reconcileChannels(available);
-    const next =
-      recommendedChannelId.value ??
-      channels.value.find((channel) => channel.id === 'npm')?.id ??
-      available[0];
-    if (next) preferences.selectChannel(next, available, false);
-  });
+  // Pinia actions read shared selection state. Track only this consumer's inputs,
+  // otherwise overlapping locale route instances can retrigger each other forever.
+  watch(
+    [() => channels.value.map((channel) => channel.id), recommendedChannelId, detectionComplete],
+    ([available, recommendation, ready]) => {
+      preferences.reconcileChannels(available);
+      // A newly created route has not detected its platform yet. Keep the hydrated
+      // selection until detection settles instead of briefly restoring SSR defaults.
+      if (!ready && preferences.channelId) return;
+      const next = recommendation ?? available.find((id) => id === 'npm') ?? available[0];
+      if (next) preferences.selectChannel(next, available, false);
+    },
+    { immediate: true },
+  );
 
   onMounted(async () => {
     try {
@@ -50,6 +56,8 @@ export function useInstallChannelSelection(channels: ComputedRef<InstallChannel[
       );
     } catch {
       detectedInstallPlatform.value = null;
+    } finally {
+      detectionComplete.value = true;
     }
   });
 

--- a/landing/composables/useInstallChannelSelection.ts
+++ b/landing/composables/useInstallChannelSelection.ts
@@ -1,4 +1,5 @@
 import type { ComputedRef } from 'vue';
+import { useInstallPreferencesStore } from '~/stores/installPreferences';
 import type { InstallChannel } from '~/types/content';
 import {
   normalizeInstallPlatform,
@@ -7,9 +8,9 @@ import {
 } from '~/utils/installPlatform';
 
 export function useInstallChannelSelection(channels: ComputedRef<InstallChannel[]>) {
-  const selectedInstallChannelId = ref<string | null>(null);
+  const preferences = useInstallPreferencesStore();
+  const selectedInstallChannelId = computed(() => preferences.channelId);
   const detectedInstallPlatform = ref<InstallPlatform | null>(null);
-  const manuallySelected = ref(false);
 
   const recommendedChannelId = computed(() => {
     if (detectedInstallPlatform.value) {
@@ -32,16 +33,13 @@ export function useInstallChannelSelection(channels: ComputedRef<InstallChannel[
   });
 
   watchEffect(() => {
-    const selectionStillExists = channels.value.some(
-      (channel) => channel.id === selectedInstallChannelId.value,
-    );
-    if (!selectionStillExists || !manuallySelected.value) {
-      selectedInstallChannelId.value =
-        recommendedChannelId.value ??
-        channels.value.find((channel) => channel.id === 'npm')?.id ??
-        channels.value[0]?.id ??
-        null;
-    }
+    const available = channels.value.map((channel) => channel.id);
+    preferences.reconcileChannels(available);
+    const next =
+      recommendedChannelId.value ??
+      channels.value.find((channel) => channel.id === 'npm')?.id ??
+      available[0];
+    if (next) preferences.selectChannel(next, available, false);
   });
 
   onMounted(async () => {
@@ -59,8 +57,10 @@ export function useInstallChannelSelection(channels: ComputedRef<InstallChannel[
     if (!channels.value.some((channel) => channel.id === channelId)) {
       return;
     }
-    manuallySelected.value = true;
-    selectedInstallChannelId.value = channelId;
+    preferences.selectChannel(
+      channelId,
+      channels.value.map((channel) => channel.id),
+    );
   }
 
   return {

--- a/landing/composables/usePageSeo.ts
+++ b/landing/composables/usePageSeo.ts
@@ -1,5 +1,5 @@
 import { computed, toValue } from 'vue';
-import { canonicalPath } from '~/utils/seo';
+import { canonicalPath, productRootUrl, productImageUrl } from '~/utils/seo';
 import type { MaybeRefOrGetter } from 'vue';
 
 type PageSeoImage = {
@@ -32,8 +32,9 @@ export const usePageSeo = (
   const { t, locale } = useI18n();
   const route = useRoute();
   const config = useRuntimeConfig();
-  const siteUrl = String(
-    config.public.siteUrl || 'https://777genius.github.io/universal-agent-plugins',
+  const siteUrl = productRootUrl(
+    String(config.public.siteUrl || 'https://777genius.github.io/universal-agent-plugins'),
+    String(config.app.baseURL),
   ).replace(/\/+$/, '');
   const siteName = 'Universal Agent Plugins';
   const githubUrl = `https://github.com/${config.public.githubRepo}`;
@@ -58,19 +59,13 @@ export const usePageSeo = (
       width: 1200,
       height: 630,
       type: 'image/png',
-      alt: 'Universal Agent Plugins - install plugins across AI agents with one CLI',
+      alt: t('shell.seo.imageAlt'),
     };
   });
 
-  const resolvedImageUrl = computed(() => {
-    const imageUrl = resolvedImage.value.url;
-    if (imageUrl.startsWith('http')) {
-      return imageUrl;
-    }
-
-    const siteBase = siteUrl.endsWith('/') ? siteUrl : `${siteUrl}/`;
-    return new URL(imageUrl.replace(/^\/+/, ''), siteBase).toString();
-  });
+  const resolvedImageUrl = computed(() =>
+    productImageUrl(resolvedImage.value.url, siteUrl, String(config.app.baseURL)),
+  );
 
   useSeoMeta({
     title,
@@ -135,8 +130,7 @@ export const usePageSeo = (
         '@id': organizationId,
         name: siteName,
         alternateName: 'UAP',
-        description:
-          'Open-source multi-agent installer and lifecycle manager for Agent Plugins 1.0.',
+        description: t('shell.seo.organizationDescription'),
         url: `${siteUrl}/`,
         logo: {
           '@type': 'ImageObject',

--- a/landing/composables/useReleaseDownloads.ts
+++ b/landing/composables/useReleaseDownloads.ts
@@ -1,3 +1,4 @@
+import { withAppBase } from '~/utils/localizedRoutes';
 import { emptyDownloadsResponse, parseGitHubRelease } from '~/utils/releaseDownloads';
 import type {
   DownloadArch,
@@ -110,7 +111,10 @@ export const useReleaseDownloads = () => {
       }
 
       try {
-        const parsed = await $fetch<DownloadsApiResponse>('/api/releases/latest');
+        const parsed = await $fetch<DownloadsApiResponse>(
+          withAppBase('/api/releases/latest', String(config.app.baseURL)),
+          { responseType: 'json' },
+        );
         writeCache(parsed);
         return parsed;
       } catch {

--- a/landing/content/download/en.json
+++ b/landing/content/download/en.json
@@ -1,0 +1,50 @@
+{
+  "shell": {
+    "download": {
+      "heading": {
+        "title": "Install your first plugin",
+        "note": "Choose how to run the CLI, select one or more agents, and copy the command."
+      },
+      "channels": {
+        "brew": {
+          "title": "Homebrew",
+          "description": "Native Go CLI for macOS and Linux. Node.js is not required.",
+          "note": "Recommended for a permanent install with automatic Homebrew upgrades."
+        },
+        "npm": {
+          "title": "npx · Node.js 22+",
+          "description": "Fastest when Node.js 22+ is already installed: run the plugin command immediately.",
+          "note": "Zero-install: npx downloads the verified CLI and runs the plugin command in one step."
+        },
+        "script": {
+          "title": "Verified install script",
+          "description": "Native install without a package manager. Node.js is not required.",
+          "note": "Downloads the correct release binary and verifies its SHA-256 and version."
+        },
+        "powershell": {
+          "title": "Windows PowerShell",
+          "description": "Native Go CLI for Windows. Node.js is not required.",
+          "note": "Downloads the Windows binary and verifies its SHA-256 and version."
+        }
+      },
+      "steps": {
+        "install-cli": {
+          "title": "Run the CLI",
+          "note": "Use npx for a quick start, or install the binary for daily use."
+        },
+        "try-plugin": {
+          "title": "Install a real plugin",
+          "note": "The same command accepts one target or a comma-separated list."
+        },
+        "build-plugin": {
+          "title": "Keep it current",
+          "note": "Use update for a new release and repair when a client drifts."
+        },
+        "validate": {
+          "title": "Remove cleanly",
+          "note": "The CLI removes managed client entries while retaining package data by default."
+        }
+      }
+    }
+  }
+}

--- a/landing/data/clients.ts
+++ b/landing/data/clients.ts
@@ -2,6 +2,7 @@ import type { ClientTarget } from '../types/registry';
 
 export interface ClientLandingPage extends ClientTarget {
   slug: string;
+  presentationKey?: string;
   intro: string;
   delivery: string;
   activation: string;
@@ -165,6 +166,14 @@ export const clientLandingPages: ClientLandingPage[] = [
 export const clients: ClientTarget[] = clientLandingPages.map(
   ({ id, name, icon, note, status }) => ({ id, name, icon, note, status }),
 );
+
+// Shell consumers can use this contract with clients[] without importing message JSON.
+export function clientPresentationKey(id: ClientTarget['id']): `registryUi.clients.${ClientTarget['id']}` {
+  return `registryUi.clients.${id}`;
+}
+
+// IDs and URLs stay canonical; captions are resolved by the active locale at the UI boundary.
+for (const client of clientLandingPages) client.presentationKey = clientPresentationKey(client.id);
 
 export const clientLandingBySlug = new Map(
   clientLandingPages.map((client) => [client.slug, client]),

--- a/landing/data/docsAvailability.ts
+++ b/landing/data/docsAvailability.ts
@@ -1,0 +1,29 @@
+/** Owned public docs IDs only. Landing publication does not publish a docs locale. */
+export const docsAvailability = {
+  home: '',
+  quickstart: 'guide/quickstart.html',
+  supportBoundary: 'reference/support-boundary.html',
+  customLogicGuide: 'guide/build-custom-plugin-logic.html',
+} as const;
+export type DocsPageId = keyof typeof docsAvailability;
+export const ownedDocsRoot = 'https://777genius.github.io/universal-agent-plugins/docs/';
+const docsLanguages = ['en', 'ru', 'es', 'fr', 'zh'] as const;
+
+export function resolveDocsLink(id: DocsPageId, locale: string, configuredUrl?: string) {
+  const language = locale === 'ru' ? 'ru' : 'en';
+  const defaultUrl = `${ownedDocsRoot}en/${docsAvailability[id]}`;
+  const source = configuredUrl || defaultUrl;
+  // Preserve unrecognized/custom destinations byte-for-byte, including external /en/ paths.
+  for (const existing of docsLanguages) {
+    const owned = `${ownedDocsRoot}${existing}/${docsAvailability[id]}`;
+    const suffix = source.slice(owned.length);
+    if (source === owned || (source.startsWith(owned) && /^[?#]/.test(suffix))) {
+      return {
+        url: `${ownedDocsRoot}${language}/${docsAvailability[id]}${suffix}`,
+        language,
+        englishFallback: locale === 'uk',
+      };
+    }
+  }
+  return { url: source, language: null, englishFallback: false };
+}

--- a/landing/data/download.ts
+++ b/landing/data/download.ts
@@ -1,0 +1,69 @@
+import type { InstallChannel, QuickstartStep } from '../types/content';
+import type { DownloadOverlay } from '../types/download';
+
+// Technical bytes are shared across locales; overlays cannot override them.
+export const downloadTechnical = {
+  installChannels: [
+    {
+      id: 'brew',
+      href: 'https://github.com/777genius/homebrew-agentplugins',
+      command: 'brew install 777genius/agentplugins/agentplugins',
+      invocation: 'agentplugins',
+      recommended: true,
+    },
+    {
+      id: 'npm',
+      href: 'https://www.npmjs.com/package/universal-agent-plugins',
+      command: 'npx universal-agent-plugins version',
+      invocation: 'npx universal-agent-plugins',
+    },
+    {
+      id: 'script',
+      href: 'https://github.com/777genius/universal-agent-plugins/blob/main/docs/NATIVE_INSTALL.md',
+      command:
+        'curl -fsSL https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.sh | sh',
+      invocation: '$HOME/.local/bin/agentplugins',
+    },
+    {
+      id: 'powershell',
+      href: 'https://github.com/777genius/universal-agent-plugins/blob/main/docs/NATIVE_INSTALL.md#windows-powershell',
+      command:
+        'irm https://raw.githubusercontent.com/777genius/universal-agent-plugins/main/install.ps1 | iex',
+      invocation: '& "$HOME\\.local\\bin\\agentplugins.exe"',
+    },
+  ],
+  quickstartSteps: [
+    {
+      id: 'install-cli',
+      command: 'npx universal-agent-plugins version',
+    },
+    {
+      id: 'try-plugin',
+      command: 'universal-agent-plugins add context7 --target codex,cursor',
+    },
+    {
+      id: 'build-plugin',
+      command:
+        'universal-agent-plugins update context7 --target codex,cursor\nuniversal-agent-plugins repair context7 --target codex,cursor',
+    },
+    {
+      id: 'validate',
+      command: 'universal-agent-plugins remove context7 --target codex,cursor',
+    },
+  ],
+};
+
+export function assembleDownloadContent(overlay: DownloadOverlay) {
+  const copy = overlay.shell.download;
+  return {
+    download: { title: copy.heading.title, note: copy.heading.note },
+    installChannels: downloadTechnical.installChannels.map((channel) => {
+      const text = copy.channels[channel.id]!;
+      return { ...channel, title: text.title, description: text.description, note: text.note };
+    }) satisfies InstallChannel[],
+    quickstartSteps: downloadTechnical.quickstartSteps.map((step) => {
+      const text = copy.steps[step.id]!;
+      return { ...step, title: text.title, note: text.note };
+    }) satisfies QuickstartStep[],
+  };
+}

--- a/landing/error.vue
+++ b/landing/error.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { isKnownLocale } from '~/data/i18n';
+import { localizedPath } from '~/utils/localizedRoutes';
 import { mdiHome } from '@mdi/js'
 import type { NuxtError } from "#app";
 
@@ -6,7 +8,8 @@ const props = defineProps<{
   error: NuxtError;
 }>();
 
-const { t } = useI18n();
+const { t, locale } = useI18n();
+
 
 const statusCode = computed(() => props.error?.statusCode || 404);
 const isNotFound = computed(() => statusCode.value === 404);
@@ -16,7 +19,7 @@ useSeoMeta({
   robots: 'noindex, nofollow',
 });
 
-const handleGoHome = () => clearError({ redirect: "/" });
+const handleGoHome = () => clearError({ redirect: localizedPath('/', isKnownLocale(locale.value) ? locale.value : 'en') });
 </script>
 
 <template>

--- a/landing/locales/en.json
+++ b/landing/locales/en.json
@@ -100,7 +100,9 @@
   },
   "language": {
     "label": "Language",
-    "search": "Search language…"
+    "search": "Search language…",
+    "switchError": "Unable to change language. Please try again.",
+    "retry": "Retry"
   },
   "features": {
     "sectionTitle": "A clean path from one plugin repo to many agents",
@@ -343,5 +345,203 @@
     "compatibilityLink": "Client compatibility (English)",
     "limitations": "Compatibility is package-specific. Schema validation does not prove runtime, OAuth or activation. Codex does not support declared MCP SSE; stdio and Streamable HTTP keep their existing adapter support.",
     "versions": "Published versions checked on 2026-09-07: universal-agent-plugins 0.1.53 (npm), plugin-kit-ai 1.2.4 (npm/PyPI), stable GitHub release agentplugins-v0.1.53."
+  },
+  "shell": {
+    "docs": {
+      "englishLabel": "{label} (documentation in English)"
+    },
+    "logo": {
+      "subtitle": "multi-agent CLI"
+    },
+    "accessibility": {
+      "home": "Universal Agent Plugins home",
+      "chooseTargets": "Choose target agents",
+      "supportedAgents": "Supported agents",
+      "license": "Apache 2.0 license"
+    },
+    "why": {
+      "eyebrow": "Why it works",
+      "title": "One standard",
+      "subtitle": "Native delivery",
+      "intro": "The package stays portable; the installer handles each client's format and lifecycle.",
+      "standardTitle": "Standard first",
+      "clientTitle": "Client-aware",
+      "clientDescription": "Codex, Cursor, Claude Code, Gemini CLI, OpenCode, and other clients receive the format they support.",
+      "lifecycleTitle": "Full lifecycle",
+      "lifecycleDescription": "Add, inspect, update, repair, switch source, or remove a plugin through the same CLI.",
+      "sourceTitle": "Source visible",
+      "sourceDescription": "Reviewed packages and community discovery remain clearly labeled, with their source available before install.",
+      "standardDescription": "Packages are read from Agent Plugins 1.0 {manifest}, without a second install manifest."
+    },
+    "faq": {
+      "eyebrow": "FAQ",
+      "title": "Common questions",
+      "items": {
+        "0": {
+          "question": "Which AI agents are supported?",
+          "answer": "Codex, ChatGPT, Cursor, GitHub Copilot CLI, VS Code, Kiro, Claude Code, Gemini CLI, OpenCode, Cline, and Windsurf are supported or prepared through an explicit client-specific path."
+        },
+        "1": {
+          "question": "Does one command install into every agent?",
+          "answer": "By default the CLI detects installed compatible agents and asks you to confirm. You can also select one or many agents explicitly."
+        },
+        "2": {
+          "question": "What happens when an agent needs sign-in?",
+          "answer": "The CLI prepares the package and shows the exact activation or sign-in step. It never receives your OAuth password."
+        },
+        "3": {
+          "question": "Can I install a plugin outside this directory?",
+          "answer": "Yes. Use a pinned GitHub source that contains a valid Agent Plugins 1.0 plugin.json package."
+        },
+        "4": {
+          "question": "Are all discovered plugins reviewed?",
+          "answer": "No. Reviewed entries and automatically discovered community packages are labeled separately so you can choose the trust level you need."
+        },
+        "5": {
+          "question": "Can I undo an installation?",
+          "answer": "Yes. The same CLI records managed state and supports inspect, update, repair, source switching, and removal."
+        }
+      }
+    },
+    "seo": {
+      "indexTitle": "Universal Agent Plugins CLI {'|'} Install Agent Plugins 1.0",
+      "indexDescription": "Install, update, repair, and remove Agent Plugins 1.0 across supported AI agents with one CLI.",
+      "downloadTitle": "Download Universal Agent Plugins CLI",
+      "downloadDescription": "Install the Universal Agent Plugins CLI on macOS, Linux, or Windows and manage Agent Plugins 1.0 from one command.",
+      "applicationSubCategory": "Agent plugin manager",
+      "softwareRequirements": "Native CLI for macOS, Linux, and Windows; or Node.js 22+ for npx",
+      "featureList": "Install, inspect, update, repair, switch source, and remove Agent Plugins 1.0",
+      "imageAlt": "Universal Agent Plugins - install plugins across AI agents with one CLI",
+      "organizationDescription": "Open-source multi-agent installer and lifecycle manager for Agent Plugins 1.0."
+    },
+    "hero": {
+      "autoLabel": "All installed agents (recommended)",
+      "autoSummary": "All installed agents",
+      "autoDescription": "Detected when you run the command",
+      "unavailable": "Temporarily unavailable",
+      "refreshing": "Refreshing plugin data",
+      "chatgptSetup": "Finish setup in ChatGPT",
+      "notAvailable": "Not available",
+      "notAvailableForPlugin": "Not available for this plugin",
+      "title": "One plugin",
+      "subtitle": "All your agents",
+      "intro": "Install, update, repair, and remove Agent Plugins 1.0 across supported AI agents with one command. Let the CLI detect installed agents, or choose exactly where the plugin goes.",
+      "github": "Open GitHub",
+      "choose": "Choose agents",
+      "chooseHint": "One, many, or auto-detect",
+      "run": "Copy and run",
+      "terminal": "In your terminal",
+      "refreshNotice": "Plugin data is refreshing. Try again shortly.",
+      "otherMethods": "Other installation methods",
+      "planNotice": "One command plans every selected agent before changing files",
+      "supportedClients": "Supported clients",
+      "clientNote": "The CLI installs or prepares the native format each client supports. Some clients may ask you to finish activation or sign in.",
+      "install": "Install {name}",
+      "explore": "Explore plugins",
+      "exploreCount": "Explore {count} plugins | Explore {count} plugin | Explore {count} plugins",
+      "delivery": {
+        "managed": "Managed install",
+        "prepared": "Prepared; client import remains",
+        "manual_activation": "Manual activation required"
+      },
+      "sourceReason": "Source reason: {reason}",
+      "diagnostics": {
+        "distributionStatus": "distribution is {status}",
+        "releaseStatus": "release {sequence} is {status}",
+        "missingComponents": "release {sequence} misses required components",
+        "unsupportedTargets": "release {sequence} does not support {targets}",
+        "blockingFailure": "release {sequence} has blocking trusted failure for {targets}",
+        "missingEvidence": "release {sequence} lacks current positive package compatibility evidence (passed materialization) for {targets}",
+        "noReleases": "no releases",
+        "defaultIneligible": "declared default {distribution} was ineligible: {reasons}",
+        "reasonSeparator": "; ",
+        "status": {
+          "candidate": "candidate",
+          "active": "active",
+          "suspended": "suspended",
+          "superseded": "superseded",
+          "revoked": "revoked"
+        }
+      }
+    },
+    "header": {
+      "plugins": "Plugins",
+      "why": "Why it works",
+      "faq": "FAQ",
+      "openMenu": "Open navigation menu",
+      "closeMenu": "Close navigation menu",
+      "menuTitle": "Navigation menu",
+      "menuDescription": "Jump to plugins, product details, frequently asked questions, or GitHub.",
+      "appearance": "Appearance"
+    },
+    "navigation": {
+      "plugins": "Plugins",
+      "why": "Why it works",
+      "faq": "FAQ",
+      "open": "Open navigation menu",
+      "close": "Close navigation menu",
+      "title": "Navigation menu",
+      "description": "Jump to plugins, product details, frequently asked questions, or GitHub.",
+      "appearance": "Appearance"
+    }
+  },
+  "registryUi": {
+    "clients": {
+      "codex": {
+        "note": "Skills and supported MCP transports",
+        "status": "Supported",
+        "activation": "Follow any activation hint printed by the CLI, then start a new Codex session."
+      },
+      "chatgpt": {
+        "note": "Verified ChatGPT connections",
+        "status": "Setup in app",
+        "activation": "Complete the final app activation or sign-in step in ChatGPT when prompted."
+      },
+      "cursor": {
+        "note": "Native Agent Plugin package",
+        "status": "Supported",
+        "activation": "Reload Cursor when requested, then verify that the plugin is discovered."
+      },
+      "copilot": {
+        "note": "Managed native plugin",
+        "status": "Supported",
+        "activation": "Restart or reload the client only when the native Copilot workflow asks for it."
+      },
+      "vscode": {
+        "note": "Copilot plugin integration",
+        "status": "Supported",
+        "activation": "If automatic activation is unavailable, follow the exact setting or import path printed by the CLI."
+      },
+      "kiro": {
+        "note": "Native folder package",
+        "status": "Supported",
+        "activation": "Follow the printed import or activation hint when Kiro requires a final client-side step."
+      },
+      "claude": {
+        "note": "Managed MCP configuration",
+        "status": "Supported",
+        "activation": "Reload Claude Code when requested and complete any service sign-in in the client or provider."
+      },
+      "gemini": {
+        "note": "Managed MCP configuration",
+        "status": "Supported",
+        "activation": "Enable or reload the integration when Gemini CLI prints a follow-up step."
+      },
+      "opencode": {
+        "note": "Managed MCP configuration",
+        "status": "Supported",
+        "activation": "Open a new OpenCode session after installation so the project configuration is reloaded."
+      },
+      "cline": {
+        "note": "Managed MCP configuration",
+        "status": "Supported",
+        "activation": "Reload Cline when requested and complete provider authentication outside the plugin package."
+      },
+      "windsurf": {
+        "note": "Prepared package; manual activation required",
+        "status": "Prepared by CLI",
+        "activation": "Follow the exact manual activation path printed after preparation."
+      }
+    }
   }
 }

--- a/landing/pages/create-plugin.vue
+++ b/landing/pages/create-plugin.vue
@@ -1,16 +1,10 @@
 <script setup lang="ts">
-const { t, locale } = useI18n();
-const config = useRuntimeConfig();
+const { t } = useI18n();
+const { quickstartUrl, docsLabel, quickstartEnglishFallback } = useDocsLinks();
 // This checkpoint preserves the existing route and indexing policy.
 // Availability is stated in visible copy, independently of robots metadata.
 usePageSeo('publicAuthoring.title', 'publicAuthoring.intro', {
   robots: 'noindex, follow',
-});
-const quickstartUrl = computed(() => {
-  const base = String(config.public.docsUrl)
-    .replace(/\/+$/, '')
-    .replace(/\/(en|ru|es|fr|zh)$/, '');
-  return `${base}/${locale.value}/guide/quickstart.html`;
 });
 </script>
 
@@ -37,7 +31,9 @@ const quickstartUrl = computed(() => {
       <section id="build-plugins" aria-labelledby="build-title">
         <h2 id="build-title">{{ t('publicAuthoring.buildTitle') }}</h2>
         <p>{{ t('publicAuthoring.standard') }}</p>
-        <p><strong>{{ t('publicAuthoring.preparation') }}</strong></p>
+        <p>
+          <strong>{{ t('publicAuthoring.preparation') }}</strong>
+        </p>
         <p>{{ t('publicAuthoring.unreleased') }}</p>
         <a href="https://agent-plugins.org/specification">
           {{ t('publicAuthoring.specLink') }}
@@ -51,8 +47,8 @@ const quickstartUrl = computed(() => {
       <section id="historical-v1" aria-labelledby="history-title">
         <h2 id="history-title">{{ t('publicAuthoring.historyTitle') }}</h2>
         <p>{{ t('publicAuthoring.history') }}</p>
-        <a :href="`${quickstartUrl}#historical-v1`">
-          {{ t('publicAuthoring.quickstartLink') }}
+        <a :href="quickstartUrl.split('#')[0] + '#historical-v1'">
+          {{ docsLabel(t('publicAuthoring.quickstartLink'), quickstartEnglishFallback) }}
         </a>
       </section>
     </div>

--- a/landing/pages/download.vue
+++ b/landing/pages/download.vue
@@ -1,23 +1,32 @@
 <script setup lang="ts">
-import { productSoftwareSchema } from '~/utils/seo';
+import { productRootUrl, productSoftwareSchema } from '~/utils/seo';
 
+const { t } = useI18n();
 const config = useRuntimeConfig();
-const description =
-  'Install the Universal Agent Plugins CLI on macOS, Linux, or Windows and manage Agent Plugins 1.0 from one command.';
-const siteUrl = String(config.public.siteUrl).replace(/\/+$/, '');
+const { docsUrl } = useDocsLinks();
+const description = computed(() => t('shell.seo.downloadDescription'));
+const siteUrl = productRootUrl(
+  String(config.public.siteUrl),
+  String(config.app.baseURL),
+).replace(/\/+$/, '');
 const githubUrl = `https://github.com/${config.public.githubRepo}`;
 
-usePageSeo('Download Universal Agent Plugins CLI', description, {
+usePageSeo(() => t('shell.seo.downloadTitle'), description, {
   translate: false,
   pageProperties: { mainEntity: { '@id': `${siteUrl}/#software` } },
-  structuredData: [
-    productSoftwareSchema({
-      siteUrl,
-      githubUrl,
-      releasesUrl: String(config.public.githubReleasesUrl),
-      docsUrl: String(config.public.docsUrl),
-      description,
-    }),
+  structuredData: () => [
+    {
+      ...productSoftwareSchema({
+        siteUrl,
+        githubUrl,
+        releasesUrl: String(config.public.githubReleasesUrl),
+        docsUrl: docsUrl.value,
+        description: description.value,
+        applicationSubCategory: t('shell.seo.applicationSubCategory'),
+      softwareRequirements: t('shell.seo.softwareRequirements'),
+        featureList: t('shell.seo.featureList'),
+      }),
+    },
   ],
 });
 </script>

--- a/landing/pages/index.vue
+++ b/landing/pages/index.vue
@@ -1,31 +1,50 @@
 <script setup lang="ts">
-import { registryFaqItems } from '~/data/registryFaq';
-import { productSoftwareSchema } from '~/utils/seo';
+import { isKnownLocale } from '~/data/i18n';
+import { localizedPath } from '~/utils/localizedRoutes';
+import { productRootUrl, productSoftwareSchema } from '~/utils/seo';
+const { t, locale } = useI18n();
+const registryFaqItems = computed(() =>
+  ['0', '1', '2', '3', '4', '5'].map((key) => ({
+    question: t(`shell.faq.items.${key}.question`),
+    answer: t(`shell.faq.items.${key}.answer`),
+  })),
+);
 
 const registry = await useRegistryPage({ discovery: true });
 const config = useRuntimeConfig();
-const description =
-  'Install, update, repair, and remove Agent Plugins 1.0 across supported AI agents with one CLI.';
-const siteUrl = String(config.public.siteUrl).replace(/\/+$/, '');
+const { docsUrl } = useDocsLinks();
+const homePath = computed(() =>
+  localizedPath('/', isKnownLocale(locale.value) ? locale.value : 'en'),
+);
+const description = computed(() => t('shell.seo.indexDescription'));
+const siteUrl = productRootUrl(
+  String(config.public.siteUrl),
+  String(config.app.baseURL),
+).replace(/\/+$/, '');
 const githubUrl = `https://github.com/${config.public.githubRepo}`;
 const softwareId = `${siteUrl}/#software`;
 
-usePageSeo('Universal Agent Plugins CLI | Install Agent Plugins 1.0', description, {
+usePageSeo(() => t('shell.seo.indexTitle'), description, {
   translate: false,
   siteIdentity: true,
   pageProperties: { about: { '@id': softwareId } },
-  structuredData: [
-    productSoftwareSchema({
-      siteUrl,
-      githubUrl,
-      releasesUrl: String(config.public.githubReleasesUrl),
-      docsUrl: String(config.public.docsUrl),
-      description,
-    }),
+  structuredData: () => [
+    {
+      ...productSoftwareSchema({
+        siteUrl,
+        githubUrl,
+        releasesUrl: String(config.public.githubReleasesUrl),
+        docsUrl: docsUrl.value,
+        description: description.value,
+        applicationSubCategory: t('shell.seo.applicationSubCategory'),
+      softwareRequirements: t('shell.seo.softwareRequirements'),
+        featureList: t('shell.seo.featureList'),
+      }),
+    },
     {
       '@type': 'FAQPage',
-      '@id': `${siteUrl}/#faq`,
-      mainEntity: registryFaqItems.map((item) => ({
+      '@id': `${siteUrl}${homePath.value}#faq`,
+      mainEntity: registryFaqItems.value.map((item) => ({
         '@type': 'Question',
         name: item.question,
         acceptedAnswer: {
@@ -44,6 +63,6 @@ usePageSeo('Universal Agent Plugins CLI | Install Agent Plugins 1.0', descriptio
     <RegistryHero :registry="registry" />
     <RegistryDirectory :registry="registry" />
     <RegistryWhy />
-    <RegistryFaq />
+    <RegistryFaq :items="registryFaqItems" />
   </div>
 </template>

--- a/landing/playwright.config.ts
+++ b/landing/playwright.config.ts
@@ -1,6 +1,9 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@playwright/test';
 
 const repositoryBase = process.env.UAP_E2E_REPOSITORY_BASE?.replace(/^\/+|\/+$/g, '') || '';
+const serverConfig = fileURLToPath(new URL('./tests/browser/serve.json', import.meta.url));
+const quotedServerConfig = "'" + serverConfig.replaceAll("'", "'\\''") + "'";
 const webRoot = process.env.UAP_E2E_WEB_ROOT || '.output/public';
 
 export default defineConfig({
@@ -11,7 +14,7 @@ export default defineConfig({
     trace: 'retain-on-failure',
   },
   webServer: {
-    command: `corepack pnpm@8.15.1 exec serve ${webRoot} -l tcp://127.0.0.1:4173`,
+    command: `corepack pnpm@8.15.1 exec serve ${webRoot} -c ${quotedServerConfig} -l tcp://127.0.0.1:4173`,
     port: 4173,
     reuseExistingServer: false,
     timeout: 60_000,

--- a/landing/tests/browser/hero-orbit.spec.ts
+++ b/landing/tests/browser/hero-orbit.spec.ts
@@ -250,7 +250,7 @@ test('installation works with WebGL forbidden and the orbit has no canvas or opt
   await page.setViewportSize({ width: 1440, height: 1000 });
   await page.addInitScript(() => {
     const original = HTMLCanvasElement.prototype.getContext;
-    HTMLCanvasElement.prototype.getContext = function (type: string, ...args: unknown[]) {
+    HTMLCanvasElement.prototype.getContext = function (this: HTMLCanvasElement, type: string, ...args: unknown[]) {
       if (/webgl/i.test(type)) throw new Error('This CSS-only page must not create WebGL');
       return original.apply(this, [type, ...args] as Parameters<typeof original>);
     } as typeof original;
@@ -265,7 +265,8 @@ test('installation works with WebGL forbidden and the orbit has no canvas or opt
   await page.getByRole('checkbox', { name: /^Cursor / }).click();
   await page.keyboard.press('Escape');
   await expect(page.locator('.hero__demo .command-snippet')).toContainText('--target cursor');
-  await page.getByRole('button', { name: 'Toggle theme', exact: true }).click();
+  await page.getByRole('button', { name: 'Light', exact: true }).click();
+  await expect(page.locator('.v-application')).toHaveClass(/v-theme--light/);
   await expect(field.locator('[data-client-id]')).toHaveCount(uniqueLogos.length);
   // Only decorative logos are deduplicated, never the actual install targets.
   await page.getByRole('button', { name: /Choose target agents:/ }).click();

--- a/landing/tests/browser/release-base.spec.ts
+++ b/landing/tests/browser/release-base.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from '@playwright/test';
+import { publishedLocales } from '../../data/i18n';
+import { localizedPath } from '../../utils/localizedRoutes';
+
+// Run remotely against both assembled bases. No server/build is launched by this file.
+for (const locale of publishedLocales) {
+  test(`${locale}: cold SPA download uses local based release API without payload or GitHub`, async ({
+    page,
+    request,
+    baseURL,
+  }) => {
+    const base = new URL(baseURL!);
+    const endpoint = new URL('api/releases/latest', base).href;
+    // Read the real static artifact independently; do not fabricate release metadata.
+    const response = await request.get(endpoint);
+    expect(response.ok()).toBe(true);
+    const release = await response.json();
+    expect(release.ok).toBe(true);
+    const version = release.version?.match(
+      /^(?:agentplugins-)?v?(\d+\.\d+\.\d+(?:-[\w.-]+)?(?:\+[\w.-]+)?)$/,
+    )?.[1];
+    expect(version).toBeTruthy();
+
+    const payloads: string[] = [];
+    const github: string[] = [];
+    const localApi: string[] = [];
+    await page.route('https://api.github.com/**', async (route) => {
+      github.push(route.request().url());
+      await route.abort('blockedbyclient');
+    });
+    await page.route(/\/download\/_payload\.json(?:\?.*)?$/, async (route) => {
+      payloads.push(route.request().url());
+      await route.abort('blockedbyclient');
+    });
+    page.on('request', (req) => {
+      const url = new URL(req.url());
+      if (url.origin === base.origin && url.pathname.includes('/api/releases/'))
+        localApi.push(url.href);
+    });
+    await page.addInitScript(() => sessionStorage.removeItem('plugin-kit-ai_release_meta'));
+    await page.goto(`.${localizedPath('/plugins/', locale)}`);
+    await expect(page.locator('h1')).toBeVisible();
+    await page.waitForFunction(() =>
+      Boolean(
+        (document.querySelector('#__nuxt') as any)?.__vue_app__?.config.globalProperties.$router,
+      ),
+    );
+    const documents: string[] = [];
+    page.on('request', (req) => {
+      if (req.isNavigationRequest() && req.frame() === page.mainFrame()) documents.push(req.url());
+    });
+    await page.evaluate(
+      async (target) => {
+        const app = (document.querySelector('#__nuxt') as any).__vue_app__;
+        const nuxt = app.$nuxt || app.config.globalProperties.$nuxt;
+        if (!nuxt) throw new Error('Hydrated Nuxt app is unavailable');
+        if (sessionStorage.getItem('plugin-kit-ai_release_meta') !== null)
+          throw new Error('Release cache is not cold');
+        const key = 'universal-agent-plugins-releases';
+        if (nuxt.payload.data[key] !== undefined || nuxt.static?.data?.[key] !== undefined)
+          throw new Error('Release payload was already seeded');
+        await app.config.globalProperties.$router.push(target);
+      },
+      localizedPath('/download/', locale),
+    );
+    await expect(page).toHaveURL(new URL(localizedPath('/download/', locale).slice(1), base).href);
+    await expect(page.locator('.download-section__release-info a')).toHaveText(`v${version}`);
+    expect(payloads.length, 'missing extracted payload path must execute').toBeGreaterThan(0);
+    expect(github.length, 'GitHub refresh must actually be blocked').toBeGreaterThan(0);
+    expect(localApi).toEqual([endpoint]);
+    expect(documents, 'must remain an SPA navigation').toEqual([]);
+    const cache = await page.evaluate(() => ({
+      keys: Object.keys(sessionStorage).filter((key) => key.includes('release_meta')),
+      entry: JSON.parse(sessionStorage.getItem('plugin-kit-ai_release_meta') || 'null'),
+    }));
+    expect(cache.keys).toEqual(['plugin-kit-ai_release_meta']);
+    expect(cache.entry.data).toEqual(release);
+    expect(cache.entry.ts).toBeGreaterThan(0);
+  });
+}

--- a/landing/tests/browser/release-base.spec.ts
+++ b/landing/tests/browser/release-base.spec.ts
@@ -40,11 +40,29 @@ for (const locale of publishedLocales) {
     await page.addInitScript(() => sessionStorage.removeItem('plugin-kit-ai_release_meta'));
     await page.goto(`.${localizedPath('/plugins/', locale)}`);
     await expect(page.locator('h1')).toBeVisible();
-    await page.waitForFunction(() =>
-      Boolean(
-        (document.querySelector('#__nuxt') as any)?.__vue_app__?.config.globalProperties.$router,
-      ),
-    );
+    await page.waitForFunction(() => {
+      const app = (document.querySelector('#__nuxt') as any)?.__vue_app__;
+      const nuxt = app?.$nuxt || app?.config.globalProperties.$nuxt;
+      return Boolean(app?.config.globalProperties.$router && nuxt?.isHydrating === false);
+    });
+    // With appManifest disabled, this build does not request a download payload
+    // on router.push. Probe the real extracted artifact through the browser to
+    // prove the blockade, without seeding Nuxt's data or payload caches.
+    const payloadUrl = new URL(
+      `${localizedPath('/download/', locale).slice(1)}_payload.json`, base,
+    ).href;
+    const extracted = await request.get(payloadUrl);
+    expect(extracted.ok()).toBe(true);
+    expect(Array.isArray(await extracted.json())).toBe(true);
+    expect(await page.evaluate(async (url) => {
+      try {
+        await fetch(url);
+        return false;
+      } catch {
+        return true;
+      }
+    }, payloadUrl), 'browser cannot load the real extracted download payload').toBe(true);
+    expect(payloads).toContain(payloadUrl);
     const documents: string[] = [];
     page.on('request', (req) => {
       if (req.isNavigationRequest() && req.frame() === page.mainFrame()) documents.push(req.url());
@@ -65,7 +83,7 @@ for (const locale of publishedLocales) {
     );
     await expect(page).toHaveURL(new URL(localizedPath('/download/', locale).slice(1), base).href);
     await expect(page.locator('.download-section__release-info a')).toHaveText(`v${version}`);
-    expect(payloads.length, 'missing extracted payload path must execute').toBeGreaterThan(0);
+    expect(payloads.length, 'extracted payload blockade must execute').toBeGreaterThan(0);
     expect(github.length, 'GitHub refresh must actually be blocked').toBeGreaterThan(0);
     expect(localApi).toEqual([endpoint]);
     expect(documents, 'must remain an SPA navigation').toEqual([]);

--- a/landing/tests/browser/serve.json
+++ b/landing/tests/browser/serve.json
@@ -1,0 +1,17 @@
+{
+  "directoryListing": false,
+  "cleanUrls": [
+    "!**/*.html"
+  ],
+  "headers": [
+    {
+      "source": "**/api/**",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/octet-stream"
+        }
+      ]
+    }
+  ]
+}

--- a/landing/tests/browser/visual-controls.spec.ts
+++ b/landing/tests/browser/visual-controls.spec.ts
@@ -77,6 +77,8 @@ test('numbered benefits remain readable in both themes and responsive layouts', 
     }
     // The desktop theme control is intentionally absent from the compact mobile header.
     await page.setViewportSize({ width: 1440, height: 1000 });
-    await page.getByRole('button', { name: 'Toggle theme', exact: true }).click();
+    const nextTheme = reducedMotion === 'no-preference' ? 'light' : 'dark';
+    await page.getByRole('button', { name: nextTheme === 'light' ? 'Light' : 'Dark', exact: true }).click();
+    await expect(page.locator('.v-application')).toHaveClass(new RegExp(`v-theme--${nextTheme}`));
   }
 });

--- a/landing/tests/install-channel-selection.test.ts
+++ b/landing/tests/install-channel-selection.test.ts
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripTypeScriptTypes } from 'node:module';
+import { test } from 'node:test';
+import { runInNewContext } from 'node:vm';
+import * as Vue from 'vue';
+import { createPinia, setActivePinia } from 'pinia';
+import { useInstallPreferencesStore } from '../stores/installPreferences.ts';
+import * as platform from '../utils/installPlatform.ts';
+
+const source = readFileSync(
+  new URL('../composables/useInstallChannelSelection.ts', import.meta.url),
+  'utf8',
+)
+  .replace(/^import[\s\S]*?from '[^']+';\n/gm, '')
+  .replace('export function', 'function')
+  .replace("await import('bowser')", 'await loadBowser()');
+function consumer(
+  channels = Vue.ref([
+    { id: 'npm', recommended: true },
+    { id: 'script' },
+    { id: 'brew' },
+    { id: 'powershell' },
+  ]),
+  fail = false,
+) {
+  let mount!: () => Promise<void>;
+  const scope = Vue.effectScope();
+  const state = scope.run(() =>
+    runInNewContext(stripTypeScriptTypes(source) + '\nuseInstallChannelSelection(channels)', {
+      ...Vue,
+      ...platform,
+      useInstallPreferencesStore,
+      channels,
+      onMounted: (callback: () => Promise<void>) => {
+        mount = callback;
+      },
+      window: { navigator: { userAgent: 'fixture' } },
+      loadBowser: async () => {
+        if (fail) throw new Error('detection unavailable');
+        return { default: { getParser: () => ({ getOSName: () => 'Linux' }) } };
+      },
+    }),
+  );
+  return { state, channels, mount: () => mount(), stop: () => scope.stop() };
+}
+
+test('overlapping automatic locale consumers settle without tracking shared action reads', async () => {
+  setActivePinia(createPinia());
+  const store = useInstallPreferencesStore();
+  // A bounded action guard turns the old infinite scheduler loop into a test failure.
+  let selections = 0;
+  store.$onAction(({ name }) => {
+    if (name === 'selectChannel' && ++selections > 20)
+      throw new Error('automatic consumers oscillated');
+  });
+  const old = consumer();
+  assert.equal(store.channelId, 'npm'); // neutral SSR setup, no navigator detection
+  await old.mount();
+  await Vue.nextTick();
+  assert.equal(store.channelId, 'script');
+  const incoming = consumer();
+  assert.equal(store.channelId, 'script'); // preserve hydrated state during async setup
+  try {
+    await incoming.mount();
+    await Vue.nextTick();
+    incoming.state.detectedInstallPlatform.value = 'windows';
+    await Vue.nextTick();
+    assert.equal(store.channelId, 'powershell');
+    const settled = selections;
+    await Vue.nextTick();
+    assert.equal(selections, settled);
+    assert.equal(store.channelUserSelected, false);
+    old.stop();
+    incoming.state.detectedInstallPlatform.value = 'macos';
+    await Vue.nextTick();
+    assert.equal(store.channelId, 'brew');
+  } finally {
+    old.stop();
+    incoming.stop();
+  }
+});
+
+test('manual priority, valid IDs, empty channels and detection fallback survive remount', async () => {
+  setActivePinia(createPinia());
+  const store = useInstallPreferencesStore();
+  const first = consumer();
+  first.state.selectInstallChannel('brew');
+  const next = consumer(undefined, true);
+  try {
+    await first.mount();
+    await next.mount();
+    await Vue.nextTick();
+    assert.equal(store.channelId, 'brew');
+    assert.equal(store.channelUserSelected, true);
+    next.state.selectInstallChannel('invalid');
+    assert.equal(store.channelId, 'brew');
+    first.stop();
+    next.channels.value = [{ id: 'npm', recommended: true }, { id: 'script' }];
+    await Vue.nextTick();
+    assert.equal(store.channelId, 'npm');
+    assert.equal(store.channelUserSelected, false);
+    next.state.detectedInstallPlatform.value = 'linux';
+    await Vue.nextTick();
+    assert.equal(store.channelId, 'script');
+    next.state.detectedInstallPlatform.value = 'mobile';
+    await Vue.nextTick();
+    assert.equal(store.channelId, 'npm');
+    next.channels.value = [];
+    await Vue.nextTick();
+    assert.equal(store.channelId, null);
+    next.channels.value = [{ id: 'script' }];
+    await Vue.nextTick();
+    assert.equal(store.channelId, 'script');
+  } finally {
+    first.stop();
+    next.stop();
+  }
+});
+
+test('failed mounted detection applies neutral fallback without resetting a pending route', async () => {
+  setActivePinia(createPinia());
+  const first = consumer();
+  await first.mount();
+  await Vue.nextTick();
+  const next = consumer(undefined, true);
+  try {
+    assert.equal(useInstallPreferencesStore().channelId, 'script');
+    first.stop();
+    await next.mount();
+    await Vue.nextTick();
+    assert.equal(useInstallPreferencesStore().channelId, 'npm');
+  } finally {
+    first.stop();
+    next.stop();
+  }
+});
+
+test('mounted and still-pending consumers cannot recursively schedule each other', async () => {
+  setActivePinia(createPinia());
+  const store = useInstallPreferencesStore();
+  let calls = 0;
+  store.$onAction(({ name }) => {
+    if (name === 'selectChannel' && ++calls > 20) throw new Error('automatic consumers oscillated');
+  });
+  const first = consumer();
+  const pending = consumer();
+  try {
+    await first.mount();
+    await Vue.nextTick();
+    assert.equal(store.channelId, 'script');
+    assert.ok(calls < 5, 'selection writes must be bounded while the new route awaits detection');
+    await pending.mount();
+    await Vue.nextTick();
+    assert.equal(store.channelId, 'script');
+  } finally {
+    first.stop();
+    pending.stop();
+  }
+});

--- a/landing/tests/public-authoring.test.ts
+++ b/landing/tests/public-authoring.test.ts
@@ -2,15 +2,17 @@ import assert from 'node:assert/strict';
 import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { test } from 'node:test';
-import { createI18n } from 'vue-i18n';
+import { createI18n, type LocaleMessageDictionary, type VueMessageType } from 'vue-i18n';
+import { resolveDocsLink } from '../data/docsAvailability.ts';
 
 const root = new URL('../../', import.meta.url);
 const read = (path: string) => readFileSync(new URL(path, root), 'utf8');
-const locales = ['en', 'ru', 'es', 'fr', 'zh'];
-const renderedCopy = (locale: string) => {
+const locales = ['en', 'ru', 'es', 'fr', 'zh'] as const;
+const renderedCopy = (locale: typeof locales[number]) => {
   const messages = JSON.parse(read(`landing/locales/${locale}.json`));
-  const { t } = createI18n({ legacy: false, locale, fallbackLocale: false,
-    messages: { [locale]: messages } }).global;
+  // Render each preserved dictionary in an isolated EN test host; Nuxt publishes only EN/RU/UK.
+  const { t } = createI18n<[LocaleMessageDictionary<VueMessageType>], 'en', false>({ legacy: false, locale: 'en', fallbackLocale: false,
+    messages: { en: messages } }).global;
   return Object.fromEntries(Object.keys(messages.publicAuthoring).map(key =>
     [key, t(`publicAuthoring.${key}`)]));
 };
@@ -48,14 +50,20 @@ test('the authoring front door renders Use/Build and preserves its indexing poli
     assert.ok(copy.versions.includes('agentplugins-v0.1.53'));
     assert.ok(copy.limitations.includes('SSE'));
   }
-  // docsUrl already ends in /en/: exercise the exact expression used in the page.
-  const expression = page.match(/const base = ([\s\S]*?);/)![1];
-  for (const locale of locales) {
-    const base = Function('config', `return ${expression}`)({
-      public: { docsUrl: 'https://777genius.github.io/universal-agent-plugins/docs/en/' },
-    });
-    assert.equal(`${base}/${locale}/guide/quickstart.html`,
-      `https://777genius.github.io/universal-agent-plugins/docs/${locale}/guide/quickstart.html`);
+  assert.ok(page.includes('useDocsLinks()'));
+  const expression = page.match(/<a :href="([^"]*historical-v1[^"]*)"/)?.[1];
+  assert.ok(expression);
+  for (const input of [
+    'https://777genius.github.io/universal-agent-plugins/docs/en/guide/quickstart.html?source=x#use-plugins',
+    'https://custom.example/docs/ru/guide/quickstart.html?source=x#historical-v1',
+    '/docs/en/guide/quickstart.html?source=x',
+  ]) {
+    const href: unknown = new Function('quickstartUrl', `return ${expression}`)(input);
+    assert.equal(href, input.split('#')[0] + '#historical-v1');
+  }
+  for (const locale of ['en', 'ru', 'uk']) {
+    assert.equal(resolveDocsLink('quickstart', locale).url,
+      `https://777genius.github.io/universal-agent-plugins/docs/${locale === 'ru' ? 'ru' : 'en'}/guide/quickstart.html`);
   }
 });
 

--- a/landing/tests/release-base.test.ts
+++ b/landing/tests/release-base.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripTypeScriptTypes } from 'node:module';
+import { test } from 'node:test';
+import { runInNewContext } from 'node:vm';
+import { withAppBase } from '../utils/localizedRoutes.ts';
+import { emptyDownloadsResponse, parseGitHubRelease } from '../utils/releaseDownloads.ts';
+
+const source = readFileSync(
+  new URL('../composables/useReleaseDownloads.ts', import.meta.url),
+  'utf8',
+)
+  .replace(/^import[\s\S]*?from '[^']+';\n/gm, '')
+  .replaceAll('export ', '');
+const script = stripTypeScriptTypes(source) + '\nuseReleaseDownloads;';
+for (const base of ['/', '/universal-agent-plugins/']) {
+  test(`release handler uses ${base} with stable cache key and ten-minute TTL`, async () => {
+    const storage = new Map<string, string>();
+    const requests: string[] = [];
+    const keys: string[] = [];
+    const pending: Promise<void>[] = [];
+    let now = 1_000_000;
+    const release = { ...emptyDownloadsResponse(), ok: true, version: '1.2.3' };
+    const useRelease = runInNewContext(script, {
+      withAppBase,
+      emptyDownloadsResponse,
+      parseGitHubRelease,
+      Date: { now: () => now },
+      window: {
+        sessionStorage: {
+          getItem: (key: string) => storage.get(key),
+          setItem: (key: string, value: string) => storage.set(key, value),
+        },
+      },
+      useRuntimeConfig: () => ({ app: { baseURL: base }, public: {} }),
+      $fetch: async (url: string, options?: { responseType?: string }) => {
+        requests.push(url);
+        if (url.startsWith('https://api.github.com/')) throw new Error('Blocked GitHub');
+        assert.equal(url, `${base}api/releases/latest`);
+        // Static hosts can serve extensionless JSON as application/octet-stream.
+        return options?.responseType === 'json' ? release : JSON.stringify(release);
+      },
+      useAsyncData: (key: string, handler: () => Promise<unknown>, options: any) => {
+        keys.push(key);
+        const data = { value: options.default() };
+        pending.push(
+          handler().then((value) => {
+            data.value = value;
+          }),
+        );
+        return { data };
+      },
+    });
+    const first = useRelease();
+    await Promise.all(pending);
+    assert.equal(first.data.value.version, '1.2.3');
+    assert.deepEqual([...storage.keys()], ['plugin-kit-ai_release_meta']);
+    now += 10 * 60 * 1000;
+    useRelease();
+    await Promise.all(pending);
+    assert.equal(
+      requests.filter((url) => url.startsWith('/')).length,
+      1,
+      'TTL boundary retains cache',
+    );
+    now++;
+    useRelease();
+    await Promise.all(pending);
+    assert.equal(
+      requests.filter((url) => url.startsWith('/')).length,
+      2,
+      'expired cache refetches',
+    );
+    assert.deepEqual(keys, Array(3).fill('universal-agent-plugins-releases'));
+  });
+}

--- a/landing/tests/seo.test.ts
+++ b/landing/tests/seo.test.ts
@@ -1,7 +1,11 @@
+import { productRoutes } from '../data/routes.ts';
+import { candidateLocales } from '../data/i18n.ts';
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
   canonicalPath,
+  pageRouteSeo,
+  noindexStaticFallback,
   productSoftwareSchema,
   seoDescription,
   spdxLicenseUrl,
@@ -46,4 +50,90 @@ describe('SEO foundations', () => {
     assert.equal(spdxLicenseUrl('Apache-2.0'), 'https://spdx.org/licenses/Apache-2.0.html');
     assert.equal(spdxLicenseUrl('invalid license'), undefined);
   });
+});
+
+describe('manifest-driven localized SEO', () => {
+  const routes = productRoutes(['context7'], ['github-copilot-cli']);
+  for (const base of ['/', '/universal-agent-plugins/']) {
+    it(`keeps reciprocal locale identity and applies base once at ${base}`, () => {
+      const site = `https://example.test${base}`;
+      for (const locale of candidateLocales) {
+        const relative = `${locale === 'en' ? '' : `/${locale}`}/plugins/context7/`;
+        for (const input of [relative, `${base}${relative.slice(1)}`]) {
+          const seo = pageRouteSeo(
+            `${input}?q=hello#security`,
+            routes,
+            site,
+            base,
+            candidateLocales,
+          );
+          assert.equal(seo.canonical, `${site}${relative.slice(1)}`);
+          assert.deepEqual(
+            seo.alternates.map((link) => link.hreflang),
+            ['en', 'ru', 'uk', 'x-default'],
+          );
+          assert.equal(
+            seo.alternates.find((link) => link.hreflang === locale)?.href,
+            seo.canonical,
+          );
+          assert.equal(seo.ogLocale, { en: 'en_US', ru: 'ru_RU', uk: 'uk_UA' }[locale]);
+          assert.equal(seo.ogAlternates.length, 2);
+        }
+      }
+    });
+  }
+  it('preserves canonical distinctions without inventing routes or publishing drafts', () => {
+    const get = (path: string) => pageRouteSeo(path, routes, 'https://example.test', '/');
+    assert.equal(get('/create-plugin/').canonical, 'https://example.test/create-plugin/');
+    assert.deepEqual(get('/create-plugin/').alternates, []);
+    for (const path of [
+      '/plugins/community/?source=test',
+      '/plugins/missing/',
+      '/agents/',
+      '/agents/copilot/',
+      '/es/',
+      '/api/registry/catalog',
+    ]) {
+      assert.equal(get(path).canonical, undefined, path);
+      assert.deepEqual(get(path).alternates, [], path);
+    }
+    assert.equal(
+      get('/agents/github-copilot-cli/').canonical,
+      'https://example.test/agents/github-copilot-cli/',
+    );
+    assert.throws(() => productRoutes(['community'], []), /Reserved/);
+    assert.throws(() => productRoutes(['same', 'same'], []), /duplicate/);
+  });
+});
+
+it('marks shared static fallbacks noindex without rewriting script or asset bytes', () => {
+  const html =
+    '<!doctype html><html><head><link rel="stylesheet" href="/_nuxt/style.css"><script>window.fixture="<meta>";</script></head><body><script src="/_nuxt/app.js"></script></body></html>';
+  const result = noindexStaticFallback(html);
+  assert.equal(result.replace('<meta name="robots" content="noindex, follow">', ''), html);
+  assert.equal(noindexStaticFallback(result), result);
+  assert(
+    !noindexStaticFallback(
+      html.replace('<head>', '<head><meta name="robots" content="index">'),
+    ).includes('content="index"'),
+  );
+  assert.throws(() => noindexStaticFallback('not html'), /no HTML head/);
+});
+
+it('accepts localized software captions without changing machine identity', () => {
+  const schema = productSoftwareSchema({
+    siteUrl: 'https://example.test/',
+    githubUrl: 'https://github.com/example/product',
+    releasesUrl: 'https://example.test/releases',
+    docsUrl: 'https://example.test/docs/en/',
+    description: 'fixture-description',
+    applicationSubCategory: 'fixture-category',
+    softwareRequirements: 'fixture-requirements',
+    featureList: 'fixture-features',
+  });
+  assert.equal(schema.applicationSubCategory, 'fixture-category');
+  assert.equal(schema.softwareRequirements, 'fixture-requirements');
+  assert.equal(schema.featureList, 'fixture-features');
+  assert.equal(schema['@id'], 'https://example.test/#software');
+  assert.equal(schema.installUrl, 'https://www.npmjs.com/package/universal-agent-plugins');
 });

--- a/landing/tests/shell-i18n.test.ts
+++ b/landing/tests/shell-i18n.test.ts
@@ -3,7 +3,7 @@ import { readFileSync, existsSync } from 'node:fs';
 import { test } from 'node:test';
 import { stripTypeScriptTypes } from 'node:module';
 import { createI18n } from 'vue-i18n';
-import { computed, ref, watchEffect, effectScope, nextTick } from 'vue';
+import { computed, ref, watch, effectScope, nextTick } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
 import { assembleDownloadContent, downloadTechnical } from '../data/download.ts';
 import { docsAvailability, resolveDocsLink, ownedDocsRoot } from '../data/docsAvailability.ts';
@@ -155,8 +155,9 @@ test('channel adapter retains manual IDs across locale remount and reconciles re
   const factory = new Function(
     'computed',
     'ref',
-    'watchEffect',
+    'watch',
     'onMounted',
+    'window',
     'useInstallPreferencesStore',
     'normalizeInstallPlatform',
     'recommendedInstallChannelId',
@@ -166,8 +167,9 @@ test('channel adapter retains manual IDs across locale remount and reconciles re
   const useSelection = factory(
     computed,
     ref,
-    watchEffect,
+    watch,
     (callback: () => void) => mounted.push(callback),
+    { navigator: { userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)' } },
     useInstallPreferencesStore,
     normalizeInstallPlatform,
     recommendedInstallChannelId,
@@ -178,6 +180,7 @@ test('channel adapter retains manual IDs across locale remount and reconciles re
   const firstScope = effectScope();
   const first = firstScope.run(() => useSelection(channels))!;
   assert.equal(first.selectedInstallChannelId.value, 'brew');
+  await mounted[0]!();
   first.detectedInstallPlatform.value = 'windows';
   await nextTick();
   assert.equal(first.selectedInstallChannelId.value, 'powershell');
@@ -189,6 +192,7 @@ test('channel adapter retains manual IDs across locale remount and reconciles re
   }));
   const secondScope = effectScope();
   const second = secondScope.run(() => useSelection(channels))!;
+  await mounted[1]!();
   second.detectedInstallPlatform.value = 'linux';
   await nextTick();
   assert.equal(second.selectedInstallChannelId.value, 'npm');

--- a/landing/tests/shell-i18n.test.ts
+++ b/landing/tests/shell-i18n.test.ts
@@ -1,0 +1,314 @@
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { test } from 'node:test';
+import { stripTypeScriptTypes } from 'node:module';
+import { createI18n } from 'vue-i18n';
+import { computed, ref, watchEffect, effectScope, nextTick } from 'vue';
+import { createPinia, setActivePinia } from 'pinia';
+import { assembleDownloadContent, downloadTechnical } from '../data/download.ts';
+import { docsAvailability, resolveDocsLink, ownedDocsRoot } from '../data/docsAvailability.ts';
+import { registryFaqItems } from '../data/registryFaq.ts';
+import { clientLandingPages } from '../data/clients.ts';
+import { isKnownLocale } from '../data/i18n.ts';
+import { localizedPath } from '../utils/localizedRoutes.ts';
+import { useInstallPreferencesStore } from '../stores/installPreferences.ts';
+import { normalizeInstallPlatform, recommendedInstallChannelId } from '../utils/installPlatform.ts';
+import type { DownloadOverlay } from '../types/download.ts';
+
+const read = (path: string) => readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+const messages: typeof import('../locales/en.json') = JSON.parse(read('locales/en.json'));
+const overlay = JSON.parse(read('content/download/en.json')) as DownloadOverlay;
+const legacy = JSON.parse(read('content/en.json'));
+
+function leaves(value: unknown, prefix = ''): Array<[string, string]> {
+  if (typeof value === 'string') return [[prefix, value]];
+  return Object.entries(value as Record<string, unknown>).flatMap(([key, child]) =>
+    leaves(child, prefix ? `${prefix}.${key}` : key),
+  );
+}
+
+test('shell English messages compile, interpolate and retain baseline FAQ facts', (context) => {
+  const errors = context.mock.method(console, 'error', () => {});
+  const { t } = createI18n<[typeof messages], 'en', false>({ legacy: false, locale: 'en', messages: { en: messages } }).global;
+  for (const [key, value] of leaves(messages.shell, 'shell')) {
+    assert.ok(value.trim(), key);
+    assert.notEqual(
+      t(key, {
+        label: 'Docs',
+        name: 'context7',
+        count: 2,
+        manifest: 'plugin.json',
+        reason: 'original',
+      }),
+      key,
+    );
+  }
+  assert.equal(t('shell.hero.install', { name: 'context7' }), 'Install context7');
+  assert.equal(
+    t('shell.docs.englishLabel', { label: 'Quickstart' }),
+    'Quickstart (documentation in English)',
+  );
+  for (const count of [0, 1, 2, 5, 11, 21, 22, 25, 101]) {
+    assert.equal(
+      t('shell.hero.exploreCount', { count }, count),
+      `Explore ${count} ${count === 1 ? 'plugin' : 'plugins'}`,
+    );
+  }
+  assert.deepEqual(
+    Object.values((messages.shell!.faq as { items: Record<string, unknown> }).items),
+    [...registryFaqItems],
+  );
+  assert.equal(errors.mock.callCount(), 0);
+});
+
+test('narrow overlay preserves every active English field and technical byte', () => {
+  const actual = assembleDownloadContent(overlay);
+  assert.deepEqual(actual.download, legacy.download);
+  assert.deepEqual(
+    actual.installChannels,
+    legacy.installChannels.filter((channel: { id: string }) =>
+      ['brew', 'npm', 'script', 'powershell'].includes(channel.id),
+    ),
+  );
+  assert.deepEqual(actual.quickstartSteps, legacy.quickstartSteps);
+  assert.deepEqual(
+    Object.keys(overlay.shell.download.channels),
+    downloadTechnical.installChannels.map((c) => c.id),
+  );
+  assert.deepEqual(
+    Object.keys(overlay.shell.download.steps),
+    downloadTechnical.quickstartSteps.map((c) => c.id),
+  );
+  for (const entry of Object.values(overlay.shell.download.channels)) {
+    assert.deepEqual(Object.keys(entry).sort(), ['description', 'note', 'title']);
+  }
+  for (const entry of Object.values(overlay.shell.download.steps)) {
+    assert.deepEqual(Object.keys(entry).sort(), ['note', 'title']);
+  }
+  const untrusted = structuredClone(overlay);
+  Object.assign(untrusted.shell.download.channels.npm!, {
+    command: 'changed',
+    invocation: 'changed',
+    href: 'https://invalid.test',
+    id: 'changed',
+    recommended: true,
+  });
+  assert.deepEqual(assembleDownloadContent(untrusted), actual);
+  const loader = read('composables/useDownloadContent.ts');
+  assert.ok(loader.includes('import(`../content/download/${language}.json`)'));
+  for (const file of [
+    'composables/useDownloadContent.ts',
+    'data/download.ts',
+    'components/sections/DownloadSection.vue',
+  ]) {
+    const source = read(file);
+    assert.doesNotMatch(
+      source,
+      /useLandingContent|(?:from|import\()\s*['"](?:~\/|\.\.\/)data\/content|content\/(?:en|ru|es|fr|zh)\.json/,
+    );
+  }
+});
+
+test('owned docs routes preserve extensions and history; UK is explicitly English', () => {
+  for (const id of Object.keys(docsAvailability) as Array<keyof typeof docsAvailability>) {
+    for (const locale of ['en', 'ru', 'uk']) {
+      const resolved = resolveDocsLink(id, locale);
+      const language = locale === 'ru' ? 'ru' : 'en';
+      assert.equal(resolved.url, `${ownedDocsRoot}${language}/${docsAvailability[id]}`);
+      assert.equal(resolved.englishFallback, locale === 'uk');
+      const path = docsAvailability[id].replace(/\.html$/, '.md') || 'index.md';
+      assert.ok(
+        existsSync(new URL(`../../website/source/${language}/${path}`, import.meta.url)),
+        resolved.url,
+      );
+    }
+  }
+  for (const locale of ['en', 'ru', 'uk']) {
+    const result = resolveDocsLink(
+      'quickstart',
+      locale,
+      `${ownedDocsRoot}en/guide/quickstart.html?source=x#historical-v1`,
+    );
+    assert.ok(result.url.endsWith('.html?source=x#historical-v1'));
+    const language = locale === 'ru' ? 'ru' : 'en';
+    assert.ok(
+      readFileSync(
+        new URL(`../../website/source/${language}/guide/quickstart.md`, import.meta.url),
+        'utf8',
+      ).includes('{#historical-v1}'),
+    );
+  }
+  for (const url of [
+    'https://example.test/en/guide/quickstart.html#history',
+    `${ownedDocsRoot}en/unknown.html`,
+    `${ownedDocsRoot}en/guide/quickstart.html/extra`,
+  ]) {
+    assert.equal(resolveDocsLink('quickstart', 'ru', url).url, url);
+  }
+});
+
+test('channel adapter retains manual IDs across locale remount and reconciles removed choices', async () => {
+  // Execute the actual adapter with Nuxt auto-imports and lifecycle supplied by the harness.
+  const source = read('composables/useInstallChannelSelection.ts')
+    .replace(/import[\s\S]*?from\s*['"][^'"]+['"];\n/g, '')
+    .replace('export function', 'function');
+  const factory = new Function(
+    'computed',
+    'ref',
+    'watchEffect',
+    'onMounted',
+    'useInstallPreferencesStore',
+    'normalizeInstallPlatform',
+    'recommendedInstallChannelId',
+    `${stripTypeScriptTypes(source)}\nreturn useInstallChannelSelection;`,
+  );
+  const mounted: Array<() => void> = [];
+  const useSelection = factory(
+    computed,
+    ref,
+    watchEffect,
+    (callback: () => void) => mounted.push(callback),
+    useInstallPreferencesStore,
+    normalizeInstallPlatform,
+    recommendedInstallChannelId,
+  );
+  setActivePinia(createPinia());
+  const translated = ref(assembleDownloadContent(overlay).installChannels);
+  const channels = computed(() => translated.value);
+  const firstScope = effectScope();
+  const first = firstScope.run(() => useSelection(channels))!;
+  assert.equal(first.selectedInstallChannelId.value, 'brew');
+  first.detectedInstallPlatform.value = 'windows';
+  await nextTick();
+  assert.equal(first.selectedInstallChannelId.value, 'powershell');
+  first.selectInstallChannel('npm');
+  firstScope.stop();
+  translated.value = translated.value.map((channel) => ({
+    ...channel,
+    title: `fixture ${channel.id}`,
+  }));
+  const secondScope = effectScope();
+  const second = secondScope.run(() => useSelection(channels))!;
+  second.detectedInstallPlatform.value = 'linux';
+  await nextTick();
+  assert.equal(second.selectedInstallChannelId.value, 'npm');
+  assert.equal(
+    channels.value.find((c) => c.id === second.selectedInstallChannelId.value)?.title,
+    'fixture npm',
+  );
+  second.selectInstallChannel('invalid');
+  assert.equal(second.selectedInstallChannelId.value, 'npm');
+  translated.value = translated.value.filter((c) => c.id !== 'npm');
+  await nextTick();
+  assert.equal(second.selectedInstallChannelId.value, 'script');
+  second.detectedInstallPlatform.value = 'mobile';
+  await nextTick();
+  assert.equal(second.recommendedChannelId.value, null);
+  secondScope.stop();
+  assert.equal(mounted.length, 2); // Detection is scheduled, never run during SSR.
+  assert.equal(useInstallPreferencesStore(createPinia()).channelId, null);
+});
+
+test('hero localizes structured fallback diagnostics and retains unknown original reasons', () => {
+  const source = read('components/registry/RegistryHero.vue');
+  const adapter = source.slice(
+    source.indexOf('type ShellDiagnostic'),
+    source.indexOf('const fallbackReason'),
+  );
+  const { t } = createI18n<[typeof messages], 'en', false>({ legacy: false, locale: 'en', messages: { en: messages } }).global;
+  const render = new Function('t', `${stripTypeScriptTypes(adapter)}\nreturn diagnosticText;`)(t);
+  assert.equal(
+    render({
+      code: 'defaultIneligible',
+      params: { distribution: 'upstream' },
+      reasons: [
+        {
+          code: 'reasons',
+          reasons: [
+            { code: 'releaseStatus', params: { sequence: 2, status: 'revoked' } },
+            { code: 'unsupportedTargets', params: { sequence: 1, targets: 'codex,cursor' } },
+          ],
+        },
+      ],
+    }),
+    'declared default upstream was ineligible: release 2 is revoked; release 1 does not support codex,cursor',
+  );
+  assert.equal(render({ code: 'future-code' }), null);
+  assert.equal(render({ code: 'defaultIneligible', reasons: [{ code: 'future-code' }] }), null);
+  assert.match(source, /reason: resolution\.value\.fallback_reason/);
+  assert.doesNotMatch(source, /fallback_reason\.(?:match|replace|split|includes)/);
+});
+
+// The original migration-copy browser assertions also exercise these rows after generation.
+test('download and client strip retain every original support qualification', () => {
+  for (const file of ['components/registry/ClientStrip.vue', 'components/sections/DownloadSection.vue']) {
+    const source = read(file);
+    assert.match(source, /registryUi\.clients\.\$\{client.id\}\.status/);
+    assert.doesNotMatch(source, /shell\.clients/);
+  }
+  const source = read('components/sections/DownloadSection.vue');
+  for (const field of ['note', 'activation']) assert.ok(source.includes(`registryUi.clients.${'${client.id}'}.${field}`));
+  assert.equal(clientLandingPages.length, 11);
+});
+
+test('shell agent links keep language prefixes and canonical trailing slashes', () => {
+  for (const file of ['components/registry/ClientStrip.vue', 'components/sections/DownloadSection.vue']) {
+    const expression = read(file).match(/const clientPath = ([\s\S]*?);/)![1];
+    const locale = ref('en');
+    const clientPath = new Function('locale', 'localizedPath', 'isKnownLocale',
+      `${stripTypeScriptTypes(`const clientPath = ${expression};`)} return clientPath;`)(locale, localizedPath, isKnownLocale);
+    for (const code of ['en', 'ru', 'uk']) {
+      locale.value = code;
+      assert.equal(clientPath('codex'), `${code === 'en' ? '' : '/' + code}/agents/codex/`);
+    }
+  }
+});
+
+
+test('visible FAQ and schema share the exact same localized page value', () => {
+  const page = read('pages/index.vue');
+  assert.match(page, /<RegistryFaq :items="registryFaqItems"/);
+  assert.match(page, /mainEntity: registryFaqItems.value.map/);
+  assert.match(read('components/registry/RegistryFaq.vue'), /v-for="item in items"/);
+  const { tm, rt } = createI18n<[typeof messages], 'en', false>({ legacy: false, locale: 'en', messages: { en: messages } }).global;
+  assert.deepEqual(Object.values(tm('shell.faq.items') as Record<string, { question: string; answer: string }>).map((item) => ({
+    question: rt(item.question), answer: rt(item.answer),
+  })), [...registryFaqItems]);
+});
+
+test('active shared controls have English reference labels', () => {
+  const { t } = createI18n<[typeof messages], 'en', false>({ legacy: false, locale: 'en', messages: { en: messages } }).global;
+  for (const key of ['language.switchError', 'language.retry', 'theme.light', 'theme.dark',
+    'download.copy', 'download.copied', 'footer.tagline', 'shell.accessibility.license']) {
+    assert.notEqual(t(key), key);
+  }
+  const header = read('components/layout/AppHeader.vue');
+  assert.match(header, /const navItems = computed/);
+  assert.match(header, /publishedLocales.length > 1/);
+  for (const key of Object.keys(messages.shell!.navigation as object)) {
+    assert.ok(header.includes(`shell.navigation.${key}`), key);
+  }
+});
+
+
+test('download overlay loader awaits available languages and safely falls back when absent', async () => {
+  const source = read('composables/useDownloadContent.ts');
+  const loadSource = source.slice(source.indexOf('  const load ='), source.indexOf('  const { data }'));
+  const executable = stripTypeScriptTypes(loadSource).replace(
+    "(await import('../content/download/en.json')).default", 'english',
+  ).replace('import(`../content/download/${language}.json`)', 'importOverlay(language)');
+  const available = { '../content/download/en.json': async () => overlay };
+  const load = new Function('importOverlay', 'english', `${executable} return load;`)(async (language: string) => {
+    const loader = (available as Record<string, () => Promise<DownloadOverlay>>)[`../content/download/${language}.json`];
+    if (!loader) throw new Error('Missing overlay');
+    return { default: await loader() };
+  }, overlay);
+  assert.deepEqual(await load('en'), overlay);
+  assert.deepEqual(await load('uk'), overlay);
+  assert.deepEqual(await load('ru'), overlay);
+  const fixture = structuredClone(overlay);
+  fixture.shell.download.heading.title = 'Future overlay fixture';
+  Object.assign(available, { '../content/download/uk.json': async () => fixture });
+  assert.equal((await load('uk')).shell.download.heading.title, 'Future overlay fixture');
+  assert.deepEqual(await load('es'), overlay);
+});

--- a/landing/types/download.ts
+++ b/landing/types/download.ts
@@ -1,0 +1,10 @@
+/** Only presentation text belongs in a translated download overlay. */
+export interface DownloadOverlay {
+  shell: {
+    download: {
+      heading: { title: string; note: string };
+      channels: Record<string, { title: string; description: string; note: string }>;
+      steps: Record<string, { title: string; note: string }>;
+    };
+  };
+}

--- a/landing/utils/seo.ts
+++ b/landing/utils/seo.ts
@@ -1,7 +1,11 @@
+import { localeMetadata, publishedLocales, type KnownLocale } from '../data/i18n.ts';
+import type { ProductRoute } from '../data/routes.ts';
+import { expandLocalizedRoutes, normalizeAppBase, localizedPath } from './localizedRoutes.ts';
+
 const DEFAULT_DESCRIPTION_LIMIT = 160;
 
 export function canonicalPath(path: string): string {
-  const normalized = `/${path}`.replace(/\/{2,}/g, '/').replace(/\/+$/, '');
+  const normalized = `/${path.split(/[?#]/, 1)[0]}`.replace(/\/{2,}/g, '/').replace(/\/+$/, '');
   return normalized === '' ? '/' : `${normalized}/`;
 }
 
@@ -34,6 +38,9 @@ type ProductSoftwareSchemaOptions = {
   releasesUrl: string;
   docsUrl: string;
   description: string;
+  applicationSubCategory?: string;
+  softwareRequirements?: string;
+  featureList?: string;
 };
 
 export function productSoftwareSchema(options: ProductSoftwareSchemaOptions) {
@@ -47,7 +54,7 @@ export function productSoftwareSchema(options: ProductSoftwareSchemaOptions) {
     url: `${siteUrl}/`,
     description: options.description,
     applicationCategory: 'DeveloperApplication',
-    applicationSubCategory: 'Agent plugin manager',
+    applicationSubCategory: options.applicationSubCategory ?? 'Agent plugin manager',
     operatingSystem: 'macOS, Linux, Windows',
     isAccessibleForFree: true,
     offers: {
@@ -58,12 +65,94 @@ export function productSoftwareSchema(options: ProductSoftwareSchemaOptions) {
     downloadUrl: options.releasesUrl,
     installUrl: npmUrl,
     softwareHelp: options.docsUrl,
-    softwareRequirements: 'Native CLI for macOS, Linux, and Windows; or Node.js 22+ for npx',
+    softwareRequirements:
+      options.softwareRequirements ??
+      'Native CLI for macOS, Linux, and Windows; or Node.js 22+ for npx',
     codeRepository: options.githubUrl,
     screenshot: `${siteUrl}/og-image.png`,
     sameAs: [options.githubUrl, npmUrl],
     publisher: { '@id': `${siteUrl}/#organization` },
     license: 'https://www.apache.org/licenses/LICENSE-2.0',
-    featureList: 'Install, inspect, update, repair, switch source, and remove Agent Plugins 1.0',
+    featureList:
+      options.featureList ??
+      'Install, inspect, update, repair, switch source, and remove Agent Plugins 1.0',
   };
+}
+
+/** siteUrl can contain the deployment path or just its origin. */
+export function productRootUrl(siteUrl: string, base = '/'): string {
+  const site = new URL(siteUrl);
+  const sitePath = site.pathname === '/' ? normalizeAppBase(base) : normalizeAppBase(site.pathname);
+  return `${site.origin}${sitePath}`;
+}
+
+export function productImageUrl(imageUrl: string, siteUrl: string, base = '/'): string {
+  if (/^https?:\/\//i.test(imageUrl)) return imageUrl;
+  if (imageUrl.startsWith('//')) return new URL(imageUrl, siteUrl).href;
+  const root = productRootUrl(siteUrl, base);
+  const rootPath = new URL(root).pathname;
+  const relative =
+    rootPath !== '/' && imageUrl.startsWith(rootPath)
+      ? imageUrl.slice(rootPath.length)
+      : imageUrl.replace(/^\/+/, '');
+  return new URL(relative, root).href;
+}
+
+/** Resolve only real published HTML identities; query and hash never enter SEO. */
+export function pageRouteSeo(
+  path: string,
+  routes: readonly ProductRoute[],
+  siteUrl: string,
+  base = '/',
+  locales: readonly KnownLocale[] = publishedLocales,
+) {
+  const appBase = normalizeAppBase(base);
+  let clean = canonicalPath(path);
+  if (appBase !== '/' && clean.startsWith(appBase))
+    clean = canonicalPath(clean.slice(appBase.length));
+  const variants = expandLocalizedRoutes(routes, locales);
+  const current = variants.find((route) => route.path === clean);
+  const root = productRootUrl(siteUrl, base);
+  const absolute = (routePath: string) => `${root}${routePath.replace(/^\/+/, '')}`;
+  if (!current)
+    return {
+      canonical: undefined,
+      alternates: [],
+      ogLocale: undefined,
+      ogAlternates: [],
+      current: undefined,
+    };
+  const source = routes.find(
+    (route) =>
+      route.family === current.family && localizedPath(route.path, current.locale) === current.path,
+  )!;
+  const alternates = current.indexable
+    ? [
+        ...locales.map((locale) => ({
+          hreflang: locale,
+          href: absolute(localizedPath(source.path, locale)),
+        })),
+        { hreflang: 'x-default', href: absolute(source.path) },
+      ]
+    : [];
+  return {
+    current,
+    canonical: current.family === 'community' ? undefined : absolute(current.path),
+    alternates,
+    ogLocale: localeMetadata[current.locale].iso.replace('-', '_'),
+    ogAlternates: current.indexable
+      ? locales
+          .filter((locale) => locale !== current.locale)
+          .map((locale) => localeMetadata[locale].iso.replace('-', '_'))
+      : [],
+  };
+}
+
+/** Nuxt's shared SSG fallback bypasses page setup, so mark its actual HTML noindex. */
+export function noindexStaticFallback(html: string): string {
+  const robots = /<meta\b[^>]*\bname\s*=\s*["']robots["'][^>]*>/gi;
+  const marker = '<meta name="robots" content="noindex, follow">';
+  if (robots.test(html)) return html.replace(robots, marker);
+  if (!/<head(?:\s[^>]*)?>/i.test(html)) throw new Error('Static fallback has no HTML head');
+  return html.replace(/<head(?:\s[^>]*)?>/i, (head) => `${head}${marker}`);
 }


### PR DESCRIPTION
Moves the active EN shell and download presentation onto translation keys and a lazy, typed download overlay. Technical commands and IDs stay in shared data; owned documentation links use explicit locale availability and preserve external overrides. Manual install-channel choices survive navigation through Pinia.

The automatic-selection adapter watches only its explicit inputs. This prevents overlapping mounted and incoming routes from repeatedly overwriting their shared channel preference, and preserves the hydrated choice until platform detection completes. Real Vue/Pinia regression tests reproduce the old loop and verify the fix, manual priority, invalid IDs and failed detection. The existing adapter harness executes controlled mounted detection.

Checkpoint 2 of 4, based on #211. Production remains EN-only; reviewed RU/UK and their browser matrix arrive in #214. Focused hosted checks and all exact-head GitHub CI checks pass at 9aaa4c20. No deployment or release publication is included.
