### PR TITLE
feat(authoring): wire paired input and stage workflows

### DIFF
--- a/.github/workflows/agentplugins-npm-publish.yml
+++ b/.github/workflows/agentplugins-npm-publish.yml
@@ -12,6 +12,28 @@ on:
         required: true
         default: false
         type: boolean
+      producer_mode:
+        description: Legacy publication or isolated prepublication pair staging
+        required: true
+        type: choice
+        default: legacy
+        options: [legacy, paired-stage]
+      source_sha:
+        description: Exact paired source and workflow SHA
+        type: string
+        required: false
+      plugin_kit_version:
+        description: Paired kit version, exactly 2.0.0
+        type: string
+        required: false
+      native_inputs:
+        description: Exact retained canonical I UTF-8 bytes including final newline, comparison only
+        type: string
+        required: false
+      input_artifact:
+        description: Exact completed I locator JSON, run_id run_attempt artifact_id artifact_sha256
+        type: string
+        required: false
 
 permissions:
   contents: read
@@ -22,7 +44,51 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  dispatch_contract:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    env:
+      PRODUCER_MODE: ${{ inputs.producer_mode }}
+      TAG: ${{ inputs.tag }}
+      SOURCE_SHA: ${{ inputs.source_sha }}
+      KIT_VERSION: ${{ inputs.plugin_kit_version }}
+      PUBLISH: ${{ inputs.publish }}
+      NATIVE_INPUTS: ${{ inputs.native_inputs }}
+      INPUT_ARTIFACT: ${{ inputs.input_artifact }}
+    steps:
+      - name: C1 preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PATH="/usr/local/bin:${PATH}"
+          [[ "${GITHUB_EVENT_NAME}" == workflow_dispatch ]]
+          case "${PRODUCER_MODE}" in
+            legacy) [[ -z "${SOURCE_SHA}${KIT_VERSION}${NATIVE_INPUTS}${INPUT_ARTIFACT}" ]]; exit 0 ;;
+            paired-stage) [[ "${PUBLISH}" == false ]] ;;
+            *) exit 1 ;;
+          esac
+          [[ "${GITHUB_ACTIONS}" == true && "${GITHUB_REPOSITORY}" == 777genius/universal-agent-plugins ]]
+          [[ "${TAG}" =~ ^agentplugins-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ && ${#TAG} -le 47 ]]
+          [[ "${KIT_VERSION}" == 2.0.0 && "${TAG}" != agentplugins-v2.0.0 ]]
+          [[ "${SOURCE_SHA}" =~ ^[0-9a-f]{40}$ && ! "${SOURCE_SHA}" =~ ^0+$ ]]
+          [[ "${GITHUB_SHA}" == "${SOURCE_SHA}" && "${GITHUB_WORKFLOW_SHA}" == "${SOURCE_SHA}" ]]
+          [[ "${GITHUB_REF}" == "refs/tags/${TAG}" ]]
+          [[ "${GITHUB_WORKFLOW_REF}" == "777genius/universal-agent-plugins/.github/workflows/agentplugins-npm-publish.yml@refs/tags/${TAG}" ]]
+          positive() { [[ "$1" =~ ^[1-9][0-9]{0,15}$ && "$1" -le 9007199254740991 ]]; }
+          positive "${GITHUB_RUN_ID}"
+          positive "${GITHUB_RUN_ATTEMPT}"; [[ "${GITHUB_RUN_ATTEMPT}" -le 1000 ]]
+          [[ ${#NATIVE_INPUTS} -gt 0 && ${#NATIVE_INPUTS} -le 32768 && "${NATIVE_INPUTS}" == *$'\n' ]]
+          locator='^[[:space:]]*\{[[:space:]]*"run_id":[[:space:]]*([1-9][0-9]{0,15}),[[:space:]]*"run_attempt":[[:space:]]*([1-9][0-9]{0,3}),[[:space:]]*"artifact_id":[[:space:]]*([1-9][0-9]{0,15}),[[:space:]]*"artifact_sha256":[[:space:]]*"([0-9a-f]{64})"[[:space:]]*\}[[:space:]]*$'
+          [[ "${INPUT_ARTIFACT}" =~ $locator ]]
+          run_id="${BASH_REMATCH[1]}"; artifact_id="${BASH_REMATCH[3]}"
+          positive "${run_id}"; positive "${artifact_id}"
+          [[ "${INPUT_ARTIFACT}" =~ $locator ]]
+          [[ "${BASH_REMATCH[2]}" -le 1000 && ! "${BASH_REMATCH[4]}" =~ ^0+$ ]]
   prepare:
+    needs: dispatch_contract
+    if: ${{ success() && github.event_name == 'workflow_dispatch' && inputs.producer_mode == 'legacy' && needs.dispatch_contract.result == 'success' }}
     name: Verify release and stage npm package
     runs-on: ubuntu-24.04
     timeout-minutes: 20
@@ -106,7 +172,7 @@ jobs:
 
   publish:
     name: Publish npm package with trusted provenance
-    if: ${{ inputs.publish == true }}
+    if: ${{ success() && github.event_name == 'workflow_dispatch' && inputs.producer_mode == 'legacy' && inputs.publish == true && needs.prepare.result == 'success' }}
     needs: prepare
     runs-on: ubuntu-24.04
     timeout-minutes: 10
@@ -155,7 +221,7 @@ jobs:
 
   verify-public:
     name: Verify public npm provenance and lifecycle
-    if: ${{ inputs.publish == true }}
+    if: ${{ success() && github.event_name == 'workflow_dispatch' && inputs.producer_mode == 'legacy' && inputs.publish == true && needs.publish.result == 'success' }}
     needs: [prepare, publish]
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -233,3 +299,310 @@ jobs:
           run_agentplugins repair context7 --target opencode --format json | jq -e '.result == "success" and .data.succeeded == 1 and .data.failed == 0 and .data.targets[0].target == "opencode" and .data.targets[0].output.result.mutated == true' >/dev/null
           jq -e '.mcp.context7' "${repair_file}" > /dev/null
           run_agentplugins remove context7 --target opencode --external-uninstalled --format json | jq -e '.result == "success" and .data.succeeded == 1 and .data.failed == 0' >/dev/null
+
+  paired_stage:
+    name: paired_stage
+    needs: dispatch_contract
+    if: ${{ success() && github.event_name == 'workflow_dispatch' && inputs.producer_mode == 'paired-stage' && inputs.publish == false && needs.dispatch_contract.result == 'success' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      actions: read
+      attestations: read
+    env:
+      PRODUCER_MODE: ${{ inputs.producer_mode }}
+      TAG: ${{ inputs.tag }}
+      SOURCE_SHA: ${{ inputs.source_sha }}
+      KIT_VERSION: ${{ inputs.plugin_kit_version }}
+      PUBLISH: ${{ inputs.publish }}
+      NATIVE_INPUTS: ${{ inputs.native_inputs }}
+      INPUT_ARTIFACT: ${{ inputs.input_artifact }}
+      GH_TOKEN: ${{ github.token }}
+    outputs:
+      stage_sha256: ${{ steps.stage.outputs.stage_sha256 }}
+      stage_artifact_id: ${{ steps.upload.outputs.artifact-id }}
+      stage_artifact_sha256: ${{ steps.upload_evidence.outputs.artifact_sha256 }}
+    steps:
+      - name: C1 preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PATH="/usr/local/bin:${PATH}"
+          [[ "${GITHUB_EVENT_NAME}" == workflow_dispatch ]]
+          case "${PRODUCER_MODE}" in
+            legacy) [[ -z "${SOURCE_SHA}${KIT_VERSION}${NATIVE_INPUTS}${INPUT_ARTIFACT}" ]]; exit 0 ;;
+            paired-stage) [[ "${PUBLISH}" == false ]] ;;
+            *) exit 1 ;;
+          esac
+          [[ "${GITHUB_ACTIONS}" == true && "${GITHUB_REPOSITORY}" == 777genius/universal-agent-plugins ]]
+          [[ "${TAG}" =~ ^agentplugins-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ && ${#TAG} -le 47 ]]
+          [[ "${KIT_VERSION}" == 2.0.0 && "${TAG}" != agentplugins-v2.0.0 ]]
+          [[ "${SOURCE_SHA}" =~ ^[0-9a-f]{40}$ && ! "${SOURCE_SHA}" =~ ^0+$ ]]
+          [[ "${GITHUB_SHA}" == "${SOURCE_SHA}" && "${GITHUB_WORKFLOW_SHA}" == "${SOURCE_SHA}" ]]
+          [[ "${GITHUB_REF}" == "refs/tags/${TAG}" ]]
+          [[ "${GITHUB_WORKFLOW_REF}" == "777genius/universal-agent-plugins/.github/workflows/agentplugins-npm-publish.yml@refs/tags/${TAG}" ]]
+          positive() { [[ "$1" =~ ^[1-9][0-9]{0,15}$ && "$1" -le 9007199254740991 ]]; }
+          positive "${GITHUB_RUN_ID}"
+          positive "${GITHUB_RUN_ATTEMPT}"; [[ "${GITHUB_RUN_ATTEMPT}" -le 1000 ]]
+          [[ ${#NATIVE_INPUTS} -gt 0 && ${#NATIVE_INPUTS} -le 32768 && "${NATIVE_INPUTS}" == *$'\n' ]]
+          locator='^[[:space:]]*\{[[:space:]]*"run_id":[[:space:]]*([1-9][0-9]{0,15}),[[:space:]]*"run_attempt":[[:space:]]*([1-9][0-9]{0,3}),[[:space:]]*"artifact_id":[[:space:]]*([1-9][0-9]{0,15}),[[:space:]]*"artifact_sha256":[[:space:]]*"([0-9a-f]{64})"[[:space:]]*\}[[:space:]]*$'
+          [[ "${INPUT_ARTIFACT}" =~ $locator ]]
+          run_id="${BASH_REMATCH[1]}"; artifact_id="${BASH_REMATCH[3]}"
+          positive "${run_id}"; positive "${artifact_id}"
+          [[ "${INPUT_ARTIFACT}" =~ $locator ]]
+          [[ "${BASH_REMATCH[2]}" -le 1000 && ! "${BASH_REMATCH[4]}" =~ ^0+$ ]]
+          [[ "${GITHUB_JOB}" == paired_stage ]]
+      - name: C1 checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: C1 setup
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "22.23.2"
+          package-manager-cache: false
+      - name: C1 stage
+        id: stage
+        shell: bash
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require('node:fs'), path = require('node:path'), assert = require('node:assert/strict');
+          const c = require('./npm/agentplugins/scripts/dual-authoring-candidate');
+          const i = require('./npm/agentplugins/scripts/authoring-native-inputs');
+          const s = require('./npm/agentplugins/scripts/stage-authoring-npm');
+          const e = process.env, selected = {tag: e.TAG, ref: `refs/tags/${e.TAG}`, source: e.SOURCE_SHA,
+            versions: {agentplugins: e.TAG.slice('agentplugins-v'.length), 'plugin-kit-ai': e.KIT_VERSION}};
+          const root = fs.mkdtempSync(path.join(e.RUNNER_TEMP, 'c1-workflow-'));
+          const scratch = path.join(root, 'scratch'); fs.mkdirSync(scratch, {mode: 0o700});
+          const options = {selected, workflow_sha: e.SOURCE_SHA};
+          const input_file = path.join(root, 'native-inputs.json');
+          const input = Buffer.from(e.NATIVE_INPUTS, 'utf8'); assert.ok(input.length <= 32768); i.decodeInputs(input);
+          fs.writeFileSync(input_file, input, {flag: 'wx', mode: 0o400});
+          const npm = fs.realpathSync(path.join(path.dirname(process.execPath), '../lib/node_modules/npm/bin/npm-cli.js'));
+          assert.equal(path.basename(npm), 'npm-cli.js'); c.readFile(npm);
+          Object.assign(options, {input_file, repo: process.cwd(), workParent: scratch, node: process.execPath, npm});
+          Object.assign(options, {artifact: JSON.parse(e.INPUT_ARTIFACT), output: path.join(root, 'output'),
+            producer: {workflow: '.github/workflows/agentplugins-npm-publish.yml', source: e.SOURCE_SHA, ref: selected.ref,
+              run_id: Number(e.GITHUB_RUN_ID), run_attempt: Number(e.GITHUB_RUN_ATTEMPT)}});
+          const file = path.join(root, 'options.json'); fs.writeFileSync(file, c.encode(options), {flag: 'wx', mode: 0o400});
+          const result = s.main(['--stage-prepublication', file]);
+          c.keys(result, ['root', 'record', 'subjects', 'stage_sha256'], 'stage CLI result');
+          const names = ['completion.json', ...c.PRODUCTS.map(p => result.record.packs[p].file)];
+          assert.equal(result.subjects.length, names.length);
+          assert.deepEqual(result.subjects.map(r => path.relative(result.root, r.file)).sort(), [...names].sort());
+          for (const row of result.subjects) assert.equal(c.digest(c.readFile(row.file, 128 * 1024 * 1024)), row.sha256);
+          const payload = [...names];
+          assert.equal(payload.length, 3);
+          const pins = (r) => payload.map(n => ({file: n, sha256: c.digest(c.readFile(path.join(r, n), 128 * 1024 * 1024))}));
+          const actual = pins(result.root);
+          const result_file = path.join(root, 'result.json');
+          fs.writeFileSync(result_file, c.encode({root: result.root, subjects: result.subjects, pins: actual}), {flag: 'wx', mode: 0o400});
+          const output = (key, value) => fs.appendFileSync(e.GITHUB_OUTPUT, `${key}<<C1_PATHS\n${value}\nC1_PATHS\n`);
+          output('result_file', result_file);
+          output('root', result.root);
+          output('subjects', result.subjects.map(r => r.file).join('\n'));
+          output('payload', payload.map(n => path.join(result.root, n)).join('\n'));
+          output('stage_sha256', c.digest(c.readFile(path.join(result.root, 'completion.json'))));
+          NODE
+      - name: C1 upload
+        id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: authoring-public-stage-${{ inputs.source_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.stage.outputs.payload }}
+          if-no-files-found: error
+          retention-days: 7
+      - name: C1 upload evidence
+        id: upload_evidence
+        env:
+          ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
+          ARTIFACT_SHA256: ${{ steps.upload.outputs.artifact-digest }}
+          COMPLETION_SHA256: ${{ steps.stage.outputs.stage_sha256 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require('node:fs'), assert = require('node:assert/strict'), e = process.env;
+          assert.match(e.ARTIFACT_ID, /^[1-9][0-9]{0,15}$/);
+          const artifact_id = Number(e.ARTIFACT_ID); assert.ok(Number.isSafeInteger(artifact_id));
+          const artifact_sha256 = e.ARTIFACT_SHA256.replace(/^sha256:/, '').toLowerCase();
+          assert.match(artifact_sha256, /^[0-9a-f]{64}$/); assert.ok(!/^0+$/.test(artifact_sha256));
+          fs.appendFileSync(e.GITHUB_OUTPUT, `artifact_sha256=${artifact_sha256}\n`);
+          console.log('C1_STAGE ' + JSON.stringify({operation: 'upload', artifact_id, artifact_sha256, stage_sha256: e.COMPLETION_SHA256}));
+          NODE
+
+  paired_stage_attestation:
+    name: paired_stage_attestation
+    needs: paired_stage
+    if: ${{ success() && github.event_name == 'workflow_dispatch' && inputs.producer_mode == 'paired-stage' && inputs.publish == false && needs.paired_stage.result == 'success' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment: npm-agentplugins
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+      attestations: write
+    env:
+      PRODUCER_MODE: ${{ inputs.producer_mode }}
+      TAG: ${{ inputs.tag }}
+      SOURCE_SHA: ${{ inputs.source_sha }}
+      KIT_VERSION: ${{ inputs.plugin_kit_version }}
+      PUBLISH: ${{ inputs.publish }}
+      NATIVE_INPUTS: ${{ inputs.native_inputs }}
+      INPUT_ARTIFACT: ${{ inputs.input_artifact }}
+      GH_TOKEN: ${{ github.token }}
+      STAGE_ARTIFACT_ID: ${{ needs.paired_stage.outputs.stage_artifact_id }}
+      STAGE_ARTIFACT_SHA256: ${{ needs.paired_stage.outputs.stage_artifact_sha256 }}
+      STAGE_SHA256: ${{ needs.paired_stage.outputs.stage_sha256 }}
+    outputs:
+      stage_sha256: ${{ steps.recheck.outputs.stage_sha256 }}
+    steps:
+      - name: C1 preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PATH="/usr/local/bin:${PATH}"
+          [[ "${GITHUB_EVENT_NAME}" == workflow_dispatch ]]
+          case "${PRODUCER_MODE}" in
+            legacy) [[ -z "${SOURCE_SHA}${KIT_VERSION}${NATIVE_INPUTS}${INPUT_ARTIFACT}" ]]; exit 0 ;;
+            paired-stage) [[ "${PUBLISH}" == false ]] ;;
+            *) exit 1 ;;
+          esac
+          [[ "${GITHUB_ACTIONS}" == true && "${GITHUB_REPOSITORY}" == 777genius/universal-agent-plugins ]]
+          [[ "${TAG}" =~ ^agentplugins-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ && ${#TAG} -le 47 ]]
+          [[ "${KIT_VERSION}" == 2.0.0 && "${TAG}" != agentplugins-v2.0.0 ]]
+          [[ "${SOURCE_SHA}" =~ ^[0-9a-f]{40}$ && ! "${SOURCE_SHA}" =~ ^0+$ ]]
+          [[ "${GITHUB_SHA}" == "${SOURCE_SHA}" && "${GITHUB_WORKFLOW_SHA}" == "${SOURCE_SHA}" ]]
+          [[ "${GITHUB_REF}" == "refs/tags/${TAG}" ]]
+          [[ "${GITHUB_WORKFLOW_REF}" == "777genius/universal-agent-plugins/.github/workflows/agentplugins-npm-publish.yml@refs/tags/${TAG}" ]]
+          positive() { [[ "$1" =~ ^[1-9][0-9]{0,15}$ && "$1" -le 9007199254740991 ]]; }
+          positive "${GITHUB_RUN_ID}"
+          positive "${GITHUB_RUN_ATTEMPT}"; [[ "${GITHUB_RUN_ATTEMPT}" -le 1000 ]]
+          [[ ${#NATIVE_INPUTS} -gt 0 && ${#NATIVE_INPUTS} -le 32768 && "${NATIVE_INPUTS}" == *$'\n' ]]
+          locator='^[[:space:]]*\{[[:space:]]*"run_id":[[:space:]]*([1-9][0-9]{0,15}),[[:space:]]*"run_attempt":[[:space:]]*([1-9][0-9]{0,3}),[[:space:]]*"artifact_id":[[:space:]]*([1-9][0-9]{0,15}),[[:space:]]*"artifact_sha256":[[:space:]]*"([0-9a-f]{64})"[[:space:]]*\}[[:space:]]*$'
+          [[ "${INPUT_ARTIFACT}" =~ $locator ]]
+          run_id="${BASH_REMATCH[1]}"; artifact_id="${BASH_REMATCH[3]}"
+          positive "${run_id}"; positive "${artifact_id}"
+          [[ "${INPUT_ARTIFACT}" =~ $locator ]]
+          [[ "${BASH_REMATCH[2]}" -le 1000 && ! "${BASH_REMATCH[4]}" =~ ^0+$ ]]
+          [[ "${GITHUB_JOB}" == paired_stage_attestation ]]
+          positive "${STAGE_ARTIFACT_ID}"
+          [[ "${STAGE_ARTIFACT_SHA256}" =~ ^[0-9a-f]{64}$ && ! "${STAGE_ARTIFACT_SHA256}" =~ ^0+$ ]]
+          [[ "${STAGE_SHA256}" =~ ^[0-9a-f]{64}$ && ! "${STAGE_SHA256}" =~ ^0+$ ]]
+      - name: C1 checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: C1 setup
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "22.23.2"
+          package-manager-cache: false
+      - name: C1 stage
+        id: stage
+        shell: bash
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require('node:fs'), path = require('node:path'), assert = require('node:assert/strict');
+          const c = require('./npm/agentplugins/scripts/dual-authoring-candidate');
+          const i = require('./npm/agentplugins/scripts/authoring-native-inputs');
+          const s = require('./npm/agentplugins/scripts/stage-authoring-npm');
+          const e = process.env, selected = {tag: e.TAG, ref: `refs/tags/${e.TAG}`, source: e.SOURCE_SHA,
+            versions: {agentplugins: e.TAG.slice('agentplugins-v'.length), 'plugin-kit-ai': e.KIT_VERSION}};
+          const root = fs.mkdtempSync(path.join(e.RUNNER_TEMP, 'c1-workflow-'));
+          const scratch = path.join(root, 'scratch'); fs.mkdirSync(scratch, {mode: 0o700});
+          const options = {selected, workflow_sha: e.SOURCE_SHA};
+          const input_file = path.join(root, 'native-inputs.json');
+          const input = Buffer.from(e.NATIVE_INPUTS, 'utf8'); assert.ok(input.length <= 32768); i.decodeInputs(input);
+          fs.writeFileSync(input_file, input, {flag: 'wx', mode: 0o400});
+          const npm = fs.realpathSync(path.join(path.dirname(process.execPath), '../lib/node_modules/npm/bin/npm-cli.js'));
+          assert.equal(path.basename(npm), 'npm-cli.js'); c.readFile(npm);
+          Object.assign(options, {input_file, repo: process.cwd(), workParent: scratch, node: process.execPath, npm});
+          Object.assign(options, {artifact: {run_id: Number(e.GITHUB_RUN_ID), run_attempt: Number(e.GITHUB_RUN_ATTEMPT),
+            artifact_id: Number(e.STAGE_ARTIFACT_ID), artifact_sha256: e.STAGE_ARTIFACT_SHA256}, stage_sha256: e.STAGE_SHA256});
+          const file = path.join(root, 'options.json'); fs.writeFileSync(file, c.encode(options), {flag: 'wx', mode: 0o400});
+          const result = s.main(['--validate-unsigned-stage', file]);
+          c.keys(result, ['root', 'record', 'subjects'], 'stage CLI result');
+          const names = ['completion.json', ...c.PRODUCTS.map(p => result.record.packs[p].file)];
+          assert.equal(result.subjects.length, names.length);
+          assert.deepEqual(result.subjects.map(r => path.relative(result.root, r.file)).sort(), [...names].sort());
+          for (const row of result.subjects) assert.equal(c.digest(c.readFile(row.file, 128 * 1024 * 1024)), row.sha256);
+          const payload = [...names];
+          assert.equal(payload.length, 3);
+          const pins = (r) => payload.map(n => ({file: n, sha256: c.digest(c.readFile(path.join(r, n), 128 * 1024 * 1024))}));
+          const actual = pins(result.root);
+          const result_file = path.join(root, 'result.json');
+          fs.writeFileSync(result_file, c.encode({root: result.root, subjects: result.subjects, pins: actual}), {flag: 'wx', mode: 0o400});
+          const output = (key, value) => fs.appendFileSync(e.GITHUB_OUTPUT, `${key}<<C1_PATHS\n${value}\nC1_PATHS\n`);
+          output('result_file', result_file);
+          output('root', result.root);
+          output('subjects', result.subjects.map(r => r.file).join('\n'));
+          output('payload', payload.map(n => path.join(result.root, n)).join('\n'));
+          output('stage_sha256', c.digest(c.readFile(path.join(result.root, 'completion.json'))));
+          NODE
+      - name: C1 attest
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6
+        with:
+          subject-path: ${{ steps.stage.outputs.subjects }}
+      - name: C1 recheck
+        id: recheck
+        env:
+          PREVIOUS: ${{ steps.stage.outputs.result_file }}
+          SIGNING_ROOT: ${{ steps.stage.outputs.root }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require('node:fs'), path = require('node:path'), assert = require('node:assert/strict');
+          const c = require('./npm/agentplugins/scripts/dual-authoring-candidate');
+          const i = require('./npm/agentplugins/scripts/authoring-native-inputs');
+          const s = require('./npm/agentplugins/scripts/stage-authoring-npm');
+          const e = process.env, selected = {tag: e.TAG, ref: `refs/tags/${e.TAG}`, source: e.SOURCE_SHA,
+            versions: {agentplugins: e.TAG.slice('agentplugins-v'.length), 'plugin-kit-ai': e.KIT_VERSION}};
+          const root = fs.mkdtempSync(path.join(e.RUNNER_TEMP, 'c1-workflow-'));
+          const scratch = path.join(root, 'scratch'); fs.mkdirSync(scratch, {mode: 0o700});
+          const options = {selected, workflow_sha: e.SOURCE_SHA};
+          const input_file = path.join(root, 'native-inputs.json');
+          const input = Buffer.from(e.NATIVE_INPUTS, 'utf8'); assert.ok(input.length <= 32768); i.decodeInputs(input);
+          fs.writeFileSync(input_file, input, {flag: 'wx', mode: 0o400});
+          const npm = fs.realpathSync(path.join(path.dirname(process.execPath), '../lib/node_modules/npm/bin/npm-cli.js'));
+          assert.equal(path.basename(npm), 'npm-cli.js'); c.readFile(npm);
+          Object.assign(options, {input_file, repo: process.cwd(), workParent: scratch, node: process.execPath, npm});
+          Object.assign(options, {artifact: {run_id: Number(e.GITHUB_RUN_ID), run_attempt: Number(e.GITHUB_RUN_ATTEMPT),
+            artifact_id: Number(e.STAGE_ARTIFACT_ID), artifact_sha256: e.STAGE_ARTIFACT_SHA256}, stage_sha256: e.STAGE_SHA256});
+          const file = path.join(root, 'options.json'); fs.writeFileSync(file, c.encode(options), {flag: 'wx', mode: 0o400});
+          const result = s.main(['--validate-unsigned-stage', file]);
+          c.keys(result, ['root', 'record', 'subjects'], 'stage CLI result');
+          const names = ['completion.json', ...c.PRODUCTS.map(p => result.record.packs[p].file)];
+          assert.equal(result.subjects.length, names.length);
+          assert.deepEqual(result.subjects.map(r => path.relative(result.root, r.file)).sort(), [...names].sort());
+          for (const row of result.subjects) assert.equal(c.digest(c.readFile(row.file, 128 * 1024 * 1024)), row.sha256);
+          const payload = [...names];
+          assert.equal(payload.length, 3);
+          const pins = (r) => payload.map(n => ({file: n, sha256: c.digest(c.readFile(path.join(r, n), 128 * 1024 * 1024))}));
+          const actual = pins(result.root);
+          const previous = JSON.parse(c.readFile(e.PREVIOUS, 1024 * 1024));
+          c.keys(previous, ['root', 'subjects', 'pins'], 'original signing comparison');
+          assert.equal(previous.root, e.SIGNING_ROOT);
+          assert.deepEqual([...previous.subjects].sort((a,b) => a.file.localeCompare(b.file)), names.map(n => ({file: path.join(e.SIGNING_ROOT, n), sha256: actual.find(row => row.file === n).sha256})).sort((a,b) => a.file.localeCompare(b.file)));
+          assert.deepEqual(previous.pins, actual); assert.deepEqual(pins(previous.root), actual);
+          for (const row of previous.subjects) assert.equal(c.digest(c.readFile(row.file, 128 * 1024 * 1024)), row.sha256);
+          // Original signing root is retained; independently reacquired bytes never replace it.
+          result.root = previous.root; result.subjects = previous.subjects;
+          const result_file = path.join(root, 'result.json');
+          fs.writeFileSync(result_file, c.encode({root: result.root, subjects: result.subjects, pins: actual}), {flag: 'wx', mode: 0o400});
+          const output = (key, value) => fs.appendFileSync(e.GITHUB_OUTPUT, `${key}<<C1_PATHS\n${value}\nC1_PATHS\n`);
+          output('result_file', result_file);
+          output('root', result.root);
+          output('subjects', result.subjects.map(r => r.file).join('\n'));
+          output('payload', payload.map(n => path.join(result.root, n)).join('\n'));
+          output('stage_sha256', c.digest(c.readFile(path.join(result.root, 'completion.json'))));
+          NODE

--- a/.github/workflows/agentplugins-release.yml
+++ b/.github/workflows/agentplugins-release.yml
@@ -15,6 +15,7 @@ on:
           - binary-only
           - paired-preparation
           - paired-promotion
+          - paired-input-provenance
       source_sha:
         description: Exact source and workflow SHA (required for paired preparation)
         required: false
@@ -22,16 +23,16 @@ on:
         description: Explicit plugin-kit version (paired first cut requires 2.0.0)
         required: false
       preparation_run:
-        description: Exact completed preparation run ID (promotion only)
+        description: Exact completed preparation run ID (promotion or input provenance)
         required: false
       preparation_attempt:
-        description: Exact preparation run attempt (promotion only)
+        description: Exact preparation run attempt (promotion or input provenance)
         required: false
       preparation_artifact:
-        description: Exact preparation artifact ID (promotion only)
+        description: Exact preparation artifact ID (promotion or input provenance)
         required: false
       preparation_digest:
-        description: Independently selected preparation ZIP SHA256 (promotion only)
+        description: Independently selected preparation ZIP SHA256 (promotion or input provenance)
         required: false
       promotion_operation:
         description: Promote exact drafts or reconcile interrupted drafts/partial publication
@@ -53,6 +54,47 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  dispatch_contract:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    env:
+      PRODUCER_MODE: ${{ inputs.producer_mode }}
+      TAG: ${{ inputs.tag }}
+      SOURCE_SHA: ${{ inputs.source_sha }}
+      KIT_VERSION: ${{ inputs.plugin_kit_version }}
+      PREPARATION_RUN: ${{ inputs.preparation_run }}
+      PREPARATION_ATTEMPT: ${{ inputs.preparation_attempt }}
+      PREPARATION_ARTIFACT: ${{ inputs.preparation_artifact }}
+      PREPARATION_DIGEST: ${{ inputs.preparation_digest }}
+      PROMOTION_OPERATION: ${{ inputs.promotion_operation }}
+      PROMOTION_RECORD: ${{ inputs.promotion_record }}
+    steps:
+      - name: C1 preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PATH="/usr/local/bin:${PATH}"
+          [[ "${GITHUB_EVENT_NAME}" == workflow_dispatch ]]
+          case "${PRODUCER_MODE}" in
+            binary-only|paired-preparation|paired-promotion) exit 0 ;;
+            paired-input-provenance) [[ -z "${PROMOTION_RECORD}" && "${PROMOTION_OPERATION}" == promote ]] ;;
+            *) exit 1 ;;
+          esac
+          [[ "${GITHUB_ACTIONS}" == true && "${GITHUB_REPOSITORY}" == 777genius/universal-agent-plugins ]]
+          [[ "${TAG}" =~ ^agentplugins-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ && ${#TAG} -le 47 ]]
+          [[ "${KIT_VERSION}" == 2.0.0 && "${TAG}" != agentplugins-v2.0.0 ]]
+          [[ "${SOURCE_SHA}" =~ ^[0-9a-f]{40}$ && ! "${SOURCE_SHA}" =~ ^0+$ ]]
+          [[ "${GITHUB_SHA}" == "${SOURCE_SHA}" && "${GITHUB_WORKFLOW_SHA}" == "${SOURCE_SHA}" ]]
+          [[ "${GITHUB_REF}" == "refs/tags/${TAG}" ]]
+          [[ "${GITHUB_WORKFLOW_REF}" == "777genius/universal-agent-plugins/.github/workflows/agentplugins-release.yml@refs/tags/${TAG}" ]]
+          positive() { [[ "$1" =~ ^[1-9][0-9]{0,15}$ && "$1" -le 9007199254740991 ]]; }
+          positive "${GITHUB_RUN_ID}"
+          positive "${GITHUB_RUN_ATTEMPT}"; [[ "${GITHUB_RUN_ATTEMPT}" -le 1000 ]]
+          positive "${PREPARATION_RUN}"; positive "${PREPARATION_ARTIFACT}"
+          positive "${PREPARATION_ATTEMPT}"; [[ "${PREPARATION_ATTEMPT}" -le 1000 ]]
+          [[ "${PREPARATION_DIGEST}" =~ ^[0-9a-f]{64}$ && ! "${PREPARATION_DIGEST}" =~ ^0+$ ]]
   validate:
     if: ${{ inputs.producer_mode == 'binary-only' }}
     runs-on: ubuntu-latest
@@ -685,3 +727,281 @@ jobs:
         run: |
           case "${PROMOTION_OPERATION}" in promote|reconcile) ;; *) exit 1 ;; esac
           node npm/agentplugins/scripts/authoring-promotion.js "${PROMOTION_OPERATION}" "${PROMOTION_ROOT}/options.json"
+
+  paired_input_admission:
+    name: paired_input_admission
+    needs: dispatch_contract
+    if: ${{ success() && github.event_name == 'workflow_dispatch' && inputs.producer_mode == 'paired-input-provenance' && needs.dispatch_contract.result == 'success' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      actions: read
+    env:
+      PRODUCER_MODE: ${{ inputs.producer_mode }}
+      TAG: ${{ inputs.tag }}
+      SOURCE_SHA: ${{ inputs.source_sha }}
+      KIT_VERSION: ${{ inputs.plugin_kit_version }}
+      PREPARATION_RUN: ${{ inputs.preparation_run }}
+      PREPARATION_ATTEMPT: ${{ inputs.preparation_attempt }}
+      PREPARATION_ARTIFACT: ${{ inputs.preparation_artifact }}
+      PREPARATION_DIGEST: ${{ inputs.preparation_digest }}
+      PROMOTION_OPERATION: ${{ inputs.promotion_operation }}
+      PROMOTION_RECORD: ${{ inputs.promotion_record }}
+      GH_TOKEN: ${{ github.token }}
+    outputs:
+      input_sha256: ${{ steps.stage.outputs.input_sha256 }}
+    steps:
+      - name: C1 preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PATH="/usr/local/bin:${PATH}"
+          [[ "${GITHUB_EVENT_NAME}" == workflow_dispatch ]]
+          case "${PRODUCER_MODE}" in
+            binary-only|paired-preparation|paired-promotion) exit 0 ;;
+            paired-input-provenance) [[ -z "${PROMOTION_RECORD}" && "${PROMOTION_OPERATION}" == promote ]] ;;
+            *) exit 1 ;;
+          esac
+          [[ "${GITHUB_ACTIONS}" == true && "${GITHUB_REPOSITORY}" == 777genius/universal-agent-plugins ]]
+          [[ "${TAG}" =~ ^agentplugins-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ && ${#TAG} -le 47 ]]
+          [[ "${KIT_VERSION}" == 2.0.0 && "${TAG}" != agentplugins-v2.0.0 ]]
+          [[ "${SOURCE_SHA}" =~ ^[0-9a-f]{40}$ && ! "${SOURCE_SHA}" =~ ^0+$ ]]
+          [[ "${GITHUB_SHA}" == "${SOURCE_SHA}" && "${GITHUB_WORKFLOW_SHA}" == "${SOURCE_SHA}" ]]
+          [[ "${GITHUB_REF}" == "refs/tags/${TAG}" ]]
+          [[ "${GITHUB_WORKFLOW_REF}" == "777genius/universal-agent-plugins/.github/workflows/agentplugins-release.yml@refs/tags/${TAG}" ]]
+          positive() { [[ "$1" =~ ^[1-9][0-9]{0,15}$ && "$1" -le 9007199254740991 ]]; }
+          positive "${GITHUB_RUN_ID}"
+          positive "${GITHUB_RUN_ATTEMPT}"; [[ "${GITHUB_RUN_ATTEMPT}" -le 1000 ]]
+          positive "${PREPARATION_RUN}"; positive "${PREPARATION_ARTIFACT}"
+          positive "${PREPARATION_ATTEMPT}"; [[ "${PREPARATION_ATTEMPT}" -le 1000 ]]
+          [[ "${PREPARATION_DIGEST}" =~ ^[0-9a-f]{64}$ && ! "${PREPARATION_DIGEST}" =~ ^0+$ ]]
+          [[ "${GITHUB_JOB}" == paired_input_admission ]]
+      - name: C1 checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: C1 setup
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "22.23.2"
+          package-manager-cache: false
+      - name: C1 stage
+        id: stage
+        shell: bash
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require('node:fs'), path = require('node:path'), assert = require('node:assert/strict');
+          const c = require('./npm/agentplugins/scripts/dual-authoring-candidate');
+          const i = require('./npm/agentplugins/scripts/authoring-native-inputs');
+          const s = require('./npm/agentplugins/scripts/stage-authoring-npm');
+          const e = process.env, selected = {tag: e.TAG, ref: `refs/tags/${e.TAG}`, source: e.SOURCE_SHA,
+            versions: {agentplugins: e.TAG.slice('agentplugins-v'.length), 'plugin-kit-ai': e.KIT_VERSION}};
+          const root = fs.mkdtempSync(path.join(e.RUNNER_TEMP, 'c1-workflow-'));
+          const scratch = path.join(root, 'scratch'); fs.mkdirSync(scratch, {mode: 0o700});
+          const options = {selected, workflow_sha: e.SOURCE_SHA};
+          Object.assign(options, {preparation: {run_id: Number(e.PREPARATION_RUN), run_attempt: Number(e.PREPARATION_ATTEMPT),
+            artifact_id: Number(e.PREPARATION_ARTIFACT), artifact_sha256: e.PREPARATION_DIGEST}, repo: process.cwd(), scratch});
+          const file = path.join(root, 'options.json'); fs.writeFileSync(file, c.encode(options), {flag: 'wx', mode: 0o400});
+          const result = i.main(['--produce-inputs', file]);
+          c.keys(result, ['root', 'input', 'subjects'], 'input CLI result');
+          const names = ['candidate/candidate.json', 'pair-prepared.json', ...c.PRODUCTS.flatMap(p => [...c.TARGETS.map(t => `${p}/${result.input.products[p].assets[t].file}`), `${p}/release-manifest.json`, `${p}/checksums.txt`]), 'native-inputs.json'];
+          assert.equal(result.subjects.length, names.length);
+          assert.deepEqual(result.subjects.map(r => path.relative(result.root, r.file)).sort(), [...names].sort());
+          for (const row of result.subjects) assert.equal(c.digest(c.readFile(row.file, 128 * 1024 * 1024)), row.sha256);
+          const payload = [...names, 'preparation-run.json', 'candidate-identity.json'];
+          assert.equal(payload.length, 21);
+          const pins = (r) => payload.map(n => ({file: n, sha256: c.digest(c.readFile(path.join(r, n), 128 * 1024 * 1024))}));
+          const actual = pins(result.root);
+          const result_file = path.join(root, 'result.json');
+          fs.writeFileSync(result_file, c.encode({root: result.root, subjects: result.subjects, pins: actual}), {flag: 'wx', mode: 0o400});
+          const output = (key, value) => fs.appendFileSync(e.GITHUB_OUTPUT, `${key}<<C1_PATHS\n${value}\nC1_PATHS\n`);
+          output('result_file', result_file);
+          output('root', result.root);
+          output('subjects', result.subjects.map(r => r.file).join('\n'));
+          output('payload', payload.map(n => path.join(result.root, n)).join('\n'));
+          output('input_sha256', c.digest(i.encodeInputs(result.input)));
+          NODE
+
+  paired_input_attestation:
+    name: paired_input_attestation
+    needs: paired_input_admission
+    if: ${{ success() && github.event_name == 'workflow_dispatch' && inputs.producer_mode == 'paired-input-provenance' && needs.paired_input_admission.result == 'success' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment: agentplugins-release
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+      attestations: write
+    env:
+      PRODUCER_MODE: ${{ inputs.producer_mode }}
+      TAG: ${{ inputs.tag }}
+      SOURCE_SHA: ${{ inputs.source_sha }}
+      KIT_VERSION: ${{ inputs.plugin_kit_version }}
+      PREPARATION_RUN: ${{ inputs.preparation_run }}
+      PREPARATION_ATTEMPT: ${{ inputs.preparation_attempt }}
+      PREPARATION_ARTIFACT: ${{ inputs.preparation_artifact }}
+      PREPARATION_DIGEST: ${{ inputs.preparation_digest }}
+      PROMOTION_OPERATION: ${{ inputs.promotion_operation }}
+      PROMOTION_RECORD: ${{ inputs.promotion_record }}
+      GH_TOKEN: ${{ github.token }}
+    outputs:
+      input_sha256: ${{ steps.recheck.outputs.input_sha256 }}
+      input_artifact_id: ${{ steps.upload.outputs.artifact-id }}
+      input_artifact_sha256: ${{ steps.upload_evidence.outputs.artifact_sha256 }}
+    steps:
+      - name: C1 preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PATH="/usr/local/bin:${PATH}"
+          [[ "${GITHUB_EVENT_NAME}" == workflow_dispatch ]]
+          case "${PRODUCER_MODE}" in
+            binary-only|paired-preparation|paired-promotion) exit 0 ;;
+            paired-input-provenance) [[ -z "${PROMOTION_RECORD}" && "${PROMOTION_OPERATION}" == promote ]] ;;
+            *) exit 1 ;;
+          esac
+          [[ "${GITHUB_ACTIONS}" == true && "${GITHUB_REPOSITORY}" == 777genius/universal-agent-plugins ]]
+          [[ "${TAG}" =~ ^agentplugins-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ && ${#TAG} -le 47 ]]
+          [[ "${KIT_VERSION}" == 2.0.0 && "${TAG}" != agentplugins-v2.0.0 ]]
+          [[ "${SOURCE_SHA}" =~ ^[0-9a-f]{40}$ && ! "${SOURCE_SHA}" =~ ^0+$ ]]
+          [[ "${GITHUB_SHA}" == "${SOURCE_SHA}" && "${GITHUB_WORKFLOW_SHA}" == "${SOURCE_SHA}" ]]
+          [[ "${GITHUB_REF}" == "refs/tags/${TAG}" ]]
+          [[ "${GITHUB_WORKFLOW_REF}" == "777genius/universal-agent-plugins/.github/workflows/agentplugins-release.yml@refs/tags/${TAG}" ]]
+          positive() { [[ "$1" =~ ^[1-9][0-9]{0,15}$ && "$1" -le 9007199254740991 ]]; }
+          positive "${GITHUB_RUN_ID}"
+          positive "${GITHUB_RUN_ATTEMPT}"; [[ "${GITHUB_RUN_ATTEMPT}" -le 1000 ]]
+          positive "${PREPARATION_RUN}"; positive "${PREPARATION_ARTIFACT}"
+          positive "${PREPARATION_ATTEMPT}"; [[ "${PREPARATION_ATTEMPT}" -le 1000 ]]
+          [[ "${PREPARATION_DIGEST}" =~ ^[0-9a-f]{64}$ && ! "${PREPARATION_DIGEST}" =~ ^0+$ ]]
+          [[ "${GITHUB_JOB}" == paired_input_attestation ]]
+      - name: C1 checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: C1 setup
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "22.23.2"
+          package-manager-cache: false
+      - name: C1 stage
+        id: stage
+        shell: bash
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require('node:fs'), path = require('node:path'), assert = require('node:assert/strict');
+          const c = require('./npm/agentplugins/scripts/dual-authoring-candidate');
+          const i = require('./npm/agentplugins/scripts/authoring-native-inputs');
+          const s = require('./npm/agentplugins/scripts/stage-authoring-npm');
+          const e = process.env, selected = {tag: e.TAG, ref: `refs/tags/${e.TAG}`, source: e.SOURCE_SHA,
+            versions: {agentplugins: e.TAG.slice('agentplugins-v'.length), 'plugin-kit-ai': e.KIT_VERSION}};
+          const root = fs.mkdtempSync(path.join(e.RUNNER_TEMP, 'c1-workflow-'));
+          const scratch = path.join(root, 'scratch'); fs.mkdirSync(scratch, {mode: 0o700});
+          const options = {selected, workflow_sha: e.SOURCE_SHA};
+          Object.assign(options, {preparation: {run_id: Number(e.PREPARATION_RUN), run_attempt: Number(e.PREPARATION_ATTEMPT),
+            artifact_id: Number(e.PREPARATION_ARTIFACT), artifact_sha256: e.PREPARATION_DIGEST}, repo: process.cwd(), scratch});
+          const file = path.join(root, 'options.json'); fs.writeFileSync(file, c.encode(options), {flag: 'wx', mode: 0o400});
+          const result = i.main(['--produce-inputs', file]);
+          c.keys(result, ['root', 'input', 'subjects'], 'input CLI result');
+          const names = ['candidate/candidate.json', 'pair-prepared.json', ...c.PRODUCTS.flatMap(p => [...c.TARGETS.map(t => `${p}/${result.input.products[p].assets[t].file}`), `${p}/release-manifest.json`, `${p}/checksums.txt`]), 'native-inputs.json'];
+          assert.equal(result.subjects.length, names.length);
+          assert.deepEqual(result.subjects.map(r => path.relative(result.root, r.file)).sort(), [...names].sort());
+          for (const row of result.subjects) assert.equal(c.digest(c.readFile(row.file, 128 * 1024 * 1024)), row.sha256);
+          const payload = [...names, 'preparation-run.json', 'candidate-identity.json'];
+          assert.equal(payload.length, 21);
+          const pins = (r) => payload.map(n => ({file: n, sha256: c.digest(c.readFile(path.join(r, n), 128 * 1024 * 1024))}));
+          const actual = pins(result.root);
+          const result_file = path.join(root, 'result.json');
+          fs.writeFileSync(result_file, c.encode({root: result.root, subjects: result.subjects, pins: actual}), {flag: 'wx', mode: 0o400});
+          const output = (key, value) => fs.appendFileSync(e.GITHUB_OUTPUT, `${key}<<C1_PATHS\n${value}\nC1_PATHS\n`);
+          output('result_file', result_file);
+          output('root', result.root);
+          output('subjects', result.subjects.map(r => r.file).join('\n'));
+          output('payload', payload.map(n => path.join(result.root, n)).join('\n'));
+          output('input_sha256', c.digest(i.encodeInputs(result.input)));
+          NODE
+      - name: C1 attest
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6
+        with:
+          subject-path: ${{ steps.stage.outputs.subjects }}
+      - name: C1 recheck
+        id: recheck
+        env:
+          PREVIOUS: ${{ steps.stage.outputs.result_file }}
+          SIGNING_ROOT: ${{ steps.stage.outputs.root }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require('node:fs'), path = require('node:path'), assert = require('node:assert/strict');
+          const c = require('./npm/agentplugins/scripts/dual-authoring-candidate');
+          const i = require('./npm/agentplugins/scripts/authoring-native-inputs');
+          const s = require('./npm/agentplugins/scripts/stage-authoring-npm');
+          const e = process.env, selected = {tag: e.TAG, ref: `refs/tags/${e.TAG}`, source: e.SOURCE_SHA,
+            versions: {agentplugins: e.TAG.slice('agentplugins-v'.length), 'plugin-kit-ai': e.KIT_VERSION}};
+          const root = fs.mkdtempSync(path.join(e.RUNNER_TEMP, 'c1-workflow-'));
+          const scratch = path.join(root, 'scratch'); fs.mkdirSync(scratch, {mode: 0o700});
+          const options = {selected, workflow_sha: e.SOURCE_SHA};
+          Object.assign(options, {preparation: {run_id: Number(e.PREPARATION_RUN), run_attempt: Number(e.PREPARATION_ATTEMPT),
+            artifact_id: Number(e.PREPARATION_ARTIFACT), artifact_sha256: e.PREPARATION_DIGEST}, repo: process.cwd(), scratch});
+          const file = path.join(root, 'options.json'); fs.writeFileSync(file, c.encode(options), {flag: 'wx', mode: 0o400});
+          const result = i.main(['--produce-inputs', file]);
+          c.keys(result, ['root', 'input', 'subjects'], 'input CLI result');
+          const names = ['candidate/candidate.json', 'pair-prepared.json', ...c.PRODUCTS.flatMap(p => [...c.TARGETS.map(t => `${p}/${result.input.products[p].assets[t].file}`), `${p}/release-manifest.json`, `${p}/checksums.txt`]), 'native-inputs.json'];
+          assert.equal(result.subjects.length, names.length);
+          assert.deepEqual(result.subjects.map(r => path.relative(result.root, r.file)).sort(), [...names].sort());
+          for (const row of result.subjects) assert.equal(c.digest(c.readFile(row.file, 128 * 1024 * 1024)), row.sha256);
+          const payload = [...names, 'preparation-run.json', 'candidate-identity.json'];
+          assert.equal(payload.length, 21);
+          const pins = (r) => payload.map(n => ({file: n, sha256: c.digest(c.readFile(path.join(r, n), 128 * 1024 * 1024))}));
+          const actual = pins(result.root);
+          const previous = JSON.parse(c.readFile(e.PREVIOUS, 1024 * 1024));
+          c.keys(previous, ['root', 'subjects', 'pins'], 'original signing comparison');
+          assert.equal(previous.root, e.SIGNING_ROOT);
+          assert.deepEqual([...previous.subjects].sort((a,b) => a.file.localeCompare(b.file)), names.map(n => ({file: path.join(e.SIGNING_ROOT, n), sha256: actual.find(row => row.file === n).sha256})).sort((a,b) => a.file.localeCompare(b.file)));
+          assert.deepEqual(previous.pins, actual); assert.deepEqual(pins(previous.root), actual);
+          for (const row of previous.subjects) assert.equal(c.digest(c.readFile(row.file, 128 * 1024 * 1024)), row.sha256);
+          // Original signing root is retained; independently reacquired bytes never replace it.
+          result.root = previous.root; result.subjects = previous.subjects;
+          const result_file = path.join(root, 'result.json');
+          fs.writeFileSync(result_file, c.encode({root: result.root, subjects: result.subjects, pins: actual}), {flag: 'wx', mode: 0o400});
+          const output = (key, value) => fs.appendFileSync(e.GITHUB_OUTPUT, `${key}<<C1_PATHS\n${value}\nC1_PATHS\n`);
+          output('result_file', result_file);
+          output('root', result.root);
+          output('subjects', result.subjects.map(r => r.file).join('\n'));
+          output('payload', payload.map(n => path.join(result.root, n)).join('\n'));
+          output('input_sha256', c.digest(i.encodeInputs(result.input)));
+          NODE
+      - name: C1 upload
+        id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: authoring-input-provenance-${{ inputs.source_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.recheck.outputs.payload }}
+          if-no-files-found: error
+          retention-days: 7
+      - name: C1 upload evidence
+        id: upload_evidence
+        env:
+          ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
+          ARTIFACT_SHA256: ${{ steps.upload.outputs.artifact-digest }}
+          COMPLETION_SHA256: ${{ steps.recheck.outputs.input_sha256 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require('node:fs'), assert = require('node:assert/strict'), e = process.env;
+          assert.match(e.ARTIFACT_ID, /^[1-9][0-9]{0,15}$/);
+          const artifact_id = Number(e.ARTIFACT_ID); assert.ok(Number.isSafeInteger(artifact_id));
+          const artifact_sha256 = e.ARTIFACT_SHA256.replace(/^sha256:/, '').toLowerCase();
+          assert.match(artifact_sha256, /^[0-9a-f]{64}$/); assert.ok(!/^0+$/.test(artifact_sha256));
+          fs.appendFileSync(e.GITHUB_OUTPUT, `artifact_sha256=${artifact_sha256}\n`);
+          NODE

--- a/cli/plugin-kit-ai/cmd/agentplugins/release_workflow_test.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins/release_workflow_test.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -83,25 +85,34 @@ type producerWorkflow struct {
 		} `yaml:"workflow_run"`
 		Dispatch struct {
 			Inputs map[string]struct {
-				Default string   `yaml:"default"`
-				Options []string `yaml:"options"`
+				Default  string   `yaml:"default"`
+				Type     string   `yaml:"type"`
+				Required bool     `yaml:"required"`
+				Options  []string `yaml:"options"`
 			} `yaml:"inputs"`
 		} `yaml:"workflow_dispatch"`
 	} `yaml:"on"`
 	Permissions map[string]string `yaml:"permissions"`
 	Jobs        map[string]struct {
 		If          string            `yaml:"if"`
+		Name        string            `yaml:"name"`
+		Runner      string            `yaml:"runs-on"`
+		Timeout     int               `yaml:"timeout-minutes"`
+		Outputs     map[string]string `yaml:"outputs"`
 		Environment any               `yaml:"environment"`
 		Needs       any               `yaml:"needs"`
 		Uses        string            `yaml:"uses"`
 		Permissions map[string]string `yaml:"permissions"`
 		Env         map[string]string `yaml:"env"`
 		Steps       []struct {
-			Name string            `yaml:"name"`
-			Run  string            `yaml:"run"`
-			Uses string            `yaml:"uses"`
-			With map[string]any    `yaml:"with"`
-			Env  map[string]string `yaml:"env"`
+			Name     string            `yaml:"name"`
+			ID       string            `yaml:"id"`
+			If       string            `yaml:"if"`
+			Continue bool              `yaml:"continue-on-error"`
+			Run      string            `yaml:"run"`
+			Uses     string            `yaml:"uses"`
+			With     map[string]any    `yaml:"with"`
+			Env      map[string]string `yaml:"env"`
 		} `yaml:"steps"`
 	} `yaml:"jobs"`
 }
@@ -174,16 +185,19 @@ func TestReleaseWorkflowRunnerCacheContext(t *testing.T) {
 func TestReleasePairedPreparationReadOnlyGraph(t *testing.T) {
 	w := readProducerWorkflow(t, "agentplugins-release.yml")
 	mode := w.On.Dispatch.Inputs["producer_mode"]
-	if mode.Default != "binary-only" || strings.Join(mode.Options, ",") != "binary-only,paired-preparation,paired-promotion" {
+	if mode.Default != "binary-only" || strings.Join(mode.Options, ",") != "binary-only,paired-preparation,paired-promotion,paired-input-provenance" {
 		t.Fatal("default binary-only dispatch contract changed")
 	}
 	if len(w.Permissions) != 1 || w.Permissions["contents"] != "read" {
 		t.Fatal("workflow must default to contents-read")
 	}
-	if len(w.Jobs) != 8 {
+	if len(w.Jobs) != 11 {
 		t.Fatal("review every new producer job for preparation reachability")
 	}
 	for name, job := range w.Jobs {
+		if name == "dispatch_contract" || strings.HasPrefix(name, "paired_input_") {
+			continue
+		}
 		if name == "paired-promotion-admission" || name == "paired-sign-and-promote" {
 			if job.If != "${{ github.event_name == 'workflow_dispatch' && inputs.producer_mode == 'paired-promotion' }}" {
 				t.Fatalf("%s loses explicit promotion isolation", name)
@@ -322,16 +336,34 @@ func TestReleasePairedRouteCannotTriggerDownstreamPublication(t *testing.T) {
 // Testing a failed event must evaluate the whole OR/AND graph, not find a token.
 func downstreamCondition(t *testing.T, expression, event, conclusion string) bool {
 	t.Helper()
+	return workflowCondition(t, expression, map[string]any{"github.event_name": event, "github.event.workflow_run.conclusion": conclusion,
+		"vars.NPM_PUBLISH_READY": "true", "vars.PYPI_TRUSTED_PUBLISHING_READY": "true", "inputs.producer_mode": "paired-promotion"})
+}
+func workflowCondition(t *testing.T, expression string, values map[string]any) bool {
+	t.Helper()
 	expression = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(expression), "${{"), "}}"))
-	values := map[string]string{"github.event_name": event, "github.event.workflow_run.conclusion": conclusion,
-		"vars.NPM_PUBLISH_READY": "true", "vars.PYPI_TRUSTED_PUBLISHING_READY": "true", "inputs.producer_mode": "paired-promotion"}
+	if expression == "" {
+		expression = "success()"
+	}
+	for _, fn := range []string{"success", "always", "failure", "cancelled"} {
+		if value, ok := values[fn]; ok {
+			expression = strings.ReplaceAll(expression, fn+"()", strconv.FormatBool(value.(bool)))
+		}
+	}
 	words := regexp.MustCompile(`'[^']*'|[a-zA-Z_][a-zA-Z0-9_.]*`)
 	expression = words.ReplaceAllStringFunc(expression, func(s string) string {
 		if strings.HasPrefix(s, "'") {
 			return strconv.Quote(s[1 : len(s)-1])
 		}
 		if value, ok := values[s]; ok {
-			return strconv.Quote(value)
+			switch v := value.(type) {
+			case string:
+				return strconv.Quote(v)
+			case bool:
+				return strconv.FormatBool(v)
+			default:
+				t.Fatal("unsupported typed context")
+			}
 		}
 		if s == "true" || s == "false" {
 			return s
@@ -659,6 +691,382 @@ func TestN2ExcludedNativeExecutionRemainsFailure(t *testing.T) {
 	for _, forbidden := range []string{"runs-on: windows", "runs-on: macos", "continue-on-error:", "strategy:", "--accept-security-risk"} {
 		if strings.Contains(string(body), forbidden) {
 			t.Fatalf("excluded native route enables %s", forbidden)
+		}
+	}
+}
+
+// Fixed C1 graph expectations; fixtures prove source reachability, not hosted
+// permission enforcement, cryptographic acceptance or genuine provider custody.
+func c1Needs(w producerWorkflow, name string) []string {
+	switch n := w.Jobs[name].Needs.(type) {
+	case nil:
+		return nil
+	case string:
+		return []string{n}
+	case []any:
+		result := []string{}
+		for _, v := range n {
+			result = append(result, v.(string))
+		}
+		return result
+	default:
+		panic("unknown needs shape")
+	}
+}
+func c1Permissions(w producerWorkflow, name string) map[string]string {
+	if w.Jobs[name].Permissions != nil {
+		return w.Jobs[name].Permissions
+	}
+	return w.Permissions
+}
+func c1Scripts(w producerWorkflow, name string) string {
+	var s strings.Builder
+	for _, step := range w.Jobs[name].Steps {
+		s.WriteString(step.Run)
+	}
+	return s.String()
+}
+func c1Contract(w producerWorkflow, name string, stage, signer bool) error {
+	job, ok := w.Jobs[name]
+	if !ok {
+		return fmt.Errorf("missing %s", name)
+	}
+	need, mode, env, timeout := "dispatch_contract", "paired-input-provenance", "agentplugins-release", 20
+	if stage {
+		mode, env = "paired-stage", "npm-agentplugins"
+		timeout = 30
+	}
+	if signer {
+		timeout = 20
+		if stage {
+			need = "paired_stage"
+		} else {
+			need = "paired_input_admission"
+		}
+	}
+	condition := "${{ success() && github.event_name == 'workflow_dispatch' && inputs.producer_mode == '" + mode + "'"
+	if stage {
+		condition += " && inputs.publish == false"
+	}
+	condition += " && needs." + need + ".result == 'success' }}"
+	if job.If != condition || !reflect.DeepEqual(c1Needs(w, name), []string{need}) {
+		return fmt.Errorf("%s mode/status/needs", name)
+	}
+	permissions := map[string]string{"contents": "read", "actions": "read"}
+	if signer {
+		permissions["id-token"] = "write"
+		permissions["attestations"] = "write"
+	} else if stage {
+		permissions["attestations"] = "read"
+	}
+	if !reflect.DeepEqual(c1Permissions(w, name), permissions) {
+		return fmt.Errorf("%s effective permissions", name)
+	}
+	if (signer && job.Environment != env) || (!signer && job.Environment != nil) || job.Runner != "ubuntu-24.04" || job.Timeout != timeout {
+		return fmt.Errorf("%s execution boundary", name)
+	}
+	if len(job.Steps) < 3 || job.Steps[0].Name != "C1 preflight" || job.Steps[0].Uses != "" {
+		return fmt.Errorf("%s preflight ordering", name)
+	}
+	attest, uploads, admission, recheck := -1, 0, -1, -1
+	for index, step := range job.Steps {
+		if step.Continue || (step.If != "" && step.If != "${{ success() }}") {
+			return fmt.Errorf("%s step bypass", name)
+		}
+		if step.ID == "stage" {
+			admission = index
+		}
+		if step.ID == "recheck" {
+			recheck = index
+		}
+		if strings.HasPrefix(step.Uses, "actions/attest@") {
+			attest = index
+			if step.Uses != "actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6" || step.With["subject-path"] != "${{ steps.stage.outputs.subjects }}" {
+				return fmt.Errorf("exact subject signing")
+			}
+		}
+		if strings.HasPrefix(step.Uses, "actions/upload-artifact@") {
+			uploads++
+			if step.Uses != "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" || step.ID != "upload" || step.With["if-no-files-found"] != "error" || step.With["retention-days"] != 7 || step.With["overwrite"] != nil {
+				return fmt.Errorf("immutable upload")
+			}
+			id := "stage"
+			if signer {
+				id = "recheck"
+			}
+			if step.With["path"] != "${{ steps."+id+".outputs.payload }}" {
+				return fmt.Errorf("fixed upload payload")
+			}
+		}
+	}
+	if signer && (attest <= admission || admission < 0 || recheck <= attest) {
+		return fmt.Errorf("independent admission/sign/recheck order")
+	}
+	if !signer && attest != -1 {
+		return fmt.Errorf("unexpected signing")
+	}
+	expectedUploads := 0
+	if stage != signer {
+		expectedUploads = 1
+	}
+	if uploads != expectedUploads {
+		return fmt.Errorf("upload lifecycle")
+	}
+	body := c1Scripts(w, name)
+	for _, forbidden := range []string{"npm publish", "npm install", "--read-stage", "allow_incomplete", "needs.paired_input_admission.outputs", "needs.paired_stage.outputs.accepted"} {
+		if strings.Contains(body, forbidden) {
+			return fmt.Errorf("forbidden C1 effect or trust substitution: %s", forbidden)
+		}
+	}
+	if signer && (!strings.Contains(body, "assert.equal(previous.root, e.SIGNING_ROOT)") || !strings.Contains(body, "pins(previous.root)") || !strings.Contains(body, "result.root = previous.root") || !strings.Contains(body, "fs.mkdtempSync")) {
+		return fmt.Errorf("original signing root recheck")
+	}
+	return nil
+}
+func TestC1InputProvenanceWorkflowContract(t *testing.T) {
+	w := readProducerWorkflow(t, "agentplugins-release.yml")
+	if len(w.Jobs) != 11 || len(w.On.Dispatch.Inputs) != 10 || w.On.Dispatch.Inputs["producer_mode"].Type != "choice" || !w.On.Dispatch.Inputs["producer_mode"].Required {
+		t.Fatal("closed release inputs/jobs")
+	}
+	for _, name := range []string{"paired_input_admission", "paired_input_attestation"} {
+		if err := c1Contract(w, name, false, name == "paired_input_attestation"); err != nil {
+			t.Fatal(err)
+		}
+		body := c1Scripts(w, name)
+		for _, text := range []string{"--produce-inputs", "preparation:", "workflow_sha: e.SOURCE_SHA", "assert.equal(payload.length, 21)", "'native-inputs.json'", "'preparation-run.json', 'candidate-identity.json'"} {
+			if !strings.Contains(body, text) {
+				t.Fatalf("%s missing %s", name, text)
+			}
+		}
+	}
+	if len(w.Jobs["paired_input_admission"].Outputs) != 1 || len(w.Jobs["paired_input_attestation"].Outputs) != 3 {
+		t.Fatal("selector-only outputs")
+	}
+}
+func TestC1PublicStageWorkflowContract(t *testing.T) {
+	w := readProducerWorkflow(t, "agentplugins-npm-publish.yml")
+	if len(w.Jobs) != 6 || len(w.On.Dispatch.Inputs) != 7 || strings.Join(w.On.Dispatch.Inputs["producer_mode"].Options, ",") != "legacy,paired-stage" || w.On.Dispatch.Inputs["producer_mode"].Default != "legacy" || w.On.Dispatch.Inputs["publish"].Type != "boolean" {
+		t.Fatal("closed stage inputs/jobs")
+	}
+	for _, name := range []string{"paired_stage", "paired_stage_attestation"} {
+		if err := c1Contract(w, name, true, name == "paired_stage_attestation"); err != nil {
+			t.Fatal(err)
+		}
+		body := c1Scripts(w, name)
+		if !strings.Contains(body, "assert.equal(payload.length, 3)") || !strings.Contains(body, "input_file") || !strings.Contains(body, "Buffer.from(e.NATIVE_INPUTS, 'utf8')") {
+			t.Fatal("three retained files and Buffer transport")
+		}
+	}
+	if strings.Count(c1Scripts(w, "paired_stage"), "--stage-prepublication") != 1 || strings.Count(c1Scripts(w, "paired_stage_attestation"), "--validate-unsigned-stage") != 2 {
+		t.Fatal("pack once and independent same-run validation")
+	}
+	for name, expected := range map[string][]string{"prepare": {"dispatch_contract"}, "publish": {"prepare"}, "verify-public": {"prepare", "publish"}} {
+		if !reflect.DeepEqual(c1Needs(w, name), expected) {
+			t.Fatalf("legacy needs changed %s", name)
+		}
+	}
+	for _, name := range []string{"prepare", "publish", "verify-public"} {
+		if !strings.Contains(w.Jobs[name].If, "inputs.producer_mode == 'legacy'") || !strings.Contains(w.Jobs[name].If, "github.event_name == 'workflow_dispatch'") || len(c1Needs(w, name)) == 0 {
+			t.Fatal("legacy isolation", name)
+		}
+	}
+}
+func TestC1WorkflowFailureReachability(t *testing.T) {
+	for _, file := range []string{"agentplugins-release.yml", "agentplugins-npm-publish.yml"} {
+		w := readProducerWorkflow(t, file)
+		modes := []string{"binary-only", "paired-preparation", "paired-promotion", "paired-input-provenance", "legacy", "paired-stage", "unknown"}
+		legacyPermissions := map[string]map[string]string{
+			"dispatch_contract": {"contents": "read"}, "validate": {"checks": "read", "contents": "read", "pull-requests": "read"},
+			"build": {"contents": "read"}, "stage-draft": {"contents": "write", "id-token": "write", "attestations": "write", "artifact-metadata": "write"},
+			"platform-proof": {"contents": "read", "attestations": "read"}, "promote-release": {"contents": "write", "attestations": "read"},
+			"paired-preparation": {"contents": "read"}, "paired-promotion-admission": {"contents": "read", "actions": "read"},
+			"paired-sign-and-promote": {"contents": "write", "actions": "read", "id-token": "write", "attestations": "write", "artifact-metadata": "write"},
+			"prepare":                 {"contents": "read", "attestations": "read"}, "publish": {"contents": "read", "id-token": "write"},
+			"verify-public": {"contents": "read", "attestations": "read"},
+		}
+		for name, job := range w.Jobs {
+			if expected, ok := legacyPermissions[name]; ok && !reflect.DeepEqual(c1Permissions(w, name), expected) {
+				t.Fatalf("effective legacy permissions %s", name)
+			}
+			if name == "dispatch_contract" {
+				continue
+			}
+			for _, mode := range modes {
+				for _, event := range []string{"workflow_dispatch", "workflow_run"} {
+					for _, status := range []string{"success", "failure", "cancelled", "skipped", ""} {
+						for _, publish := range []bool{true, false} {
+							values := map[string]any{"github.event_name": event, "inputs.producer_mode": mode, "inputs.publish": publish,
+								"success": status == "success", "failure": status == "failure", "cancelled": status == "cancelled", "always": true}
+							for dependency := range w.Jobs {
+								values["needs."+dependency+".result"] = status
+							}
+							// GitHub's implicit success() applies when no status function is present.
+							reachable := workflowCondition(t, job.If, values)
+							if !strings.Contains(job.If, "success()") {
+								reachable = reachable && status == "success"
+							}
+							for _, dep := range c1Needs(w, name) {
+								reachable = reachable && values["needs."+dep+".result"] == "success"
+							}
+							if (status != "success") && reachable {
+								t.Fatalf("%s reachable after %s", name, status)
+							}
+							if strings.HasPrefix(name, "paired_input_") || strings.HasPrefix(name, "paired_stage") {
+								expected := status == "success" && event == "workflow_dispatch" && ((strings.HasPrefix(name, "paired_input_") && mode == "paired-input-provenance") || (strings.HasPrefix(name, "paired_stage") && mode == "paired-stage" && !publish))
+								if reachable != expected {
+									t.Fatalf("%s reachability %s %s %s %v", name, mode, event, status, publish)
+								}
+								for _, step := range job.Steps {
+									for _, state := range []string{"failure", "cancelled", "skipped", ""} {
+										stopped := map[string]any{"success": false, "failure": state == "failure", "cancelled": state == "cancelled", "always": true}
+										if workflowCondition(t, step.If, stopped) {
+											t.Fatalf("sensitive step survives %s", state)
+										}
+									}
+
+									if workflowCondition(t, step.If, values) && reachable && step.Continue {
+										t.Fatal("sensitive step tolerates failure")
+									}
+								}
+								if err := c1Contract(w, name, strings.HasPrefix(name, "paired_stage"), strings.HasSuffix(name, "attestation")); err != nil {
+									t.Fatal(err)
+								}
+							}
+							if file == "agentplugins-npm-publish.yml" && (name == "prepare" || name == "publish" || name == "verify-public") {
+								expected := status == "success" && event == "workflow_dispatch" && mode == "legacy" && (name == "prepare" || publish)
+								if reachable != expected {
+									t.Fatalf("legacy reachability %s %s %s %s %v", name, mode, event, status, publish)
+								}
+							}
+							if mode == "paired-stage" && (name == "prepare" || name == "publish" || name == "verify-public") && reachable {
+								t.Fatal("paired stage reaches legacy")
+							}
+						}
+					}
+				}
+			}
+		}
+		name := "paired_input_attestation"
+		if file == "agentplugins-npm-publish.yml" {
+			name = "paired_stage_attestation"
+		}
+		original := w.Jobs[name]
+		for _, mutation := range []string{"mode", "or true", "always", "needs", "output authorization", "permissions", "continue"} {
+			job := original
+			job.Steps = append(job.Steps[:0:0], job.Steps...)
+			switch mutation {
+			case "mode":
+				job.If = "${{ success() }}"
+			case "or true":
+				job.If = strings.TrimSuffix(job.If, " }}") + " || true }}"
+			case "always":
+				job.If = "${{ always() }}"
+			case "needs":
+				job.Needs = nil
+			case "output authorization":
+				job.If = "${{ needs.paired_stage.outputs.accepted == 'true' }}"
+			case "permissions":
+				job.Permissions = map[string]string{"contents": "write"}
+			case "continue":
+				job.Steps[0].Continue = true
+			}
+			w.Jobs[name] = job
+			if c1Contract(w, name, file == "agentplugins-npm-publish.yml", true) == nil {
+				t.Fatal("mutation accepted", mutation)
+			}
+		}
+		w.Jobs[name] = original
+	}
+}
+func TestC1WorkflowPreflightNoEffects(t *testing.T) {
+	for _, file := range []string{"agentplugins-release.yml", "agentplugins-npm-publish.yml"} {
+		w := readProducerWorkflow(t, file)
+		stage := file == "agentplugins-npm-publish.yml"
+		mode := "paired-input-provenance"
+		if stage {
+			mode = "paired-stage"
+		}
+		good := map[string]string{"PRODUCER_MODE": mode, "TAG": "agentplugins-v0.1.54", "KIT_VERSION": "2.0.0", "SOURCE_SHA": strings.Repeat("a", 40),
+			"GITHUB_EVENT_NAME": "workflow_dispatch", "GITHUB_ACTIONS": "true", "GITHUB_REPOSITORY": "777genius/universal-agent-plugins",
+			"GITHUB_SHA": strings.Repeat("a", 40), "GITHUB_WORKFLOW_SHA": strings.Repeat("a", 40), "GITHUB_REF": "refs/tags/agentplugins-v0.1.54",
+			"GITHUB_WORKFLOW_REF": "777genius/universal-agent-plugins/.github/workflows/" + file + "@refs/tags/agentplugins-v0.1.54",
+			"GITHUB_RUN_ID":       "21", "GITHUB_RUN_ATTEMPT": "2", "PUBLISH": "false", "NATIVE_INPUTS": "{}\n",
+			"INPUT_ARTIFACT":  `{"run_id":11,"run_attempt":1,"artifact_id":31,"artifact_sha256":"` + strings.Repeat("b", 64) + `"}`,
+			"PREPARATION_RUN": "11", "PREPARATION_ATTEMPT": "1", "PREPARATION_ARTIFACT": "31", "PREPARATION_DIGEST": strings.Repeat("b", 64), "PROMOTION_RECORD": "", "PROMOTION_OPERATION": "promote"}
+		names := []string{"dispatch_contract", "paired_input_admission", "paired_input_attestation"}
+		if stage {
+			names = []string{"dispatch_contract", "paired_stage", "paired_stage_attestation"}
+		}
+		for _, name := range names {
+			good["GITHUB_JOB"] = name
+			good["STAGE_ARTIFACT_ID"] = "901"
+			good["STAGE_ARTIFACT_SHA256"] = strings.Repeat("c", 64)
+			good["STAGE_SHA256"] = strings.Repeat("d", 64)
+			job := w.Jobs[name]
+			if len(job.Steps) == 0 {
+				t.Fatal("missing preflight")
+			}
+			for _, step := range job.Steps {
+				if step.Run != "" {
+					cmd := exec.Command("/bin/bash", "-n")
+					cmd.Stdin = strings.NewReader(step.Run)
+					if out, err := cmd.CombinedOutput(); err != nil {
+						t.Fatalf("shell syntax %s: %v %s", name, err, out)
+					}
+				}
+			}
+			cases := []map[string]string{{}}
+			for _, key := range []string{"PRODUCER_MODE", "TAG", "KIT_VERSION", "SOURCE_SHA", "GITHUB_EVENT_NAME", "GITHUB_ACTIONS", "GITHUB_REPOSITORY", "GITHUB_SHA", "GITHUB_WORKFLOW_SHA", "GITHUB_REF", "GITHUB_WORKFLOW_REF", "GITHUB_RUN_ID", "GITHUB_RUN_ATTEMPT"} {
+				for _, bad := range []string{"", "invalid", "$(touch injected)", "bad\nvalue"} {
+					cases = append(cases, map[string]string{key: bad})
+				}
+			}
+			if stage {
+				for _, bad := range []map[string]string{{"PUBLISH": "true"}, {"INPUT_ARTIFACT": "{}"}, {"INPUT_ARTIFACT": strings.ReplaceAll(good["INPUT_ARTIFACT"], `"run_attempt":1`, `"run_attempt":1001`)}, {"NATIVE_INPUTS": ""}, {"PRODUCER_MODE": "legacy"}} {
+					cases = append(cases, bad)
+				}
+			} else {
+				for _, key := range []string{"PREPARATION_RUN", "PREPARATION_ATTEMPT", "PREPARATION_ARTIFACT", "PREPARATION_DIGEST", "PROMOTION_RECORD", "PROMOTION_OPERATION"} {
+					cases = append(cases, map[string]string{key: "invalid"})
+				}
+			}
+			if name != "dispatch_contract" {
+				cases = append(cases, map[string]string{"GITHUB_JOB": "publish"})
+			}
+			if name == "paired_stage_attestation" {
+				for _, key := range []string{"STAGE_ARTIFACT_ID", "STAGE_ARTIFACT_SHA256", "STAGE_SHA256"} {
+					cases = append(cases, map[string]string{key: "invalid"})
+				}
+			}
+			for index, changes := range cases {
+				dir := t.TempDir()
+				bin := filepath.Join(dir, "bin")
+				if err := os.Mkdir(bin, 0700); err != nil {
+					t.Fatal(err)
+				}
+				for _, tool := range []string{"node", "git", "npm", "gh", "tar", "python3", "curl"} {
+					if err := os.WriteFile(filepath.Join(bin, tool), []byte("#!/bin/bash\necho effect >> \"$MARKER\"\nexit 93\n"), 0700); err != nil {
+						t.Fatal(err)
+					}
+				}
+				cmd := exec.Command("/bin/bash", "-c", job.Steps[0].Run)
+				cmd.Dir = dir
+				cmd.Env = []string{"PATH=/usr/local/bin:" + bin + ":/usr/bin:/bin", "MARKER=" + filepath.Join(dir, "effect")}
+				for key, value := range good {
+					if replacement, ok := changes[key]; ok {
+						value = replacement
+					}
+					cmd.Env = append(cmd.Env, key+"="+value)
+				}
+				output, err := cmd.CombinedOutput()
+				if (err == nil) != (index == 0) {
+					t.Fatalf("%s preflight case %v: %v %s", name, changes, err, output)
+				}
+				entries, err := os.ReadDir(dir)
+				if err != nil || len(entries) != 1 || entries[0].Name() != "bin" {
+					t.Fatalf("preflight produced effects: %v %v", entries, err)
+				}
+			}
 		}
 	}
 }

--- a/npm/agentplugins/scripts/authoring-native-inputs.js
+++ b/npm/agentplugins/scripts/authoring-native-inputs.js
@@ -287,6 +287,8 @@ function readInputs(value) {
   const snapshot = preparationSnapshot(root, o.body);
   const prepPin = o.input.preparation.artifact;
   const prepBefore = p.inspectArtifact(prepPin, WORKFLOW, o.input.identity.commit, o.scratch);
+  p.checkPreparationRef(prepPin, o.selected, o.scratch);
+  p.checkPreparationRef(o.artifact, o.selected, o.scratch);
   const prepared = p.acquireInputPreparation(o.body, o.scratch);
   const original = preparationSnapshot(prepared.root, o.body);
   const relative = (s, base) => ({ ...s,
@@ -305,11 +307,126 @@ function readInputs(value) {
   agree(preparationSnapshot(prepared.root, o.body), original, "original preparation changed");
   agree(preparationSnapshot(root, o.body), snapshot, "provenance preparation changed");
   agree(inputSubjects(root, o.body), subjects, "provenance subjects changed");
+  p.checkPreparationRef(prepPin, o.selected, o.scratch);
+  p.checkPreparationRef(o.artifact, o.selected, o.scratch);
   agree(operationOptions(value, true), o, "caller inputs changed during authentication");
   return { root, input: o.input, subjects };
 }
 
+/** Derive I only from the checked original preparation and independently bound
+ * current provenance caller. Both fixed jobs repeat this operation. */
+function produceInputsFromPreparation(value) {
+  fields(value, ["selected", "workflow_sha", "preparation", "repo", "scratch"], "preparation producer options");
+  const p = require("./authoring-promotion"), packing = require("./stage-dual-authoring-npm");
+  const selected = p.workflowSelection(value.selected, value.workflow_sha);
+  const pin = artifact(value.preparation);
+  for (const name of ["repo", "scratch"]) c.safeDirectory(value[name]);
+  const executing = path.resolve(__dirname, "../../..");
+  for (const root of [value.repo, executing]) {
+    if (root === value.scratch || root.startsWith(value.scratch + path.sep) || value.scratch.startsWith(root + path.sep)) {
+      fail("provenance source/scratch overlap");
+    }
+  }
+  const env = { PATH: "/usr/local/bin:/usr/bin:/bin", HOME: value.scratch, LC_ALL: "C.UTF-8" };
+  const toolFiles = [process.execPath, "/usr/bin/git", "/usr/bin/gh", fs.realpathSync("/usr/bin/python3")];
+  const tools = () => toolFiles.map(file => ({ file, sha256: c.digest(c.readFile(file)) }));
+  const toolPins = tools(), callerArgs = [...process.execArgv];
+  const source = packing.blobs(value.repo, selected.source, env, "stage");
+  const caller = p.inspectInputCaller(selected, value.workflow_sha, value.scratch);
+  if (caller.run_id === pin.run_id) fail("separate original preparation required");
+  const before = p.inspectArtifact(pin, WORKFLOW, selected.source, value.scratch);
+  p.checkPreparationRef(pin, selected, value.scratch);
+  const work = fs.mkdtempSync(path.join(value.scratch, "derive-inputs-"));
+  const archive = p.acquireArtifact(pin, WORKFLOW, selected.source, work);
+  const files = ["preparation-run.json", "candidate-identity.json", "candidate/candidate.json", "pair-prepared.json",
+    ...c.PRODUCTS.flatMap(product => [...c.TARGETS.map(target =>
+      `${product}/${c.assetName(product, selected.versions[product], target)}`),
+    `${product}/release-manifest.json`, `${product}/checksums.txt`])];
+  const root = p.extractArtifact(archive, pin, "preparation", files, path.join(work, "frozen"), work);
+  const snapshot = () => files.map(file => ({ file, sha256: c.digest(c.readFile(path.join(root, file), MAX_NATIVE_BYTES)) }));
+  const originals = snapshot();
+  const candidateBytes = c.readFile(path.join(root, "candidate/candidate.json"), MAX_INPUT_BYTES);
+  const candidate = JSON.parse(candidateBytes);
+  const id = identity({ repository: c.REPOSITORY, commit: selected.source, engine_revision: selected.source, versions: selected.versions });
+  const tentative = { schema: INPUT_SCHEMA, identity: id, authoring_mode: MODE, asset_scope: SCOPE,
+    candidate_sha256: c.digest(candidateBytes), pair_marker_sha256: c.digest(c.readFile(path.join(root, "pair-prepared.json"), MAX_INPUT_BYTES)),
+    products: Object.fromEntries(c.PRODUCTS.map(product => [product, {
+      tag: (product === "agentplugins" ? "agentplugins-v" : "v") + selected.versions[product],
+      manifest_sha256: c.digest(c.readFile(path.join(root, product, "release-manifest.json"), MAX_INPUT_BYTES)),
+      checksums_sha256: c.digest(c.readFile(path.join(root, product, "checksums.txt"), MAX_INPUT_BYTES)),
+      assets: candidate.products?.[product]?.assets }])),
+    preparation: { sha256: c.digest(c.readFile(path.join(root, "preparation-run.json"), MAX_INPUT_BYTES)), artifact: pin },
+    producer: caller };
+  const body = encodeInputs(tentative);
+  preparationSnapshot(root, body); // candidate, projections, metadata and original receipt
+  const result = produceInputs({ input: body, selected, workflow_sha: value.workflow_sha, scratch: value.scratch });
+  const retained = [...inputSubjects(result.root, body), ...["preparation-run.json", "candidate-identity.json"].map(file =>
+    ({ file: path.join(result.root, file), sha256: c.digest(c.readFile(path.join(result.root, file), MAX_INPUT_BYTES)) }))];
+  agree(retained.filter(row => path.basename(row.file) !== INPUT_FILE).map(row =>
+    ({ file: path.relative(result.root, row.file), sha256: row.sha256 })).sort((a, b) => a.file.localeCompare(b.file)),
+  [...originals].sort((a, b) => a.file.localeCompare(b.file)), "derived versus revalidated original payload");
+  agree(snapshot(), originals, "derivation root changed");
+  agree(p.inspectArtifact(pin, WORKFLOW, selected.source, value.scratch), before, "original provider changed");
+  p.checkPreparationRef(pin, selected, value.scratch);
+  agree(p.inspectInputCaller(selected, value.workflow_sha, value.scratch), caller, "current provenance caller");
+  agree(packing.blobs(value.repo, selected.source, env, "stage"), source, "provenance source changed");
+  agree(p.workflowSelection(value.selected, value.workflow_sha), selected, "provenance selection changed");
+  agree(tools(), toolPins, "provenance tools changed");
+  agree(process.execArgv, callerArgs, "provenance interpreter arguments");
+  return result;
+}
+
+// Fixed file transport for the two C1 modules. Options remain comparison pins;
+// reading a file never turns its I bytes into authenticated input provenance.
+function inputFileOptions(file, names) {
+  if (typeof file !== "string" || !path.isAbsolute(file) || path.resolve(file) !== file || /[\x00-\x1f]/.test(file)) {
+    fail("normalized absolute options file required");
+  }
+  const raw = c.readFile(file, MAX_INPUT_BYTES);
+  const value = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(raw));
+  fields(value, names, "CLI options");
+  // Canonical options prevent duplicate keys and ambiguous transport spelling.
+  if (!raw.equals(c.encode(value))) fail("canonical options required");
+  let input, inputFile;
+  if (names.includes("input_file")) {
+    inputFile = value.input_file;
+    if (typeof inputFile !== "string" || !path.isAbsolute(inputFile) || path.resolve(inputFile) !== inputFile ||
+        /[\x00-\x1f]/.test(inputFile) || inputFile === file) fail("normalized distinct input_file required");
+    input = c.readFile(inputFile, MAX_INPUT_BYTES);
+    decodeInputs(input);
+    delete value.input_file;
+    value.input = input;
+  }
+  const files = [file, ...(inputFile ? [inputFile] : [])];
+  for (const root of [path.resolve(__dirname, "../../.."), value.repo,
+    ...[value.node, value.npm].filter(v => typeof v === "string").map(v => path.dirname(v))].filter(Boolean)) {
+    for (const candidate of files) if (candidate === root || candidate.startsWith(root + path.sep)) fail("CLI transport overlaps source/tools");
+  }
+  return { value, recheck() {
+    agree(c.readFile(file, MAX_INPUT_BYTES), raw, "CLI options bytes");
+    if (inputFile) agree(c.readFile(inputFile, MAX_INPUT_BYTES), input, "CLI comparison I bytes");
+  } };
+}
+
+function main(args) {
+  if (args.length !== 2 || !["--produce-inputs", "--read-inputs"].includes(args[0])) {
+    fail("usage: authoring-native-inputs.js --produce-inputs|--read-inputs <absolute-options.json>");
+  }
+  const producing = args[0] === "--produce-inputs";
+  const transport = inputFileOptions(args[1], producing ?
+    ["selected", "workflow_sha", "preparation", "repo", "scratch"] :
+    ["input_file", "selected", "workflow_sha", "scratch", "artifact"]);
+  const result = producing ? produceInputsFromPreparation(transport.value) : readInputs(transport.value);
+  transport.recheck();
+  return result;
+}
+
 module.exports = Object.freeze({ encodeInputs, decodeInputs, encodeDescriptor, decodeDescriptor,
-  produceInputs, readInputs, inputSubjects,
+  produceInputs, readInputs, inputSubjects, produceInputsFromPreparation, inputFileOptions, main,
   INPUT_SCHEMA, DESCRIPTOR_SCHEMA, INPUT_FILE, MODE, SCOPE, WORKFLOW, PACKAGES,
   MAX_INPUT_BYTES, MAX_DESCRIPTOR_BYTES, MAX_NATIVE_BYTES });
+
+if (require.main === module) {
+  try { process.stdout.write(c.encode(main(process.argv.slice(2)))); }
+  catch (error) { process.stderr.write(`C1 inputs: ${error.message}\n`); process.exitCode = 1; }
+}

--- a/npm/agentplugins/scripts/authoring-promotion.js
+++ b/npm/agentplugins/scripts/authoring-promotion.js
@@ -186,15 +186,171 @@ function inspectArtifact(pin, workflow, source, cwd) {
 function acquireArtifact(pin, workflow, source, cwd) {
   cliVersion(cwd);
   const before = inspectArtifact(pin, workflow, source, cwd);
+  return downloadArtifactBytes(pin, before.item, cwd, () =>
+    exact(inspectArtifact(pin, workflow, source, cwd), before, "artifact changed during acquisition"));
+}
+// Same private bounded byte path after distinct completed/current admission.
+function downloadArtifactBytes(pin, item, cwd, recheck) {
   const file = path.join(cwd, `artifact-${pin.artifact_id}.zip`);
   if (fs.existsSync(file)) fail("artifact destination already exists");
-  // gh api follows the provider's supported artifact ZIP redirect. No free URL.
-  // Binary output is bounded in memory, never extracted or executed here.
   const zip = gh(["api", "--hostname", "github.com", `repos/${REPOSITORY}/actions/artifacts/${pin.artifact_id}/zip`], cwd, 2 * 1024 * LIMIT, null);
-  if (zip.length !== before.item.size_in_bytes || c.digest(zip) !== pin.artifact_sha256) fail("artifact ZIP digest/size mismatch");
-  exact(inspectArtifact(pin, workflow, source, cwd), before, "artifact changed during acquisition");
+  if (zip.length !== item.size_in_bytes || c.digest(zip) !== pin.artifact_sha256) fail("artifact ZIP digest/size mismatch");
+  recheck();
   fs.writeFileSync(file, zip, { flag: "wx", mode: 0o400 });
   return file;
+}
+
+// Fixed C1 provider adapters. Log mapping and runner/process custody require
+// independent genuine acceptance before positive execution. These checks do not
+// confer that acceptance, and unsupported checked-ZIP kinds remain closed.
+const STAGE_WORKFLOW = ".github/workflows/agentplugins-npm-publish.yml";
+function workflowSelection(value, workflowSha) {
+  c.keys(value, ["tag", "ref", "source", "versions"], "workflow selection");
+  c.keys(value.versions, c.PRODUCTS, "selected versions");
+  const identityValue = { repository: REPOSITORY, commit: value.source, engine_revision: value.source, versions: value.versions };
+  identity(identityValue); sha(value.source, 40);
+  if (value.source.length !== 40 || Object.values(value.versions).some(v => typeof v !== "string" || v.length > 32 || /[\r\n]/.test(v))) fail("bounded workflow identity required");
+  exact(value.versions["plugin-kit-ai"], "2.0.0", "first kit version");
+  exact([value.tag, value.ref, workflowSha], [tag(identityValue, "agentplugins"), `refs/tags/${tag(identityValue, "agentplugins")}`, value.source], "selected workflow ref/source");
+  return { tag: value.tag, ref: value.ref, source: value.source, versions: { ...value.versions } };
+}
+function callerNumber(name, maximum = Number.MAX_SAFE_INTEGER) {
+  const text = process.env[name];
+  if (typeof text !== "string" || !/^[1-9][0-9]{0,15}$/.test(text)) fail("exact caller integer required");
+  return integer(Number(text), maximum);
+}
+function currentCaller(selected, workflow, jobs) {
+  const expected = { GITHUB_ACTIONS: "true", GITHUB_EVENT_NAME: "workflow_dispatch", GITHUB_REPOSITORY: REPOSITORY,
+    GITHUB_SHA: selected.source, GITHUB_WORKFLOW_SHA: selected.source, GITHUB_REF: selected.ref,
+    GITHUB_WORKFLOW_REF: `${REPOSITORY}/${workflow}@${selected.ref}` };
+  exact(Object.fromEntries(Object.keys(expected).map(k => [k, process.env[k]])), expected, "current workflow caller");
+  if (!jobs.includes(process.env.GITHUB_JOB)) fail("fixed C1 caller job required");
+  return { workflow, source: selected.source, run_id: callerNumber("GITHUB_RUN_ID"), run_attempt: callerNumber("GITHUB_RUN_ATTEMPT", 1000) };
+}
+function attemptAtRef(pin, workflow, selected, cwd, status) {
+  const run = api(`actions/runs/${integer(pin.run_id)}/attempts/${integer(pin.run_attempt, 1000)}`, cwd);
+  exact([run.id, run.run_attempt, run.repository?.full_name, run.head_repository?.full_name,
+    run.head_sha, run.path, run.event, run.head_branch, run.status, run.conclusion],
+  [pin.run_id, pin.run_attempt, REPOSITORY, REPOSITORY, selected.source, workflow,
+    "workflow_dispatch", selected.tag, status, status === "completed" ? "success" : null], "provider invocation/ref");
+  return run;
+}
+function attemptJobs(pin, selected, cwd) {
+  const response = api(`actions/runs/${pin.run_id}/attempts/${pin.run_attempt}/jobs?per_page=100`, cwd);
+  if (!Array.isArray(response.jobs) || response.jobs.length > 100 || response.total_count !== response.jobs.length) fail("complete bounded attempt jobs required");
+  for (const job of response.jobs) {
+    integer(job.id);
+    exact([job.run_id, job.run_attempt, job.head_sha, job.head_branch],
+      [pin.run_id, pin.run_attempt, selected.source, selected.tag], "provider job attempt/ref");
+  }
+  if (new Set(response.jobs.map(j => j.id)).size !== response.jobs.length) fail("duplicate provider job ID");
+  return response.jobs;
+}
+function oneJob(jobs, name, status) {
+  const found = jobs.filter(job => job.name === name);
+  if (found.length !== 1 || found[0].status !== status || found[0].conclusion !== (status === "completed" ? "success" : null)) {
+    fail("exact fixed successful producer/current job required");
+  }
+  return found[0];
+}
+function checkPreparationRef(pin, selected, cwd) {
+  return attemptAtRef(pin, WORKFLOW, selected, cwd, "completed");
+}
+function inspectInputCaller(selected, workflowSha, cwd) {
+  selected = workflowSelection(selected, workflowSha);
+  const caller = currentCaller(selected, WORKFLOW, ["paired_input_admission", "paired_input_attestation"]);
+  cliVersion(cwd);
+  attemptAtRef(caller, WORKFLOW, selected, cwd, "in_progress");
+  const jobs = attemptJobs(caller, selected, cwd);
+  oneJob(jobs, process.env.GITHUB_JOB, "in_progress");
+  if (process.env.GITHUB_JOB === "paired_input_attestation") oneJob(jobs, "paired_input_admission", "completed");
+  for (const p of c.PRODUCTS) checkTag({ identity: { commit: selected.source, versions: selected.versions } }, p, cwd);
+  return caller;
+}
+function inspectStageCaller(selected, workflowSha, cwd) {
+  selected = workflowSelection(selected, workflowSha);
+  const caller = currentCaller(selected, STAGE_WORKFLOW, ["paired_stage"]);
+  cliVersion(cwd);
+  attemptAtRef(caller, STAGE_WORKFLOW, selected, cwd, "in_progress");
+  oneJob(attemptJobs(caller, selected, cwd), "paired_stage", "in_progress");
+  for (const p of c.PRODUCTS) checkTag({ identity: { commit: selected.source, versions: selected.versions } }, p, cwd);
+  return { ...caller, ref: selected.ref };
+}
+function stageJobEvidence(pin, selected, cwd) {
+  const job = oneJob(attemptJobs(pin, selected, cwd), "paired_stage", "completed");
+  // Names are fixed in YAML; provider records expose step names, not YAML IDs.
+  const names = ["C1 preflight", "C1 checkout", "C1 setup", "C1 stage", "C1 upload", "C1 upload evidence"];
+  if (!Array.isArray(job.steps)) fail("retained producer steps required");
+  const allowed = ["Set up job", ...names, "Post C1 setup", "Post C1 checkout", "Complete job"];
+  if (job.steps.some(step => !allowed.includes(step.name))) fail("unreviewed producer step");
+  let last = 0;
+  for (const name of names) {
+    const rows = job.steps.filter(step => step.name === name);
+    if (rows.length !== 1 || rows[0].status !== "completed" || rows[0].conclusion !== "success" ||
+        !Number.isSafeInteger(rows[0].number) || rows[0].number <= last) fail("fixed ordered successful stage steps required");
+    last = rows[0].number;
+  }
+  const log = gh(["api", "--hostname", "github.com", `repos/${REPOSITORY}/actions/jobs/${job.id}/logs`], cwd, 4 * LIMIT);
+  const records = [];
+  for (const line of log.split("\n")) {
+    // Only standalone timestamped log records; echoed command source is not evidence.
+    const match = /^\d{4}-\d\d-\d\dT[0-9:.]+Z C1_STAGE (.*)\r?$/.exec(line);
+    if (match) records.push(JSON.parse(match[1]));
+  }
+  if (records.length !== 5) fail("five ordered retained stage operation records required");
+  const [start, agent, kit, completion, upload] = records;
+  c.keys(start, ["operation", "source", "ref", "run_id", "run_attempt", "input_sha256", "input_artifact"], "stage start transcript");
+  exact([start.operation, start.source, start.ref, start.run_id, start.run_attempt],
+    ["start", selected.source, selected.ref, pin.run_id, pin.run_attempt], "stage start invocation");
+  sha(start.input_sha256); locator(start.input_artifact);
+  for (const [i, row] of [agent, kit].entries()) {
+    c.keys(row, ["operation", "product", "pack"], "stage pack transcript");
+    exact([row.operation, row.product], ["pack", c.PRODUCTS[i]], "ordered two packs");
+  }
+  c.keys(completion, ["operation", "stage_sha256"], "stage completion transcript");
+  exact(completion.operation, "completion", "completed stage operation"); sha(completion.stage_sha256);
+  c.keys(upload, ["operation", "artifact_id", "artifact_sha256", "stage_sha256"], "stage upload transcript");
+  exact(upload, { operation: "upload", artifact_id: pin.artifact_id, artifact_sha256: pin.artifact_sha256,
+    stage_sha256: completion.stage_sha256 }, "retained upload selector");
+  return { job, records };
+}
+function inspectCurrentStage(value) {
+  c.keys(value, ["artifact", "selected", "workflow_sha", "scratch"], "current stage options");
+  const pin = locator(value.artifact), selected = workflowSelection(value.selected, value.workflow_sha);
+  c.safeDirectory(value.scratch);
+  const caller = currentCaller(selected, STAGE_WORKFLOW, ["paired_stage_attestation"]);
+  exact([pin.run_id, pin.run_attempt], [caller.run_id, caller.run_attempt], "current stage locator");
+  cliVersion(value.scratch);
+  attemptAtRef(pin, STAGE_WORKFLOW, selected, value.scratch, "in_progress");
+  oneJob(attemptJobs(pin, selected, value.scratch), "paired_stage_attestation", "in_progress");
+  const evidence = stageJobEvidence(pin, selected, value.scratch);
+  const item = api(`actions/artifacts/${pin.artifact_id}`, value.scratch);
+  exact([item.id, item.expired, item.digest, item.workflow_run?.id, item.workflow_run?.head_sha, item.name],
+    [pin.artifact_id, false, `sha256:${pin.artifact_sha256}`, pin.run_id, selected.source,
+      `authoring-public-stage-${selected.source}-${pin.run_id}-${pin.run_attempt}`], "current stage artifact custody");
+  integer(item.size_in_bytes, 2 * 1024 * LIMIT);
+  const created = Date.parse(item.created_at), started = Date.parse(evidence.job.started_at), ended = Date.parse(evidence.job.completed_at);
+  if (![created, started, ended].every(Number.isFinite) || created < started || created > ended) fail("artifact outside producer upload interval");
+  // Incidental timestamps and growing unrelated jobs are deliberately omitted.
+  return { item: { id: item.id, digest: item.digest, size_in_bytes: item.size_in_bytes, name: item.name },
+    job_id: evidence.job.id, records: evidence.records };
+}
+function acquireCurrentStage(value) {
+  const before = inspectCurrentStage(value);
+  return downloadArtifactBytes(value.artifact, before.item, value.scratch, () =>
+    exact(inspectCurrentStage(value), before, "current stage custody changed"));
+}
+function checkStageEvidence(artifact, selected, workflowSha, record, stageSha, cwd) {
+  selected = workflowSelection(selected, workflowSha); locator(artifact);
+  const evidence = stageJobEvidence(artifact, selected, cwd);
+  const expected = [
+    { operation: "start", source: record.producer.source, ref: record.producer.ref, run_id: record.producer.run_id,
+      run_attempt: record.producer.run_attempt, input_sha256: record.native_inputs.sha256, input_artifact: record.native_inputs.artifact },
+    ...c.PRODUCTS.map(product => ({ operation: "pack", product, pack: record.packs[product] })),
+    { operation: "completion", stage_sha256: stageSha },
+    { operation: "upload", artifact_id: artifact.artifact_id, artifact_sha256: artifact.artifact_sha256, stage_sha256: stageSha }];
+  exact(evidence.records, expected, "retained operation transcript versus exact S");
+  return { job_id: evidence.job.id, records: evidence.records };
 }
 
 // Extract only the file already checked by acquireArtifact. Python opens once,
@@ -565,7 +721,7 @@ if (require.main === module) {
   try { process.stdout.write(JSON.stringify(main(process.argv.slice(2))) + "\n"); }
   catch (error) { process.stderr.write(`authoring promotion: ${error.message}\n`); process.exitCode = 1; }
 }
-module.exports = { SCHEMA, WORKFLOW, GH_VERSION, LANES, encodeRecord, decodeRecord, validateSelection, admitRecord, requireNativeContracts,
+module.exports = { inspectStageCaller, workflowSelection, inspectInputCaller, checkPreparationRef, acquireCurrentStage, inspectCurrentStage, checkStageEvidence, SCHEMA, WORKFLOW, GH_VERSION, LANES, encodeRecord, decodeRecord, validateSelection, admitRecord, requireNativeContracts,
   inspectArtifact, acquireArtifact, extractArtifact, acquirePreparation, checkNativeContracts, admitNativeEvidence,
   acquireInputPreparation, readInputPreparation, checkInputTags,
   mapVerifiedOutput, verifySubject, verifyStageSubject, frozenSubjects, releasePins, inspectPair, promote };

--- a/npm/agentplugins/scripts/stage-authoring-npm.js
+++ b/npm/agentplugins/scripts/stage-authoring-npm.js
@@ -439,6 +439,7 @@ function stagePrepublication(value) {
   context.env.PATH = "/usr/local/bin:/usr/bin:/bin";
   const source = packing.blobs(o.repo, o.input.identity.commit, context.env, "stage");
   const toolPins = toolSnapshot(o), tools = stageTools(o, context), callerArgs = [...process.execArgv];
+  agreeStage(promotion.inspectStageCaller(o.selected, o.workflow_sha, context.root), o.producer, "provider stage caller");
   const providers = stageProviders(o, o.artifact, context.root);
   const admitted = stageReadInputs(o, o.artifact, context.root);
   const before = stageInputSnapshot(admitted.root, o.body);
@@ -453,6 +454,8 @@ function stagePrepublication(value) {
   agreeStage(packing.blobs(o.repo, o.input.identity.commit, context.env, "stage"), source, "source before packing");
   agreeStage(toolSnapshot(o), toolPins, "tools before packing");
   fs.mkdirSync(o.output, { mode: 0o700 });
+  process.stderr.write("C1_STAGE " + JSON.stringify({ operation: "start", source: o.producer.source, ref: o.producer.ref,
+    run_id: o.producer.run_id, run_attempt: o.producer.run_attempt, input_sha256: c.digest(o.body), input_artifact: o.artifact }) + "\n");
   const packs = {};
   for (const product of c.PRODUCTS) {
     const root = path.join(o.output, product); fs.mkdirSync(root, { mode: 0o700 });
@@ -462,6 +465,7 @@ function stagePrepublication(value) {
     const retained = retainedPack(o.output, product, o.input), { shasum, ...legacy } = retained;
     agreeStage(packed, legacy, "pack return versus retained bytes");
     packs[product] = retained; // actual SHA1, without changing v1 pack return/receipts
+    process.stderr.write("C1_STAGE " + JSON.stringify({ operation: "pack", product, pack: retained }) + "\n");
   }
   for (const product of c.PRODUCTS) {
     checkGeneratedRoot(path.join(o.output, product), pair[product]);
@@ -474,6 +478,7 @@ function stagePrepublication(value) {
   agreeStage(toolSnapshot(o), toolPins, "tools after packing");
   agreeStage(process.execArgv, callerArgs, "caller interpreter arguments");
   agreeStage(stageOptions(value, false), o, "caller before completion");
+  agreeStage(promotion.inspectStageCaller(o.selected, o.workflow_sha, context.root), o.producer, "provider stage completion");
   for (const product of c.PRODUCTS) {
     checkGeneratedRoot(path.join(o.output, product), pair[product]);
     agreeStage(retainedPack(o.output, product, o.input), packs[product], "retained pair before completion");
@@ -486,6 +491,8 @@ function stagePrepublication(value) {
     producer: o.producer, assertions: Object.fromEntries(ASSERTIONS.map(n => [n, true])) };
   const completed = decodeStage(encodeStage(record, o.body), o.body);
   packing.completeRecord(o.output, completed);
+  process.stderr.write("C1_STAGE " + JSON.stringify({ operation: "completion",
+    stage_sha256: c.digest(c.readFile(path.join(o.output, "completion.json"), MAX_STAGE_BYTES)) }) + "\n");
   return completed;
 }
 
@@ -493,12 +500,48 @@ function stagePrepublication(value) {
  * referenced I through readInputs. The required input Buffer is a comparison
  * pin, never an authentication flag. Check both retained packs without packing.
  * Returns staging evidence only, never qualification or execution permission. */
-function readStage(value) {
+function retainedContext(value) {
   const o = stageOptions(value, true), context = packing.npmContext(o.workParent);
   context.env.PATH = "/usr/local/bin:/usr/bin:/bin";
-  const source = packing.blobs(o.repo, o.input.identity.commit, context.env, "stage"), toolPins = toolSnapshot(o);
+  return { o, context, source: packing.blobs(o.repo, o.input.identity.commit, context.env, "stage"), toolPins: toolSnapshot(o) };
+}
+function recheckSubjects(result) {
+  for (const row of result.subjects) pinFile(row.file, row.sha256, 128 * 1024 * 1024);
+}
+function readStage(value) {
+  const { o, context, source, toolPins } = retainedContext(value);
   const before = promotion.inspectArtifact(o.artifact, STAGE_WORKFLOW, o.input.identity.commit, context.root);
   const archive = promotion.acquireArtifact(o.artifact, STAGE_WORKFLOW, o.input.identity.commit, context.root);
+  const retained = openRetainedStage(o, context, archive);
+  const { record, subjects } = retained;
+  const multiset = subjects.map(s => ({ name: path.basename(s.file), digest: { sha256: s.sha256 } }));
+  for (const subject of subjects) promotion.verifyStageSubject(subject.file, { name: path.basename(subject.file),
+    sha256: subject.sha256, source: record.producer.source, workflow_sha: o.workflow_sha, ref: record.producer.ref,
+    run_id: record.producer.run_id, run_attempt: record.producer.run_attempt, subjects: multiset }, context.root);
+  const result = validateRetainedStage(value, o, context, source, toolPins, retained);
+  agreeStage(promotion.inspectArtifact(o.artifact, STAGE_WORKFLOW, o.input.identity.commit, context.root), before, "completed stage provider");
+  agreeStage(packing.blobs(o.repo, o.input.identity.commit, context.env, "stage"), source, "source after signatures");
+  agreeStage(toolSnapshot(o), toolPins, "tools after signatures");
+  agreeStage(stageOptions(value, true), o, "caller after signatures");
+  recheckSubjects(result);
+  return result;
+}
+/** Fixed same-run unsigned acquisition, only for paired_stage_attestation.
+ * It cannot weaken the completed reader or accept a caller's staging root. */
+function validateUnsignedStage(value) {
+  const { o, context, source, toolPins } = retainedContext(value);
+  const custody = { artifact: o.artifact, selected: o.selected, workflow_sha: o.workflow_sha, scratch: context.root };
+  const before = promotion.inspectCurrentStage(custody);
+  const archive = promotion.acquireCurrentStage(custody);
+  const result = validateRetainedStage(value, o, context, source, toolPins, openRetainedStage(o, context, archive));
+  stageCaller(result.record.producer);
+  agreeStage(promotion.inspectCurrentStage(custody), before, "current stage provider");
+  recheckSubjects(result);
+  return result;
+}
+// Both entrypoints share precisely the retained byte checks. This private
+// function has no completed/authenticated switches or injected verifier.
+function openRetainedStage(o, context, archive) {
   const names = ["completion.json", ...c.PRODUCTS.map(p => `${inputs.PACKAGES[p]}-${o.input.identity.versions[p]}.tgz`)];
   const root = promotion.extractArtifact(archive, o.artifact, "public-stage", names, path.join(context.root, "stage"), context.root);
   const body = pinFile(path.join(root, "completion.json"), o.stage_sha256, MAX_STAGE_BYTES), record = decodeStage(body, o.body);
@@ -509,10 +552,11 @@ function readStage(value) {
   }
   const subjects = names.map(name => ({ file: path.join(root, name), sha256: name === "completion.json" ? o.stage_sha256 :
     record.packs[c.PRODUCTS.find(p => record.packs[p].file === name)].sha256 }));
-  const multiset = subjects.map(s => ({ name: path.basename(s.file), digest: { sha256: s.sha256 } }));
-  for (const subject of subjects) promotion.verifyStageSubject(subject.file, { name: path.basename(subject.file),
-    sha256: subject.sha256, source: invocation.source, workflow_sha: o.workflow_sha, ref: invocation.ref,
-    run_id: invocation.run_id, run_attempt: invocation.run_attempt, subjects: multiset }, context.root);
+  return { root, record, subjects, body };
+}
+function validateRetainedStage(value, o, context, source, toolPins, retained) {
+  const { root, record, subjects, body } = retained;
+  const evidence = promotion.checkStageEvidence(o.artifact, o.selected, o.workflow_sha, record, o.stage_sha256, context.root);
   const providers = stageProviders(o, record.native_inputs.artifact, context.root);
   const admitted = stageReadInputs(o, record.native_inputs.artifact, context.root);
   const snapshot = stageInputSnapshot(admitted.root, o.body);
@@ -523,7 +567,7 @@ function readStage(value) {
     agreeStage(retainedPack(root, product, o.input), record.packs[product], "authenticated retained pack");
     packing.verifyPack(path.join(root, record.packs[product].file), pair[product], path.join(context.root, `read-${product}`), context.env);
   }
-  agreeStage(promotion.inspectArtifact(o.artifact, STAGE_WORKFLOW, o.input.identity.commit, context.root), before, "stage provider");
+  agreeStage(promotion.checkStageEvidence(o.artifact, o.selected, o.workflow_sha, record, o.stage_sha256, context.root), evidence, "stage operation evidence");
   agreeStage(stageProviders(o, record.native_inputs.artifact, context.root), providers, "input providers");
   agreeStage(stageInputSnapshot(admitted.root, o.body), snapshot, "reader inputs");
   agreeStage(packing.blobs(o.repo, o.input.identity.commit, context.env, "stage"), source, "reader source");
@@ -613,13 +657,32 @@ function prepare(options) {
   packing.completeRecord(options.output, record);
   return record;
 }
+function main(args) {
+  if (args.length !== 2) throw new Error("one operation and absolute options file required");
+  if (args[0] === "--prepare") {
+    if (!path.isAbsolute(args[1])) throw new Error("absolute preparation options required");
+    return prepare(JSON.parse(c.readFile(args[1], 1024 * 1024)));
+  }
+  if (!["--stage-prepublication", "--read-stage", "--validate-unsigned-stage"].includes(args[0])) throw new Error("unknown C1 stage operation");
+  const producing = args[0] === "--stage-prepublication";
+  const transport = inputs.inputFileOptions(args[1], ["input_file", "selected", "workflow_sha", "artifact", "repo", "workParent", "node", "npm",
+    ...(producing ? ["producer", "output"] : ["stage_sha256"])]);
+  let result;
+  if (producing) {
+    const record = stagePrepublication(transport.value), root = transport.value.output;
+    const stage_sha256 = c.digest(c.readFile(path.join(root, "completion.json"), MAX_STAGE_BYTES));
+    const subjects = [{ file: path.join(root, "completion.json"), sha256: stage_sha256 },
+      ...c.PRODUCTS.map(product => ({ file: path.join(root, record.packs[product].file), sha256: record.packs[product].sha256 }))];
+    result = { root, record, subjects, stage_sha256 };
+  } else result = args[0] === "--read-stage" ? readStage(transport.value) : validateUnsignedStage(transport.value);
+  transport.recheck();
+  return result;
+}
 // Public blob verification re-enters this module while the CLI is preparing.
 module.exports = { prepare, packageFiles, ALLOWLIST, COMMON,
-  encodeStage, decodeStage, pairedPackageFiles, STAGE_ALLOWLIST, stagePrepublication, readStage };
+  encodeStage, decodeStage, pairedPackageFiles, STAGE_ALLOWLIST, stagePrepublication, readStage, validateUnsignedStage, main };
 
 if (require.main === module) {
-  try {
-    if (process.argv.length !== 4 || process.argv[2] !== "--prepare" || !path.isAbsolute(process.argv[3])) throw new Error("usage: stage-authoring-npm.js --prepare <absolute-options.json>");
-    process.stdout.write(c.encode(prepare(JSON.parse(c.readFile(process.argv[3], 1024 * 1024)))));
-  } catch (e) { process.stderr.write(`public npm preparation: ${e.message}\n`); process.exitCode = 1; }
+  try { process.stdout.write(c.encode(main(process.argv.slice(2)))); }
+  catch (e) { process.stderr.write(`public npm preparation: ${e.message}\n`); process.exitCode = 1; }
 }

--- a/npm/agentplugins/test/authoring-native-inputs.test.js
+++ b/npm/agentplugins/test/authoring-native-inputs.test.js
@@ -307,7 +307,7 @@ test("structural consistency only: constructor and decoder byte limits include e
 
 test("structural consistency only: four codecs stay pure beside separately named custody operations", () => {
   assert.deepEqual(Object.entries(contract).filter(([, v]) => typeof v === "function").map(([k]) => k),
-    ["encodeInputs", "decodeInputs", "encodeDescriptor", "decodeDescriptor", "produceInputs", "readInputs", "inputSubjects"]);
+    ["encodeInputs", "decodeInputs", "encodeDescriptor", "decodeDescriptor", "produceInputs", "readInputs", "inputSubjects", "produceInputsFromPreparation", "inputFileOptions", "main"]);
   assert.ok(Object.isFrozen(contract));
   const f = fixture(), snapshot = json(f), input = encodeInputs(f);
   const d = descriptor(f, input, "agentplugins"), before = json(d);
@@ -393,6 +393,7 @@ function c1Fixture(t) {
     artifact_id: 501, artifact_sha256: sha(90) };
   const reading = { ...options, artifact };
   const calls = [];
+  t.mock.method(promotion, "checkPreparationRef", () => ({fixture_only: "completed original ref"}));
   t.mock.method(promotion, "checkInputTags", (bytes, cwd) => {
     calls.push("tags"); assert.deepEqual(bytes, body); assert.equal(cwd, scratch);
   });
@@ -585,3 +586,104 @@ test("C1 provenance producer completion collision preserves the existing file", 
   assert.throws(() => contract.produceInputs(f.options), /EEXIST/);
   assert.deepEqual(fs.readFileSync(file), previous);
 });
+
+function workflowPreparation(t) {
+  const f = c1Fixture(t), packing = require('../scripts/stage-dual-authoring-npm');
+  const originalRead = c.readFile;
+  const tools = new Set([process.execPath, '/usr/bin/git', '/usr/bin/gh', fs.realpathSync('/usr/bin/python3')]);
+  t.mock.method(c, 'readFile', (file, max) => tools.has(file) ? Buffer.from(`tool fixture ${file}`) : originalRead(file, max));
+  const repo = path.join(path.dirname(f.scratch), 'repo'); fs.mkdirSync(repo);
+  const derivation = path.join(path.dirname(f.scratch), 'derivation'); fs.mkdirSync(derivation);
+  for (const name of f.files) {
+    fs.mkdirSync(path.dirname(path.join(derivation, name)), {recursive: true});
+    fs.copyFileSync(path.join(f.root, name), path.join(derivation, name));
+  }
+  const options = {selected: f.options.selected, workflow_sha: f.options.workflow_sha,
+    preparation: f.input.preparation.artifact, repo, scratch: f.scratch};
+  t.mock.method(packing, 'blobs', () => ({fixture_only: 'source pins'}));
+  t.mock.method(promotion, 'inspectInputCaller', () => copy(f.input.producer));
+  t.mock.method(promotion, 'checkPreparationRef', () => ({fixture_only: 'original tag invocation'}));
+  t.mock.method(promotion, 'acquireArtifact', (pin, workflow, source, work) => {
+    assert.deepEqual(pin, options.preparation); assert.equal(workflow, contract.WORKFLOW);
+    assert.equal(source, options.selected.source); return path.join(work, `artifact-${pin.artifact_id}.zip`);
+  });
+  t.mock.method(promotion, 'extractArtifact', (archive, pin, kind, files) => {
+    assert.equal(kind, 'preparation'); assert.deepEqual([...files].sort(), [...f.files].sort());
+    assert.equal(path.basename(archive), `artifact-${pin.artifact_id}.zip`); return derivation;
+  });
+  return {...f, derivation, producerOptions: options};
+}
+test('C1 workflow derives I from checked original preparation and revalidates without Q', t => {
+  const f = workflowPreparation(t), file = path.join(f.scratch, 'options.json');
+  fs.writeFileSync(file, c.encode(f.producerOptions));
+  const result = contract.main(['--produce-inputs', file]);
+  assert.deepEqual(result.input, f.input); assert.equal(result.subjects.length, 19);
+  assert.deepEqual(fs.readFileSync(path.join(result.root, 'native-inputs.json')), f.body);
+  assert.deepEqual(Object.keys(result).sort(), ['input', 'root', 'subjects']);
+  assert.equal(f.calls.filter(x => typeof x === 'object').length, 0);
+});
+for (const name of ['candidate/candidate.json', 'candidate-identity.json', 'pair-prepared.json', 'preparation-run.json',
+  'agentplugins/release-manifest.json', 'plugin-kit-ai/checksums.txt']) {
+  test(`C1 workflow contradictory original ${name} rejects derivation`, t => {
+    const f = workflowPreparation(t);
+    // Preparation receipts are immutable; substitute contradictory comparison
+    // bytes at the existing read seam, never overwrite a read-only receipt.
+    const read = c.readFile;
+    t.mock.method(c, 'readFile', (file, max) => {
+      const body = read(file, max);
+      return file === path.join(f.derivation, name) ? Buffer.concat([body, Buffer.from('\n')]) : body;
+    });
+    assert.throws(() => contract.produceInputsFromPreparation(f.producerOptions));
+    assert.equal(fs.existsSync(path.join(f.root, 'native-inputs.json')), false);
+  });
+}
+test('C1 workflow file transport passes exact Buffer to completed I authentication', t => {
+  const f = c1Fixture(t), input_file = path.join(f.scratch, 'comparison.json'), file = path.join(f.scratch, 'options.json');
+  fs.writeFileSync(input_file, f.body);
+  const {input, ...options} = f.reading;
+  fs.writeFileSync(file, c.encode({...options, input_file}));
+  const result = contract.main(['--read-inputs', file]);
+  assert.deepEqual(result.input, f.input);
+  assert.equal(f.calls.filter(x => typeof x === 'object').length, 19);
+});
+for (const defect of ['object', 'Buffer JSON', 'unknown field', 'relative file', 'duplicate key', 'unknown flag', 'extra flag']) {
+  test(`C1 workflow ${defect} transport fails before provider effects`, t => {
+    const f = c1Fixture(t), file = path.join(f.scratch, 'options.json');
+    const {input, ...options} = f.reading;
+    const value = {...options, input_file: path.join(f.scratch, 'comparison.json')};
+    fs.writeFileSync(value.input_file, f.body);
+    if (defect === 'object') value.input_file = f.input;
+    if (defect === 'Buffer JSON') {delete value.input_file; value.input = f.body;}
+    if (defect === 'unknown field') value.authenticated = true;
+    if (defect === 'relative file') value.input_file = 'comparison.json';
+    let bytes = c.encode(value);
+    if (defect === 'duplicate key') bytes = Buffer.from(bytes.toString().replace('{', '{"input_file":"ignored",'));
+    fs.writeFileSync(file, bytes);
+    const args = [defect === 'unknown flag' ? '--produce' : '--read-inputs', file];
+    if (defect === 'extra flag') args.push('--read-inputs');
+    assert.throws(() => contract.main(args)); assert.equal(f.calls.length, 0);
+  });
+}
+test('C1 workflow comparison file change during authentication rejects CLI success', t => {
+  const f = c1Fixture(t), input_file = path.join(f.scratch, 'comparison.json'), file = path.join(f.scratch, 'options.json');
+  fs.writeFileSync(input_file, f.body); const {input, ...options} = f.reading;
+  fs.writeFileSync(file, c.encode({...options, input_file}));
+  t.mock.method(promotion, 'verifySubject', () => fs.writeFileSync(input_file, Buffer.from('changed')));
+  assert.throws(() => contract.main(['--read-inputs', file]), /CLI comparison/);
+});
+
+for (const defect of ['source', 'caller', 'tools', 'original ref', 'reacquired original']) {
+  test(`C1 workflow derivation rejects changed ${defect} before a usable result`, t => {
+    const f = workflowPreparation(t); let checks = 0;
+    if (defect === 'source') t.mock.method(require('../scripts/stage-dual-authoring-npm'), 'blobs', () => ({fixture_only: ++checks}));
+    if (defect === 'caller') t.mock.method(promotion, 'inspectInputCaller', () => ({...f.input.producer, run_attempt: f.input.producer.run_attempt + checks++}));
+    if (defect === 'original ref') t.mock.method(promotion, 'checkPreparationRef', () => {throw Error('foreign original tag ref');});
+    if (defect === 'tools') {
+      const original = c.readFile;
+      t.mock.method(c, 'readFile', (file, max) => file === '/usr/bin/gh' ? Buffer.from(`changed tool ${checks++}`) : original(file,max));
+    }
+    if (defect === 'reacquired original') t.mock.method(promotion, 'acquireInputPreparation', () => {throw Error('original preparation contradiction');});
+    assert.throws(() => contract.produceInputsFromPreparation(f.producerOptions));
+    assert.equal(f.calls.filter(v => typeof v === 'object').length, 0, 'no signing or authentication result from producer fixture');
+  });
+}

--- a/npm/agentplugins/test/authoring-promotion.test.js
+++ b/npm/agentplugins/test/authoring-promotion.test.js
@@ -910,3 +910,112 @@ test("C1 stage integration fixed npm signer uses existing verification interface
     assert.throws(() => p.verifyStageSubject(active.file, expected, root)); assert.equal(calls.length, before);
   }
 });
+
+// New fixed workflow interfaces only. Provider/log bytes below are explicitly
+// mocked orchestration evidence, never genuine custody or N2 acceptance.
+function c1WorkflowProvider(t) {
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'c1-workflow-provider-'));
+  const artifact = {run_id: 701, run_attempt: 3, artifact_id: 801, artifact_sha256: hash('opaque checked byte fixture')};
+  const workflow = '.github/workflows/agentplugins-npm-publish.yml';
+  const fields = {GITHUB_ACTIONS: 'true', GITHUB_EVENT_NAME: 'workflow_dispatch', GITHUB_REPOSITORY: c.REPOSITORY,
+    GITHUB_SHA: selected.source, GITHUB_WORKFLOW_SHA: selected.source, GITHUB_REF: selected.ref,
+    GITHUB_WORKFLOW_REF: `${c.REPOSITORY}/${workflow}@${selected.ref}`, GITHUB_RUN_ID: '701', GITHUB_RUN_ATTEMPT: '3',
+    GITHUB_JOB: 'paired_stage_attestation'};
+  for (const [key, value] of Object.entries(fields)) {
+    const prior = process.env[key]; process.env[key] = value;
+    t.after(() => {if (prior === undefined) delete process.env[key]; else process.env[key] = prior;});
+  }
+  const run = {id: 701, run_attempt: 3, status: 'in_progress', conclusion: null, event: 'workflow_dispatch',
+    repository: {full_name: c.REPOSITORY}, head_repository: {full_name: c.REPOSITORY}, head_sha: selected.source,
+    path: workflow, head_branch: selected.tag};
+  const job = {id: 901, run_id: 701, run_attempt: 3, head_sha: selected.source, head_branch: selected.tag,
+    name: 'paired_stage', status: 'completed', conclusion: 'success', started_at: '2026-09-09T01:00:00Z',
+    completed_at: '2026-09-09T01:10:00Z', steps: ['C1 preflight', 'C1 checkout', 'C1 setup', 'C1 stage', 'C1 upload', 'C1 upload evidence']
+      .map((name, i) => ({name, number: i + 2, status: 'completed', conclusion: 'success'}))};
+  const signing = {...job, id: 902, name: 'paired_stage_attestation', status: 'in_progress', conclusion: null};
+  const jobs = {total_count: 2, jobs: [job, signing]};
+  const item = {id: 801, expired: false, digest: `sha256:${artifact.artifact_sha256}`,
+    workflow_run: {id: 701, head_sha: selected.source}, size_in_bytes: Buffer.byteLength('opaque checked byte fixture'),
+    name: `authoring-public-stage-${selected.source}-701-3`, created_at: '2026-09-09T01:05:00Z'};
+  const records = [
+    {operation: 'start', source: selected.source, ref: selected.ref, run_id: 701, run_attempt: 3,
+      input_sha256: hash('I'), input_artifact: {run_id: 601, run_attempt: 2, artifact_id: 701, artifact_sha256: hash('I zip')}},
+    {operation: 'pack', product: 'agentplugins', pack: {fixture_only: 'agent'}},
+    {operation: 'pack', product: 'plugin-kit-ai', pack: {fixture_only: 'kit'}},
+    {operation: 'completion', stage_sha256: hash('S')},
+    {operation: 'upload', artifact_id: 801, artifact_sha256: artifact.artifact_sha256, stage_sha256: hash('S')}];
+  const calls = [];
+  t.mock.method(cp, 'spawnSync', (exe, args, options) => {
+    assert.equal(exe, '/usr/bin/gh'); calls.push(args);
+    let stdout;
+    const endpoint = args.at(-1);
+    if (args[0] === '--version') stdout = `gh version ${p.GH_VERSION} (mocked)\n`;
+    else if (endpoint.endsWith('/zip')) stdout = Buffer.from('opaque checked byte fixture');
+    else if (endpoint.endsWith('/logs')) stdout = records.map(r => `2026-09-09T01:06:00.000Z C1_STAGE ${JSON.stringify(r)}\n`).join('');
+    else if (endpoint.endsWith('/jobs?per_page=100')) stdout = JSON.stringify(jobs);
+    else if (endpoint.includes('/attempts/')) stdout = JSON.stringify(run);
+    else if (endpoint.includes('/commits/')) stdout = JSON.stringify({sha: selected.source});
+    else if (endpoint.endsWith('/artifacts/801')) stdout = JSON.stringify(item);
+    else assert.fail(`unexpected provider request ${endpoint}`);
+    return {status: 0, stdout};
+  });
+  return {scratch, artifact, workflow, run, job, signing, jobs, item, records, calls,
+    options: {artifact, selected, workflow_sha: selected.source, scratch}};
+}
+test('C1 workflow current unsigned custody downloads exact same checked bytes; completed reader stays closed', t => {
+  const f = c1WorkflowProvider(t);
+  assert.throws(() => p.inspectArtifact(f.artifact, f.workflow, selected.source, f.scratch), /successful workflow/);
+  const file = p.acquireCurrentStage(f.options);
+  assert.deepEqual(fs.readFileSync(file), Buffer.from('opaque checked byte fixture'));
+  assert.equal(f.calls.filter(args => args.at(-1).endsWith('/zip')).length, 1);
+  assert.throws(() => p.acquireCurrentStage(f.options), /already exists/);
+  assert.equal(f.calls.filter(args => args.at(-1).endsWith('/zip')).length, 1);
+});
+for (const defect of ['failed', 'cancelled', 'skipped', 'incomplete', 'old attempt', 'foreign run', 'foreign ref',
+  'unknown caller', 'ambiguous producer', 'artifact ID', 'artifact name', 'artifact digest', 'expired', 'upload time',
+  'missing log', 'duplicate pack', 'reordered packs', 'wrong upload', 'wrong completion', 'extra step', 'step failed', 'partial jobs']) {
+  test(`C1 workflow fixed current-stage rejects ${defect} before download`, t => {
+    const f = c1WorkflowProvider(t);
+    if (['failed', 'cancelled', 'skipped'].includes(defect)) f.job.conclusion = defect;
+    if (defect === 'incomplete') f.job.status = 'in_progress';
+    if (defect === 'old attempt') f.run.run_attempt--;
+    if (defect === 'foreign run') f.options.artifact = {...f.artifact, run_id: 700};
+    if (defect === 'foreign ref') f.run.head_branch = 'main';
+    if (defect === 'unknown caller') process.env.GITHUB_JOB = 'publish';
+    if (defect === 'ambiguous producer') {f.jobs.jobs.push({...f.job, id: 903}); f.jobs.total_count++;}
+    if (defect === 'artifact ID') f.item.id++;
+    if (defect === 'artifact name') f.item.name += '-other';
+    if (defect === 'artifact digest') f.item.digest = `sha256:${hash('other')}`;
+    if (defect === 'expired') f.item.expired = true;
+    if (defect === 'upload time') f.item.created_at = '2026-09-10T00:00:00Z';
+    if (defect === 'missing log') f.records.pop();
+    if (defect === 'duplicate pack') f.records.splice(2, 0, f.records[1]);
+    if (defect === 'reordered packs') [f.records[1], f.records[2]] = [f.records[2], f.records[1]];
+    if (defect === 'wrong upload') f.records[4].artifact_id++;
+    if (defect === 'wrong completion') f.records[4].stage_sha256 = hash('different');
+    if (defect === 'extra step') f.job.steps.push({name: 'npm publish', number: 20});
+    if (defect === 'step failed') f.job.steps[3].conclusion = 'failure';
+    if (defect === 'partial jobs') f.jobs.total_count++;
+    assert.throws(() => p.acquireCurrentStage(f.options));
+    assert.equal(f.calls.filter(args => args.at(-1).endsWith('/zip')).length, 0);
+    assert.deepEqual(fs.readdirSync(f.scratch), []);
+  });
+}
+test('C1 workflow current-stage cannot accept completed toggle, caller root or verifier', t => {
+  const f = c1WorkflowProvider(t);
+  for (const key of ['allow_incomplete', 'authenticated', 'root', 'verify', 'producer']) {
+    assert.throws(() => p.acquireCurrentStage({...f.options, [key]: true}));
+  }
+  assert.equal(f.calls.length, 0);
+});
+test('C1 workflow provenance signer independently requires live provider caller and successful admission', t => {
+  const f = c1WorkflowProvider(t);
+  process.env.GITHUB_JOB = 'paired_input_attestation';
+  process.env.GITHUB_WORKFLOW_REF = `${c.REPOSITORY}/${p.WORKFLOW}@${selected.ref}`;
+  f.run.path = p.WORKFLOW; f.job.name = 'paired_input_admission'; f.signing.name = 'paired_input_attestation';
+  const caller = p.inspectInputCaller(selected, selected.source, f.scratch);
+  assert.deepEqual(caller, {workflow: p.WORKFLOW, source: selected.source, run_id: 701, run_attempt: 3});
+  f.job.conclusion = 'failure';
+  assert.throws(() => p.inspectInputCaller(selected, selected.source, f.scratch));
+  assert.equal(f.calls.filter(args => args.at(-1).endsWith('/zip')).length, 0);
+});

--- a/npm/agentplugins/test/authoring-public-stage.test.js
+++ b/npm/agentplugins/test/authoring-public-stage.test.js
@@ -403,7 +403,7 @@ test("C1 pure inventories: separate exact stage additions and unchanged legacy e
     ".github/workflows/agentplugins-release.yml", ".github/workflows/agentplugins-npm-publish.yml"]);
   assert.ok(Object.isFrozen(stage.STAGE_ALLOWLIST));
   assert.deepEqual(Object.keys(stage), ["prepare", "packageFiles", "ALLOWLIST", "COMMON",
-    "encodeStage", "decodeStage", "pairedPackageFiles", "STAGE_ALLOWLIST", "stagePrepublication", "readStage"]);
+    "encodeStage", "decodeStage", "pairedPackageFiles", "STAGE_ALLOWLIST", "stagePrepublication", "readStage", "validateUnsignedStage", "main"]);
 });
 
 test("C1 pure runtime regression: existing loadRelease rejects v2 and v1/null using only in-memory reads", t => {
@@ -487,6 +487,12 @@ function integrationFixture(t, hook = () => {}) {
   t.mock.method(promotion, "checkInputTags", body => { assert.deepEqual(body, f.inputBytes); event("tags"); });
   t.mock.method(promotion, "inspectArtifact", (pin, workflow, source) => {
     assert.equal(source, f.input.identity.commit); event("inspect", { pin, workflow }); return clone({ pin, workflow, source });
+  });
+  t.mock.method(promotion, "inspectStageCaller", () => { event("stage-caller"); return clone(options.producer); });
+  t.mock.method(promotion, "checkStageEvidence", () => { event("stage-evidence"); return {fixture_only: "ordered provider transcript"}; });
+  t.mock.method(promotion, "inspectCurrentStage", o => { event("current-custody", o); return {fixture_only: clone(o.artifact)}; });
+  t.mock.method(promotion, "acquireCurrentStage", o => {
+    event("acquire-current", o); return put(o.scratch, `artifact-${o.artifact.artifact_id}.zip`, Buffer.from("checked current ZIP fixture"));
   });
   t.mock.method(promotion, "acquireArtifact", (pin, workflow, source, cwd) => {
     assert.equal(workflow, options.producer.workflow); assert.equal(source, f.input.identity.commit);
@@ -768,4 +774,66 @@ test("C1 stage integration existing pack engine validates entries, modes, bytes,
     }
   }
   assert.equal(count, 14);
+});
+
+function workflowTransport(f, options, basename) {
+  const {input, ...rest} = options;
+  const input_file = f.put(f.base, `${basename}-I.json`, input);
+  return f.put(f.base, `${basename}.json`, c.encode({...rest, input_file}));
+}
+test('C1 workflow CLI producer emits closed result and unsigned validator never packs or checks S signatures', t => {
+  const f = integrationFixture(t);
+  const produced = f.api.main(['--stage-prepublication', workflowTransport(f, f.options, 'produce')]);
+  assert.deepEqual(Object.keys(produced), ['root', 'record', 'subjects', 'stage_sha256']);
+  assert.equal(produced.subjects.length, 3); assert.equal(f.calls.filter(([n]) => n === 'pack').length, 2);
+  const result = f.api.main(['--validate-unsigned-stage', workflowTransport(f, f.readOptions(), 'unsigned')]);
+  assert.deepEqual(result.record, produced.record); assert.equal(result.subjects.length, 3);
+  assert.equal(f.calls.filter(([n]) => n === 'pack').length, 2);
+  assert.equal(f.calls.filter(([n]) => n === 'signer').length, 0);
+  assert.ok(f.calls.some(([n]) => n === 'read-I')); assert.ok(f.calls.some(([n]) => n === 'stage-evidence'));
+  const completed = f.api.main(['--read-stage', workflowTransport(f, f.readOptions(), 'completed')]);
+  assert.deepEqual(completed.record, result.record);
+  assert.equal(f.calls.filter(([n]) => n === 'signer').length, 3);
+  assert.equal(f.calls.filter(([n]) => n === 'pack').length, 2);
+});
+for (const defect of ['current custody', 'I signature', 'operation evidence', 'completion.json', 'agent pack', 'kit pack', 'generated pin']) {
+  test(`C1 workflow unsigned validator rejects ${defect} without pack or S signing`, t => {
+    let reading = false;
+    const f = integrationFixture(t, (name) => {
+      if (reading && ((defect === 'I signature' && name === 'read-I') ||
+        (defect === 'operation evidence' && name === 'stage-evidence') ||
+        (defect === 'current custody' && name === 'current-custody'))) throw Error(defect);
+    });
+    f.api.stagePrepublication(f.options); const options = f.readOptions(); reading = true;
+    if (defect.endsWith('pack')) {
+      const product = defect === 'agent pack' ? 'agentplugins' : 'plugin-kit-ai';
+      fs.appendFileSync(path.join(f.options.output, `${inputs.PACKAGES[product]}-${f.input.identity.versions[product]}.tgz`), 'changed');
+    }
+    if (defect === 'completion.json' || defect === 'generated pin') {
+      const original = c.readFile;
+      const retained = fs.readFileSync(path.join(f.options.output, 'completion.json'));
+      const record = JSON.parse(retained); record.generated.agentplugins['README.md'] = sha(19);
+      const changed = defect === 'completion.json' ? Buffer.concat([retained, Buffer.from('changed')]) : c.encode(record);
+      if (defect === 'generated pin') options.stage_sha256 = c.digest(changed);
+      t.mock.method(c, 'readFile', (file, max) => path.basename(file) === 'completion.json' ? changed : original(file, max));
+    }
+    assert.throws(() => f.api.validateUnsignedStage(options));
+    assert.equal(f.calls.filter(([n]) => n === 'pack').length, 2);
+    assert.equal(f.calls.filter(([n]) => n === 'signer').length, 0);
+  });
+}
+test('C1 workflow stage CLI rejects object/path transport, unknown operations and input mutation', t => {
+  const f = integrationFixture(t), file = workflowTransport(f, f.options, 'options');
+  for (const args of [['--unknown', file], ['--read-stage', file, file], ['--read-stage', 'relative']]) assert.throws(() => f.api.main(args));
+  const options = JSON.parse(fs.readFileSync(file)); options.input_file = {type: 'Buffer', data: [1]};
+  fs.writeFileSync(file, c.encode(options)); assert.throws(() => f.api.main(['--stage-prepublication', file]));
+  assert.equal(f.calls.length, 0);
+});
+test('C1 workflow second pack failure cannot emit completion transcript or S', t => {
+  const transcript = [];
+  t.mock.method(process.stderr, 'write', chunk => {transcript.push(String(chunk)); return true;});
+  const f = integrationFixture(t, (name, data) => {if (name === 'pack' && data.product === 'plugin-kit-ai') throw Error('second pack failed');});
+  assert.throws(() => f.api.stagePrepublication(f.options), /second pack/);
+  assert.equal(fs.existsSync(path.join(f.options.output, 'completion.json')), false);
+  assert.equal(transcript.filter(line => line.includes('"operation":"completion"')).length, 0);
 });


### PR DESCRIPTION
Adds paired-input-provenance and paired-stage workflow routes with explicit admission/signing job separation, CLI transport for the existing APIs, and a current-run unsigned-stage validator. The completed-stage reader continues to require completed success and all three signatures. Legacy publishing routes remain isolated from the new modes.

Stacked on #227 at 4ef512f4fb77881c25c7b34dcfc21fe675a3a13a. Refs #225 and #208. Nine files, 1,792 changed lines.

Validation: author reports 112 selected Node tests and 11 focused Go tests passed, plus eight YAML JavaScript syntax checks. Orchestration verified the sealed artifact manifest, exact patch, all file hashes/modes, unchanged 3,365 unowned regular files, and commit identity. Independent hosted review ACCEPT on 0d50e5b58a9b45fcdc01b5a8ceee1e8059471a42 independently reran all 112 Node and 11 Go tests. All 10 required repository CI checks passed on that exact head. Reviewer additionally verified the one tracked symlink unchanged by link text/mode; it was omitted from the author regular-file count. All 10 review manifest entries were independently checksum-verified.

This is source integration only. Genuine provider/action log mapping, protected signing execution, accepted N2 and artifact kinds, tool custody, public E2E and release qualification remain open. Mocked tests do not prove those gates. The runtime's automatic handoff materialization failed; the separately sealed author patch was verified and mechanically committed without retrying materialization.
