### PR TITLE
fix(release): allow trusted verifier to read draft metadata

### DIFF
--- a/.github/workflows/agentplugins-release.yml
+++ b/.github/workflows/agentplugins-release.yml
@@ -344,7 +344,9 @@ jobs:
     needs: [validate, stage-draft, platform-proof]
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # GitHub draft visibility requires push capability; contents: read can return null.
+      # This trusted producer verifier still only reads APIs/assets and verifies attestations.
+      contents: write
       attestations: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/repotests/agentplugins_release_contract_test.go
+++ b/repotests/agentplugins_release_contract_test.go
@@ -68,7 +68,9 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 	draftReceiptJob := yamlJob(t, releaseWorkflow, "verified-draft")
 	for _, want := range []string{
 		"needs: [validate, stage-draft, platform-proof]",
-		"contents: read", "attestations: read",
+		"contents: write", "attestations: read",
+		"persist-credentials: false",
+		"        env:\n          GH_TOKEN: ${{ github.token }}",
 		"ref: ${{ needs.validate.outputs.commit }}",
 		"RELEASE_ID: ${{ needs.stage-draft.outputs.release_id }}",
 		"EXPECTED_ASSET_SET_DIGEST: ${{ needs.stage-draft.outputs.asset_set_digest }}",
@@ -86,9 +88,15 @@ func TestAgentpluginsReleaseContractsStayFailClosed(t *testing.T) {
 			mustNotContain(t, job, forbidden)
 		}
 	}
