### PR TITLE
fix(testing): enforce portable native preflight and archive paths

### DIFF
--- a/.github/workflows/agentplugins-native-clients.yml
+++ b/.github/workflows/agentplugins-native-clients.yml
@@ -9,8 +9,15 @@ on:
       - 'repotests/testdata/agentplugins_native_probe/**'
       - 'install/integrationctl/agentplugins/**'
       - 'scripts/run-native-client-matrix.py'
-      - 'scripts/test_native_client_matrix.py'
+      - 'scripts/native_client*.py'
+      - 'scripts/test_native_client*.py'
+      - 'scripts/verify-agentplugins-draft.py'
+      - 'scripts/test_agentplugins_draft.py'
+      - 'scripts/verify-released-native-evidence.py'
+      - 'scripts/test_released_native_evidence.py'
+      - 'npm/agentplugins/**'
       - '.github/workflows/agentplugins-native-clients.yml'
+      - '.github/workflows/agentplugins-released-native-clients.yml'
   workflow_dispatch:
 
 permissions:
@@ -49,7 +56,10 @@ jobs:
           go-version: '1.25.13'
           cache: false
       - name: Verify native matrix safety and evidence gates
-        run: python scripts/test_native_client_matrix.py
+        shell: bash
+        run: |
+          python -m unittest discover -s scripts -p 'test_native_client*.py'
+          python -m unittest discover -s scripts -p 'test_released_native_evidence.py'
       - name: Build exact source and execute pinned native client in disposable fixture
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/agentplugins-released-native-clients.yml
+++ b/.github/workflows/agentplugins-released-native-clients.yml
@@ -140,6 +140,7 @@ jobs:
           node-version: '22'
           package-manager-cache: false
       - name: Verify native matrix safety and evidence gates
+        shell: bash
         run: |
           python -m unittest discover -s scripts -p 'test_native_client*.py'
           python -m unittest discover -s scripts -p 'test_released_native_evidence.py'

