### PR TITLE
fix(authoring): integrate offline public evidence checkpoint

### DIFF
--- a/cli/plugin-kit-ai/cmd/agentplugins/main_test.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins/main_test.go
@@ -1,17 +1,25 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"errors"
+	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/777genius/plugin-kit-ai/cli/internal/authoringcli"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/directoryv1"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 )
 
 type failingRoundTripper struct{}
@@ -110,5 +118,131 @@ func TestInvalidScopeAndTargetDoNotCreateDataRoot(t *testing.T) {
 				t.Fatalf("invalid invocation mutated data root: %v", statErr)
 			}
 		})
+	}
+}
+
+// Serial transport fixture: intended requests are recorded and denied in memory.
+// No socket, trusted assessment, scanner executable or cache entry is supplied.
+type offlineSecurityTransport struct{ urls []string }
+
+func (r *offlineSecurityTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.urls = append(r.urls, req.URL.String())
+	return nil, errors.New("offline-security-transport-sentinel")
+}
+func securityFixtureTree(t *testing.T, root string) map[string]string {
+	t.Helper()
+	entries := map[string]string{}
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		st, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if !st.IsDir() && !st.Mode().IsRegular() {
+			return fmt.Errorf("unexpected fixture entry %s", p)
+		}
+		var b []byte
+		if !st.IsDir() {
+			b, err = os.ReadFile(p)
+			if err != nil {
+				return err
+			}
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+		entries[rel] = fmt.Sprintf("%s/%x", st.Mode(), sha256.Sum256(b))
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return entries
+}
+func TestOfflinePublicInstallerSecurityBoundary(t *testing.T) {
+	home, source, state := t.TempDir(), t.TempDir(), t.TempDir()
+	client := filepath.Join(home, ".codex")
+	if err := os.Mkdir(client, 0700); err != nil {
+		t.Fatal(err)
+	}
+	for p, body := range map[string]string{filepath.Join(client, "config.toml"): "# synthetic client\n",
+		filepath.Join(source, "plugin.json"): `{"$schema":"` + domain.PluginSchemaV1 + `","name":"demo"}`} {
+		if err := os.WriteFile(p, []byte(body), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", client)
+	t.Setenv("AGENTPLUGINS_HOME", state)
+	t.Setenv("PATH", home)
+	t.Setenv("AGENTPLUGINS_SECURITY_ORIGIN", "")
+	beforeSource, beforeHome, beforeState := securityFixtureTree(t, source), securityFixtureTree(t, home), securityFixtureTree(t, state)
+	transport := &offlineSecurityTransport{}
+	oldTransport, oldArgs, oldOut, oldErr := http.DefaultTransport, os.Args, os.Stdout, os.Stderr
+	defer func() { http.DefaultTransport, os.Args, os.Stdout, os.Stderr = oldTransport, oldArgs, oldOut, oldErr }()
+	http.DefaultTransport = transport
+	stdout, err := os.CreateTemp(t.TempDir(), "stdout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stdout.Close()
+	stderr, err := os.CreateTemp(t.TempDir(), "stderr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stderr.Close()
+	os.Stdout, os.Stderr = stdout, stderr
+	argv := []string{"add", source, "--target=codex", "--scope=project", "--dry-run", "--format=json"}
+	os.Args = append([]string{"agentplugins"}, argv...)
+	var out, errout bytes.Buffer
+	err = executeRelease(context.Background(), argv, authoringcli.Streams{Out: &out, Err: &errout}, run)
+	if err == nil || out.Len() != 0 || errout.String() != "agentplugins: --scope project is not supported by the current client adapters; the public CLI supports user scope only\n" || len(transport.urls) != 0 {
+		t.Fatalf("preflight boundary: %v %q %q requests=%v", err, out.String(), errout.String(), transport.urls)
+	}
+	if !reflect.DeepEqual(beforeState, securityFixtureTree(t, state)) || !reflect.DeepEqual(beforeSource, securityFixtureTree(t, source)) || !reflect.DeepEqual(beforeHome, securityFixtureTree(t, home)) {
+		t.Fatal("preflight acquired or wrote state")
+	}
+	os.Args = []string{"agentplugins", "add", source, "--target=codex", "--dry-run", "--format=json"}
+	err = run()
+	if err == nil || !strings.Contains(err.Error(), "security assessment failed before installation") || !strings.Contains(err.Error(), "offline-security-transport-sentinel") {
+		t.Fatalf("security bypassed: %v", err)
+	}
+	if len(transport.urls) != 4 {
+		t.Fatalf("expected three index attempts then scanner acquisition: %v", transport.urls)
+	}
+	for _, url := range transport.urls[:3] {
+		if url != defaultSecurityOrigin+"latest.json" {
+			t.Fatalf("unexpected index URL %s", url)
+		}
+	}
+	if !strings.HasPrefix(transport.urls[3], "https://github.com/777genius/lintai/releases/download/v0.1.3/lintai-v0.1.3-") {
+		t.Fatal(transport.urls)
+	}
+	b, err := os.ReadFile(stdout.Name())
+	if err != nil || len(b) != 0 {
+		t.Fatalf("published result: %s %v", b, err)
+	}
+	b, err = os.ReadFile(stderr.Name())
+	if err != nil || string(b) != "Resolving and validating one Agent Plugin package for every selected target...\n" {
+		t.Fatalf("progress changed: %s %v", b, err)
+	}
+	if !reflect.DeepEqual(beforeSource, securityFixtureTree(t, source)) || !reflect.DeepEqual(beforeHome, securityFixtureTree(t, home)) {
+		t.Fatal("source/client mutation")
+	}
+	// Only empty scanner acquisition directories are permitted; no lifecycle state,
+	// assessment cache, executable bytes or leaked private source snapshot.
+	want := []string{".", "security", "security/lintai", "security/lintai/0.1.3", "security/lintai/0.1.3/" + runtime.GOOS + "-" + runtime.GOARCH}
+	entries := securityFixtureTree(t, state)
+	if len(entries) != len(want) {
+		t.Fatalf("unexpected installer effects: %v", entries)
+	}
+	for _, rel := range want {
+		st, err := os.Stat(filepath.Join(state, rel))
+		if err != nil || !st.IsDir() {
+			t.Fatalf("unexpected scanner scratch %s %v", rel, err)
+		}
 	}
 }

--- a/cli/plugin-kit-ai/cmd/agentplugins/release_root_test.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins/release_root_test.go
@@ -225,3 +225,40 @@ func TestReleaseCompletionProcessStderr(t *testing.T) {
 		}
 	}
 }
+
+func TestReleaseOfflineInstallerObservationDispatch(t *testing.T) {
+	sentinel := errors.New("valid production dry-run still requires installer")
+	for _, tc := range []struct {
+		args  []string
+		calls int
+	}{
+		{[]string{"add", "/disposable/generated skill", "--target=codex", "--dry-run", "--format=json"}, 1},
+		{[]string{"add", "--help", "--format=json"}, 0},
+		{[]string{"author", "--help", "--format=json"}, 0},
+		{[]string{"author"}, 0},
+	} {
+		var out, stderr bytes.Buffer
+		calls := 0
+		err := executeRelease(context.Background(), tc.args, authoringcli.Streams{Out: &out, Err: &stderr}, func() error { calls++; return sentinel })
+		if calls != tc.calls {
+			t.Fatalf("dispatch %v calls=%d", tc.args, calls)
+		}
+		if tc.calls == 1 {
+			if !errors.Is(err, sentinel) || out.Len() != 0 || stderr.String() != "agentplugins: "+sentinel.Error()+"\n" {
+				t.Fatal(err, out.String(), stderr.String())
+			}
+		} else if err != nil || stderr.Len() != 0 {
+			t.Fatal(err, stderr.String())
+		}
+		if tc.args[0] == "add" && tc.calls == 0 {
+			var got any
+			if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			want := `{"schema_version":1,"command":"help","result":"success","data":{"commands":null,"use":"agentplugins add"}}` + "\n"
+			if out.String() != want {
+				t.Fatalf("installer visibility JSON changed: %s", out.String())
+			}
+		}
+	}
+}

--- a/cli/plugin-kit-ai/internal/authoring/commands/packed_installer_test.go
+++ b/cli/plugin-kit-ai/internal/authoring/commands/packed_installer_test.go
@@ -253,3 +253,72 @@ func TestPackedInstallerSourceHarness(t *testing.T) {
 		})
 	}
 }
