### PR TITLE
fix(testing): qualify drafts through isolated metadata jobs

### DIFF
--- a/.github/workflows/agentplugins-released-native-clients.yml
+++ b/.github/workflows/agentplugins-released-native-clients.yml
@@ -65,6 +65,9 @@ defaults:
 
 jobs:
   validate:
+    permissions:
+      contents: read
+      actions: read
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -74,6 +77,7 @@ jobs:
           path: harness
       - name: Reject incomplete or mixed acquisition identities before any acquisition
         env:
+          GH_TOKEN: ${{ github.token }}
           RELEASE_STATE: ${{ inputs.release_state }}
           RELEASE_TAG: ${{ inputs.release_tag }}
           RELEASE_COMMIT: ${{ inputs.release_commit }}
@@ -90,7 +94,12 @@ jobs:
             --expected-asset-set-digest "$EXPECTED_ASSET_SET_DIGEST" --release-id "$RELEASE_ID" \
             --producer-artifact-id "$PRODUCER_ARTIFACT_ID" --producer-artifact-digest "$PRODUCER_ARTIFACT_DIGEST"
   native-client:
-    needs: validate
+    needs: [validate, draft-snapshot]
+    if: ${{ always() && needs.validate.result == 'success' && (inputs.release_state == 'public' || needs.draft-snapshot.result == 'success') }}
+    permissions:
+      contents: read
+      actions: read
+      attestations: read
     name: ${{ matrix.client }} runtime (${{ matrix.platform.target }})
     strategy:
       fail-fast: false
@@ -134,8 +143,12 @@ jobs:
         run: |
           python -m unittest discover -s scripts -p 'test_native_client*.py'
           python -m unittest discover -s scripts -p 'test_released_native_evidence.py'
-      - name: Verify released installer and execute pinned native client in disposable fixture
+      - name: Prepare authenticated release bytes without client execution
+        id: prepare
         env:
+          SNAPSHOT_ARTIFACT_ID: ${{ needs.draft-snapshot.outputs.artifact-id }}
+          SNAPSHOT_ARTIFACT_DIGEST: ${{ needs.draft-snapshot.outputs.artifact-digest }}
+          SNAPSHOT_SHA256: ${{ needs.draft-snapshot.outputs.receipt-sha256 }}
           GH_TOKEN: ${{ github.token }}
           EXPECTED_COMMIT: ${{ github.sha }}
           AGENTPLUGINS_NATIVE_DISPOSABLE_HOSTED: '1'
@@ -155,6 +168,40 @@ jobs:
             draft_source=(--producer-source "$GITHUB_WORKSPACE/producer-source")
           fi
           python scripts/run-native-client-matrix.py \
