### PR TITLE
fix: restore Pages builds and published locale checks

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -22,9 +22,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Keep docs on its own packageManager; landing uses a newer lockfile format.
+      - uses: pnpm/action-setup@v5
+        id: pnpm-docs
+        with:
+          package_json_file: website/package.json
+          dest: ${{ runner.temp }}/pnpm-docs
+
       - uses: pnpm/action-setup@v5
         with:
-          version: 8.15.1
+          package_json_file: landing/package.json
+          dest: ${{ runner.temp }}/pnpm-landing
 
       - uses: actions/setup-node@v6
         with:
@@ -41,7 +49,9 @@ jobs:
 
       - name: Install docs toolchain
         working-directory: website
-        run: pnpm install --frozen-lockfile
+        run: |
+          export PATH="${{ steps.pnpm-docs.outputs.bin_dest }}:$PATH"
+          pnpm install --frozen-lockfile
 
       # Keep the renamed CLI Pages site self-contained: every deployment carries
       # a verified, byte-exact compatibility copy of the registry feeds. This
@@ -81,7 +91,9 @@ jobs:
           DOCS_BASE_PATH: /universal-agent-plugins/docs/
           DOCS_HOSTNAME: https://777genius.github.io
         working-directory: website
-        run: pnpm run docs:build
+        run: |
+          export PATH="${{ steps.pnpm-docs.outputs.bin_dest }}:$PATH"
+          pnpm run docs:build
 
       - name: Assemble GitHub Pages artifact
         env:

--- a/.github/workflows/landing.yml
+++ b/.github/workflows/landing.yml
@@ -37,15 +37,14 @@ jobs:
 
       - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
         with:
-          version: 12.3.4
+          package_json_file: landing/package.json
+          dest: ${{ runner.temp }}/pnpm-landing
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.21.1"
           cache: pnpm
-          cache-dependency-path: |
-            landing/pnpm-lock.yaml
-            website/pnpm-lock.yaml
+          cache-dependency-path: landing/pnpm-lock.yaml
 
       - name: Verify and stage signed registry feeds
         run: |
@@ -121,17 +120,23 @@ jobs:
           go-version: "1.25.13"
           cache: false
 
+      # Keep docs on its own packageManager; landing uses a newer lockfile format.
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
+        id: pnpm-docs
+        with:
+          package_json_file: website/package.json
+          dest: ${{ runner.temp }}/pnpm-docs
+
       - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
         with:
-          version: 12.3.4
+          package_json_file: landing/package.json
+          dest: ${{ runner.temp }}/pnpm-landing
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.21.1"
           cache: pnpm
-          cache-dependency-path: |
-            landing/pnpm-lock.yaml
-            website/pnpm-lock.yaml
+          cache-dependency-path: landing/pnpm-lock.yaml
 
       - name: Verify and stage signed registry feeds
         run: |
@@ -149,7 +154,9 @@ jobs:
 
       - name: Install docs dependencies
         working-directory: website
-        run: pnpm install --frozen-lockfile
+        run: |
+          export PATH="${{ steps.pnpm-docs.outputs.bin_dest }}:$PATH"
+          pnpm install --frozen-lockfile
 
       - name: Prepare and validate landing
         working-directory: landing
@@ -163,7 +170,9 @@ jobs:
 
       - name: Validate and build public docs
         working-directory: website
-        run: pnpm run docs:check
+        run: |
+          export PATH="${{ steps.pnpm-docs.outputs.bin_dest }}:$PATH"
+          pnpm run docs:check
 
       - name: Assemble and validate exact final Pages artifact
         working-directory: landing

--- a/.github/workflows/registry-compatibility-mirror.yml
+++ b/.github/workflows/registry-compatibility-mirror.yml
@@ -41,9 +41,17 @@ jobs:
           go-version: "1.25.13"
           cache: false
 
+      # Keep docs on its own packageManager; landing uses a newer lockfile format.
+      - uses: pnpm/action-setup@v5
+        id: pnpm-docs
+        with:
+          package_json_file: website/package.json
+          dest: ${{ runner.temp }}/pnpm-docs
+
       - uses: pnpm/action-setup@v5
         with:
-          version: 12.3.4
+          package_json_file: landing/package.json
+          dest: ${{ runner.temp }}/pnpm-landing
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -69,7 +77,9 @@ jobs:
 
       - name: Install docs toolchain
         working-directory: website
-        run: pnpm install --frozen-lockfile
+        run: |
+          export PATH="${{ steps.pnpm-docs.outputs.bin_dest }}:$PATH"
+          pnpm install --frozen-lockfile
 
       - name: Verify and stage signed feeds
         env:
@@ -105,7 +115,9 @@ jobs:
           DOCS_BASE_PATH: /universal-agent-plugins/docs/
           DOCS_HOSTNAME: https://777genius.github.io
         working-directory: website
-        run: pnpm run docs:build
+        run: |
+          export PATH="${{ steps.pnpm-docs.outputs.bin_dest }}:$PATH"
+          pnpm run docs:build
 
       - name: Assemble GitHub Pages artifact
         env:

--- a/landing/composables/useDownloadContent.ts
+++ b/landing/composables/useDownloadContent.ts
@@ -5,7 +5,9 @@ import type { DownloadOverlay } from '~/types/download';
 export const useDownloadContent = async () => {
   const { locale } = useI18n();
   const load = async (code: string): Promise<DownloadOverlay> => {
-    const language = code === 'ru' || code === 'uk' ? code : 'en';
+    // The route locale comes from the publication manifest. Load its reviewed
+    // overlay instead of silently serving English for newly published locales.
+    const language = code;
     try {
       return (await import(`../content/download/${language}.json`)).default;
     } catch (error) {

--- a/landing/tests/browser/i18n-integration.spec.ts
+++ b/landing/tests/browser/i18n-integration.spec.ts
@@ -164,7 +164,7 @@ test('unknown routes and localized APIs remain real static 404s', async ({ reque
     'plugins/unknown-plugin/',
     'ru/api/registry/catalog',
     'uk/api/releases/latest',
-    'es/plugins/',
+    'zz/plugins/',
   ]) {
     const response = await request.get(`./${route}`);
     expect(response.status(), route).toBe(404);

--- a/landing/tests/browser/i18n-state.helpers.ts
+++ b/landing/tests/browser/i18n-state.helpers.ts
@@ -22,6 +22,11 @@ export function downloadHeading(locale: PublishedLocale) {
   return overlay.shell.download.heading.title;
 }
 
+export function downloadChannelTitle(locale: PublishedLocale, channel: string) {
+  const overlay: DownloadOverlay = JSON.parse(readFileSync(new URL(`../../content/download/${locale}.json`, import.meta.url), 'utf8'));
+  return overlay.shell.download.channels[channel]!.title;
+}
+
 export async function hydrated(page: Page) {
   await page.waitForFunction(() => {
     const root = document.querySelector('#__nuxt') as HTMLElement & {

--- a/landing/tests/browser/i18n-state.spec.ts
+++ b/landing/tests/browser/i18n-state.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import {
-  automatic, downloadHeading, hydrated, deferred, delayedMirror, exactCommands, locales, navigate, offline,
+  automatic, downloadChannelTitle, downloadHeading, hydrated, deferred, delayedMirror, exactCommands, locales, navigate, offline,
   projections, registryFixture, targets, wording,
 } from './i18n-state.helpers';
 
@@ -142,7 +142,7 @@ test('manual download channel beats delayed detection and locale remount', async
     await navigate(page, '/download/');
     await expect.poll(() => held, { message: 'Expected deferred detection script' }).toBeGreaterThan(0);
     await expect(page.locator('.download-section__platform-note')).toHaveCount(0);
-    const npm = page.locator('.download-section__install-tab').filter({ hasText: 'npx' });
+    const npm = page.locator('.download-section__install-tab').filter({ hasText: downloadChannelTitle('en', 'npm') });
     await npm.click();
     await expect(npm).toHaveAttribute('aria-pressed', 'true');
     const commands = await page.locator('.download-section__steps code').allTextContents();
@@ -154,7 +154,8 @@ test('manual download channel beats delayed detection and locale remount', async
     for (const locale of locales.filter((value) => value !== 'en')) {
       await navigate(page, '/download/', locale);
       await expect(page.getByRole('heading', { name: downloadHeading(locale), exact: true })).toBeVisible();
-      await expect(npm).toHaveAttribute('aria-pressed', 'true');
+      const localizedNpm = page.locator('.download-section__install-tab').filter({ hasText: downloadChannelTitle(locale, 'npm') });
+      await expect(localizedNpm).toHaveAttribute('aria-pressed', 'true');
       await expect.poll(() => page.locator('.download-section__steps code').allTextContents()).toEqual(commands);
     }
     expect(errors).toEqual([]);

--- a/landing/tests/browser/locale-install-navigation.spec.ts
+++ b/landing/tests/browser/locale-install-navigation.spec.ts
@@ -45,10 +45,10 @@ for (const target of publishedLocales.filter((locale) => locale !== 'en')) {
         expect(commands.join('\n')).toContain('curl');
         const initialUrl = page.url();
         if (width < 768) await page.getByRole('button', { name: 'Open navigation menu' }).click();
-        const switcher = page
-          .getByRole('button', { name: /language|язык|мова/i })
+        const initialSwitcher = page
+          .getByRole('button', { name: `${wording('en')('language.label')}: ${localeMetadata.en.name}`, exact: true })
           .filter({ visible: true });
-        await switcher.click();
+        await initialSwitcher.click();
         await page
           .getByRole('menuitemradio', { name: localeMetadata[target].name, exact: true })
           .click();
@@ -56,6 +56,9 @@ for (const target of publishedLocales.filter((locale) => locale !== 'en')) {
         await expect(page.locator('html')).toHaveAttribute('lang', target);
         // URL/html.lang alone passed before the freeze. These require a completed
         // scheduler, localized route content and a responsive real language menu.
+        const switcher = page
+          .getByRole('button', { name: `${wording(target)('language.label')}: ${localeMetadata[target].name}`, exact: true })
+          .filter({ visible: true });
         await expect(switcher).toHaveAttribute('aria-busy', 'false');
         if (width < 768) {
           await page.getByRole('button', { name: wording(target)('shell.navigation.close'), exact: true }).click();

--- a/repotests/pages_contract_integration_test.go
+++ b/repotests/pages_contract_integration_test.go
@@ -1,9 +1,13 @@
 package pluginkitairepo_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestPagesSite_CombinesLandingRootAndDocsSubpath(t *testing.T) {
@@ -107,4 +111,131 @@ func TestPagesSite_CombinesLandingRootAndDocsSubpath(t *testing.T) {
 	}
 	robots := string(robotsBody)
 	mustContain(t, robots, `Sitemap: ${docsSitemapUrl}`)
+}
+
+// Resolve the executable selected by each step, including the job-wide PATH
+// updates from action-setup and the step-local docs override. A single pnpm
+// version cannot read both committed lockfiles; docs scripts also invoke pnpm.
+func TestPagesWorkflows_PackageManagerAlignment(t *testing.T) {
+	root := RepoRoot(t)
+	managers := map[string]string{}
+	for _, dir := range []string{"landing", "website"} {
+		body, err := os.ReadFile(filepath.Join(root, dir, "package.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var pkg struct {
+			PackageManager string `json:"packageManager"`
+		}
+		if err := json.Unmarshal(body, &pkg); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.HasPrefix(pkg.PackageManager, "pnpm@") {
+			t.Fatalf("%s must declare pnpm", dir)
+		}
+		managers[dir] = strings.TrimPrefix(pkg.PackageManager, "pnpm@")
+	}
+	files, err := filepath.Glob(filepath.Join(root, ".github", "workflows", "*.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	checked := 0
+	for _, file := range files {
+		body, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var workflow struct {
+			Jobs map[string]struct {
+				Defaults struct {
+					Run struct {
+						Directory string `yaml:"working-directory"`
+					}
+				}
+				Steps []struct {
+					ID        string            `yaml:"id"`
+					Uses      string            `yaml:"uses"`
+					With      map[string]string `yaml:"with"`
+					Directory string            `yaml:"working-directory"`
+					Run       string            `yaml:"run"`
+				} `yaml:"steps"`
+			} `yaml:"jobs"`
+		}
+		if err := yaml.Unmarshal(body, &workflow); err != nil {
+			t.Fatalf("%s: %v", file, err)
+		}
+		for jobName, job := range workflow.Jobs {
+			relevant := false
+			for _, step := range job.Steps {
+				dir := step.Directory
+				if dir == "" {
+					dir = job.Defaults.Run.Directory
+				}
+				relevant = relevant || (managers[dir] != "" && strings.Contains(step.Run, "pnpm "))
+			}
+			if !relevant {
+				continue
+			}
+			t.Run(filepath.Base(file)+"/"+jobName, func(t *testing.T) {
+				active := ""
+				outputs := map[string]string{}
+				destinations := map[string]bool{}
+				for _, step := range job.Steps {
+					if strings.HasPrefix(step.Uses, "pnpm/action-setup@") {
+						active = step.With["version"]
+						if manifest := step.With["package_json_file"]; manifest != "" {
+							want := managers[filepath.Dir(manifest)]
+							if want == "" || (active != "" && active != want) {
+								t.Fatalf("setup conflicts with %s", manifest)
+							}
+							active = want
+						}
+						if dest := step.With["dest"]; dest != "" {
+							if destinations[dest] {
+								t.Fatalf("toolchains overwrite %s", dest)
+							}
+							destinations[dest] = true
+						}
+						outputs[step.ID] = active
+					}
+					dir := step.Directory
+					if dir == "" {
+						dir = job.Defaults.Run.Directory
+					}
+					want := managers[dir]
+					if want == "" || !strings.Contains(step.Run, "pnpm ") {
+						continue
+					}
+					checked++
+					selected := active
+					invocations := 0
+					for _, line := range strings.Split(step.Run, "\n") {
+						line = strings.TrimSpace(line)
+						for id, version := range outputs {
+							// Export is intentional: nested package scripts must use
+							// the same manager as the outer invocation.
+							if line == `export PATH="${{ steps.`+id+`.outputs.bin_dest }}:$PATH"` {
+								selected = version
+							}
+						}
+						if strings.HasPrefix(line, "pnpm ") {
+							invocations++
+							if selected != want {
+								t.Errorf("%s: selected pnpm@%s, packageManager requires pnpm@%s", dir, selected, want)
+							}
+							if strings.HasPrefix(line, "pnpm install") && !strings.Contains(line, "--frozen-lockfile") {
+								t.Errorf("%s install must remain frozen", dir)
+							}
+						}
+					}
+					if invocations == 0 {
+						t.Fatalf("unrecognized pnpm invocation in %s: %s", dir, step.Run)
+					}
+				}
+			})
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no package-manager steps checked")
+	}
 }


### PR DESCRIPTION
Pages could not install landing's pnpm 12 lockfile with pnpm 8, while the other mixed jobs selected pnpm 12 for the pnpm 8 documentation package. These jobs now select each package's declared manager in separate locations, including nested docs scripts, and retain frozen installs. A regression test catches all three original mismatches.

Publishing six more locales also exposed an English-only download-content fallback and browser selectors tied to older language labels. Download pages now load every published locale's reviewed overlay; tests use translated menu and npm-channel titles and an actually unpublished 404 route. Selected-channel, command-identity, translation and menu-responsiveness assertions remain intact.

Validation on `8864021cf4d3f867b24ef97ce7df8ce2553f9d48`: independent base and delta review found no blocking defects; all PR checks passed, including 133 conformance cases, 221 browser tests, and 171 combined-site browser cases at each of `/` and `/universal-agent-plugins/`. Both package managers completed real frozen installs and production landing/docs assembly. No dependency versions, lockfiles, public availability labels, legacy capabilities or preview flags changed.