+
+// Assessment values here are deliberate test inputs, never lintai output/cache.
+type boundaryAssessment struct {
+	*packedScanner
+	fail       bool
+	assessment domain.SecurityAssessment
+}
+
+func (s *boundaryAssessment) Evaluate(ctx context.Context, in domain.SecurityEvaluationInput) (domain.SecurityAssessment, error) {
+	a, err := s.packedScanner.Evaluate(ctx, in)
+	if err != nil {
+		return a, err
+	}
+	if s.fail {
+		return a, fmt.Errorf("injected assessment failure")
+	}
+	a.Outcome = domain.SecurityBlockingFindings
+	a.Counts = domain.SecurityCounts{Blocking: 1, Total: 1}
+	a.Findings = []domain.SecurityFinding{{Code: "TEST-BLOCKING", Disposition: "block", Severity: "high", Path: "plugin.json", Message: "Deliberate test input"}}
+	s.assessment = a
+	return a, nil
+}
+func TestPackedInstallerAssessmentBoundaries(t *testing.T) {
+	for _, fail := range []bool{true, false} {
+		t.Run(fmt.Sprintf("assessment-error-%t", fail), func(t *testing.T) {
+			source := filepath.Join(t.TempDir(), "demo")
+			author := commands.App{Projects: project.Service{Scratch: t.TempDir()}, Revision: publicRevision, PublicContract: true}
+			if _, code, out := publicRun(t, author, []string{"init", source, "--name=demo", "--template=skill", "--format=json"}, false); code != 0 {
+				t.Fatal(out)
+			}
+			fixture, scratch := t.TempDir(), t.TempDir()
+			beforeSource, beforeFixture, beforeScratch := packedTree(t, source), packedTree(t, fixture), packedTree(t, scratch)
+			registry, err := specregistry.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			detector := &fixtureDetector{clients: []domain.DetectedClient{{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: fixture}}}
+			scanner := &boundaryAssessment{packedScanner: &packedScanner{fixtureScanner: fixtureScanner{t: t}, source: source, scratch: scratch, tree: beforeSource}, fail: fail}
+			app := agentpluginscli.App{UserHome: fixture, ManagedRoot: filepath.Join(fixture, "managed"), Detector: detector, StateStore: noEffectState{},
+				SourceAcquirer: sourceacquisition.Acquirer{TempRoot: scratch}, PackageLoader: loader.Loader{Registry: registry}, NativePackageLoader: loader.OpenAILoader{Loader: loader.Loader{Registry: registry}}, SecurityEvaluator: scanner,
+				Lifecycle: usecase.Service{Stager: noEffectStager{}, Activator: noEffectActivator{}}}
+			var out, stderr bytes.Buffer
+			err = authoringcli.Factory(func() (*cobra.Command, error) { return agentpluginscli.NewRoot(app), nil }).Execute(context.Background(),
+				[]string{"add", source, "--target=codex", "--dry-run", "--format=json"}, authoringcli.Streams{Out: &out, Err: &stderr})
+			if fail {
+				if err == nil || !strings.Contains(err.Error(), "injected assessment failure") || out.Len() != 0 {
+					t.Fatal("assessment error published result", err, out.String())
+				}
+			} else {
+				var report struct {
+					Result string
+					Data   struct {
+						DryRun   bool `json:"dry_run"`
+						Security domain.SecurityAssessment
+					}
+				}
+				if err != nil || json.Unmarshal(out.Bytes(), &report) != nil || report.Result != "success" || !report.Data.DryRun || !reflect.DeepEqual(report.Data.Security, scanner.assessment) {
+					t.Fatal("blocking findings lost", err, out.String())
+				}
+			}
+			if stderr.Len() != 0 || detector.calls != 1 || scanner.calls != 1 {
+				t.Fatal("wrong seam or output", stderr.String(), detector.calls, scanner.calls)
+			}
+			if !reflect.DeepEqual(beforeSource, packedTree(t, source)) || !reflect.DeepEqual(beforeFixture, packedTree(t, fixture)) || !reflect.DeepEqual(beforeScratch, packedTree(t, scratch)) {
+				t.Fatal("assessment path mutated fixture or leaked acquisition")
+			}
+		})
+	}
+}

--- a/npm/agentplugins/scripts/packed-installer-bridge.js
+++ b/npm/agentplugins/scripts/packed-installer-bridge.js
@@ -158,7 +158,18 @@ function publicInit(lane) {
     ...(lane.endsWith("remote") ? ["--url=https://docs.example.com/mcp"] : lane.endsWith("stdio") ? ["--runtime=node"] : []),
     ...(template === "hybrid" ? ["--mcp-template=mcp-" + lane.split("-")[1]] : [])];
 }