-	for _, forbidden := range []string{"contents: write", "id-token: write", "gh release edit", "gh release create", "if:"} {
+	for _, forbidden := range []string{"id-token: write", "attestations: write", "gh release", "npm ", "npx ", "install.sh", "install.ps1", "platform-proof.js", "if:", "\n    env:", "persist-credentials: true"} {
 		mustNotContain(t, draftReceiptJob, forbidden)
 	}
+	// Draft API visibility needs write capability only on the trusted producer reader.
+	mustContain(t, releaseWorkflow, "\npermissions:\n  contents: read\n")
+	for _, job := range []string{yamlJob(t, releaseWorkflow, "validate"), yamlJob(t, releaseWorkflow, "build"), releaseProofJob} {
+		mustNotContain(t, job, ": write")
+	}
+	mustNotContain(t, platformWorkflow, ": write")
 	mustAppearBefore(t, draftReceiptJob, "python3 scripts/verify-agentplugins-draft.py", "actions/upload-artifact@")
 	mustContain(t, releasePromoteJob, "EXPECTED_ASSET_SET_DIGEST: ${{ needs.stage-draft.outputs.asset_set_digest }}")
 	mustContain(t, releasePromoteJob, "gh release edit \"${TAG}\"")

--- a/scripts/test_agentplugins_draft.py
+++ b/scripts/test_agentplugins_draft.py
@@ -4,6 +4,7 @@ import copy
 import importlib.util
 import json
 from pathlib import Path
+import re
 import shutil
 import subprocess
 import tempfile
@@ -54,6 +55,9 @@ class DraftTests(unittest.TestCase):
     def fake_run(self, command, **kwargs):
         self.calls.append(command)
         if command[0] == "node":
+            self.assertEqual(command[:3], ["node", str(Path(self.args.source) /
+                "npm/agentplugins/scripts/release-assets.js"), "verify"])
+            self.assertEqual(command[4:], [self.args.tag, self.args.commit])
             return self.real_run(command, stderr=subprocess.PIPE, **kwargs)
         self.assertEqual(command[0], "gh")
         if command[1:3] == ["attestation", "verify"]:
@@ -64,10 +68,18 @@ class DraftTests(unittest.TestCase):
                 raise subprocess.CalledProcessError(1, command)
             return b"verified"
         self.assertEqual(command[1], "api")
+        # A visibility-capable token must never turn this verifier into an API writer.
+        self.assertFalse(set(command) & {"-X", "--method", "--input"})
         endpoint = command[2]
+        if endpoint != "graphql":
+            self.assertFalse(set(command) & {"-f", "-F", "--field", "--raw-field"})
         if endpoint != "graphql":
             self.assertTrue(endpoint.startswith("repos/777genius/universal-agent-plugins/"))
         if endpoint == "graphql":
+            self.assertEqual(command[3:5], ["-f",
+                "query=query($owner:String!,$name:String!,$tag:String!){"
+                "repository(owner:$owner,name:$name){release(tagName:$tag){databaseId}}}"])
+            self.assertEqual(len(command), 11)
             self.assertIn("owner=777genius", command)
             self.assertIn("name=universal-agent-plugins", command)
             self.reads += 1
@@ -169,6 +181,15 @@ class DraftTests(unittest.TestCase):
         self.commit = "b" * 40
         self.rejects()
 
+    def test_draft_hidden_by_api_visibility_fails_closed(self):
+        self.lookup_id = None
+        with patch.object(draft, "run", side_effect=self.fake_run):
+            with self.assertRaisesRegex(ValueError, "release missing or recreated"):
+                draft.verify(self.args)
+        self.assertEqual(len(self.calls), 1)
+        self.assertEqual(self.calls[0][1:3], ["api", "graphql"])
+        self.assertFalse(Path(self.args.receipt).exists())
+
     def test_changes_during_verification(self):
         changes = [lambda: self.metadata.update(draft=False),
                    lambda: self.metadata.update(prerelease=True),
@@ -247,6 +268,60 @@ class DraftTests(unittest.TestCase):
             with self.assertRaises(subprocess.CalledProcessError):
                 draft.verify(self.args)
         self.assertFalse(Path(self.args.receipt).exists())
+
+
+class ProducerPermissionTests(unittest.TestCase):
+    def setUp(self):
+        self.workflow = (SOURCE / ".github/workflows/agentplugins-release.yml").read_text()
+
+    def job(self, name):
+        return re.search(r"(?ms)^  " + re.escape(name) +
+                         r":\n.*?(?=^  [\w-]+:\n|\Z)", self.workflow).group()
+
+    def test_write_is_limited_to_trusted_producer_jobs(self):
+        header = self.workflow.split("\njobs:\n", 1)[0]
+        self.assertIn("\npermissions:\n  contents: read\n", header)
+        self.assertNotIn(": write", header)
+        for name in ("validate", "build", "platform-proof"):
+            self.assertNotIn(": write", self.job(name))
+        platform = (SOURCE / ".github/workflows/agentplugins-platform-proof.yml").read_text()
+        self.assertNotIn(": write", platform)
+        job = self.job("verified-draft")
+        permissions, steps = job.split("    steps:\n", 1)
+        self.assertIn("    permissions:\n", permissions)
+        grants = re.findall(r"^      ([\w-]+): (read|write)$", permissions, re.M)
+        self.assertEqual(grants, [("contents", "write"), ("attestations", "read")])
+        self.assertNotIn("env:", permissions)
+        self.assertEqual(job.count("GH_TOKEN:"), 1)
+        self.assertIn("        env:\n          GH_TOKEN: ${{ github.token }}", steps)
+        self.assertIn("          persist-credentials: false\n", steps)
+        self.assertIn("          ref: ${{ needs.validate.outputs.commit }}\n", steps)
+        # Only the frozen-source verifier runs; no installer, plugin, npm, or mutation step.
+        runs = re.findall(r"(?ms)^        run: \|\n(.*?)(?=^      -|\Z)", steps)
+        self.assertEqual(len(runs), 1)
+        commands = runs[0].replace("\\\n", "").strip().splitlines()
+        self.assertEqual(len(commands), 1)
+        self.assertTrue(commands[0].startswith("python3 scripts/verify-agentplugins-draft.py "))
+        self.assertNotRegex(commands[0], r"[;`]|&&|\|\||\$\(")
+        self.assertIn('--source "${GITHUB_WORKSPACE}"', commands[0])
+
+    def test_producer_trust_and_promotion_defaults_remain_fail_closed(self):
+        self.assertRegex(self.workflow, r"publish_release:\n(?:        .*\n)*?        type: boolean\n        default: false\n")
+        validate = self.job("validate")
+        for guard in ('test "${WORKFLOW_REF}" = "refs/heads/main"',
+                      '"${WORKFLOW_COMMIT}" != "${head_commit}"',
+                      'test "${head_commit}" = "$(git rev-parse refs/remotes/origin/main)"',
+                      'test "${head_commit}" = "$(git rev-list -n 1 "refs/tags/${TAG}")"',
+                      '.merged_at != null and .base.ref == "main"',
+                      'require_check dependency-review', 'require_check "${name}"'):
+            self.assertIn(guard, validate)
+        self.assertIn("needs: [validate, stage-draft, platform-proof]", self.job("verified-draft"))
+        promote = self.job("promote-release")
+        self.assertIn("if: ${{ inputs.publish_release == true }}", promote)
+        self.assertIn("needs: [validate, stage-draft, platform-proof, verified-draft]", promote)
+        for name in ("stage-draft", "verified-draft", "promote-release"):
+            self.assertNotRegex(self.job(name), r"always\(\)|!cancelled\(\)|failure\(\)|continue-on-error:")
+        self.assertNotIn("if:", self.job("verified-draft"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The final draft verifier could not see the unpublished release with a contents-read GitHub token. Producer run 34301731798 passed all six native platform proofs, then failed its live draft lookup.

Grant contents-write only to the trusted verified-draft job for GitHub draft visibility. The job still performs read-only verification, executes trusted frozen policy only, and keeps its token scoped to that step. Platform proof permissions, exact source/tag/CI guards, and explicit-only publication remain unchanged.

Validation: 16 offline Python tests and diff checks passed. Added permission-boundary and publication-default regression coverage. Independent high-effort review approved the exact commit; its sandbox could not run temporary-directory tests, so the complete focused test run is performed separately. This PR does not publish or modify the existing 0.1.54 draft.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved release verification reliability when draft releases are not visible through the API.
  - Restricted verification workflows to read-only validation and prevented unauthorized publishing, installation, or release actions.
  - Limited write access to trusted release-producing jobs.

- **Tests**
  - Expanded automated coverage for workflow permissions, credential handling, command execution, API access, and fail-closed behavior.
  - Added safeguards to ensure release verification uses the expected validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->