--- a/docs/released-native-client-proof.md
+++ b/docs/released-native-client-proof.md
@@ -116,10 +116,21 @@ gh api repos/777genius/universal-agent-plugins/git/commits/<resolved-harness-SHA
 ```
 
 Record these identities for both the nine-lane and three-lane dispatches and
-require their receipts to match the captured commit/tree. Refuse a combined
-nine-plus-three qualification with mixed harness versions: if `main` advances
-between dispatches and their resolved SHAs differ, repeat the affected scope
-on `main` until both scopes have the same captured harness commit/tree.
+require each scope's receipts to match its recorded harness SHA/tree and helper
+hashes. Two independently qualified scopes may use distinct recorded harness
+identities. Each scope must have passed its own exact required lanes,
+`draft-complete` aggregation and final `draft-recheck`. Both scopes must bind
+the same frozen producer invocation (commit/tree and run/attempt), release
+identity and asset set, original producer bundle bytes and package bytes.
+Archive and verify each scope separately using its recorded identities.
+Do not substitute lanes across scopes, mix lanes from different dispatches or
+harness identities within one scope, or rewrite receipts. A partial or failed
+historical-nine run, including its successful Linux arm64 lanes, cannot replace
+any lane of a new historical-nine qualification.
+Combined coverage must record both scopes' harness identities and their
+qualification times, including each final draft recheck time. A retained,
+fully qualified scope may be reused without a current recheck; its original
+qualification remains tied to its recorded time and harness identity.
 Use the watch and download commands above for each run, with separate fresh
 output directories.
 

--- a/scripts/native_client_draft.py
+++ b/scripts/native_client_draft.py
@@ -107,6 +107,8 @@ def unpack_bundle(body, root):
         names = set()
         for member in archive.infolist():
             name = member.filename
+            require(member.orig_filename == name and '\0' not in name,
+                    'aliased artifact path')
             parts = PurePosixPath(name).parts
             require(name and '\\' not in name and not name.startswith('/')
                     and all(p not in ('..', '.') and ':' not in p for p in parts)
@@ -433,6 +435,7 @@ def receive(source, args, kind):
     with zipfile.ZipFile(io.BytesIO(body)) as archive:
         members = archive.infolist()
         require(len(members) == 1 and members[0].filename == 'receipt.json'
+                and members[0].orig_filename == members[0].filename
                 and members[0].file_size <= RECEIPT_LIMIT
                 and (members[0].external_attr >> 16) & 0o170000 in (0, 0o100000), 'unexpected receipt archive')
         raw = archive.read(members[0])

--- a/scripts/test_native_client_draft.py
+++ b/scripts/test_native_client_draft.py
@@ -520,12 +520,14 @@ class ReceiptBoundaryTests(unittest.TestCase):
         return dict(kind='snapshot', binding={'run_id': 99, 'run_attempt': 2, 'harness_commit': 'd'*40},
                     producer_tree='f'*40, live=live)
 
-    def receive(self, record, *, raw=None, artifact_change=None, env_change=None, extra=False):
+    def receive(self, record, *, raw=None, artifact_change=None, env_change=None, extra=False, member_name='receipt.json'):
         binding = self.fixture()['binding']
         raw = raw if raw is not None else json.dumps(record).encode()
         stream = io.BytesIO()
         with zipfile.ZipFile(stream, 'w', zipfile.ZIP_DEFLATED) as z:
-            z.writestr('receipt.json', raw)
+            member = zipfile.ZipInfo('fixture')
+            member.filename = member_name
+            z.writestr(member, raw)
             if extra: z.writestr('payload.sh', 'false')
         body = stream.getvalue()
         sha = hashlib.sha256(body).hexdigest()
@@ -559,6 +561,12 @@ class ReceiptBoundaryTests(unittest.TestCase):
         for raw in [b'{"kind":"snapshot","kind":"snapshot"}', b' '*(draft.RECEIPT_LIMIT+1)]:
             with self.assertRaises(ValueError): self.receive(self.fixture(), raw=raw)
         with self.assertRaises(ValueError): self.receive(self.fixture(), extra=True)
+
+    def test_raw_receipt_name_rejected_before_read(self):
+        with patch.object(zipfile.ZipFile, 'read', side_effect=AssertionError('receipt read before archive validation')) as read:
+            with self.assertRaisesRegex(ValueError, 'unexpected receipt archive'):
+                self.receive(self.fixture(), member_name='receipt.json\0alias')
+            read.assert_not_called()
 
     def test_exact_lane_sets(self):
         record = dict(kind='lanes-verified', binding=self.fixture()['binding'], snapshot_sha256='c'*64,

--- a/scripts/test_native_client_draft.py
+++ b/scripts/test_native_client_draft.py
@@ -145,7 +145,10 @@ class DraftTests(unittest.TestCase):
                 body = io.BytesIO()
                 with zipfile.ZipFile(body, 'w') as archive:
                     for name in names:
-                        archive.writestr(name, b'fixture')
+                        member = zipfile.ZipInfo(name)
+                        # Preserve malicious bytes despite Windows constructor normalization.
+                        member.filename = name
+                        archive.writestr(member, b'fixture')
                 with self.subTest(names=names), self.assertRaises(ValueError):
                     draft.unpack_bundle(body.getvalue(), Path(temp))
         body = io.BytesIO()
@@ -249,12 +252,13 @@ class DraftTests(unittest.TestCase):
     def test_live_helper_contract_and_missing_draft(self):
         with tempfile.TemporaryDirectory() as temp:
             receipt = Path(temp) / 'receipt.json'
+            source = (Path(temp) / 'harness').resolve()
             with patch.object(draft, 'output', side_effect=RuntimeError('missing draft')) as child:
                 with self.assertRaises(RuntimeError):
-                    draft.live_verify(Path('/harness'), Path('/producer'), args(), receipt)
+                    draft.live_verify(source, Path(temp) / 'producer', args(), receipt)
             self.assertFalse(receipt.exists())
             command = child.call_args.args[0]
-            self.assertIn('/harness/scripts/verify-agentplugins-draft.py', command)
+            self.assertIn(str(source / 'scripts/verify-agentplugins-draft.py'), command)
             self.assertIn('--run-attempt', command)
             self.assertNotIn('--release-state', command)
 
@@ -338,7 +342,7 @@ class AggregateTests(unittest.TestCase):
             lane = root / client
             lane.mkdir()
             log = lane / 'native-tests.log'
-            log.write_text(''.join('--- PASS: ' + t + ' (0.1s)\n' for t in sorted(tests)))
+            log.write_bytes(''.join('--- PASS: ' + t + ' (0.1s)\n' for t in sorted(tests)).encode('utf-8'))
             release = dict(release_state='draft', repository=draft.REPOSITORY, tag='agentplugins-v1.2.3',
                            version='1.2.3', commit='a' * 40, tree='f' * 40, release_id=34, checksums_sha256='c' * 64,
                            producer=producer, tarball_sha256='1' * 64, binary_sha256='2' * 64, size=6, file='agentplugins_1.2.3_linux_amd64',
@@ -422,7 +426,7 @@ class AggregateTests(unittest.TestCase):
                     paths[0].unlink()
                 else:
                     log = paths[0].parent / 'native-tests.log'
-                    log.write_text(log.read_text() + '    --- SKIP: test/substage (0.0s)\n')
+                    log.write_bytes(log.read_bytes() + b'    --- SKIP: test/substage (0.0s)\n')
                     record = json.loads(paths[0].read_bytes())
                     record['artifact_sha256']['native-tests.log'] = draft.digest(log)
                     paths[0].write_text(json.dumps(record))
@@ -621,12 +625,13 @@ class ReceiptBoundaryTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp:
             arguments = SimpleNamespace(repository=draft.REPOSITORY, tag='agentplugins-v1.2.3', commit='a'*40,
                 asset_set_digest='c'*64, release_id=34, run_id=12, run_attempt=2,
-                source=temp+'/producer', policy_source=temp+'/harness', receipt=temp+'/receipt.json')
+                source=str(Path(temp) / 'producer'), policy_source=str(Path(temp) / 'harness'),
+                receipt=str(Path(temp) / 'receipt.json'))
             calls = []
             def command(argv, **unused):
                 calls.append(argv)
                 if argv[0] == 'git': return b'a'*40 if argv[-1] == 'HEAD' else b''
-                self.assertEqual(argv[:2], ['node', temp+'/harness/npm/agentplugins/scripts/release-assets.js'])
+                self.assertEqual(argv[:2], ['node', str(Path(arguments.policy_source).resolve() / 'npm/agentplugins/scripts/release-assets.js')])
                 raise ValueError('stop before mocked asset validation')
             with patch.object(verifier, 'snapshot', return_value={'assets':[]}), patch.object(verifier, 'run', side_effect=command):
                 with self.assertRaisesRegex(ValueError, 'stop before'): verifier.verify(arguments)

--- a/scripts/test_native_client_draft.py
+++ b/scripts/test_native_client_draft.py
@@ -159,6 +159,23 @@ class DraftTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp, self.assertRaises(ValueError):
             draft.unpack_bundle(body.getvalue(), Path(temp))
 
+    def test_bundle_raw_names_rejected_before_read(self):
+        for sep in ('/', '\\'):
+            for name in ('a\\evil', 'a\0evil'):
+                with self.subTest(sep=sep, name=name), tempfile.TemporaryDirectory() as temp:
+                    root = Path(temp)
+                    body = io.BytesIO()
+                    with zipfile.ZipFile(body, 'w') as archive:
+                        member = zipfile.ZipInfo('fixture')
+                        member.filename = name
+                        archive.writestr(member, b'fixture')
+                    with patch.object(zipfile.os, 'sep', sep), \
+                         patch.object(zipfile.ZipFile, 'read',
+                                      side_effect=AssertionError('ZIP body read')):
+                        with self.assertRaisesRegex(ValueError, 'artifact path'):
+                            draft.unpack_bundle(body.getvalue(), root)
+                    self.assertEqual(list(root.iterdir()), [])
+
     def test_package_pins_and_dependencies(self):
         verified = verified_release()
         with tempfile.TemporaryDirectory() as temp:

--- a/scripts/test_native_client_linux.py
+++ b/scripts/test_native_client_linux.py
@@ -95,18 +95,18 @@ class PreparedInputTests(unittest.TestCase):
                                release_tag='agentplugins-v1.2.3', release_commit='a'*40,
                                release_repo=matrix.draft.REPOSITORY)
 
-        def public(*unused):
-            path = root / 'installer'
+        def public(source, directory, *unused):
+            path = directory / 'installer'
             path.write_bytes(b'installer')
             return path, {'version': '1.2.3'}
 
-        def draft(*unused):
-            tarball = root / 'package.tgz'
+        def draft(source, directory, arguments, evidence):
+            tarball = directory / 'package.tgz'
             tarball.write_bytes(b'package')
-            assets = root / 'assets'
+            assets = directory / 'assets'
             assets.mkdir()
             (assets / 'installer').write_bytes(b'installer')
-            (root / 'initial-draft.json').write_text('{}')
+            (evidence / 'initial-draft.json').write_text('{}')
             return tarball, assets, {'version': '1.2.3'}, {'version': '1.2.3'}
 
         with patch.object(matrix, 'provision', side_effect=self.fake_provision) as tools, \
@@ -114,7 +114,7 @@ class PreparedInputTests(unittest.TestCase):
              patch.object(matrix.draft, 'acquire', side_effect=draft) as acquire:
             matrix.prepared_release(Path(temp), args)
             self.assertEqual([call.args for call in tools.call_args_list],
-                             [(matrix.PINS[args.target][name], root / 'prepared-tools', name)
+                             [(matrix.PINS[args.target][name], root.resolve() / 'prepared-tools', name)
                               for name in (client, 'lintai', 'rg')])
             self.assertEqual(release.call_count, int(state == 'public'))
             self.assertEqual(acquire.call_count, int(state == 'draft'))
@@ -144,8 +144,8 @@ class PreparedInputTests(unittest.TestCase):
                 root = Path(temp)/'prepared'
                 args = SimpleNamespace(prepared_input=root, prepare_only=True, release_state='public', target='linux-amd64',
                                        client='codex', release_tag='agentplugins-v1.2.3', release_commit='a'*40, release_repo=matrix.draft.REPOSITORY)
-                def acquire(*unused):
-                    binary = root/'installer'; binary.write_bytes(b'original')
+                def acquire(source, directory, *unused):
+                    binary = directory/'installer'; binary.write_bytes(b'original')
                     return binary, {'version':'1.2.3'}
                 with patch.object(matrix, 'provision_release', side_effect=acquire), \
                      patch.object(matrix, 'provision', side_effect=self.fake_provision):
@@ -173,7 +173,11 @@ class PreparedInputTests(unittest.TestCase):
             for client in matrix.PATTERNS:
                 with self.subTest(state=state, client=client), TemporaryDirectory() as temp, \
                      patch.dict(matrix.os.environ, {}, clear=True), ExitStack() as stack:
-                    args = self.prepare_fixture(temp, state, client)
+                    # Exercise a resolvable alias on every OS without symlink privileges.
+                    alias = Path(temp) / 'alias'
+                    alias.mkdir()
+                    args = self.prepare_fixture(alias / '..', state, client)
+                    self.assertNotEqual(args.prepared_input, args.prepared_input.resolve())
                     self.forbid_acquisition(stack)
                     release = matrix.prepared_release(Path(temp), args)
                     self.assertEqual(len(release), 4 if state == 'draft' else 2)
@@ -253,7 +257,7 @@ class PreparedInputTests(unittest.TestCase):
             with self.subTest(state=state), TemporaryDirectory() as temp, \
                  patch.dict(matrix.os.environ, {}, clear=True), ExitStack() as stack:
                 args = self.prepare_fixture(temp, state)
-                matrix.os.environ.update(RUNNER_TEMP=temp, EXPECTED_COMMIT='a'*40)
+                matrix.os.environ.update(RUNNER_TEMP=temp, EXPECTED_COMMIT='a'*40, SystemRoot=temp)
                 argv = ['runner', '--client', args.client, '--target', args.target,
                         '--output', str(Path(temp) / 'output'), '--release-state', state,
                         '--release-tag', args.release_tag, '--release-commit', args.release_commit,
@@ -268,15 +272,17 @@ class PreparedInputTests(unittest.TestCase):
                 stack.enter_context(patch.object(matrix.draft, 'helper_hashes', return_value={}))
                 stack.enter_context(patch.object(matrix.shutil, 'which', return_value=sys.executable))
                 stack.enter_context(patch.object(matrix.subprocess, 'check_output',
-                                                side_effect=['a'*40, 'b'*40, b'']))
+                                                side_effect=['a'*40, 'b'*40, b'', 'git version fixture']))
                 stack.enter_context(patch.object(matrix, 'profile_environment', return_value={}))
-                stack.enter_context(patch.object(matrix.os, 'name', 'posix'))
+                # Keep the native OS branch; this Codex fixture needs no Git Bash.
+                stack.enter_context(patch.object(matrix, 'find_git_bash', return_value=None))
 
                 def build(command, **kwargs):
                     self.assertEqual(command[:2], ['go', 'build'])
                     binary_dir = Path(command[command.index('-o') + 1]).parent
+                    suffix = '.exe' if matrix.os.name == 'nt' else ''
                     for name in (args.client, 'lintai', 'rg'):
-                        self.assertEqual((binary_dir / name).read_bytes(), ('frozen-' + name).encode())
+                        self.assertEqual((binary_dir / (name + suffix)).read_bytes(), ('frozen-' + name).encode())
                     raise BuildReached()
 
                 run = stack.enter_context(patch.object(matrix.subprocess, 'run', side_effect=build))

--- a/scripts/test_released_native_evidence.py
+++ b/scripts/test_released_native_evidence.py
@@ -179,6 +179,15 @@ class EvidenceTests(unittest.TestCase):
                 self.mutate(change)
                 with self.assertRaises(ValueError): self.verify()
 
+    def test_fixture_lf_bytes_remain_bound_after_outer_reindex(self):
+        log = next(self.record_path.parent.rglob('command.log'))
+        self.assertEqual(log.read_bytes(), b'fixture command transcript\n')
+        self.verify()
+        log.write_bytes(b'fixture command transcript\r\n')
+        self.refresh_hashes()
+        with self.assertRaisesRegex(ValueError, 'fixture transcript mismatch'):
+            self.verify()
+
     def test_transcript_hash_and_unrecorded_content_fail(self):
         log = self.record_path.parent / 'native-tests.log'
         log.write_text('forged')
@@ -730,10 +739,15 @@ class ContainerPreflightTests(unittest.TestCase):
                 struct.pack_into('<Q', extended, 4, 60)
                 extended_body = body[:end]+extended+b'\0'*16+locator+body[end:]
                 proof.preflight_zip(extended_body, 12)
-                # The local stdlib supports extensible sectors; older versions
-                # can still reject them after this bounded preflight.
-                with zipfile.ZipFile(io.BytesIO(extended_body)) as archive:
-                    self.assertEqual(archive.read('0'), b'fixture')
+                # Preflight accepts extensible sectors on every Python version.
+                # Older stdlibs can reject this encoding after preflight.
+                try:
+                    archive = zipfile.ZipFile(io.BytesIO(extended_body))
+                except zipfile.BadZipFile as error:
+                    self.assertEqual(str(error), 'Bad magic number for central directory')
+                else:
+                    with archive:
+                        self.assertEqual(archive.read('0'), b'fixture')
                 sentinel_end = bytearray(body[end:])
                 struct.pack_into('<2H2I', sentinel_end, 8, 65535, 65535, 0xffffffff, 0xffffffff)
                 for candidate in (body, body[:end]+record+locator+body[end:],

--- a/scripts/verify-released-native-evidence.py
+++ b/scripts/verify-released-native-evidence.py
@@ -11,7 +11,7 @@ import argparse
 import hashlib
 from functools import lru_cache
 import json
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 import re
 import stat
 import struct
@@ -118,7 +118,7 @@ def verify_attestations(release):
 def verify_fixtures(bodies, record, client, target):
     found = []
     for path, body in bodies.items():
-        base = Path(path).name
+        base = PurePosixPath(path).name
         if base not in ('evidence.json', 'tool-collision-evidence.json', 'extended-runtime-evidence.json'):
             continue
         data = json.loads(body, object_pairs_hook=unique_object)
@@ -147,7 +147,7 @@ def verify_fixtures(bodies, record, client, target):
             require(status in ('passed', 'not_evaluated', 'not_proven', 'not_applicable') or (windows_claude and stage_name == 'stdio_discovery' and status == 'observed_unsupported'), 'failed fixture stage: ' + path)
             for ref in stage.get('artifacts', []) if isinstance(stage, dict) else []:
                 safe_name(ref)
-                require(str(Path(path).parent / ref) in bodies, 'missing stage artifact')
+                require(str(PurePosixPath(path).parent / ref) in bodies, 'missing stage artifact')
         release = record['installer_release']
         identity = data.get('source_identity', data)
         require(identity.get('installer_base_commit') == release['commit'] and identity.get('installer_tree') == release['tree'] and identity.get('installer_patch_sha256') in ([], ''), 'fixture source mismatch')
@@ -172,7 +172,7 @@ def verify_fixtures(bodies, record, client, target):
         require(isinstance(hashes, dict) and hashes, 'missing fixture transcripts')
         for ref, sha in hashes.items():
             safe_name(ref)
-            full = str(Path(path).parent / ref)
+            full = str(PurePosixPath(path).parent / ref)
             require(full in bodies and exact_hex(sha, 64) and digest(bodies[full]) == sha, 'fixture transcript mismatch')
     expected = {'codex': {'codex'}, 'claude': {'claude-lifecycle', 'claude-runtime'}, 'opencode': {'opencode.json', 'opencode.jsonc', 'extended', ('api/server',), ('api server',), ('api/server', 'api server')}}
     require(set(found) == expected[client], 'missing or unexpected structured fixtures')


### PR DESCRIPTION
The first packaged-client run exposed preflight assumptions that passed on Linux but failed on macOS and Windows before client execution. Fixtures now respect resolved temporary paths and native path syntax. The offline verifier uses POSIX archive keys on every OS, and raw ZIP member aliases are rejected before extraction or receipt reads.

Both native workflows run the full Python safety suites with fail-fast shell behavior. Ordinary PR CI now covers these suites on macOS and Windows, closing the gap that allowed the earlier preflight failures through. Tests remain enabled and evidence hash checks remain strict.

The runbook preserves independently qualified scopes with their own harness identities, exact producer/package bindings and verification times. Linux amd64 run 34307075390 already passed all three actual packaged-client lanes, aggregation and final draft verification; historical-nine will be rerun after this fix. No installer bytes or release assets change, and no publication is enabled.

Validation: 109 focused Linux tests passed on the final head. Independent source-packet review approved the applied corrections, conditional on native CI. The full Python preflight has now passed on both native macOS and Windows runners; remaining CI is in progress.