-function publicEvidence(cfg, native, configPath) {
+function installerBoundary(projectRoot) {
+  return { executable_observation: "help-and-preflight-rejection", valid_add_dry_run: "not_evaluated",
+    argv: ["add", path.join(projectRoot, "skill"), "--target=codex", "--dry-run", "--format=json"],
+    reason: "production-security-inputs-not-offline" };
+}
+function installerHelp(value) {
+  assert.deepEqual(value, { schema_version: 1, command: "help", result: "success",
+    data: { use: "agentplugins add", commands: null } }, "installer help visibility only");
+}
+function publicEvidence(cfg, native, configPath, intake = "public-fixture/v1") {
+  assert.ok(["public-fixture/v1", "public-fixture/v2"].includes(intake), "explicit public schema required");
+  const v2 = intake === "public-fixture/v2";
   c.keys(cfg, ["prepare", "completionDigest", "evidenceOutput"], "public config");
   const o = cfg.prepare, v = o.candidate;
   c.keys(o, ["candidate", "repo", "node", "npm", "output", "projectionPins", "pairMarkerDigest"], "public preparation");
@@ -169,8 +180,8 @@ function publicEvidence(cfg, native, configPath) {
     "pair_marker_sha256", "projection_pins", "fixtureRoot", "target", "packs", "binaries", "installations", "tools",
     "invocations", "invocations_sha256", "downloads_sha256", "result_sha256", "projects", "trees",
     "fixture_acquisition_execution", "qualification", "signed_promotion", "public_eligible", "release_eligible",
-    "platform_acceptance", "attested", "runtime_evidence"], "public terminal");
-  assert.equal(native.schema, "dual-authoring-public-native/v1"); assert.equal(native.status, "completed");
+    "platform_acceptance", "attested", "runtime_evidence", ...(v2 ? ["installer_boundary"] : [])], "public terminal");
+  assert.equal(native.schema, v2 ? "dual-authoring-public-native/v2" : "dual-authoring-public-native/v1"); assert.equal(native.status, "completed");
   falseClaims(native); assert.equal(native.signed_promotion, false); assert.equal(native.public_eligible, false);
   assert.equal(native.qualification, null); assert.equal(native.fixture_acquisition_execution, true);
   assert.equal(native.runtime_evidence, "not_evaluated"); assert.equal(native.target, "linux-amd64");
@@ -262,12 +273,20 @@ function publicEvidence(cfg, native, configPath) {
     }
   }
   command("plugin-kit-ai", ["update", "--all", "--format=json"], 2);
-  command("agentplugins", ["add", path.join(native.projects.agentplugins, "skill"), "--target=codex", "--dry-run", "--format=json"]);
+  if (v2) {
+    assert.deepEqual(native.installer_boundary, installerBoundary(native.projects.agentplugins), "outstanding production add requirement");
+    command("agentplugins", ["add", "--help", "--format=json"]);
+    command("agentplugins", ["add", path.join(native.projects.agentplugins, "skill"), "--target=codex", "--scope=project", "--dry-run", "--format=json"], 1);
+  } else command("agentplugins", ["add", path.join(native.projects.agentplugins, "skill"), "--target=codex", "--dry-run", "--format=json"]);
   assert.equal(native.invocations, expected.length); assert.equal(invocations.length, expected.length);
   invocations.forEach((row, i) => {
     c.keys(row, ["product", "argv", "status", "signal", "stdout", "stderr"], "public invocation");
     const want = expected[i]; assert.equal(row.product, want.product); assert.deepEqual(row.argv, want.argv);
-    assert.equal(row.status, want.status); assert.equal(row.signal, null); assert.equal(row.stderr, ""); assert.equal(typeof row.stdout, "string");
+    assert.equal(row.status, want.status); assert.equal(row.signal, null); assert.equal(typeof row.stdout, "string");
+    const rejection = v2 && i === 70;
+    assert.equal(row.stderr, rejection ? "agentplugins: --scope project is not supported by the current client adapters; the public CLI supports user scope only\n" : "");
+    if (rejection) assert.equal(row.stdout, "");
+    if (v2 && i === 69) installerHelp(JSON.parse(row.stdout));
     if (want.author) {
       const result = JSON.parse(row.stdout); assert.equal(result.result, "success"); assert.equal(result.schema_version, 1);
       assert.equal(result.data.revision, v.identity.commit); assert.equal(result.data.engine, "standard-first-slice/1");
@@ -286,18 +305,19 @@ function publicEvidence(cfg, native, configPath) {
   return { identity: v.identity, repo: o.repo, candidate_sha256: v.manifestDigest, packs: native.packs, projects,
     snapshots: [...roots.slice(1).map(root => snapshot(root)), snapshot(native.fixtureRoot, true)],
     public_evidence: { schema: native.schema, signed_promotion: false, public_eligible: false, qualification: null,
-      pair_marker_sha256: native.pair_marker_sha256, tools: native.tools, binaries: native.binaries } };
+      pair_marker_sha256: native.pair_marker_sha256, tools: native.tools, binaries: native.binaries,
+      ...(v2 ? { installer_boundary: native.installer_boundary } : {}) } };
 }
 function intake(request) {
   if (!Object.hasOwn(request, "intake")) return privateIntake(request);
   c.keys(request, [...REQUEST_KEYS, "intake"], "public bridge request");
-  assert.equal(request.intake, "public-fixture/v1"); assert.equal(request.disposableEvidence, true);
+  assert.ok(["public-fixture/v1", "public-fixture/v2"].includes(request.intake)); assert.equal(request.disposableEvidence, true);
   pin(request.nativeConfig, request.nativeConfigSha256);
   const cfg = json(request.nativeConfig);
   const terminal = path.join(cfg.evidenceOutput, "public-native-completion.json"); pin(terminal, request.nativeCompletionSha256);
   const native = json(terminal);
   assert.equal(native.identity.commit, request.expectedCommit); assert.equal(native.fixtureRoot, request.fixtureRoot);
-  return publicEvidence(cfg, native, request.nativeConfig);
+  return publicEvidence(cfg, native, request.nativeConfig, request.intake);
 }
 function seal(request) {
   const inputs = intake(request);
@@ -333,4 +353,4 @@ if (require.main === module) {
     } else throw new Error("usage: node packed-installer-bridge.js seal REQUEST OUTPUT | verify CONFIG SHA256 COMMIT");
   } catch (error) { process.stderr.write(`packed installer bridge: ${error.message}\n`); process.exitCode = 1; }
 }
-module.exports = { LANES, PRODUCTS, intake, seal, verify, snapshot, publicInit, publicEvidence, publishSeal };
+module.exports = { LANES, PRODUCTS, intake, seal, verify, snapshot, publicInit, publicEvidence, publishSeal, installerBoundary, installerHelp };