+            --prepare-only --prepared-input "$RUNNER_TEMP/prepared-release" \
+            --target-scope '${{ inputs.target_scope }}' \
+            --release-state "$RELEASE_STATE" "${draft_source[@]}" \
+            --producer-run-id "$PRODUCER_RUN_ID" --producer-run-attempt "$PRODUCER_RUN_ATTEMPT" \
+            --expected-asset-set-digest "$EXPECTED_ASSET_SET_DIGEST" --release-id "$RELEASE_ID" \
+            --producer-artifact-id "$PRODUCER_ARTIFACT_ID" --producer-artifact-digest "$PRODUCER_ARTIFACT_DIGEST" \
+            --release-tag "$RELEASE_TAG" \
+            --release-commit "$RELEASE_COMMIT" \
+            --client '${{ matrix.client }}' \
+            --target '${{ matrix.platform.target }}' \
+            --output '${{ runner.temp }}/native-client-proof'
+      - name: Execute pinned native client from rehashed prepared inputs
+        env:
+          PREPARED_SHA256: ${{ steps.prepare.outputs.prepared-sha256 }}
+          EXPECTED_COMMIT: ${{ github.sha }}
+          AGENTPLUGINS_NATIVE_DISPOSABLE_HOSTED: '1'
+          RELEASE_STATE: ${{ inputs.release_state }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_COMMIT: ${{ inputs.release_commit }}
+          PRODUCER_RUN_ID: ${{ inputs.producer_run_id }}
+          PRODUCER_RUN_ATTEMPT: ${{ inputs.producer_run_attempt }}
+          EXPECTED_ASSET_SET_DIGEST: ${{ inputs.expected_asset_set_digest }}
+          PRODUCER_ARTIFACT_ID: ${{ inputs.producer_artifact_id }}
+          PRODUCER_ARTIFACT_DIGEST: ${{ inputs.producer_artifact_digest }}
+          RELEASE_ID: ${{ inputs.release_id }}
+        shell: bash
+        run: |
+          draft_source=()
+          if [[ "$RELEASE_STATE" == draft ]]; then
+            draft_source=(--producer-source "$GITHUB_WORKSPACE/producer-source")
+          fi
+          python scripts/run-native-client-matrix.py \
+            --prepared-input "$RUNNER_TEMP/prepared-release" \
+            --target-scope '${{ inputs.target_scope }}' \
             --release-state "$RELEASE_STATE" "${draft_source[@]}" \
             --producer-run-id "$PRODUCER_RUN_ID" --producer-run-attempt "$PRODUCER_RUN_ATTEMPT" \
             --expected-asset-set-digest "$EXPECTED_ASSET_SET_DIGEST" --release-id "$RELEASE_ID" \
@@ -173,9 +220,79 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  draft-snapshot:
+    needs: validate
+    if: ${{ inputs.release_state == 'draft' && github.repository == '777genius/universal-agent-plugins' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && github.workflow_ref == '777genius/universal-agent-plugins/.github/workflows/agentplugins-released-native-clients.yml@refs/heads/main' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      actions: read
+      attestations: read
+    outputs:
+      artifact-id: ${{ steps.upload.outputs.artifact-id }}
+      artifact-digest: ${{ steps.upload.outputs.artifact-digest }}
+      receipt-sha256: ${{ steps.verify.outputs.receipt-sha256 }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+          path: harness
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.release_commit }}
+          path: producer-source
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: '22'
+          package-manager-cache: false
+      - name: Verify draft metadata using trusted harness policy
+        id: verify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_STATE: ${{ inputs.release_state }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_COMMIT: ${{ inputs.release_commit }}
+          PRODUCER_RUN_ID: ${{ inputs.producer_run_id }}
+          PRODUCER_RUN_ATTEMPT: ${{ inputs.producer_run_attempt }}
+          EXPECTED_ASSET_SET_DIGEST: ${{ inputs.expected_asset_set_digest }}
+          PRODUCER_ARTIFACT_ID: ${{ inputs.producer_artifact_id }}
+          PRODUCER_ARTIFACT_DIGEST: ${{ inputs.producer_artifact_digest }}
+          RELEASE_ID: ${{ inputs.release_id }}
+          TARGET_SCOPE: ${{ inputs.target_scope }}
+          HARNESS_COMMIT: ${{ github.sha }}
+        shell: bash
+        run: |
+          mkdir "$RUNNER_TEMP/draft-snapshot"
+          python scripts/native_client_draft.py \
+            --release-state "$RELEASE_STATE" --release-tag "$RELEASE_TAG" --release-commit "$RELEASE_COMMIT" \
+            --producer-run-id "$PRODUCER_RUN_ID" --producer-run-attempt "$PRODUCER_RUN_ATTEMPT" \
+            --expected-asset-set-digest "$EXPECTED_ASSET_SET_DIGEST" --release-id "$RELEASE_ID" \
+            --producer-artifact-id "$PRODUCER_ARTIFACT_ID" --producer-artifact-digest "$PRODUCER_ARTIFACT_DIGEST" \
+            --target-scope "$TARGET_SCOPE" --harness-commit "$HARNESS_COMMIT" \
+            --producer-source "$GITHUB_WORKSPACE/producer-source" \
+            --metadata snapshot --receipt "$RUNNER_TEMP/draft-snapshot/receipt.json"
+      - name: Upload authenticated snapshot
+        id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: draft-snapshot
+          path: ${{ runner.temp }}/draft-snapshot/
+          if-no-files-found: error
+          retention-days: 14
+
   draft-complete:
-    name: Qualify all required draft native lanes and reverify live draft
-    needs: [validate, native-client]
+    name: Verify all required draft native lanes (read-only)
+    permissions:
+      contents: read
+      actions: read
+      attestations: read
+    outputs:
+      artifact-id: ${{ steps.upload.outputs.artifact-id }}
+      artifact-digest: ${{ steps.upload.outputs.artifact-digest }}
+      receipt-sha256: ${{ steps.verify.outputs.receipt-sha256 }}
+    needs: [validate, draft-snapshot, native-client]
     if: ${{ inputs.release_state == 'draft' && needs.validate.result == 'success' && needs.native-client.result == 'success' }}
     runs-on: ubuntu-24.04
     steps:
@@ -197,8 +314,76 @@ jobs:
         with:
           pattern: released-native-client-*
           path: ${{ runner.temp }}/native-lanes
-      - name: Require complete fixture stages then read-only final draft verification
+      - name: Require complete fixture stages and snapshot binding
+        id: verify
         env:
+          SNAPSHOT_ARTIFACT_ID: ${{ needs.draft-snapshot.outputs.artifact-id }}
+          SNAPSHOT_ARTIFACT_DIGEST: ${{ needs.draft-snapshot.outputs.artifact-digest }}
+          SNAPSHOT_SHA256: ${{ needs.draft-snapshot.outputs.receipt-sha256 }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_STATE: ${{ inputs.release_state }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_COMMIT: ${{ inputs.release_commit }}
+          PRODUCER_RUN_ID: ${{ inputs.producer_run_id }}
+          PRODUCER_RUN_ATTEMPT: ${{ inputs.producer_run_attempt }}
+          EXPECTED_ASSET_SET_DIGEST: ${{ inputs.expected_asset_set_digest }}
+          PRODUCER_ARTIFACT_ID: ${{ inputs.producer_artifact_id }}
+          PRODUCER_ARTIFACT_DIGEST: ${{ inputs.producer_artifact_digest }}
+          RELEASE_ID: ${{ inputs.release_id }}
+          TARGET_SCOPE: ${{ inputs.target_scope }}
+          HARNESS_COMMIT: ${{ github.sha }}
+        shell: bash
+        run: |
+          mkdir "$RUNNER_TEMP/draft-lanes"
+          python scripts/native_client_draft.py \
+            --release-state "$RELEASE_STATE" --release-tag "$RELEASE_TAG" --release-commit "$RELEASE_COMMIT" \
+            --producer-run-id "$PRODUCER_RUN_ID" --producer-run-attempt "$PRODUCER_RUN_ATTEMPT" \
+            --expected-asset-set-digest "$EXPECTED_ASSET_SET_DIGEST" --release-id "$RELEASE_ID" \
+            --producer-artifact-id "$PRODUCER_ARTIFACT_ID" --producer-artifact-digest "$PRODUCER_ARTIFACT_DIGEST" \
+            --target-scope "$TARGET_SCOPE" --harness-commit "$HARNESS_COMMIT" \
+            --producer-source "$GITHUB_WORKSPACE/producer-source" \
+            --evidence "$RUNNER_TEMP/native-lanes" --receipt "$RUNNER_TEMP/draft-lanes/receipt.json"
+      - name: Upload lanes receipt only after successful aggregation
+        id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: draft-lanes
+          path: ${{ runner.temp }}/draft-lanes/
+          if-no-files-found: error
+          retention-days: 14
+
+  draft-recheck:
+    needs: [draft-snapshot, draft-complete]
+    if: ${{ inputs.release_state == 'draft' && needs.draft-complete.result == 'success' && github.repository == '777genius/universal-agent-plugins' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && github.workflow_ref == '777genius/universal-agent-plugins/.github/workflows/agentplugins-released-native-clients.yml@refs/heads/main' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      actions: read
+      attestations: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+          path: harness
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.release_commit }}
+          path: producer-source
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: '22'
+          package-manager-cache: false
+      - name: Verify draft metadata using trusted harness policy
+        id: verify
+        env:
+          SNAPSHOT_ARTIFACT_ID: ${{ needs.draft-snapshot.outputs.artifact-id }}
+          SNAPSHOT_ARTIFACT_DIGEST: ${{ needs.draft-snapshot.outputs.artifact-digest }}
+          SNAPSHOT_SHA256: ${{ needs.draft-snapshot.outputs.receipt-sha256 }}
+          LANES_ARTIFACT_ID: ${{ needs.draft-complete.outputs.artifact-id }}
+          LANES_ARTIFACT_DIGEST: ${{ needs.draft-complete.outputs.artifact-digest }}
+          LANES_SHA256: ${{ needs.draft-complete.outputs.receipt-sha256 }}
           GH_TOKEN: ${{ github.token }}
           RELEASE_STATE: ${{ inputs.release_state }}
           RELEASE_TAG: ${{ inputs.release_tag }}
@@ -221,8 +406,9 @@ jobs:
             --producer-artifact-id "$PRODUCER_ARTIFACT_ID" --producer-artifact-digest "$PRODUCER_ARTIFACT_DIGEST" \
             --target-scope "$TARGET_SCOPE" --harness-commit "$HARNESS_COMMIT" \
             --producer-source "$GITHUB_WORKSPACE/producer-source" \
-            --evidence "$RUNNER_TEMP/native-lanes" --receipt "$RUNNER_TEMP/draft-qualification/qualification.json"
-      - name: Upload qualification only after successful aggregation and final verification
+            --metadata recheck --receipt "$RUNNER_TEMP/draft-qualification/qualification.json"
+      - name: Upload qualification after final verification
+        id: upload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: draft-native-qualification-${{ inputs.target_scope }}

--- a/docs/released-native-client-proof.md
+++ b/docs/released-native-client-proof.md
@@ -1,22 +1,32 @@
 # Reproduce released installer native-client evidence
 
-This proof downloads an exact public `777genius/universal-agent-plugins` binary release
-and runs the real pinned Codex, Claude Code, and OpenCode clients against it.
-The nine jobs use disposable GitHub-hosted Linux arm64 (`ubuntu-24.04-arm`),
-macOS arm64 and Windows amd64 runners.
+This proof acquires an exact `777genius/universal-agent-plugins` installer in
+one of two explicit modes: `public` downloads a published stable release;
+`draft` authenticates an unpublished draft and its frozen producer npm bundle.
+Both run genuine pinned Codex, Claude Code, and OpenCode clients in scripted
+fixtures. Select `target_scope=historical-nine` for nine jobs on disposable
+GitHub-hosted Linux arm64 (`ubuntu-24.04-arm`), macOS arm64 and Windows amd64
+runners, or `target_scope=linux-amd64` for three jobs on `ubuntu-24.04`.
+Linux amd64 is supplemental coverage, not a replacement for the historical nine.
+The draft 0.1.54 candidate is planned, not built yet; this runbook records no
+new native qualification.
 Never run these clients against your existing projects or profiles.
 
-Use a UAP tag containing `.github/workflows/agentplugins-released-native-clients.yml`.
+Use an immutable UAP harness tag containing `.github/workflows/agentplugins-released-native-clients.yml`.
 The workflow and checkout execute at that tag's exact commit. The installer
 producer tag and SHA are separate inputs; the proof checks their equality
 against GitHub and records both producer and harness identities. Both sources
 are in the same canonical UAP repository; the old `plugin-kit-ai` repository
 name redirects there. Their release and harness commits can still differ.
 
+For public acquisition, omit all draft provenance inputs:
+
 ```sh
 gh workflow run agentplugins-released-native-clients.yml \
   --repo 777genius/universal-agent-plugins \
   --ref <immutable-UAP-harness-tag> \
+  -f release_state=public \
+  -f target_scope=historical-nine \
   -f release_tag=agentplugins-vX.Y.Z \
   -f release_commit=<40-character-installer-producer-SHA>
 gh run list --repo 777genius/universal-agent-plugins \
@@ -27,33 +37,95 @@ gh run download <run-id> --repo 777genius/universal-agent-plugins \
   --dir ./released-native-evidence
 ```
 
-Dispatch requires repository Actions permissions. To reproduce independently,
+Dispatch requires repository Actions permissions. To reproduce public mode independently,
 fork the repository and dispatch the same checked-in workflow at the same
 harness commit in your fork; change `--repo` above to your fork. The installer
 producer remains `777genius/universal-agent-plugins`. No client account or model
 credential is used.
 
-The runner rejects draft/prerelease assets, incorrect producer commits, modified
+Public mode rejects draft/prerelease assets and all draft provenance inputs.
+Both modes reject incorrect producer commits, modified
 checksums, mismatched manifest metadata, missing attestations and unexpected
 binary versions. Attestations must identify the producer release workflow and
 exact producer source SHA. It verifies the complete six-binary release asset set
-and the selected binary's provenance before execution. Harness and probe are
+and the selected binary's provenance before execution. The current notices-bearing
+asset set is **nine**: six binaries, `release-manifest.json`, `checksums.txt`,
+and `THIRD_PARTY_NOTICES.txt`, as enforced by `release-assets.js` and the draft
+archive verifier. Historical 0.1.53 has eight assets (no companion notices).
+Harness and probe are
 source-built helpers with separate hashes; the installer is never rebuilt in
 released mode. Client, scanner and ripgrep archives retain their checked-in pins.
 
-Download all nine `released-native-client-*` artifacts. Each must have
+Download all `released-native-client-*` artifacts for the selected scope
+(nine for `historical-nine`, three for `linux-amd64`). Each must have
 `runner-evidence.json` with `status: passed`, all required tests passed and no
 skipped tests; transcripts and fixture evidence accompany it. Identity includes
 the released installer digest, producer tag/commit/tree, verified attestations,
 harness commit/tree and helper hashes. Artifacts expire after 14 days, so archive
-them before publication as described below. A configured lane is not successful
+them privately before expiry as described below; publication is optional.
+A configured lane is not successful
 runtime evidence until its corresponding job passes.
 
 These suites prove fixture installation, discovery and scripted native runtime
 behavior. They do not prove real-model quality, OAuth or live external-service
 availability. The separate platform proof covers additional installer targets.
-Linux native client coverage is arm64 only; it does not imply Linux amd64 client
-proof.
+The historical 0.1.53 Linux native client evidence is arm64 only; configuring
+the new Linux amd64 scope does not establish a successful run.
+
+## Draft dispatch and acquisition
+
+Dispatch only after the exact producer attempt has passed all six platform
+proofs, their aggregate and `verified-draft`. Use the canonical repository for
+draft acquisition; public-mode fork instructions do not grant draft access.
+Freeze the release ID, producer run/attempt, `agentplugins-npm-<version>` artifact
+ID and original ZIP digest, and the digest of `checksums.txt`. IDs/attempts are
+positive integers; both digests are 64 lowercase hex characters (no `sha256:`
+prefix), and the producer SHA is 40 lowercase hex characters.
+
+```sh
+gh workflow run agentplugins-released-native-clients.yml \
+  --repo 777genius/universal-agent-plugins \
+  --ref <immutable-UAP-harness-tag> \
+  -f release_state=draft \
+  -f target_scope=historical-nine \
+  -f release_tag=agentplugins-vX.Y.Z \
+  -f release_commit=<40-character-installer-producer-SHA> \
+  -f producer_run_id=<successful-producer-run-ID> \
+  -f producer_run_attempt=<successful-producer-attempt> \
+  -f release_id=<frozen-draft-release-ID> \
+  -f expected_asset_set_digest=<checksums.txt-SHA256> \
+  -f producer_artifact_id=<producer-npm-artifact-ID> \
+  -f producer_artifact_digest=<original-producer-artifact-ZIP-SHA256>
+```
+
+Dispatch separately with `target_scope=linux-amd64` for the three supplemental
+lanes, retaining the same frozen identities and immutable harness ref. Record
+each harness run URL/attempt and resolved harness commit/tree. Use the watch and
+download commands above for each run, with separate fresh output directories.
+
+Draft mode verifies the exact successful producer attempt and artifact ID/name,
+the still-unpublished, non-prerelease draft and all nine attested assets. It uses
+the original npm tarball from that producer artifact, never a local rebuild,
+repack or registry substitute. Package pins and notices must match the frozen
+release. In a disposable project it installs offline with scripts disabled,
+checks installed bytes, proves cold bootstrap from the frozen binary and a warm
+launch without that proof source, then runs the cached binary in native fixtures.
+Acquisition authentication is excluded from npm and client runtime environments.
+
+Require every selected lane to pass without skips and the `draft-complete` job
+to pass. That job checks lane/package/helper identities and fixture evidence,
+reauthenticates the producer and reverifies the live draft has not changed, then
+uploads `draft-native-qualification-<scope>` with `qualification.json` and
+`final-draft.json`. Retain these alongside the lanes and original producer ZIP
+using the private offline archive instructions below. Qualification is scoped
+to that dispatch; publication of evidence is not required. This installer proof
+does not qualify the standard authoring executable release (D5).
+
+## Optional historical public archive procedure
+
+This is the historical nine-lane public evidence procedure. Any new publication
+requires explicit owner permission after disclosure review; draft qualification
+uses unpublished/private archives and does not depend on publication.
 
 For a durable release record, the release operator downloads all nine artifacts
 from the successful run, verifies each identity and test verdict above, and
@@ -62,7 +134,8 @@ packs their original contents with the run metadata (`gh run view <run-id>
 Publish the archive and its SHA-256 sidecar on a separate evidence release tied
 to the exact harness SHA. Its tag must not begin with `agentplugins-v`, for example
 `native-evidence-run-<run-id>`. Never add evidence assets to the installer release:
-its closed set of eight assets is checked by installation and proof tooling.
+the historical 0.1.53 closed set of eight assets is checked by installation and
+proof tooling (current notices-bearing releases have nine).
 Use a uniquely named archive, for example
 `released-native-evidence-run-<run-id>.tar.gz`, and `gh release upload
 <native-evidence-tag> <archive> <sha256-sidecar> --repo
@@ -156,7 +229,9 @@ While Actions artifacts remain available, `gh run download 34166817934 --repo
 ./native-053-input` is an alternative acquisition route. It expires; the public
 release ZIP above is the durable route. Never execute log or fixture contents.
 
-Publication is an operator step, separate from the read-only verifier: create
+For this historical public procedure, any new publication requires explicit
+owner permission after disclosure review. Publication is optional and separate
+from the read-only verifier: create
 the non-installer tag at the original harness SHA, attach the exact ZIP and
 checksum sidecar without overwrite, and include release/harness identities,
 run URL, archive hash and verifier source digest in the notes. Record the later
@@ -166,7 +241,10 @@ publication status. Original logs intentionally retain dummy fixture keys,
 loopback ports, runner paths and built-in client prompts. Their disclosure review
 must inspect content; safe paths and file extensions do not sanitize logs.
 
-For **offline draft archives**, preserve the existing scope-2
+## Private offline draft archives
+
+Keep draft evidence unpublished; any later publication requires explicit owner
+permission after disclosure review. Preserve the existing scope-2
 `draft-native-qualification-<scope>` artifact's original `qualification.json`
 and `final-draft.json` in a separate directory, and all expected
 `released-native-client-<client>-<target>` directories with every original indexed

--- a/docs/released-native-client-proof.md
+++ b/docs/released-native-client-proof.md
@@ -8,16 +8,19 @@ fixtures. Select `target_scope=historical-nine` for nine jobs on disposable
 GitHub-hosted Linux arm64 (`ubuntu-24.04-arm`), macOS arm64 and Windows amd64
 runners, or `target_scope=linux-amd64` for three jobs on `ubuntu-24.04`.
 Linux amd64 is supplemental coverage, not a replacement for the historical nine.
-The draft 0.1.54 candidate is planned, not built yet; this runbook records no
-new native qualification.
+This runbook records no new native qualification.
 Never run these clients against your existing projects or profiles.
 
-Use an immutable UAP harness tag containing `.github/workflows/agentplugins-released-native-clients.yml`.
-The workflow and checkout execute at that tag's exact commit. The installer
-producer tag and SHA are separate inputs; the proof checks their equality
-against GitHub and records both producer and harness identities. Both sources
-are in the same canonical UAP repository; the old `plugin-kit-ai` repository
-name redirects there. Their release and harness commits can still differ.
+For public reproduction, use an immutable UAP harness tag containing
+`.github/workflows/agentplugins-released-native-clients.yml`.
+The public workflow and checkout execute at that tag's exact commit.
+Draft dispatch is restricted to this workflow in the canonical repository on
+`main`; each run checks out its captured immutable `github.sha`
+and binds that harness commit/tree into its receipts.
+The installer producer tag and SHA are separate inputs; the proof
+checks the producer tag's commit against GitHub and records both identities.
+Both sources are in the canonical UAP repository; the old `plugin-kit-ai`
+name redirects there. Producer and harness commits may differ.
 
 For public acquisition, omit all draft provenance inputs:
 
@@ -75,17 +78,19 @@ the new Linux amd64 scope does not establish a successful run.
 ## Draft dispatch and acquisition
 
 Dispatch only after the exact producer attempt has passed all six platform
-proofs, their aggregate and `verified-draft`. Use the canonical repository for
-draft acquisition; public-mode fork instructions do not grant draft access.
+proofs, their aggregate and `verified-draft`. Draft dispatch requires the
+canonical repository's workflow on `refs/heads/main`; public-mode fork and
+immutable-tag instructions do not apply to draft acquisition.
 Freeze the release ID, producer run/attempt, `agentplugins-npm-<version>` artifact
 ID and original ZIP digest, and the digest of `checksums.txt`. IDs/attempts are
 positive integers; both digests are 64 lowercase hex characters (no `sha256:`
 prefix), and the producer SHA is 40 lowercase hex characters.
+An in-progress producer attempt does not satisfy this prerequisite.
 
 ```sh
 gh workflow run agentplugins-released-native-clients.yml \
   --repo 777genius/universal-agent-plugins \
-  --ref <immutable-UAP-harness-tag> \
+  --ref main \
   -f release_state=draft \
   -f target_scope=historical-nine \
   -f release_tag=agentplugins-vX.Y.Z \
@@ -99,9 +104,10 @@ gh workflow run agentplugins-released-native-clients.yml \
 ```
 
 Dispatch separately with `target_scope=linux-amd64` for the three supplemental
-lanes, retaining the same frozen identities and immutable harness ref. Record
-each harness run URL/attempt and resolved harness commit/tree. Use the watch and
-download commands above for each run, with separate fresh output directories.
+lanes, again using `--ref main` and retaining the same frozen producer and
+release identities. Capture each scope's resolved harness SHA from its run,
+then resolve its tree:
+
 
 Draft mode verifies the exact successful producer attempt and artifact ID/name,
 the still-unpublished, non-prerelease draft and all nine attested assets. It uses

--- a/docs/released-native-client-proof.md
+++ b/docs/released-native-client-proof.md
@@ -108,6 +108,20 @@ lanes, again using `--ref main` and retaining the same frozen producer and
 release identities. Capture each scope's resolved harness SHA from its run,
 then resolve its tree:
 
+```sh
+gh run view <scope-run-id> --repo 777genius/universal-agent-plugins \
+  --json headSha,url,attempt
+gh api repos/777genius/universal-agent-plugins/git/commits/<resolved-harness-SHA> \
+  --jq '.tree.sha'
+```
+
+Record these identities for both the nine-lane and three-lane dispatches and
+require their receipts to match the captured commit/tree. Refuse a combined
+nine-plus-three qualification with mixed harness versions: if `main` advances
+between dispatches and their resolved SHAs differ, repeat the affected scope
+on `main` until both scopes have the same captured harness commit/tree.
+Use the watch and download commands above for each run, with separate fresh
+output directories.
 
 Draft mode verifies the exact successful producer attempt and artifact ID/name,
 the still-unpublished, non-prerelease draft and all nine attested assets. It uses
@@ -116,13 +130,23 @@ repack or registry substitute. Package pins and notices must match the frozen
 release. In a disposable project it installs offline with scripts disabled,
 checks installed bytes, proves cold bootstrap from the frozen binary and a warm
 launch without that proof source, then runs the cached binary in native fixtures.
-Acquisition authentication is excluded from npm and client runtime environments.
+Acquisition authentication is not inherited by npm or client child environments.
+This proof assumes trusted pinned clients, the canonical package and
+repository-owned fixtures. The child environment provides no OS process
+isolation from the runner or the subsequent artifact-upload step. Network
+access remains enabled, no real-model or OAuth credentials are supplied, and
+collected logs are not guaranteed to be secret-free.
 
 Require every selected lane to pass without skips and the `draft-complete` job
-to pass. That job checks lane/package/helper identities and fixture evidence,
-reauthenticates the producer and reverifies the live draft has not changed, then
-uploads `draft-native-qualification-<scope>` with `qualification.json` and
-`final-draft.json`. Retain these alongside the lanes and original producer ZIP
+to pass its read-only aggregation of lane/package/helper identities, fixture
+evidence and snapshot binding, producing the `draft-lanes` receipt.
+Then require `draft-recheck` to pass: this metadata-only job authenticates the
+snapshot and lanes receipts, reauthenticates the producer and reverifies the
+live draft before uploading `draft-native-qualification-<scope>` with
+`qualification.json` and `final-draft.json`.
+The metadata-only `draft-snapshot` and `draft-recheck` jobs require
+`contents: write` for draft visibility, even though they do not publish releases.
+Retain the qualification files alongside the lanes and original producer ZIP
 using the private offline archive instructions below. Qualification is scoped
 to that dispatch; publication of evidence is not required. This installer proof
 does not qualify the standard authoring executable release (D5).
@@ -149,7 +173,8 @@ Use a uniquely named archive, for example
 and SHA, harness SHA, Actions run URL, published asset URLs and archive digest
 in the separate evidence release's notes, and link that release from the durable
 release documentation. Download the published assets again and verify the digest
-before calling the evidence durable; this workflow has no release-write permission.
+before calling the evidence durable; public-mode workflow jobs have no
+release-write permission.
 
 The Linux runner label is a native arm64 GitHub-hosted VM, as documented in
 [GitHub's runner reference](https://docs.github.com/en/actions/reference/runners/github-hosted-runners).

--- a/scripts/native_client_draft.py
+++ b/scripts/native_client_draft.py
@@ -131,7 +131,7 @@ def live_verify(source, producer_source, args, receipt):
             '--commit', args.release_commit, '--release-id', str(args.release_id),
             '--asset-set-digest', args.expected_asset_set_digest,
             '--run-id', str(args.producer_run_id), '--run-attempt', str(args.producer_run_attempt),
-            '--source', str(producer_source), '--receipt', str(receipt)])
+            '--source', str(producer_source), '--policy-source', str(source), '--receipt', str(receipt)])
     record = json.loads(receipt.read_bytes())
     require(record['release_state'] == 'verified-draft'
             and record['release']['id'] == int(args.release_id)
@@ -148,7 +148,10 @@ def acquire(source, directory, args, evidence):
     require(not output(['git', '-C', str(producer_source), 'status', '--porcelain', '--untracked-files=normal']), 'dirty producer checkout')
     tree = output(['git', '-C', str(producer_source), 'rev-parse', 'HEAD^{tree}']).decode().strip()
     require(re.fullmatch(r'[0-9a-f]{40}', tree), 'invalid producer tree')
-    live = live_verify(source, producer_source, args, evidence / 'initial-draft.json')
+    snapshot = receive(source, args, 'snapshot')
+    require(snapshot['producer_tree'] == tree, 'mixed producer tree')
+    live = snapshot['live']
+    (evidence / 'initial-draft.json').write_text(json.dumps(live))
     body = output(['gh', 'api', f'repos/{REPOSITORY}/actions/artifacts/{args.producer_artifact_id}/zip'])
     require(hashlib.sha256(body).hexdigest() == args.producer_artifact_digest, 'artifact download digest mismatch')
     bundle = directory / 'draft-bundle'
@@ -358,11 +361,157 @@ def helper_hashes(source):
         'npm/agentplugins/scripts/release-assets.js')}
 
 
+NATIVE_WORKFLOW = '.github/workflows/agentplugins-released-native-clients.yml'
+RECEIPT_LIMIT = 64 << 10
+
+
+def strict_json(body):
+    require(len(body) <= RECEIPT_LIMIT, 'oversized receipt')
+    def pairs(items):
+        result = {}
+        for key, value in items:
+            require(key not in result, 'duplicate receipt key')
+            result[key] = value
+        return result
+    return json.loads(body, object_pairs_hook=pairs, parse_constant=lambda _: require(False, 'invalid JSON number'))
+
+
+def keys(record, names):
+    require(type(record) is dict and set(record) == set(names.split()), 'unexpected receipt fields')
+
+
+def trusted_binding(source, args):
+    env = os.environ
+    require(env.get('GITHUB_REPOSITORY') == REPOSITORY and env.get('GITHUB_EVENT_NAME') == 'workflow_dispatch'
+            and env.get('GITHUB_REF') == 'refs/heads/main'
+            and env.get('GITHUB_WORKFLOW_REF') == f'{REPOSITORY}/{NATIVE_WORKFLOW}@refs/heads/main',
+            'draft requires canonical main workflow dispatch')
+    sha = env.get('GITHUB_SHA', '')
+    require(re.fullmatch(r'[0-9a-f]{40}', sha) and
+            output(['git', '-C', str(source), 'rev-parse', 'HEAD']).decode().strip() == sha,
+            'wrong immutable harness checkout')
+    require(not output(['git', '-C', str(source), 'status', '--porcelain', '--untracked-files=normal']),
+            'dirty harness checkout')
+    tree = output(['git', '-C', str(source), 'rev-parse', 'HEAD^{tree}']).decode().strip()
+    require(re.fullmatch(r'[0-9a-f]{40}', tree), 'invalid harness tree')
+    for key in ('GITHUB_RUN_ID', 'GITHUB_RUN_ATTEMPT'):
+        require(re.fullmatch(r'[1-9]\d*', env.get(key, '')), 'invalid native invocation')
+    return dict(repository=REPOSITORY, workflow=NATIVE_WORKFLOW, harness_commit=sha, harness_tree=tree,
+                run_id=int(env['GITHUB_RUN_ID']), run_attempt=int(env['GITHUB_RUN_ATTEMPT']),
+                target_scope=args.target_scope, release_tag=args.release_tag, release_commit=args.release_commit,
+                **{key: str(getattr(args, key)) for key in FIELDS}, helper_sha256=helper_hashes(source))
+
+
+def emit(path, record):
+    body = (json.dumps(record, sort_keys=True) + '\n').encode()
+    require(len(body) <= RECEIPT_LIMIT, 'oversized receipt')
+    with Path(path).open('xb') as stream:
+        stream.write(body)
+    if os.environ.get('GITHUB_OUTPUT'):
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as stream:
+            stream.write('receipt-sha256=' + hashlib.sha256(body).hexdigest() + '\n')
+
+
+def receive(source, args, kind):
+    # Only trusted job outputs select transport. No dispatch URLs or names.
+    prefix = 'SNAPSHOT' if kind == 'snapshot' else 'LANES'
+    artifact_id, sha, archive_sha = [os.environ.get(prefix + suffix, '') for suffix in
+                                   ('_ARTIFACT_ID', '_SHA256', '_ARTIFACT_DIGEST')]
+    require(re.fullmatch(r'[1-9]\d*', artifact_id) and re.fullmatch(r'[0-9a-f]{64}', sha)
+            and re.fullmatch(r'[0-9a-f]{64}', archive_sha), 'invalid receipt transport identity')
+    binding = trusted_binding(source, args)
+    artifact = api(f'repos/{REPOSITORY}/actions/artifacts/{artifact_id}')
+    require(artifact['id'] == int(artifact_id) and artifact['expired'] is False
+            and artifact['name'] == 'draft-' + kind
+            and artifact['digest'] == 'sha256:' + archive_sha
+            and 0 < artifact['size_in_bytes'] <= RECEIPT_LIMIT * 2
+            and artifact['workflow_run']['id'] == binding['run_id']
+            and artifact['workflow_run']['head_sha'] == binding['harness_commit'], 'wrong receipt artifact')
+    body = output(['gh', 'api', f'repos/{REPOSITORY}/actions/artifacts/{artifact_id}/zip'])
+    require(len(body) <= RECEIPT_LIMIT * 2 and hashlib.sha256(body).hexdigest() == archive_sha,
+            'receipt archive digest mismatch')
+    with zipfile.ZipFile(io.BytesIO(body)) as archive:
+        members = archive.infolist()
+        require(len(members) == 1 and members[0].filename == 'receipt.json'
+                and members[0].file_size <= RECEIPT_LIMIT
+                and (members[0].external_attr >> 16) & 0o170000 in (0, 0o100000), 'unexpected receipt archive')
+        raw = archive.read(members[0])
+    require(hashlib.sha256(raw).hexdigest() == sha, 'receipt digest mismatch')
+    record = strict_json(raw)
+    keys(record, 'kind binding producer_tree live' if kind == 'snapshot' else
+         'kind binding snapshot_sha256 tarball_sha256 lanes')
+    require(record['kind'] == ('snapshot' if kind == 'snapshot' else 'lanes-verified')
+            and json.dumps(record['binding'], sort_keys=True) == json.dumps(binding, sort_keys=True), 'receipt invocation mismatch')
+    if kind == 'snapshot':
+        require(re.fullmatch(r'[0-9a-f]{40}', record['producer_tree']), 'invalid producer tree')
+        live = record['live']
+        keys(live, 'schema_version release_state verified_at repository release asset_set_digest subjects signer_workflow producer_commit producer_run_id producer_run_attempt')
+        keys(live['release'], 'id tag commit draft prerelease updated_at assets')
+        require(len(live['subjects']) == len(live['release']['assets']) == 9, 'incomplete snapshot subjects')
+        for item in live['subjects']:
+            keys(item, 'name id size sha256')
+        for item in live['release']['assets']:
+            keys(item, 'id name size state created_at updated_at digest')
+        require(live['producer_commit'] == args.release_commit and live['producer_run_id'] == int(args.producer_run_id)
+                and live['producer_run_attempt'] == int(args.producer_run_attempt)
+                and live['asset_set_digest'] == args.expected_asset_set_digest
+                and live['release']['id'] == int(args.release_id), 'snapshot producer mismatch')
+    else:
+        require(record['snapshot_sha256'] == os.environ['SNAPSHOT_SHA256']
+                and re.fullmatch(r'[0-9a-f]{64}', record['tarball_sha256']), 'mixed snapshot or package')
+        targets = ['linux-amd64'] if args.target_scope == 'linux-amd64' else ['linux-arm64', 'darwin-arm64', 'windows-amd64']
+        expected = {(c, t) for c in ('codex', 'claude', 'opencode') for t in targets}
+        require(type(record['lanes']) is list and len(record['lanes']) == len(expected), 'missing lanes')
+        for lane in record['lanes']:
+            keys(lane, 'client target evidence_sha256')
+            pair = (lane['client'], lane['target'])
+            require(pair in expected and re.fullmatch(r'[0-9a-f]{64}', lane['evidence_sha256']), 'invalid lane')
+            expected.remove(pair)
+    return record
+
+
+def metadata(source, args):
+    binding = trusted_binding(source, args)
+    producer = authenticate(args)
+    producer_source = Path(args.producer_source).resolve()
+    tree = output(['git', '-C', str(producer_source), 'rev-parse', 'HEAD^{tree}']).decode().strip()
+    require(re.fullmatch(r'[0-9a-f]{40}', tree), 'invalid producer tree')
+    destination = Path(args.receipt)
+    require(not destination.exists(), 'receipt already exists')
+    if args.metadata == 'recheck':
+        initial = receive(source, args, 'snapshot')
+        lanes = receive(source, args, 'lanes')
+        require(tree == initial['producer_tree'], 'mixed producer tree')
+    # Temporary live receipt cannot leave a final success artifact on comparison failure.
+    with tempfile.TemporaryDirectory() as directory:
+        final = live_verify(source, producer_source, args, Path(directory) / 'live.json')
+    if args.metadata == 'snapshot':
+        emit(destination, dict(kind='snapshot', binding=binding, producer_tree=tree, live=final))
+        return
+    require(final['release'] == initial['live']['release'] and final['subjects'] == initial['live']['subjects'],
+            'draft changed during native qualification')
+    from datetime import datetime
+    require(datetime.fromisoformat(final['verified_at']) > datetime.fromisoformat(initial['live']['verified_at']),
+            'final verification is not fresh')
+    result = dict(schema_version=2, status='passed', release_state='verified-draft', target_scope=args.target_scope,
+                  producer_commit=args.release_commit, harness_commit=binding['harness_commit'],
+                  harness_tree=binding['harness_tree'], tarball_sha256=lanes['tarball_sha256'], producer=producer,
+                  helper_sha256=binding['helper_sha256'], lanes=lanes['lanes'], final_draft=final,
+                  invocation=dict(binding=binding, snapshot_sha256=os.environ['SNAPSHOT_SHA256'],
+                                  lanes_sha256=os.environ['LANES_SHA256'],
+                                  transport={k: os.environ[k] for k in ('SNAPSHOT_ARTIFACT_ID', 'SNAPSHOT_ARTIFACT_DIGEST',
+                                             'LANES_ARTIFACT_ID', 'LANES_ARTIFACT_DIGEST')}),
+                  limitation='genuine pinned clients; scripted loopback providers; no real-model or OAuth qualification')
+    emit(destination.with_name('final-draft.json'), final)
+    emit(destination, result)
+
+
 def aggregate(source, args):
     validate(args)
     require(args.release_state == 'draft', 'aggregate receipt is draft-only')
     root, destination = Path(args.evidence), Path(args.receipt)
     require(not destination.exists(), 'qualification receipt already exists')
+    snapshot = receive(source, args, 'snapshot')
     matrix = load_script('run-native-client-matrix')
     targets = ['linux-amd64'] if args.target_scope == 'linux-amd64' else ['linux-arm64', 'darwin-arm64', 'windows-amd64']
     expected = {(client, target) for target in targets for client in matrix.REQUIRED_TESTS}
@@ -379,6 +528,9 @@ def aggregate(source, args):
         require(record['commit'] == args.harness_commit and re.fullmatch(r'[0-9a-f]{40}', record['tree']), 'mixed harness checkout')
         require(record['helper_sha256'] == helper_hashes(source), 'mixed harness helper bytes')
         release = record['installer_release']
+        require(release['initial_draft'] == snapshot['live'], 'lane snapshot mismatch')
+        for subject in snapshot['live']['subjects']:
+            verify_attestation(release['attestations'][subject['name']], subject['name'], subject['sha256'], args.release_commit)
         producer = release['producer']
         require(release['release_state'] == 'draft' and release['repository'] == REPOSITORY
                 and release['tag'] == args.release_tag and release['commit'] == args.release_commit
@@ -421,21 +573,11 @@ def aggregate(source, args):
         verifier.verify_fixtures(bodies, record, client, target)
         lanes.append({'client': client, 'target': target, 'evidence_sha256': digest(path)})
     require(seen == expected, 'missing lanes')
-    # Reauthenticate after all runtime lanes, then call the unchanged read-only helper.
-    authenticate(args)
-    producer_source = Path(args.producer_source).resolve()
-    require(output(['git', '-C', str(producer_source), 'rev-parse', 'HEAD']).decode().strip() == args.release_commit, 'wrong final producer checkout')
-    require(not output(['git', '-C', str(producer_source), 'status', '--porcelain', '--untracked-files=normal']), 'dirty final producer checkout')
-    final = live_verify(source, producer_source, args, destination.with_name('final-draft.json'))
-    require(final['release'] == common[3] and final['subjects'] == common[4], 'draft changed during native qualification')
-    result = {'schema_version': 1, 'status': 'passed', 'release_state': 'verified-draft',
-              'target_scope': args.target_scope, 'producer_commit': args.release_commit,
-              'harness_commit': args.harness_commit, 'harness_tree': common[0],
-              'tarball_sha256': common[2], 'producer': producer, 'helper_sha256': helper_hashes(source),
-              'lanes': lanes, 'final_draft': final,
-              'limitation': 'genuine pinned clients; scripted loopback providers; no real-model or OAuth qualification'}
-    with destination.open('x', encoding='utf-8') as stream:
-        stream.write(json.dumps(result, indent=2) + '\n')
+    require(common == (snapshot['binding']['harness_tree'], snapshot['producer_tree'], common[2],
+                       snapshot['live']['release'], snapshot['live']['subjects']), 'lanes differ from snapshot')
+    emit(destination, {'kind': 'lanes-verified', 'binding': snapshot['binding'],
+                       'snapshot_sha256': os.environ['SNAPSHOT_SHA256'],
+                       'tarball_sha256': common[2], 'lanes': lanes})
 
 
 def main():
@@ -446,6 +588,7 @@ def main():
     for field in ('release_tag', 'release_commit', *FIELDS):
         parser.add_argument('--' + field.replace('_', '-'), default='')
     parser.add_argument('--validate-only', action='store_true')
+    parser.add_argument('--metadata', choices=('snapshot', 'recheck'))
     parser.add_argument('--producer-source', type=Path)
     parser.add_argument('--harness-commit')
     parser.add_argument('--target-scope', choices=('historical-nine', 'linux-amd64'), default='historical-nine')
@@ -453,7 +596,12 @@ def main():
     parser.add_argument('--receipt', type=Path)
     args = parser.parse_args()
     validate(args)
-    if not args.validate_only:
+    if args.validate_only and args.release_state == 'draft':
+        trusted_binding(Path(__file__).resolve().parents[1], args)
+        authenticate(args)
+    elif args.metadata:
+        metadata(Path(__file__).resolve().parents[1], args)
+    elif not args.validate_only:
         aggregate(Path(__file__).resolve().parents[1], args)
 
 

--- a/scripts/run-native-client-matrix.py
+++ b/scripts/run-native-client-matrix.py
@@ -230,19 +230,40 @@ def prepared_release(source, args):
         else:
             installer, release = provision_release(source, root, args.target, args.release_tag, args.release_commit, args.release_repo)
             paths, verified = [str(installer.relative_to(root))], None
+        tool_dir = root / 'prepared-tools'
+        tool_dir.mkdir()
+        tools = {}
+        for name in (args.client, 'lintai', 'rg'):
+            pin = PINS[args.target][name]
+            path, evidence = provision(pin, tool_dir, name)
+            tools[name] = dict(path=path.relative_to(root).as_posix(),
+                               pin=list(pin), evidence=evidence)
         record = dict(state=args.release_state, tag=args.release_tag, commit=args.release_commit,
-                      target=args.target, release=release, paths=paths, verified=verified,
+                      target=args.target, client=args.client, tools=tools,
+                      release=release, paths=paths, verified=verified,
                       files={p.relative_to(root).as_posix(): draft.digest(p) for p in root.rglob('*') if p.is_file()})
         (root / 'prepared.json').write_text(json.dumps(record))
         if os.environ.get('GITHUB_OUTPUT'):
             with open(os.environ['GITHUB_OUTPUT'], 'a') as stream:
                 stream.write('prepared-sha256=' + draft.digest(root / 'prepared.json') + '\n')
         return
+    record = load_prepared(args)
+    paths = [root / name for name in record['paths']]
+    draft.require(all(p.resolve().is_relative_to(root) and p.exists() for p in paths), 'missing prepared input')
+    if args.release_state == 'draft':
+        return *paths, record['verified'], record['release']
+    return paths[0], record['release']
+
+
+def load_prepared(args):
+    """Authenticate the frozen release and tools without acquiring anything."""
+    root = args.prepared_input.resolve()
     draft.require(not any(os.environ.get(k) for k in ('GH_TOKEN', 'GITHUB_TOKEN', 'NODE_AUTH_TOKEN', 'NPM_TOKEN')),
-                  'prepared execution must be credential-free')
+                  'prepared execution must not receive GH_TOKEN, GITHUB_TOKEN, NODE_AUTH_TOKEN, or NPM_TOKEN in its environment')
     draft.require(not args.prepared_input.is_symlink() and not (root / 'prepared.json').is_symlink()
                   and draft.digest(root / 'prepared.json') == os.environ.get('PREPARED_SHA256'), 'prepared manifest mismatch')
     record = json.loads((root / 'prepared.json').read_bytes())
+    draft.require(record.get('client') == args.client, 'mixed prepared client')
     draft.require((record['state'], record['tag'], record['commit'], record['target']) ==
                   (args.release_state, args.release_tag, args.release_commit, args.target), 'mixed prepared inputs')
     files = {p.relative_to(root).as_posix(): p for p in root.rglob('*') if p.is_file()}
@@ -250,11 +271,36 @@ def prepared_release(source, args):
                   not any(p.is_symlink() for p in root.rglob('*')), 'unexpected prepared files')
     for name, sha in record['files'].items():
         draft.require(draft.digest(files[name]) == sha, 'tampered prepared file')
-    paths = [root / name for name in record['paths']]
-    draft.require(all(p.resolve().is_relative_to(root) and p.exists() for p in paths), 'missing prepared input')
-    if args.release_state == 'draft':
-        return *paths, record['verified'], record['release']
-    return paths[0], record['release']
+    tools = record.get('tools', {})
+    draft.require(set(tools) == {args.client, 'lintai', 'rg'}, 'missing prepared tools')
+    for name, tool in tools.items():
+        pin = PINS[args.target][name]
+        require_verified_pin(pin[4])
+        draft.require(tool['pin'] == list(pin), 'prepared tool pin mismatch')
+        draft.require(tool['path'] in record['files'] and
+                      tool['evidence']['binary_sha256'] == record['files'][tool['path']],
+                      'prepared tool digest mismatch')
+    return record
+
+
+def prepared_tools(args, directory):
+    """Keep standalone acquisition, but consume only frozen bytes when supplied."""
+    names = (args.client, 'lintai', 'rg')
+    if args.prepared_input is None:
+        return {name: provision(PINS[args.target][name], directory, name) for name in names}
+    record = load_prepared(args)
+    root = args.prepared_input.resolve()
+    result = {}
+    for name in names:
+        tool = record['tools'][name]
+        body = (root / tool['path']).read_bytes()
+        draft.require(hashlib.sha256(body).hexdigest() == tool['evidence']['binary_sha256'],
+                      'tampered prepared tool')
+        path = directory / (name + ('.exe' if os.name == 'nt' else ''))
+        path.write_bytes(body)
+        path.chmod(0o700)
+        result[name] = path, tool['evidence']
+    return result
 
 
 def main():
@@ -293,7 +339,7 @@ def main():
     output = args.output.resolve()
     output.mkdir(parents=True, exist_ok=False)
     scratch = Path(tempfile.mkdtemp(prefix="uap-native-hosted-", dir=os.environ["RUNNER_TEMP"])).resolve()
-    identity = {"schema_version": 1, "client": args.client, "target": args.target, "started_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), "isolation": "disposable GitHub-hosted machine; explicit runtime environment; fresh project and profiles", "network": "not blocked; scripted loopback model endpoints; no real-model or OAuth proof", "status": "failed", "scratch": str(scratch)}
+    identity = {"schema_version": 1, "client": args.client, "target": args.target, "started_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), "isolation": "disposable GitHub-hosted machine; explicit subprocess environments and fresh profiles; no OS/process isolation from runner or later steps", "network": "not blocked; scripted loopback model endpoints; no real-model or OAuth proof", "status": "failed", "scratch": str(scratch)}
     try:
         for key, rev in [("commit", "HEAD"), ("tree", "HEAD^{tree}")]:
             identity[key] = subprocess.check_output(["git", "rev-parse", rev], cwd=source, encoding="utf-8", errors="strict").strip()
@@ -306,11 +352,12 @@ def main():
             require_verified_pin(PINS[args.target][key][4])
         binary_dir = scratch / "bin"
         binary_dir.mkdir()
-        client, client_evidence = provision(PINS[args.target][args.client], binary_dir, args.client)
-        scanner, scanner_evidence = provision(PINS[args.target]["lintai"], binary_dir, "lintai")
+        tools = prepared_tools(args, binary_dir)
+        client, client_evidence = tools[args.client]
+        scanner, scanner_evidence = tools["lintai"]
         identity["client_asset"] = client_evidence
         identity["scanner_asset"] = scanner_evidence
-        _, identity["ripgrep_asset"] = provision(PINS[args.target]["rg"], binary_dir, "rg")
+        _, identity["ripgrep_asset"] = tools["rg"]
         suffix = ".exe" if os.name == "nt" else ""
         installer, probe, tests = [binary_dir / (p + suffix) for p in ("agentplugins", "native-probe", "repotests")]
         commands = [(["go", "build", "-trimpath", "-o", str(probe), "./repotests/testdata/agentplugins_native_probe"], source), (["go", "test", "-c", "-o", str(tests), "./repotests"], source)]

--- a/scripts/run-native-client-matrix.py
+++ b/scripts/run-native-client-matrix.py
@@ -220,6 +220,43 @@ def find_git_bash(git):
     return None
 
 
+def prepared_release(source, args):
+    root = args.prepared_input.resolve()
+    if args.prepare_only:
+        root.mkdir(parents=True, exist_ok=False)
+        if args.release_state == 'draft':
+            tarball, assets, verified, release = draft.acquire(source, root, args, root)
+            paths = [str(p.relative_to(root)) for p in (tarball, assets)]
+        else:
+            installer, release = provision_release(source, root, args.target, args.release_tag, args.release_commit, args.release_repo)
+            paths, verified = [str(installer.relative_to(root))], None
+        record = dict(state=args.release_state, tag=args.release_tag, commit=args.release_commit,
+                      target=args.target, release=release, paths=paths, verified=verified,
+                      files={p.relative_to(root).as_posix(): draft.digest(p) for p in root.rglob('*') if p.is_file()})
+        (root / 'prepared.json').write_text(json.dumps(record))
+        if os.environ.get('GITHUB_OUTPUT'):
+            with open(os.environ['GITHUB_OUTPUT'], 'a') as stream:
+                stream.write('prepared-sha256=' + draft.digest(root / 'prepared.json') + '\n')
+        return
+    draft.require(not any(os.environ.get(k) for k in ('GH_TOKEN', 'GITHUB_TOKEN', 'NODE_AUTH_TOKEN', 'NPM_TOKEN')),
+                  'prepared execution must be credential-free')
+    draft.require(not args.prepared_input.is_symlink() and not (root / 'prepared.json').is_symlink()
+                  and draft.digest(root / 'prepared.json') == os.environ.get('PREPARED_SHA256'), 'prepared manifest mismatch')
+    record = json.loads((root / 'prepared.json').read_bytes())
+    draft.require((record['state'], record['tag'], record['commit'], record['target']) ==
+                  (args.release_state, args.release_tag, args.release_commit, args.target), 'mixed prepared inputs')
+    files = {p.relative_to(root).as_posix(): p for p in root.rglob('*') if p.is_file()}
+    draft.require(set(files) == set(record['files']) | {'prepared.json'} and
+                  not any(p.is_symlink() for p in root.rglob('*')), 'unexpected prepared files')
+    for name, sha in record['files'].items():
+        draft.require(draft.digest(files[name]) == sha, 'tampered prepared file')
+    paths = [root / name for name in record['paths']]
+    draft.require(all(p.resolve().is_relative_to(root) and p.exists() for p in paths), 'missing prepared input')
+    if args.release_state == 'draft':
+        return *paths, record['verified'], record['release']
+    return paths[0], record['release']
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--client", choices=PATTERNS, required=True)
@@ -232,6 +269,9 @@ def main():
     for field in draft.FIELDS:
         parser.add_argument("--" + field.replace("_", "-"), default="")
     parser.add_argument("--producer-source", type=Path)
+    parser.add_argument("--prepare-only", action="store_true")
+    parser.add_argument("--prepared-input", type=Path)
+    parser.add_argument("--target-scope", choices=('historical-nine', 'linux-amd64'), default='historical-nine')
     args = parser.parse_args()
     draft.validate(args)
     if args.release_state == "draft" and args.producer_source is None:
@@ -242,6 +282,14 @@ def main():
         parser.error("--release-tag and --release-commit must be supplied together")
     require_hosted(args.target)
     source = Path(__file__).resolve().parents[1]
+    if args.prepare_only:
+        if args.prepared_input is None or not args.release_tag:
+            parser.error("preparation requires --prepared-input and an exact release")
+        prepared_release(source, args)
+        return
+    prepared = prepared_release(source, args) if args.prepared_input else None
+    if args.release_state == 'draft' and prepared is None:
+        parser.error("draft execution requires prepared inputs")
     output = args.output.resolve()
     output.mkdir(parents=True, exist_ok=False)
     scratch = Path(tempfile.mkdtemp(prefix="uap-native-hosted-", dir=os.environ["RUNNER_TEMP"])).resolve()
@@ -268,9 +316,10 @@ def main():
         commands = [(["go", "build", "-trimpath", "-o", str(probe), "./repotests/testdata/agentplugins_native_probe"], source), (["go", "test", "-c", "-o", str(tests), "./repotests"], source)]
         if args.release_state == "draft":
             identity["helper_sha256"] = draft.helper_hashes(source)
-            tarball, frozen_assets, verified, identity["installer_release"] = draft.acquire(source, binary_dir, args, output)
+            tarball, frozen_assets, verified, identity["installer_release"] = prepared
+            shutil.copyfile(args.prepared_input / "initial-draft.json", output / "initial-draft.json")
         elif args.release_tag:
-            installer, identity["installer_release"] = provision_release(source, binary_dir, args.target, args.release_tag, args.release_commit, args.release_repo)
+            installer, identity["installer_release"] = prepared if prepared is not None else provision_release(source, binary_dir, args.target, args.release_tag, args.release_commit, args.release_repo)
         else:
             commands.insert(0, (["go", "build", "-trimpath", "-o", str(installer), "./cmd/agentplugins"], source / "cli/plugin-kit-ai"))
         project = scratch / "project"

--- a/scripts/test_native_client_draft.py
+++ b/scripts/test_native_client_draft.py
@@ -260,7 +260,7 @@ class DraftTests(unittest.TestCase):
 
     def test_acquisition_artifact_tamper_before_extraction_or_execution(self):
         with tempfile.TemporaryDirectory() as temp:
-            with patch.object(draft, 'authenticate', return_value={}), patch.object(draft, 'live_verify', return_value={}), \
+            with patch.object(draft, 'authenticate', return_value={}), patch.object(draft, 'receive', return_value={'producer_tree': 'd' * 40, 'live': {}}), \
                  patch.object(draft, 'output', side_effect=[b'a' * 40, b'', b'd' * 40, b'altered zip']), \
                  patch.object(draft, 'unpack_bundle') as unpack:
                 with self.assertRaisesRegex(ValueError, 'download digest'):
@@ -342,7 +342,7 @@ class AggregateTests(unittest.TestCase):
             release = dict(release_state='draft', repository=draft.REPOSITORY, tag='agentplugins-v1.2.3',
                            version='1.2.3', commit='a' * 40, tree='f' * 40, release_id=34, checksums_sha256='c' * 64,
                            producer=producer, tarball_sha256='1' * 64, binary_sha256='2' * 64, size=6, file='agentplugins_1.2.3_linux_amd64',
-                           initial_draft=initial)
+                           initial_draft=initial, attestations={n['name']: attestation(n['name'], n['sha256']) for n in initial['subjects']})
             packaged = dict(bootstrap_source='local_frozen_asset', cold_bootstrap=True, warm_without_proof_source=True,
                             npm_ignore_scripts=True, tarball_sha256='1' * 64, binary_sha256='2' * 64,
                             size=6, version='agentplugins 1.2.3')
@@ -366,12 +366,14 @@ class AggregateTests(unittest.TestCase):
         verifier = Mock()
         if fixture_failure:
             verifier.verify_fixtures.side_effect = ValueError('missing fixture stage')
+        snapshot = {'live': final, 'producer_tree': 'f' * 40, 'binding': {'harness_tree': 'e' * 40}}
         with patch.object(draft, 'load_script', side_effect=lambda n: matrix if n == 'run-native-client-matrix' else verifier), \
-             patch.object(draft, 'authenticate') as auth, patch.object(draft, 'output', side_effect=[b'a' * 40, b'']), \
-             patch.object(draft, 'live_verify', side_effect=RuntimeError('draft gone') if live_failure else None, return_value=final) as live:
+             patch.object(draft, 'receive', side_effect=RuntimeError('snapshot unavailable') if live_failure else None, return_value=snapshot), \
+             patch.dict(os.environ, SNAPSHOT_SHA256='9' * 64), \
+             patch.object(draft, 'authenticate') as auth, patch.object(draft, 'live_verify') as live:
             draft.aggregate(source, args(target_scope='linux-amd64', evidence=root, receipt=root / 'qualification.json', harness_commit='d' * 40))
-        auth.assert_called_once()
-        live.assert_called_once()
+        auth.assert_not_called()
+        live.assert_not_called()
         self.assertEqual(verifier.verify_fixtures.call_count, 3)
 
     def test_complete_lanes_final_verification_then_receipt(self):
@@ -380,9 +382,9 @@ class AggregateTests(unittest.TestCase):
             _, initial = self.fixture(root)
             self.run_aggregate(root, initial)
             result = json.loads((root / 'qualification.json').read_bytes())
-            self.assertEqual(result['status'], 'passed')
+            self.assertEqual(result['kind'], 'lanes-verified')
             self.assertEqual(len(result['lanes']), 3)
-            self.assertEqual(result['producer']['artifact_id'], 56)
+            self.assertEqual(result['snapshot_sha256'], '9' * 64)
 
     def test_failures_never_issue_qualification(self):
         changes = [lambda r: r.update(status='failed'), lambda r: r.update(exit_code=1),
@@ -470,7 +472,7 @@ class AcquisitionIntegrationTests(unittest.TestCase):
                 directory = root / 'acquired'
                 directory.mkdir()
                 with patch.object(draft, 'authenticate', return_value={'artifact_id': 56}), \
-                     patch.object(draft, 'live_verify', return_value=live), patch.object(draft, 'output', side_effect=child):
+                     patch.object(draft, 'receive', return_value={'producer_tree': 'd' * 40, 'live': live}), patch.object(draft, 'output', side_effect=child):
                     if tamper != 'none':
                         with self.assertRaises(ValueError):
                             draft.acquire(root, directory, arguments, root)
@@ -482,5 +484,155 @@ class AcquisitionIntegrationTests(unittest.TestCase):
                         self.assertEqual(set(record['attestations']), set(frozen))
 
 
-if __name__ == '__main__':
+
+class ReceiptBoundaryTests(unittest.TestCase):
+    def fixture(self):
+        live = dict(schema_version=1, release_state='verified-draft', verified_at='2026-09-09T01:00:00+00:00',
+                    repository=draft.REPOSITORY, release=dict(id=34, tag='agentplugins-v1.2.3', commit='a'*40,
+                    draft=True, prerelease=False, updated_at='now', assets=[]), asset_set_digest='c'*64,
+                    subjects=[], signer_workflow='github.com/'+draft.REPOSITORY+'/'+draft.WORKFLOW,
+                    producer_commit='a'*40, producer_run_id=12, producer_run_attempt=2)
+        for i in range(9):
+            live['subjects'].append(dict(name=str(i), id=i+1, size=1, sha256='b'*64))
+            live['release']['assets'].append(dict(name=str(i), id=i+1, size=1, state='uploaded',
+                                                created_at='then', updated_at='now', digest='sha256:'+'b'*64))
+        return dict(kind='snapshot', binding={'run_id': 99, 'run_attempt': 2, 'harness_commit': 'd'*40},
+                    producer_tree='f'*40, live=live)
+
+    def receive(self, record, *, raw=None, artifact_change=None, env_change=None, extra=False):
+        binding = self.fixture()['binding']
+        raw = raw if raw is not None else json.dumps(record).encode()
+        stream = io.BytesIO()
+        with zipfile.ZipFile(stream, 'w', zipfile.ZIP_DEFLATED) as z:
+            z.writestr('receipt.json', raw)
+            if extra: z.writestr('payload.sh', 'false')
+        body = stream.getvalue()
+        sha = hashlib.sha256(body).hexdigest()
+        kind = 'snapshot' if record['kind'] == 'snapshot' else 'lanes'
+        prefix = kind.upper()
+        env = {prefix+'_ARTIFACT_ID': '71', prefix+'_ARTIFACT_DIGEST': sha,
+               prefix+'_SHA256': hashlib.sha256(raw).hexdigest(), 'SNAPSHOT_SHA256': 'c'*64}
+        if kind == 'snapshot': env['SNAPSHOT_SHA256'] = hashlib.sha256(raw).hexdigest()
+        env.update(env_change or {})
+        artifact = dict(id=71, name='draft-'+kind, expired=False, digest='sha256:'+sha,
+                        size_in_bytes=len(body), workflow_run=dict(id=99, head_sha='d'*40))
+        if artifact_change: artifact_change(artifact)
+        with patch.dict(os.environ, env, clear=True), patch.object(draft, 'trusted_binding', return_value=binding), \
+             patch.object(draft, 'api', return_value=artifact), patch.object(draft, 'output', return_value=body):
+            return draft.receive(Path('/harness'), args(target_scope='linux-amd64'), kind)
+
+    def test_transport_and_exact_invocation(self):
+        self.assertEqual(self.receive(self.fixture()), self.fixture())
+        for change in [lambda r:r['binding'].update(run_id=98), lambda r:r['binding'].update(run_attempt=1),
+                       lambda r:r['binding'].update(harness_commit='e'*40), lambda r:r.update(extra=True),
+                       lambda r:r['live'].update(producer_run_attempt=1), lambda r:r['live'].update(producer_commit='e'*40),
+                       lambda r:r['live']['subjects'][0].update(command='evil')]:
+            record = self.fixture(); change(record)
+            with self.assertRaises(ValueError): self.receive(record)
+        for change in [lambda a:a.update(id=72), lambda a:a.update(expired=True),
+                       lambda a:a.update(digest='sha256:'+'0'*64), lambda a:a['workflow_run'].update(id=98),
+                       lambda a:a['workflow_run'].update(head_sha='e'*40), lambda a:a.update(name='draft-other')]:
+            with self.assertRaises(ValueError): self.receive(self.fixture(), artifact_change=change)
+        for changes in [{'SNAPSHOT_SHA256':'0'*64}, {'SNAPSHOT_ARTIFACT_DIGEST':'0'*64}]:
+            with self.assertRaises(ValueError): self.receive(self.fixture(), env_change=changes)
+        for raw in [b'{"kind":"snapshot","kind":"snapshot"}', b' '*(draft.RECEIPT_LIMIT+1)]:
+            with self.assertRaises(ValueError): self.receive(self.fixture(), raw=raw)
+        with self.assertRaises(ValueError): self.receive(self.fixture(), extra=True)
+
+    def test_exact_lane_sets(self):
+        record = dict(kind='lanes-verified', binding=self.fixture()['binding'], snapshot_sha256='c'*64,
+                      tarball_sha256='b'*64, lanes=[dict(client=c, target='linux-amd64', evidence_sha256='b'*64)
+                                                  for c in ('codex','claude','opencode')])
+        self.assertEqual(self.receive(record), record)
+        for change in [lambda r:r['lanes'].pop(), lambda r:r['lanes'].append(r['lanes'][0]),
+                       lambda r:r['lanes'][0].update(target='linux-arm64'), lambda r:r['lanes'][0].update(client='claude'),
+                       lambda r:r.update(snapshot_sha256='d'*64), lambda r:r['lanes'][0].update(path='evil')]:
+            modified = copy.deepcopy(record); change(modified)
+            with self.assertRaises(ValueError): self.receive(modified)
+
+    def test_canonical_main_guard_and_immutable_checkout(self):
+        env = dict(GITHUB_REPOSITORY=draft.REPOSITORY, GITHUB_EVENT_NAME='workflow_dispatch', GITHUB_REF='refs/heads/main',
+                   GITHUB_WORKFLOW_REF=f'{draft.REPOSITORY}/{draft.NATIVE_WORKFLOW}@refs/heads/main',
+                   GITHUB_SHA='d'*40, GITHUB_RUN_ID='99', GITHUB_RUN_ATTEMPT='2')
+        for change in [{}, {'GITHUB_REF':'refs/tags/v1'}, {'GITHUB_REPOSITORY':'fork/repo'},
+                       {'GITHUB_WORKFLOW_REF':'other'}, {'GITHUB_EVENT_NAME':'pull_request'}, {'GITHUB_SHA':'e'*40}]:
+            with patch.dict(os.environ, {**env, **change}, clear=True), \
+                 patch.object(draft, 'output', side_effect=[b'd'*40, b'', b'e'*40]), patch.object(draft, 'helper_hashes', return_value={}):
+                if change:
+                    with self.assertRaises(ValueError): draft.trusted_binding(Path('/harness'), args(target_scope='linux-amd64'))
+                else:
+                    self.assertEqual(draft.trusted_binding(Path('/harness'), args(target_scope='linux-amd64'))['run_attempt'], 2)
+
+    def test_final_recheck_never_qualifies_replacement_or_failed_authentication(self):
+        initial = self.fixture()
+        initial['binding'].update(harness_tree='e'*40, helper_sha256={})
+        mutations = [None, 'auth', 'hidden', 'deleted', 'published', 'recreated', 'tag', 'id', 'size', 'digest', 'created_at', 'updated_at', 'subject']
+        for mutation in mutations:
+            final = copy.deepcopy(initial['live']); final['verified_at'] = '2026-09-09T02:00:00+00:00'
+            if mutation == 'published': final['release']['draft'] = False
+            elif mutation == 'recreated': final['release']['id'] = 35
+            elif mutation == 'tag': final['release']['commit'] = 'e'*40
+            elif mutation == 'subject': final['subjects'][0]['sha256'] = 'e'*64
+            elif mutation in ('id','size','digest','created_at','updated_at'): final['release']['assets'][0][mutation] = 'changed'
+            with tempfile.TemporaryDirectory() as temp, patch.dict(os.environ, SNAPSHOT_SHA256='c'*64, LANES_SHA256='b'*64,
+                    SNAPSHOT_ARTIFACT_ID='71', SNAPSHOT_ARTIFACT_DIGEST='b'*64, LANES_ARTIFACT_ID='72', LANES_ARTIFACT_DIGEST='b'*64), \
+                 patch.object(draft, 'trusted_binding', return_value=initial['binding']), \
+                 patch.object(draft, 'authenticate', side_effect=ValueError('producer failed') if mutation == 'auth' else None, return_value={}), \
+                 patch.object(draft, 'output', return_value=b'f'*40), \
+                 patch.object(draft, 'receive', side_effect=[initial, dict(tarball_sha256='b'*64, lanes=[])]), \
+                 patch.object(draft, 'live_verify', side_effect=ValueError('unavailable') if mutation in ('hidden','deleted') else None, return_value=final):
+                destination = Path(temp)/'qualification.json'
+                arguments = args(metadata='recheck', receipt=destination, target_scope='linux-amd64')
+                if mutation:
+                    with self.assertRaises(ValueError): draft.metadata(Path('/harness'), arguments)
+                    self.assertFalse(destination.exists())
+                    self.assertFalse(destination.with_name('final-draft.json').exists())
+                else:
+                    draft.metadata(Path('/harness'), arguments)
+                    self.assertEqual(json.loads(destination.read_bytes())['schema_version'], 2)
+
+    def test_workflow_write_and_preparation_boundaries(self):
+        import re
+        source = Path(__file__).resolve().parents[1]
+        workflow = (source/draft.NATIVE_WORKFLOW).read_text()
+        jobs = dict(re.findall(r'^  ([\w-]+):\n(.*?)(?=^  [\w-]+:|\Z)', workflow.split('jobs:\n')[1], re.M|re.S))
+        self.assertEqual({name for name, body in jobs.items() if 'contents: write' in body}, {'draft-snapshot','draft-recheck'})
+        self.assertNotIn('write', workflow.split('jobs:\n')[0])
+        for name in ('draft-snapshot','draft-recheck'):
+            body = jobs[name]
+            for guard in ("github.ref == 'refs/heads/main'", "github.repository == '777genius/universal-agent-plugins'", "github.workflow_ref =="):
+                self.assertIn(guard, body)
+            self.assertIn('runs-on: ubuntu-24.04', body)
+            self.assertIn('ref: ${{ github.sha }}', body)
+            self.assertEqual(body.count('persist-credentials: false'), 2)
+            self.assertEqual(body.count('GH_TOKEN:'), 1)
+            for forbidden in ('run-native-client-matrix', 'download-artifact', 'setup-go', 'npm install', 'native-lanes', 'always()'):
+                self.assertNotIn(forbidden, body)
+        runtime = jobs['native-client'].split('- name: Execute pinned')[1].split('- name: Upload')[0]
+        self.assertNotIn('GH_TOKEN', runtime)
+        self.assertIn('--prepared-input', runtime)
+        self.assertIn('steps.prepare.outputs.prepared-sha256', runtime)
+        self.assertIn('--prepare-only', jobs['native-client'])
+        self.assertIn('--metadata recheck', jobs['draft-recheck'])
+        self.assertIn("needs.draft-complete.result == 'success'", jobs['draft-recheck'])
+
+    def test_explicit_policy_source_never_executes_producer_script(self):
+        verifier = draft.load_script('verify-agentplugins-draft')
+        with tempfile.TemporaryDirectory() as temp:
+            arguments = SimpleNamespace(repository=draft.REPOSITORY, tag='agentplugins-v1.2.3', commit='a'*40,
+                asset_set_digest='c'*64, release_id=34, run_id=12, run_attempt=2,
+                source=temp+'/producer', policy_source=temp+'/harness', receipt=temp+'/receipt.json')
+            calls = []
+            def command(argv, **unused):
+                calls.append(argv)
+                if argv[0] == 'git': return b'a'*40 if argv[-1] == 'HEAD' else b''
+                self.assertEqual(argv[:2], ['node', temp+'/harness/npm/agentplugins/scripts/release-assets.js'])
+                raise ValueError('stop before mocked asset validation')
+            with patch.object(verifier, 'snapshot', return_value={'assets':[]}), patch.object(verifier, 'run', side_effect=command):
+                with self.assertRaisesRegex(ValueError, 'stop before'): verifier.verify(arguments)
+            self.assertEqual(len(calls), 3)
+            self.assertFalse(Path(arguments.receipt).exists())
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_native_client_linux.py
+++ b/scripts/test_native_client_linux.py
@@ -73,5 +73,48 @@ class LinuxHostedSafetyTests(unittest.TestCase):
                     matrix.require_hosted("linux-arm64")
 
 
+
+class PreparedInputTests(unittest.TestCase):
+    def test_preparation_returns_before_client_provisioning(self):
+        import sys
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as temp, patch.object(matrix, 'require_hosted'), \
+             patch.object(matrix, 'prepared_release') as prepare, patch.object(matrix, 'provision') as provision, \
+             patch.object(matrix.subprocess, 'run', side_effect=AssertionError('execution during preparation')), \
+             patch.object(sys, 'argv', ['runner', '--client', 'codex', '--target', 'linux-amd64', '--output', temp,
+                  '--release-tag', 'agentplugins-v1.2.3', '--release-commit', 'a'*40, '--prepare-only', '--prepared-input', temp]):
+            matrix.main()
+            prepare.assert_called_once()
+            provision.assert_not_called()
+
+    def test_prepared_runtime_rehashes_and_never_falls_back(self):
+        import json
+        import os
+        from tempfile import TemporaryDirectory
+        from types import SimpleNamespace
+        for mutation in ('none','missing','tamper','manifest','credential','extra'):
+            with self.subTest(mutation=mutation), TemporaryDirectory() as temp, patch.dict(os.environ, {}, clear=True):
+                root = Path(temp)/'prepared'
+                args = SimpleNamespace(prepared_input=root, prepare_only=True, release_state='public', target='linux-amd64',
+                                       release_tag='agentplugins-v1.2.3', release_commit='a'*40, release_repo=matrix.draft.REPOSITORY)
+                def acquire(*unused):
+                    binary = root/'installer'; binary.write_bytes(b'original')
+                    return binary, {'version':'1.2.3'}
+                with patch.object(matrix, 'provision_release', side_effect=acquire):
+                    matrix.prepared_release(Path(temp), args)
+                args.prepare_only = False
+                os.environ['PREPARED_SHA256'] = matrix.draft.digest(root/'prepared.json')
+                if mutation == 'missing': (root/'installer').unlink()
+                elif mutation == 'tamper': (root/'installer').write_bytes(b'changed')
+                elif mutation == 'manifest': (root/'prepared.json').write_text('{}')
+                elif mutation == 'credential': os.environ['GH_TOKEN'] = 'test-sentinel'
+                elif mutation == 'extra': (root/'extra').write_bytes(b'new')
+                with patch.object(matrix, 'provision_release', side_effect=AssertionError('network fallback')):
+                    if mutation == 'none':
+                        self.assertEqual(matrix.prepared_release(Path(temp), args)[0].read_bytes(), b'original')
+                    else:
+                        with self.assertRaises(ValueError): matrix.prepared_release(Path(temp), args)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_native_client_linux.py
+++ b/scripts/test_native_client_linux.py
@@ -1,6 +1,11 @@
 """Linux hosted-runner safety tests; no client execution or network access."""
+from contextlib import ExitStack
 import importlib.util
+import json
 from pathlib import Path
+import sys
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
 import unittest
 from unittest.mock import patch
 
@@ -75,7 +80,49 @@ class LinuxHostedSafetyTests(unittest.TestCase):
 
 
 class PreparedInputTests(unittest.TestCase):
-    def test_preparation_returns_before_client_provisioning(self):
+    @staticmethod
+    def fake_provision(pin, directory, name):
+        path = directory / name
+        path.write_bytes(('frozen-' + name).encode())
+        path.chmod(0o600)
+        return path, dict(source='fixture', version=pin[2], archive=pin[3],
+                          archive_integrity=pin[4], binary_sha256=matrix.draft.digest(path))
+
+    def prepare_fixture(self, temp, state='public', client='codex'):
+        root = Path(temp) / 'prepared'
+        args = SimpleNamespace(prepared_input=root, prepare_only=True, release_state=state,
+                               client=client, target='linux-amd64',
+                               release_tag='agentplugins-v1.2.3', release_commit='a'*40,
+                               release_repo=matrix.draft.REPOSITORY)
+
+        def public(*unused):
+            path = root / 'installer'
+            path.write_bytes(b'installer')
+            return path, {'version': '1.2.3'}
+
+        def draft(*unused):
+            tarball = root / 'package.tgz'
+            tarball.write_bytes(b'package')
+            assets = root / 'assets'
+            assets.mkdir()
+            (assets / 'installer').write_bytes(b'installer')
+            (root / 'initial-draft.json').write_text('{}')
+            return tarball, assets, {'version': '1.2.3'}, {'version': '1.2.3'}
+
+        with patch.object(matrix, 'provision', side_effect=self.fake_provision) as tools, \
+             patch.object(matrix, 'provision_release', side_effect=public) as release, \
+             patch.object(matrix.draft, 'acquire', side_effect=draft) as acquire:
+            matrix.prepared_release(Path(temp), args)
+            self.assertEqual([call.args for call in tools.call_args_list],
+                             [(matrix.PINS[args.target][name], root / 'prepared-tools', name)
+                              for name in (client, 'lintai', 'rg')])
+            self.assertEqual(release.call_count, int(state == 'public'))
+            self.assertEqual(acquire.call_count, int(state == 'draft'))
+        args.prepare_only = False
+        matrix.os.environ['PREPARED_SHA256'] = matrix.draft.digest(root / 'prepared.json')
+        return args
+
+    def test_preparation_returns_before_runtime_setup(self):
         import sys
         from tempfile import TemporaryDirectory
         with TemporaryDirectory() as temp, patch.object(matrix, 'require_hosted'), \
@@ -96,11 +143,12 @@ class PreparedInputTests(unittest.TestCase):
             with self.subTest(mutation=mutation), TemporaryDirectory() as temp, patch.dict(os.environ, {}, clear=True):
                 root = Path(temp)/'prepared'
                 args = SimpleNamespace(prepared_input=root, prepare_only=True, release_state='public', target='linux-amd64',
-                                       release_tag='agentplugins-v1.2.3', release_commit='a'*40, release_repo=matrix.draft.REPOSITORY)
+                                       client='codex', release_tag='agentplugins-v1.2.3', release_commit='a'*40, release_repo=matrix.draft.REPOSITORY)
                 def acquire(*unused):
                     binary = root/'installer'; binary.write_bytes(b'original')
                     return binary, {'version':'1.2.3'}
-                with patch.object(matrix, 'provision_release', side_effect=acquire):
+                with patch.object(matrix, 'provision_release', side_effect=acquire), \
+                     patch.object(matrix, 'provision', side_effect=self.fake_provision):
                     matrix.prepared_release(Path(temp), args)
                 args.prepare_only = False
                 os.environ['PREPARED_SHA256'] = matrix.draft.digest(root/'prepared.json')
@@ -114,6 +162,127 @@ class PreparedInputTests(unittest.TestCase):
                         self.assertEqual(matrix.prepared_release(Path(temp), args)[0].read_bytes(), b'original')
                     else:
                         with self.assertRaises(ValueError): matrix.prepared_release(Path(temp), args)
+
+    def forbid_acquisition(self, stack):
+        for owner, name in ((matrix, 'provision'), (matrix, 'provision_release'),
+                            (matrix.draft, 'acquire'), (matrix.urllib.request, 'urlopen')):
+            stack.enter_context(patch.object(owner, name, side_effect=AssertionError('acquisition during consumption')))
+
+    def test_prepared_public_and_draft_tools_round_trip(self):
+        for state in ('public', 'draft'):
+            for client in matrix.PATTERNS:
+                with self.subTest(state=state, client=client), TemporaryDirectory() as temp, \
+                     patch.dict(matrix.os.environ, {}, clear=True), ExitStack() as stack:
+                    args = self.prepare_fixture(temp, state, client)
+                    self.forbid_acquisition(stack)
+                    release = matrix.prepared_release(Path(temp), args)
+                    self.assertEqual(len(release), 4 if state == 'draft' else 2)
+                    self.assertEqual(release[0].read_bytes(), b'package' if state == 'draft' else b'installer')
+                    self.assertEqual(release[-1], {'version': '1.2.3'})
+                    if state == 'draft':
+                        self.assertEqual((release[1] / 'installer').read_bytes(), b'installer')
+                        self.assertEqual(release[2], {'version': '1.2.3'})
+                    runtime = Path(temp) / 'bin'
+                    runtime.mkdir()
+                    tools = matrix.prepared_tools(args, runtime)
+                    self.assertEqual(set(tools), {client, 'lintai', 'rg'})
+                    for name, (path, evidence) in tools.items():
+                        self.assertEqual(path.parent, runtime)
+                        self.assertEqual(path.read_bytes(), ('frozen-' + name).encode())
+                        self.assertEqual(evidence['binary_sha256'], matrix.draft.digest(path))
+                        self.assertEqual(evidence['archive_integrity'], matrix.PINS[args.target][name][4])
+                        if matrix.os.name != 'nt':
+                            self.assertEqual(path.stat().st_mode & 0o777, 0o700)
+
+    def test_prepared_tools_reject_mixed_or_damaged_inputs(self):
+        mutations = ('client', 'target', 'pin', 'metadata', 'missing-tools',
+                     'missing-client', 'missing-lintai', 'missing-rg',
+                     'tamper-client', 'tamper-lintai', 'tamper-rg')
+        for state in ('public', 'draft'):
+            for mutation in mutations:
+                with self.subTest(state=state, mutation=mutation), TemporaryDirectory() as temp, \
+                     patch.dict(matrix.os.environ, {}, clear=True), ExitStack() as stack:
+                    args = self.prepare_fixture(temp, state)
+                    root = args.prepared_input
+                    manifest = root / 'prepared.json'
+                    record = json.loads(manifest.read_bytes())
+                    if mutation == 'client':
+                        args.client = 'claude'
+                    elif mutation == 'target':
+                        args.target = 'linux-arm64'
+                    elif mutation == 'pin':
+                        pin = list(matrix.PINS[args.target]['rg'])
+                        pin[4] = 'sha256:' + '0'*64
+                        stack.enter_context(patch.dict(matrix.PINS[args.target], rg=tuple(pin)))
+                    elif mutation == 'metadata':
+                        record['tools']['rg']['evidence']['version'] = 'changed'
+                        manifest.write_text(json.dumps(record))
+                    elif mutation == 'missing-tools':
+                        del record['tools']
+                        manifest.write_text(json.dumps(record))
+                        matrix.os.environ['PREPARED_SHA256'] = matrix.draft.digest(manifest)
+                    else:
+                        action, name = mutation.split('-', 1)
+                        name = args.client if name == 'client' else name
+                        path = root / record['tools'][name]['path']
+                        if action == 'missing':
+                            path.unlink()
+                        else:
+                            path.write_bytes(b'changed')
+                    runtime = Path(temp) / 'bin'
+                    runtime.mkdir()
+                    self.forbid_acquisition(stack)
+                    with self.assertRaises(ValueError):
+                        matrix.prepared_release(Path(temp), args)
+                    with self.assertRaises(ValueError):
+                        matrix.prepared_tools(args, runtime)
+                    self.assertEqual(list(runtime.iterdir()), [])
+
+    def test_standalone_tools_keep_acquisition(self):
+        with TemporaryDirectory() as temp, patch.object(matrix, 'provision', side_effect=self.fake_provision) as acquire:
+            args = SimpleNamespace(prepared_input=None, client='claude', target='linux-amd64')
+            tools = matrix.prepared_tools(args, Path(temp))
+            self.assertEqual(set(tools), {'claude', 'lintai', 'rg'})
+            self.assertEqual(acquire.call_count, 3)
+
+    def test_prepared_main_reaches_build_with_local_tools(self):
+        class BuildReached(Exception):
+            pass
+
+        for state in ('public', 'draft'):
+            with self.subTest(state=state), TemporaryDirectory() as temp, \
+                 patch.dict(matrix.os.environ, {}, clear=True), ExitStack() as stack:
+                args = self.prepare_fixture(temp, state)
+                matrix.os.environ.update(RUNNER_TEMP=temp, EXPECTED_COMMIT='a'*40)
+                argv = ['runner', '--client', args.client, '--target', args.target,
+                        '--output', str(Path(temp) / 'output'), '--release-state', state,
+                        '--release-tag', args.release_tag, '--release-commit', args.release_commit,
+                        '--prepared-input', str(args.prepared_input)]
+                if state == 'draft':
+                    argv += ['--producer-source', temp]
+                    for field in matrix.draft.FIELDS:
+                        argv += ['--' + field.replace('_', '-'), 'a'*64 if 'digest' in field else '1']
+                self.forbid_acquisition(stack)
+                stack.enter_context(patch.object(sys, 'argv', argv))
+                stack.enter_context(patch.object(matrix, 'require_hosted'))
+                stack.enter_context(patch.object(matrix.draft, 'helper_hashes', return_value={}))
+                stack.enter_context(patch.object(matrix.shutil, 'which', return_value=sys.executable))
+                stack.enter_context(patch.object(matrix.subprocess, 'check_output',
+                                                side_effect=['a'*40, 'b'*40, b'']))
+                stack.enter_context(patch.object(matrix, 'profile_environment', return_value={}))
+                stack.enter_context(patch.object(matrix.os, 'name', 'posix'))
+
+                def build(command, **kwargs):
+                    self.assertEqual(command[:2], ['go', 'build'])
+                    binary_dir = Path(command[command.index('-o') + 1]).parent
+                    for name in (args.client, 'lintai', 'rg'):
+                        self.assertEqual((binary_dir / name).read_bytes(), ('frozen-' + name).encode())
+                    raise BuildReached()
+
+                run = stack.enter_context(patch.object(matrix.subprocess, 'run', side_effect=build))
+                with self.assertRaises(BuildReached):
+                    matrix.main()
+                run.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/scripts/test_released_native_evidence.py
+++ b/scripts/test_released_native_evidence.py
@@ -359,13 +359,42 @@ class DraftArchiveTests(unittest.TestCase):
         destination.unlink()
         args = SimpleNamespace(**vars(self.args), target_scope=self.args.scope, evidence=self.root,
                                receipt=destination, producer_source=source)
-        def final_receipt(*unused):
-            return self.q['final_draft']
-        with patch.object(self.native, 'authenticate'), patch.object(self.native, 'live_verify', side_effect=final_receipt), \
-             patch.object(self.native, 'output', side_effect=[b'a'*40, b'']), \
+        import os
+        initial = self.q['final_draft']
+        binding = dict(repository=self.native.REPOSITORY, workflow=self.native.NATIVE_WORKFLOW,
+                       harness_commit=self.args.harness_commit, harness_tree=self.args.harness_tree, run_id=99, run_attempt=2,
+                       target_scope=self.args.scope, release_tag=self.args.release_tag, release_commit=self.args.release_commit,
+                       helper_sha256=self.native.helper_hashes(source), **{k:str(getattr(args,k)) for k in self.native.FIELDS})
+        record = json.loads(next(self.root.rglob('runner-evidence.json')).read_bytes())
+        snapshot = dict(kind='snapshot', binding=binding, producer_tree=record['installer_release']['tree'], live=initial)
+        sha = proof.digest((json.dumps(snapshot, sort_keys=True)+'\n').encode())
+        with patch.dict(os.environ, SNAPSHOT_SHA256=sha, LANES_SHA256='b'*64, SNAPSHOT_ARTIFACT_ID='71',
+                        SNAPSHOT_ARTIFACT_DIGEST='b'*64, LANES_ARTIFACT_ID='72', LANES_ARTIFACT_DIGEST='b'*64), \
+             patch.object(self.native, 'receive', return_value=snapshot), \
              patch('subprocess.Popen', side_effect=AssertionError('unexpected process')):
             self.native.aggregate(source, args)
+            lanes = json.loads(destination.read_bytes())
+            os.environ['LANES_SHA256'] = self.native.digest(destination)
+            destination.unlink()
+            destination.with_name('final-draft.json').unlink()
+            import copy
+            final = copy.deepcopy(initial)
+            final['verified_at'] = '2099-01-01T00:00:00+00:00'
+            args.metadata = 'recheck'
+            with patch.object(self.native, 'receive', side_effect=[snapshot, lanes]), \
+                 patch.object(self.native, 'trusted_binding', return_value=binding), \
+                 patch.object(self.native, 'authenticate', return_value=self.q['producer']), \
+                 patch.object(self.native, 'live_verify', return_value=final), \
+                 patch.object(self.native, 'output', return_value=snapshot['producer_tree'].encode()):
+                self.native.metadata(source, args)
             summary, _ = proof.verify_draft(self.root, self.args)
+            current = json.loads(destination.read_bytes())
+            for change in (lambda q:q['invocation']['binding'].update(run_attempt=3),
+                           lambda q:q['invocation'].update(lanes_sha256='0'*64), lambda q:q.pop('invocation')):
+                modified = copy.deepcopy(current); change(modified)
+                destination.write_text(json.dumps(modified))
+                with self.assertRaises(ValueError): proof.verify_draft(self.root, self.args)
+            destination.write_text(json.dumps(current))
         self.assertEqual(len(summary['jobs']), 9)
 
     def test_draft_qualification_schema_identities_and_lanes(self):

--- a/scripts/verify-agentplugins-draft.py
+++ b/scripts/verify-agentplugins-draft.py
@@ -88,6 +88,12 @@ def verify(args):
     receipt = Path(args.receipt)
     require(not receipt.exists(), "receipt path already exists")
     source = Path(args.source).resolve()
+    policy = Path(getattr(args, 'policy_source', None) or source).resolve()
+    if getattr(args, 'policy_source', None):
+        require(run(['git', '-C', str(source), 'rev-parse', 'HEAD']).decode().strip() == args.commit,
+                'wrong producer checkout')
+        require(not run(['git', '-C', str(source), 'status', '--porcelain', '--untracked-files=normal']),
+                'dirty producer checkout')
     before = snapshot(args.repository, args.tag, args.commit, args.release_id)
     with tempfile.TemporaryDirectory(prefix="agentplugins-draft-") as directory:
         root = Path(directory)
@@ -97,7 +103,7 @@ def verify(args):
             require(len(data) == asset["size"], "download size mismatch")
             (root / asset["name"]).write_bytes(data)
         verified = json.loads(run([
-            "node", str(source / "npm/agentplugins/scripts/release-assets.js"),
+            "node", str(policy / "npm/agentplugins/scripts/release-assets.js"),
             "verify", str(root), args.tag, args.commit]))
         require(verified["gate_eligible"] is True
                 and verified["repository"] == ASSET_PRODUCER_REPOSITORY,
@@ -137,6 +143,7 @@ def main():
         parser.add_argument(f"--{name}", required=True)
     for name in ("release-id", "run-id", "run-attempt"):
         parser.add_argument(f"--{name}", required=True, type=int)
+    parser.add_argument("--policy-source", help="trusted verifier checkout; source remains producer data")
     verify(parser.parse_args())
 
 

--- a/scripts/verify-released-native-evidence.py
+++ b/scripts/verify-released-native-evidence.py
@@ -420,8 +420,8 @@ def verify_draft(root, args):
                  (('qualification.json', QUALIFICATION_JSON_LIMIT), ('final-draft.json', FINAL_DRAFT_JSON_LIMIT))}
     require(not args.qualification.is_symlink() and {p.name for p in args.qualification.iterdir()} == set(originals), 'unexpected qualification files')
     q = read_json(originals['qualification.json'])
-    object_keys(q, 'schema_version status release_state target_scope producer_commit harness_commit harness_tree tarball_sha256 producer helper_sha256 lanes final_draft limitation', 'qualification')
-    require(type(q['schema_version']) is int and q['schema_version'] == 1 and q['status'] == 'passed'
+    object_keys(q, 'schema_version status release_state target_scope producer_commit harness_commit harness_tree tarball_sha256 producer helper_sha256 lanes final_draft limitation' + (' invocation' if q.get('schema_version') == 2 else ''), 'qualification')
+    require(type(q['schema_version']) is int and q['schema_version'] in (1, 2) and q['status'] == 'passed'
             and q['release_state'] == 'verified-draft' and q['target_scope'] == args.scope
             and q['producer_commit'] == args.release_commit and q['harness_commit'] == args.harness_commit
             and q['harness_tree'] == args.harness_tree, 'qualification identity mismatch')
@@ -434,6 +434,26 @@ def verify_draft(root, args):
         'scripts/run-native-client-matrix.py', 'scripts/native_client_draft.py',
         'scripts/verify-agentplugins-draft.py', 'scripts/verify-released-native-evidence.py',
         'npm/agentplugins/scripts/release-assets.js'} and all(exact_hex(v, 64) for v in helpers.values()), 'unsupported helper inventory')
+    if 'invocation' in q:
+        invocation = q['invocation']
+        object_keys(invocation, 'binding snapshot_sha256 lanes_sha256 transport', 'invocation')
+        binding = invocation['binding']
+        object_keys(binding, 'repository workflow harness_commit harness_tree run_id run_attempt target_scope release_tag release_commit producer_run_id producer_run_attempt expected_asset_set_digest producer_artifact_id producer_artifact_digest release_id helper_sha256', 'invocation binding')
+        require(binding['repository'] == REPOSITORY and binding['workflow'] == native.NATIVE_WORKFLOW
+                and binding['harness_commit'] == args.harness_commit and binding['harness_tree'] == args.harness_tree
+                and binding['target_scope'] == args.scope and binding['release_tag'] == args.release_tag
+                and binding['release_commit'] == args.release_commit and binding['helper_sha256'] == helpers
+                and all(binding[k] == str(getattr(args, k)) for k in native.FIELDS)
+                and all(type(binding[k]) is int and binding[k] > 0 for k in ('run_id', 'run_attempt')),
+                'mixed final invocation')
+        require(all(exact_hex(invocation[k], 64) for k in ('snapshot_sha256', 'lanes_sha256')), 'invalid invocation digest')
+        transport = invocation['transport']
+        object_keys(transport, 'SNAPSHOT_ARTIFACT_ID SNAPSHOT_ARTIFACT_DIGEST LANES_ARTIFACT_ID LANES_ARTIFACT_DIGEST', 'transport')
+        require(all(isinstance(transport[k], str) and re.fullmatch(r'[1-9]\d*', transport[k]) for k in
+                    ('SNAPSHOT_ARTIFACT_ID', 'LANES_ARTIFACT_ID'))
+                and transport['SNAPSHOT_ARTIFACT_ID'] != transport['LANES_ARTIFACT_ID']
+                and all(exact_hex(transport[k], 64) for k in ('SNAPSHOT_ARTIFACT_DIGEST', 'LANES_ARTIFACT_DIGEST')),
+                'invalid invocation transport')
     bundle = original_file(args.producer_bundle, ZIP_CONTAINER_LIMIT)
     assets, verified, tarball, launcher = draft_bundle(bundle, args, native)
     require(q['tarball_sha256'] == tarball, 'qualification tarball mismatch')
@@ -502,6 +522,14 @@ def verify_draft(root, args):
                 and release.get('tarball_sha256') == tarball
                 and all(type(release['producer'][k]) is int for k in ('run_id', 'run_attempt', 'artifact_id')), 'draft lane producer/package mismatch')
         initial = release['initial_draft']
+        if q['schema_version'] == 2:
+            def receipt_digest(value):
+                return digest((json.dumps(value, sort_keys=True) + '\n').encode())
+            require(receipt_digest(dict(kind='snapshot', binding=binding, producer_tree=release['tree'], live=initial))
+                    == invocation['snapshot_sha256'], 'lane differs from invocation snapshot')
+            require(receipt_digest(dict(kind='lanes-verified', binding=binding, snapshot_sha256=invocation['snapshot_sha256'],
+                                        tarball_sha256=tarball, lanes=q['lanes'])) == invocation['lanes_sha256'],
+                    'qualification differs from lanes receipt')
         receipt(initial)
         from datetime import datetime
         require(datetime.fromisoformat(initial['verified_at']) <= datetime.fromisoformat(final['verified_at']), 'final receipt predates initial verification')


### PR DESCRIPTION
Draft qualification previously could not read unpublished release metadata with a read-only token. This separates trusted metadata verification into dedicated jobs while keeping native client jobs read-only. The runtime uses the frozen producer npm package and preverified client/tool bytes, with no acquisition authentication passed directly to runtime subprocesses.

Snapshot and completion receipts bind the producer, harness, current run and exact artifact identities. Final qualification rechecks the unchanged unpublished draft after every required client lane passes. Public historical reproduction remains supported. The runbook distinguishes fresh profiles from OS/process isolation and documents the trusted-client boundary.

Validation: 106 focused Python tests passed on the integrated code. Independent review found and corrected a remaining authenticated tool download in the execution phase. Independent final production source review and the follow-up documentation review are complete with no remaining blockers. Review used exact source packets because the hosted runtime did not expose filesystem tools; tests were run separately by orchestration on the server. CI is pending. Genuine packaged-client qualification will follow this harness delivery; this PR does not claim it has passed. No release publication is enabled.