--- a/npm/agentplugins/scripts/packed-installer-bridge.md
+++ b/npm/agentplugins/scripts/packed-installer-bridge.md
@@ -180,9 +180,9 @@ and attestation remain false. Local synthetic/source tests are not this run.
 
 Public preparation is **not** private native completion. The public producer
 `test/public-authoring-native.test.js` now emits an exclusive
-`public-native-completion.json` (`dual-authoring-public-native/v1`) only after
+`public-native-completion.json` (`dual-authoring-public-native/v2`) only after
 both products finish five lanes, `extra-skill`, static parity, isolation, cache
-recovery, and lifecycle checks. Its 70 authoring/installer invocation records
+recovery, and lifecycle checks. Its 71 authoring/installer invocation records
 are ordered and complete. Five successful npm installations separately bind
 actual fixture tarball paths and SHA256 values (independent prefixes, shared
 prefix, and reinstall). Preparation tarballs remain separate, unqualified
@@ -200,7 +200,7 @@ read-only byte consistency; it does not authenticate an arbitrary supplied log.
 Use the existing six request fields (`expectedCommit`, `nativeConfig`,
 `nativeConfigSha256`, `nativeCompletionSha256`, `fixtureRoot`,
 `disposableEvidence`) with the additional exact field
-`"intake": "public-fixture/v1"`. The completion digest must independently pin
+`"intake": "public-fixture/v2"`. The completion digest must independently pin
 `public-native-completion.json`. Omitting `intake` still selects the unchanged
 strict private schema. Unknown intake values and public/private substitution
 fail closed. Seal with the same `packed-installer-bridge.js seal REQUEST OUTPUT`
@@ -233,3 +233,31 @@ The final integrated source (including the independently owned preparation
 initialization fix) still needs owner-scheduled public native execution and
 packed planner acceptance. These focused synthetic tests do not satisfy that
 E2E or the external release/required-check prerequisites.
+
+Public v2 explicitly narrows executable installer evidence to command visibility
+and preflight rejection. Rows 1–69 retain the original authoring sequence; row 70
+is `agentplugins add --help --format=json` (one successful help JSON document,
+empty stderr); row 71 adds `--scope=project` to the original generated Skill
+vector and requires exit 1, no signal, empty stdout and the exact user-scope-only
+error. Totals are 69 zero exits, one retired-command exit 2, and one preflight
+exit 1. Both project trees, client and installer roots retain entries/bytes/modes.
+The test-only helper rejects valid installer vectors before spawning; it does
+not establish process-level network denial for Go descendants.
+
+The required `installer_boundary` is sealed into `public_evidence` and the
+public summary: `executable_observation: help-and-preflight-rejection`,
+`valid_add_dry_run: not_evaluated`, `reason: production-security-inputs-not-offline`,
+and `argv` retains the original valid add vector without the rejected scope.
+Strict v1 intake remains explicitly selectable and cannot accept v2; private
+schemas/counts remain unchanged. `check_public(..., require_valid_add=True)`
+rejects this evidence as insufficient for successful production add.
+
+The existing ten-project/thirty-plan acceptance still runs the real Go CLI and
+planner with injected detector/security/effects. It does not execute production
+main, Security Index or lintai. Help, rejection and injected assessments cannot
+close Milestone A's still-required successful distributed installer dry-run on
+generated projects. That separate legitimate installer acceptance must bind
+actual public launcher/native bytes, genuine security inputs, structured plans,
+source/client preservation and separately accounted scanner/cache/acquisition
+effects. It remains outstanding after v2 core success, independent review and
+fresh successor E2E; no historical candidate bytes may be relabelled.

--- a/npm/agentplugins/scripts/packed-installer-bridge.test.js
+++ b/npm/agentplugins/scripts/packed-installer-bridge.test.js
@@ -167,3 +167,51 @@ test('SYNTHETIC public intake: exact lanes, executed packs, pins and schema sepa
  } finally {c.frozenCandidate=original;}
  assert.throws(()=>bridge.seal(f.request),'unstubbed candidate rejects synthetic bytes');
 });
+
+// v1 remains independently accepted; v2 must be explicitly selected.
+test('SYNTHETIC v2 help/preflight boundary cannot stand for production add', posixFixture, t => {
+ const original = c.frozenCandidate, f = publicFixture(t);
+ c.frozenCandidate = () => ({manifest:{products:f.assets,build:{go_sha256:hash(f.tool)}}});
+ const inv = path.join(path.dirname(f.nativePath), 'invocations.json');
+ const oldRows = JSON.parse(fs.readFileSync(inv));
+ const help = {product:'agentplugins', argv:['add','--help','--format=json'], status:0, signal:null, stderr:'',
+  stdout:JSON.stringify({schema_version:1,command:'help',result:'success',data:{use:'agentplugins add',commands:null}})};
+ const rejection = {...help, argv:['add',path.join(f.projects.agentplugins,'skill'),'--target=codex','--scope=project','--dry-run','--format=json'],
+  status:1, stdout:'', stderr:'agentplugins: --scope project is not supported by the current client adapters; the public CLI supports user scope only\n'};
+ const rows = [...oldRows.slice(0,69), help, rejection];
+ const boundary = {executable_observation:'help-and-preflight-rejection',valid_add_dry_run:'not_evaluated',
+  argv:oldRows[69].argv,reason:'production-security-inputs-not-offline'};
+ const terminal = {...f.terminal,schema:'dual-authoring-public-native/v2',installer_boundary:boundary};
+ function seal(changes = {}, observations = rows, intake = 'public-fixture/v2') {
+  write(inv, observations);
+  write(f.nativePath, {...terminal,invocations:observations.length,invocations_sha256:hash(inv),...changes});
+  return bridge.seal({...f.request,intake,nativeCompletionSha256:hash(f.nativePath)});
+ }
+ try {
+  const accepted = seal();
+  assert.equal(rows.length,71);
+  assert.deepEqual(rows.reduce((n,r)=>(n[r.status]=(n[r.status]||0)+1,n),{}),{0:69,1:1,2:1});
+  assert.deepEqual(accepted.inputs.public_evidence.installer_boundary,boundary);
+  assert.throws(()=>seal({},rows,'public-fixture/v1'));
+  assert.throws(()=>seal({schema:'dual-authoring-public-native/v1'}));
+  for (const installer_boundary of [undefined,{},true,{...boundary,valid_add_dry_run:true},
+    {...boundary,valid_add_dry_run:'success'},{...boundary,reason:undefined},{...boundary,argv:rejection.argv},
+    {...boundary,executable_observation:'successful-add'},{...boundary,accepted:true}]) {
+   assert.throws(()=>seal({installer_boundary}));
+  }
+  for (const bad of [oldRows, rows.slice(0,70), [...rows.slice(0,69),rejection],
+    [...rows.slice(0,69),rejection,help], [...rows.slice(0,69),help,help]]) assert.throws(()=>seal({},bad));
+  for (const i of [69,70]) for (const change of [{status:0},{status:2},{signal:'SIGTERM'},
+    {stdout:'{}'},{stdout:help.stdout+'{}'},{stderr:'arbitrary'},{stderr:''},
+    {argv:oldRows[69].argv}]) {
+   if (Object.entries(change).every(([k,v])=>JSON.stringify(rows[i][k])===JSON.stringify(v))) continue;
+   assert.throws(()=>seal({},rows.map((r,j)=>j===i?{...r,...change}:r)));
+  }
+  for (const value of [{}, {schema_version:1,command:'help',result:'failure',data:{use:'agentplugins add',commands:null}},
+    {schema_version:1,command:'help',result:'success',data:{use:'agentplugins',commands:null}}]) {
+   assert.throws(()=>seal({},rows.map((r,i)=>i===69?{...r,stdout:JSON.stringify(value)}:r)));
+  }
+  assert.deepEqual(seal().inputs.public_evidence.installer_boundary,boundary);
+ } finally { c.frozenCandidate = original; }
+ assert.throws(()=>seal(), 'synthetic fixtures cannot publish native evidence');
+});

--- a/npm/agentplugins/test/public-authoring-native.test.js
+++ b/npm/agentplugins/test/public-authoring-native.test.js
@@ -14,7 +14,7 @@ const bridge = require("../scripts/packed-installer-bridge");
 const adapter = require("../scripts/authoring-release");
 const packing = require("../scripts/stage-dual-authoring-npm");
 const stager = require("../scripts/stage-authoring-npm");
-const { preload, run, ok, environment } = require("./public-authoring-pack.test");
+const { preload, run, ok, environment, nativeObservation } = require("./public-authoring-pack.test");
 
 function tree(root) {
   const result = {};
@@ -122,10 +122,10 @@ test("PUBLIC NATIVE: exact integrated packs, both actual bins, static parity and
     const root = path.join(context.root, `${p} projects ü`); fs.mkdirSync(root); return [p, root];
   }));
   function invoke(p, argv, status = 0, json = true) {
-    const r = run(o.node, [bin(p), ...argv], { ...transportEnv, PATH: "/absent-peer-binary-path" }, projects[p]);
+    const r = nativeObservation(p, o.node, bin(p), argv, { ...transportEnv, PATH: "/absent-peer-binary-path" }, projects[p]);
     invocations.push({ product: p, argv, status: r.status, signal: r.signal, stdout: r.stdout, stderr: r.stderr });
     fs.writeFileSync(path.join(cfg.evidenceOutput, "invocations.json"), c.encode(invocations));
-    assert.equal(r.status, status, r.stdout + r.stderr); assert.equal(r.stderr, "");
+    assert.equal(r.status, status, r.stdout + r.stderr);
     return json ? JSON.parse(r.stdout) : r.stdout;
   }
   function author(p, argv, status = 0, compare = true) {
@@ -170,9 +170,16 @@ test("PUBLIC NATIVE: exact integrated packs, both actual bins, static parity and
   const retired = invoke("plugin-kit-ai", ["update", "--all", "--format=json"], 2);
   assert.equal(retired.data.error.code, "v1_operation_unavailable");
   assert.deepEqual(tree(projects["plugin-kit-ai"]), before);
-  // Installer dry-run uses an explicitly isolated synthetic client root/home.
-  const dry = invoke("agentplugins", ["add", path.join(projects.agentplugins, "skill"), "--target=codex", "--dry-run", "--format=json"]);
-  assert.ok(dry); assert.deepEqual(tree(projects["plugin-kit-ai"]), before);
+  // Genuine executable visibility/preflight only; valid production add remains required.
+  const preservedRoots = [...Object.values(projects), client, installer];
+  const preserved = preservedRoots.map(root => bridge.snapshot(root));
+  const help = invoke("agentplugins", ["add", "--help", "--format=json"]);
+  bridge.installerHelp(help);
+  assert.deepEqual(preservedRoots.map(root => bridge.snapshot(root)), preserved);
+  assert.equal(invoke("agentplugins", ["add", path.join(projects.agentplugins, "skill"), "--target=codex",
+    "--scope=project", "--dry-run", "--format=json"], 1, false), "");
+  assert.deepEqual(preservedRoots.map(root => bridge.snapshot(root)), preserved);
+  const installer_boundary = bridge.installerBoundary(projects.agentplugins);
   const runtime = require("../lib/public-authoring");
   for (const p of c.PRODUCTS) {
     const packageRoot = path.resolve(bin(p), "../..");
@@ -197,7 +204,7 @@ test("PUBLIC NATIVE: exact integrated packs, both actual bins, static parity and
   fs.writeFileSync(path.join(cfg.evidenceOutput, "result.json"), c.encode({ source: candidate.identity.commit,
     fixture_acquisition_execution: true, signed_promotion: false, public_eligible: false, runtime_evidence: "not_evaluated" }), { flag: "wx" });
   for (const p of c.PRODUCTS) assert.deepEqual(bridge.LANES.map(lane => tree(path.join(projects[p], lane))), trees[p], "all generated projects preserved through lifecycle");
-  const terminal = { schema: "dual-authoring-public-native/v1", status: "completed",
+  const terminal = { schema: "dual-authoring-public-native/v2", installer_boundary, status: "completed",
     identity: candidate.identity, candidate_sha256: candidate.manifestDigest, completion_sha256: cfg.completionDigest,
     config_sha256: c.digest(c.readFile(config)), pair_marker_sha256: o.pairMarkerDigest, projection_pins: o.projectionPins,
     fixtureRoot: context.root, target, packs, binaries, installations,
@@ -210,7 +217,7 @@ test("PUBLIC NATIVE: exact integrated packs, both actual bins, static parity and
     release_eligible: false, platform_acceptance: false, attested: false, runtime_evidence: "not_evaluated" };
   // Validate the full contract before exclusive terminal publication. No success
   // marker exists if a lane, pin, or lifecycle assertion above failed.
-  bridge.publicEvidence(cfg, terminal, config);
+  bridge.publicEvidence(cfg, terminal, config, "public-fixture/v2");
   const terminalPath = path.join(cfg.evidenceOutput, "public-native-completion.json");
   fs.writeFileSync(terminalPath, c.encode(terminal), { flag: "wx", mode: 0o600 });
   t.diagnostic("public native completion: " + JSON.stringify({ file: terminalPath, sha256: c.digest(c.readFile(terminalPath)), source: candidate.identity.commit }));

--- a/npm/agentplugins/test/public-authoring-pack.test.js
+++ b/npm/agentplugins/test/public-authoring-pack.test.js
@@ -38,6 +38,53 @@ https.get = options => {
 function run(exe, args, env, cwd) {
   return cp.spawnSync(exe, args, { env, cwd, encoding: "utf8", timeout: 30000, maxBuffer: 8 * 1024 * 1024 });
 }
+// Driver-only intent guard; this does not observe networking in native children.
+const PREFLIGHT_STDERR = "agentplugins: --scope project is not supported by the current client adapters; the public CLI supports user scope only\n";
+function nativeObservation(product, exe, bin, argv, env, cwd, spawn = run) {
+  const bridge = require("../scripts/packed-installer-bridge");
+  const rejected = ["add", path.join(cwd, "skill"), "--target=codex", "--scope=project", "--dry-run", "--format=json"];
+  const same = args => JSON.stringify(args) === JSON.stringify(argv);
+  if (product === "agentplugins") {
+    const allowed = [["version", "--format=json"], ["--help"], ["add", "--help", "--format=json"], rejected];
+    const author = [["version"], ["--help"]];
+    for (const lane of bridge.LANES) {
+      const source = path.join(cwd, lane);
+      author.push(bridge.publicInit(lane), ["skills", "init", "extra-skill", source, "--description=Disposable fixture."],
+        ["skills", "validate", source], ...["validate", "inspect", "test"].map(n => [n, source]));
+    }
+    allowed.push(...author.map(args => ["author", ...args, "--format=json"]));
+    assert.ok(allowed.some(same), "offline native observation denied before spawn: production-security-inputs-not-offline");
+  }
+  const result = spawn(exe, [bin, ...argv], env, cwd);
+  assert.equal(result.signal, null);
+  assert.equal(result.stderr, product === "agentplugins" && same(rejected) ? PREFLIGHT_STDERR : "");
+  return result;
+}
+if (require.main === module) test("offline native guard rejects original valid add before spawn effects", () => {
+  let calls = 0;
+  const source = "/disposable/agentplugins projects ü";
+  const argv = ["add", path.join(source, "skill"), "--target=codex", "--dry-run", "--format=json"];
+  for (const args of [argv, ["install", ...argv.slice(1)], ["--target=codex", ...argv],
+    [...argv, "--help"], [...argv, "--scope=project"], ["author", "publish", "--format=json"]]) {
+    assert.throws(() => nativeObservation("agentplugins", NODE, "/unused/bin", args, {}, source,
+      () => { calls++; throw new Error("spawn effect"); }), /denied before spawn/);
+  }
+  assert.equal(calls, 0);
+});
+if (require.main === module) test("offline native guard allows only designated installer results", () => {
+  const cwd = "/disposable/agentplugins projects ü", bin = "/unused/bin";
+  for (const argv of [["add", "--help", "--format=json"],
+    ["add", path.join(cwd, "skill"), "--target=codex", "--scope=project", "--dry-run", "--format=json"],
+    ["author", "test", path.join(cwd, "skill"), "--format=json"]]) {
+    const stderr = argv.includes("--scope=project") ? PREFLIGHT_STDERR : "";
+    const invoke = result => nativeObservation("agentplugins", NODE, bin, argv, {}, cwd, (exe, args) => {
+      assert.equal(exe, NODE); assert.deepEqual(args, [bin, ...argv]); return result;
+    });
+    assert.equal(invoke({ signal: null, stderr }).stderr, stderr);
+    assert.throws(() => invoke({ signal: null, stderr: stderr + "unexpected output" }));
+    assert.throws(() => invoke({ signal: "SIGTERM", stderr }));
+  }
+});
 function ok(result) { assert.equal(result.status, 0, result.stderr || result.stdout); return result.stdout; }
 function packageBytes(root) {
   const files = {};
@@ -212,7 +259,7 @@ packing.blobs = (...args) => {
     assert.throws(() => packing.blobs(REPO, head, context.env, "arbitrary"), /fixed/);
   });
 }
-module.exports = { preload, run, ok, packageBytes, environment };
+module.exports = { preload, run, ok, packageBytes, environment, nativeObservation, PREFLIGHT_STDERR };
 
 if (require.main === module) test("shared completion helper preserves a collision and rolls back an uncertain marker", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "public completion-"));

--- a/scripts/check-packed-ci.py
+++ b/scripts/check-packed-ci.py
@@ -269,11 +269,26 @@ def unchanged_snapshots(inputs):
         require(actual == expected, 'sealed tree changed')
 
 
-def check_public(root, sha):
+def public_boundary(native, intake, require_valid_add=False):
+    require(intake in ('public-fixture/v1', 'public-fixture/v2'), 'explicit public intake')
+    v2 = intake == 'public-fixture/v2'
+    require(native['schema'] == 'dual-authoring-public-native/' + ('v2' if v2 else 'v1'), 'public schema substitution')
+    if v2:
+        expected = dict(executable_observation='help-and-preflight-rejection', valid_add_dry_run='not_evaluated',
+            argv=['add', str(Path(native['projects']['agentplugins']) / 'skill'), '--target=codex', '--dry-run', '--format=json'],
+            reason='production-security-inputs-not-offline')
+        require(native.get('installer_boundary') == expected, 'outstanding production add requirement')
+    else:
+        require('installer_boundary' not in native, 'v2 boundary in v1')
+    require(not require_valid_add, 'insufficient evidence for successful production add: separate installer acceptance required')
+    return native.get('installer_boundary')
+
+
+def check_public(root, sha, require_valid_add=False, require_summary=True):
     run = read(root / 'public-run.json'); false_claims(run)
     require(run['schema'] == 'public-packed-run/v1' and run['head'] == sha and re.fullmatch('[0-9a-f]{40}', sha), 'public run identity')
     options = run['options']; request = options['request']
-    require(request['intake'] == 'public-fixture/v1' and request['expectedCommit'] == sha, 'public request identity')
+    require(request['intake'] in ('public-fixture/v1', 'public-fixture/v2') and request['expectedCommit'] == sha, 'public request identity')
     require(digest(options['nativeTap']) == options['nativeTapSha256'], 'changed public TAP')
     public_tap(data(options['nativeTap']).decode(), request)
     require(digest(request['nativeConfig']) == request['nativeConfigSha256'], 'changed public config')
@@ -281,11 +296,17 @@ def check_public(root, sha):
     terminal_path = Path(cfg['evidenceOutput']) / 'public-native-completion.json'
     require(digest(terminal_path) == request['nativeCompletionSha256'], 'changed public terminal')
     native = read(terminal_path); false_claims(native, (*CLAIMS, 'signed_promotion', 'public_eligible'))
-    require(native['schema'] == 'dual-authoring-public-native/v1' and native['status'] == 'completed' and
+    boundary = public_boundary(native, request['intake'], require_valid_add)
+    require(native['status'] == 'completed' and
         native['qualification'] is None and native['identity']['commit'] == native['identity']['engine_revision'] == sha, 'public terminal contract')
     require(digest(Path(cfg['evidenceOutput']) / 'invocations.json') == native['invocations_sha256'], 'public invocation pin')
     sealed_path = root / 'bridge-config/sealed.json'; sealed = read(sealed_path); false_claims(sealed)
     require(sealed['schema'] == 'packed-installer-bridge/v1' and sealed['request'] == request == read(root / 'bridge-config/request.json'), 'public sealed request')
+    evidence = sealed['inputs'].get('public_evidence', {})
+    if boundary is not None:
+        require(evidence.get('schema') == native['schema'] and evidence.get('installer_boundary') == boundary, 'sealed installer boundary')
+    else:
+        require('installer_boundary' not in evidence, 'v2 sealed boundary in v1')
     repo = Path(__file__).resolve().parent.parent; bridge = repo / 'npm/agentplugins/scripts/packed-installer-bridge.js'
     require(sealed['verifier_sha256'] == digest(bridge) and sealed['helper_sha256'] == digest(bridge.with_name('dual-authoring-candidate.js')), 'public verifier changed')
     for key in ('go', 'node'):
@@ -322,6 +343,11 @@ def check_public(root, sha):
         len({p['source'] for p in projects}) == 10, 'public ten distinct projects')
     plans(result)
     require(log('head').strip() == sha and log('clean') == log('terminal-clean') == '', 'public exact clean checkout')
+    if boundary is not None and require_summary:
+        summary = read(root / 'summary.json'); false_claims(summary, (*CLAIMS, 'signed_promotion', 'public_eligible'))
+        require(summary == dict(status='passed', intake=request['intake'], head=sha, projects=10, plans=30,
+            scope='public-authoring-help-preflight-and-injected-planner', installer_boundary=boundary,
+            release_eligible=False, platform_acceptance=False, attested=False, signed_promotion=False, public_eligible=False), 'public summary scope/gap')
 
 
 if __name__ == '__main__':

--- a/scripts/run-packed-ci.py
+++ b/scripts/run-packed-ci.py
@@ -152,13 +152,15 @@ def public_main(root, sha, options_path):
     options = proof.read(options_path)
     proof.require(set(options) == {'request', 'nativeTap', 'nativeTapSha256', 'go', 'node', 'modCache'}, 'public runner options')
     request = options['request']
-    proof.require(request.get('intake') == 'public-fixture/v1' and request['expectedCommit'] == sha, 'explicit public intake SHA')
+    proof.require(request.get('intake') in ('public-fixture/v1', 'public-fixture/v2') and request['expectedCommit'] == sha, 'explicit public intake SHA')
     proof.require(proof.digest(options['nativeTap']) == options['nativeTapSha256'], 'public transcript pin')
     proof.public_tap(proof.data(options['nativeTap']).decode(), request)
     proof.require(re.fullmatch('[0-9a-f]{40}', sha), 'exact SHA required')
     proof.require(root.is_absolute() and root.resolve() == root and not root.is_relative_to(repo), 'external canonical output required')
     # Output must be disjoint before creating logs or planner homes.
     cfg = proof.read(request['nativeConfig']); candidate = cfg['prepare']['candidate']
+    native = proof.read(Path(cfg['evidenceOutput']) / 'public-native-completion.json')
+    boundary = proof.public_boundary(native, request['intake'])
     protected = [repo, Path(options_path), Path(options['nativeTap']), Path(request['nativeConfig']),
         Path(request['fixtureRoot']), Path(cfg['evidenceOutput']), Path(cfg['prepare']['output']),
         Path(candidate['root']), Path(candidate['pairMarker']), Path(candidate['workParent']),
@@ -193,9 +195,12 @@ def public_main(root, sha, options_path):
     proof.require(printed == proof.digest(sealed), 'public seal pin')
     planner(root, sha, go, node, sealed, printed, run)
     proof.require(run('terminal-clean', ['/usr/bin/git', 'status', '--porcelain=v1', '--untracked-files=all']) == '', 'checkout changed')
-    proof.check_public(root, sha)
-    write(root / 'summary.json', dict(status='passed', intake='public-fixture/v1', head=sha, projects=10, plans=30,
+    proof.check_public(root, sha, require_summary=False)
+    write(root / 'summary.json', dict(status='passed',
+        **(dict(scope='public-authoring-help-preflight-and-injected-planner', installer_boundary=boundary) if boundary is not None else {}),
+        intake=request['intake'], head=sha, projects=10, plans=30,
         release_eligible=False, platform_acceptance=False, attested=False, signed_promotion=False, public_eligible=False))
+    proof.check_public(root, sha)
 
 
 if __name__ == '__main__':

--- a/scripts/test_packed_ci.py
+++ b/scripts/test_packed_ci.py
@@ -231,15 +231,29 @@ class TerminalControls(unittest.TestCase):
 
 class PublicControls(unittest.TestCase):
     def test_public_terminal_and_matrix_controls(self):
+        self.public_terminal_controls('v1')
+
+    def test_public_v2_terminal_and_matrix_controls(self):
+        self.public_terminal_controls('v2')
+
+    def public_terminal_controls(self, version):
         root, sha, put, get = TerminalControls.fixture(self)
         # Reuse only the synthetic planner transcripts; no native claim.
         private = get('run.json'); tools = private['tools']; claims = {k: False for k in p.CLAIMS}
-        request = dict(intake='public-fixture/v1', expectedCommit=sha, nativeConfig=str(root / 'public-config.json'))
+        request = dict(intake='public-fixture/' + version, expectedCommit=sha, nativeConfig=str(root / 'public-config.json'))
         put('public-config.json', dict(evidenceOutput=str(root / 'public-native')))
         put('public-native/invocations.json', [])
-        native = dict(schema='dual-authoring-public-native/v1', status='completed', identity=private['identity'],
+        native = dict(schema='dual-authoring-public-native/' + version, status='completed', identity=private['identity'],
             qualification=None, tools=tools, invocations_sha256=p.digest(root / 'public-native/invocations.json'),
             signed_promotion=False, public_eligible=False, **claims)
+        if version == 'v2':
+            native['projects'] = {'agentplugins': '/fixture/agentplugins projects ü'}
+            native['installer_boundary'] = dict(executable_observation='help-and-preflight-rejection', valid_add_dry_run='not_evaluated',
+                argv=['add', '/fixture/agentplugins projects ü/skill', '--target=codex', '--dry-run', '--format=json'],
+                reason='production-security-inputs-not-offline')
+            put('summary.json', dict(status='passed', intake=request['intake'], head=sha, projects=10, plans=30,
+                scope='public-authoring-help-preflight-and-injected-planner', installer_boundary=native['installer_boundary'],
+                signed_promotion=False, public_eligible=False, **claims))
         put('public-native/public-native-completion.json', native)
         request.update(nativeConfigSha256=p.digest(request['nativeConfig']),
             nativeCompletionSha256=p.digest(root / 'public-native/public-native-completion.json'))
@@ -249,6 +263,8 @@ class PublicControls(unittest.TestCase):
             go=tools['go']['path'], node=tools['node']['path'], modCache=str(root / 'unused-modules'))
         put('public-run.json', dict(schema='public-packed-run/v1', head=sha, options=options, tools=tools, **claims))
         sealed = get('bridge-config/sealed.json'); sealed['request'] = request
+        if version == 'v2':
+            sealed['inputs']['public_evidence'] = dict(schema=native['schema'], installer_boundary=native['installer_boundary'])
         inventory_root = root / 'sealed-tree'; inventory_root.mkdir()
         entries = [dict(path='.', mode=inventory_root.stat().st_mode & 0o777, kind='directory')]
         sealed['inputs']['snapshots'] = [dict(root=str(inventory_root), entries=entries,
@@ -269,6 +285,17 @@ class PublicControls(unittest.TestCase):
                     UAP_PACKED_INSTALLER_COMMIT=sha, UAP_PACKED_INSTALLER_OUTPUT=str(root / 'results/completion.json'))
             put('logs/' + name + '.json', phase)
         p.check_public(root, sha)
+        if version == 'v2':
+            with self.assertRaisesRegex(ValueError, 'insufficient evidence'): p.check_public(root, sha, require_valid_add=True)
+            for key, value in [('installer_boundary', None), ('scope', 'successful-production-add')]:
+                original = get('summary.json'); put('summary.json', dict(original, **{key: value}))
+                with self.assertRaisesRegex(ValueError, 'summary scope/gap'): p.check_public(root, sha)
+                put('summary.json', original)
+            original = get('bridge-config/sealed.json')
+            bad = get('bridge-config/sealed.json'); del bad['inputs']['public_evidence']['installer_boundary']
+            put('bridge-config/sealed.json', bad)
+            with self.assertRaisesRegex(ValueError, 'sealed installer boundary'): p.check_public(root, sha)
+            put('bridge-config/sealed.json', original)
         valid_tap = (root / 'public.tap').read_text()
         for bad in [tap([p.PUBLIC_TEST]), valid_tap.replace(sha, 'b'*40), valid_tap + '# public native completion: ' + marker + '\n']:
             with self.assertRaises(ValueError): p.public_tap(bad, request)
@@ -286,6 +313,27 @@ class PublicControls(unittest.TestCase):
         for text in [tap([p.PUBLIC_TEST])[:-1], tap([p.PUBLIC_TEST]).replace('# skipped 0', '# skipped 1'), tap(p.NATIVE_TESTS)]:
             put('public.tap', text)
             with self.assertRaises(ValueError): p.check_public(root, sha)
+
+    def test_public_v2_boundary_and_success_consumer(self):
+        native = dict(schema='dual-authoring-public-native/v2', projects={'agentplugins': '/fixture/agentplugins projects ü'},
+            installer_boundary=dict(executable_observation='help-and-preflight-rejection', valid_add_dry_run='not_evaluated',
+                argv=['add', '/fixture/agentplugins projects ü/skill', '--target=codex', '--dry-run', '--format=json'],
+                reason='production-security-inputs-not-offline'))
+        self.assertEqual(p.public_boundary(native, 'public-fixture/v2'), native['installer_boundary'])
+        with self.assertRaisesRegex(ValueError, 'insufficient evidence'):
+            p.public_boundary(native, 'public-fixture/v2', require_valid_add=True)
+        for intake in ('public-fixture/v1', 'private', None):
+            with self.assertRaises(ValueError): p.public_boundary(native, intake)
+        boundary = native['installer_boundary']
+        for bad in (None, {}, True, dict(boundary, valid_add_dry_run=True), dict(boundary, reason=''),
+            dict(boundary, argv=[]), dict(boundary, accepted=True)):
+            with self.subTest(bad=bad), self.assertRaises(ValueError):
+                p.public_boundary(dict(native, installer_boundary=bad), 'public-fixture/v2')
+        for key in boundary:
+            bad = dict(boundary); del bad[key]
+            with self.assertRaises(ValueError): p.public_boundary(dict(native, installer_boundary=bad), 'public-fixture/v2')
+        with self.assertRaises(ValueError):
+            p.public_boundary(dict(native, schema='dual-authoring-public-native/v1'), 'public-fixture/v2')
 
     def test_public_runner_rejects_missing_or_wrong_contract_before_output(self):
         root = Path(tempfile.mkdtemp(prefix='public-packed-runner-SYNTHETIC-'))


### PR DESCRIPTION
Integrates the previously reviewed offline public v2 evidence correction from #204 into the current C1/C2 feature branch, restoring the 71-call help/preflight contract required by the C3 plan. Successful production installer dry-run remains explicitly not evaluated.

Stacked on #216. Refs #204, #199, #229, #208. Exact merge head f5ad7deab99a494f2919a5277c877c0aaefb5ead preserves both parents: 8a7e18f9a4e8bdd3b42c8291576f631c20ea4cd3 and 9606e240df1cacdaa618fedec8340f812a582acf. Delta from the first parent: 11 files, 498 additions and 29 deletions. The only conflict was appended documentation; both the offline v2 explanation and C2 acquisition section remain verbatim. Ten other incoming files match #204 exactly.

Independent hosted integration review on gpt-6-astra low accepted this exact head with no blocking findings. All 22 sealed artifact checksums were verified. Fresh focused checks passed: Node 11, Python 16, and Go 3+2 top-level tests. All ten native/packed/polyglot/source-acquisition CI checks passed on f5ad7deab99a494f2919a5277c877c0aaefb5ead, including Windows. The earlier failure is superseded by this new integration-head evidence, not waived. All 3,379 tracked source paths were preserved during review; ten incoming non-document blobs and both appended documentation sections match their accepted parents.

This does not run or qualify the genuine public/native journey, Security Index/scanner, process observer, C3, N2 or release. Historical denied observer and security reviews are not retried. No main activation or public release.
