### PR TITLE
fix(cli): explain skipped client installation requirements

### DIFF
--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -204,30 +204,32 @@ func runAddLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *option
 	return err
 }
 
-func promptTargetChoices(cmd *cobra.Command, app App, detected, skipped, allClients []domain.DetectedClient) ([]domain.ClientID, []domain.DetectedClient, error) {
-	if len(detected) == 0 {
-		return nil, nil, fmt.Errorf("no supported local AI client was detected; use --target chatgpt for ChatGPT, or install/detect another client")
-	}
+func promptTargetChoices(cmd *cobra.Command, app App, detected []domain.DetectedClient, skipped []targetSkip, allClients []domain.DetectedClient) ([]domain.ClientID, []domain.DetectedClient, error) {
 	detected = append([]domain.DetectedClient(nil), detected...)
-	skipped = append([]domain.DetectedClient(nil), skipped...)
+	skipped = append([]targetSkip(nil), skipped...)
 	sort.SliceStable(detected, func(i, j int) bool { return targetOrder(detected[i].ClientID) < targetOrder(detected[j].ClientID) })
-	sort.SliceStable(skipped, func(i, j int) bool { return targetOrder(skipped[i].ClientID) < targetOrder(skipped[j].ClientID) })
+	sort.SliceStable(skipped, func(i, j int) bool { return targetOrder(skipped[i].Client) < targetOrder(skipped[j].Client) })
 	request := prompt.TargetSelectionRequest{}
 	for _, c := range detected {
 		request.Choices = append(request.Choices, prompt.TargetChoice{ID: c.ClientID, Label: prompt.SafeText(c.DisplayName)})
 		request.DefaultIDs = append(request.DefaultIDs, c.ClientID)
 	}
 	for _, c := range skipped {
-		request.SkippedLabels = append(request.SkippedLabels, prompt.SafeText(c.DisplayName))
+		request.SkippedLabels = append(request.SkippedLabels, prompt.SafeText(string(c.Client)+": "+c.Reason))
 	}
-	if err := prompt.ValidateRequest(request); err != nil {
-		return nil, nil, err
+	if len(detected) > 0 {
+		if err := prompt.ValidateRequest(request); err != nil {
+			return nil, nil, err
+		}
 	}
-	if len(detected) == 1 {
+	if len(detected) <= 1 {
 		for _, label := range request.SkippedLabels {
-			if _, err := fmt.Fprintln(reviewWriter(cmd, app), "Skipped installed clients that this package cannot install together: "+label); err != nil {
+			if _, err := fmt.Fprintln(reviewWriter(cmd, app), "Skipped (not installed in this attempt): "+label); err != nil {
 				return nil, nil, err
 			}
+		}
+		if len(detected) == 0 {
+			return nil, nil, fmt.Errorf("no eligible detected client; nothing was installed. Install/detect a supported client or address the skipped reasons. --target chatgpt checks package eligibility for ChatGPT; it does not register remote MCP or install the full plugin in ChatGPT Plugins")
 		}
 		return request.DefaultIDs, allClients, cmd.Context().Err()
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
@@ -433,6 +433,7 @@ func setPreflightNextActions(targets []addTargetResult) {
 	for index := range targets {
 		if targets[index].Output.Result.Plan.Status != domain.PlanUnsupported {
 			targets[index].NextAction = "resolve the reported client requirement and retry; nothing was installed"
+			targets[index].Output.NextAction = targets[index].NextAction
 		}
 	}
 }

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
@@ -147,6 +147,7 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 	combined.Succeeded = len(planned.Targets)
 	if err != nil {
 		combined.Status, combined.Failed, combined.Succeeded = "preflight_failed", len(inputs), 0
+		setPreflightNextActions(combined.Targets)
 		_ = renderAddMultiResult(cmd, opts, combined, loaded.envelope)
 		return fmt.Errorf("group preflight failed; no target was changed (selected targets: %v): %w%s", targets, err, addGroupNextAction(combined.Targets))
 	}
@@ -193,6 +194,7 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 	if err != nil {
 		if applied.Phase == usecase.GroupPhasePlanned && !applied.Mutated {
 			combined.Status, combined.Failed, combined.Succeeded = "preflight_failed", len(inputs), 0
+			setPreflightNextActions(combined.Targets)
 			_ = renderAddMultiResult(cmd, opts, combined, loaded.envelope)
 			return fmt.Errorf("group apply preflight failed; no target was changed (selected targets: %v): %w%s", targets, err, addGroupNextAction(combined.Targets))
 		}
@@ -422,6 +424,17 @@ func humanAddGroupPlans(targets []addTargetResult) []usecase.AddResult {
 		results[index] = result
 	}
 	return results
+}
+
+// A ready plan is not actionable when the selected group failed preflight.
+// Preserve unsupported-package recovery instructions, but never promise
+// activation from a plan whose requirements were rejected.
+func setPreflightNextActions(targets []addTargetResult) {
+	for index := range targets {
+		if targets[index].Output.Result.Plan.Status != domain.PlanUnsupported {
+			targets[index].NextAction = "resolve the reported client requirement and retry; nothing was installed"
+		}
+	}
 }
 
 func addGroupNextAction(targets []addTargetResult) string {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
@@ -355,6 +355,19 @@ func renderAddMultiResult(cmd *cobra.Command, opts *options, result addMultiResu
 		}
 		return writeJSONResult(cmd.OutOrStdout(), "add", overall, result)
 	}
+	if result.Status == "preflight_failed" {
+		if _, err := fmt.Fprintln(cmd.OutOrStdout(), "Nothing was installed: a selected client could not pass the checks before installation. See the error below; there is no new configuration to activate."); err != nil {
+			return err
+		}
+		for _, target := range result.Targets {
+			if target.Output.Result.Plan.Status == domain.PlanUnsupported {
+				if err := renderHumanPlan(cmd.OutOrStdout(), envelope, target.Output.Result); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
 	if len(result.Targets) == 1 {
 		return renderAddResult(cmd.OutOrStdout(), "human", envelope, result.Targets[0].Output.Result, result.DryRun)
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -929,7 +929,7 @@ func TestInteractiveAddSkipsDetectedClientThatPackageCannotServe(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(stdout, "Skipped installed clients that this package cannot install together: chatgpt") {
+	if !strings.Contains(stdout, "Skipped (not installed in this attempt): chatgpt") {
 		t.Fatalf("package-aware interactive output = %q", stdout)
 	}
 	if strings.Contains(stdout, "Detected supported clients (all selected by default)") {
@@ -952,7 +952,7 @@ func TestInteractiveAddSkipsDetectedClientThatCannotPassActivationPreflight(t *t
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(stdout, "Skipped installed clients that this package cannot install together: kiro") {
+	if !strings.Contains(stdout, "Skipped (not installed in this attempt): kiro") {
 		t.Fatalf("activation-aware interactive output = %q", stdout)
 	}
 	if strings.Contains(stdout, "Detected supported clients (all selected by default)") {
@@ -2063,10 +2063,10 @@ func TestChatGPTMCPWithoutAppBindingFailsBeforeMutation(t *testing.T) {
 	plugin := writeCLIPlugin(t)
 	writeCLIMCP(t, plugin)
 	stdout, _, err := fixture.execute(false, "add", plugin, "--target", "chatgpt")
-	if err == nil || !strings.Contains(err.Error(), "Developer Mode") || !strings.Contains(err.Error(), ".app.json") {
+	if err == nil || !strings.Contains(err.Error(), "Plugins developer mode") || !strings.Contains(err.Error(), ".app.json") {
 		t.Fatalf("missing app error = %v", err)
 	}
-	if !strings.Contains(stdout, "Developer Mode") || !strings.Contains(stdout, ".app.json") || !strings.Contains(stdout, "demo") {
+	if !strings.Contains(stdout, "Plugins developer mode") || !strings.Contains(stdout, ".app.json") || !strings.Contains(stdout, "demo") {
 		t.Fatalf("human unsupported plan omitted recovery guidance: %s", stdout)
 	}
 	state, err := fixture.store.Load()
@@ -2087,7 +2087,7 @@ func TestChatGPTUnsupportedPlanRendersStructuredJSONGuidance(t *testing.T) {
 	if err == nil {
 		t.Fatal("unsupported ChatGPT dry-run succeeded")
 	}
-	if !strings.Contains(stdout, `"status":"unsupported"`) || !strings.Contains(stdout, `"user_actions"`) || !strings.Contains(stdout, "Developer Mode") || !strings.Contains(stdout, ".app.json") {
+	if !strings.Contains(stdout, `"status":"unsupported"`) || !strings.Contains(stdout, `"user_actions"`) || !strings.Contains(stdout, "Plugins developer mode") || !strings.Contains(stdout, ".app.json") {
 		t.Fatalf("JSON unsupported plan omitted structured guidance: %s", stdout)
 	}
 	state, stateErr := fixture.store.Load()
@@ -2142,7 +2142,7 @@ func TestChatGPTUnsupportedUpdateRendersRecoveryWithoutMutation(t *testing.T) {
 					t.Fatalf("JSON update omitted structured user actions: %s", stdout)
 				}
 			}
-			for _, expected := range []string{"Developer Mode", ".app.json", "demo"} {
+			for _, expected := range []string{"Plugins developer mode", ".app.json", "demo"} {
 				if !strings.Contains(stdout, expected) || !strings.Contains(updateErr.Error(), expected) {
 					t.Fatalf("%s update omitted %q recovery guidance: stdout=%q error=%v", test.format, expected, stdout, updateErr)
 				}
@@ -2211,7 +2211,7 @@ func TestNoDetectedClientSuggestsExplicitChatGPTTarget(t *testing.T) {
 	fixture := newCLIFixture(t, nil)
 	plugin := writeCLIPlugin(t)
 	_, _, err := fixture.execute(true, "add", plugin)
-	if err == nil || !strings.Contains(err.Error(), "--target chatgpt") || !strings.Contains(err.Error(), "install/detect another client") {
+	if err == nil || !strings.Contains(err.Error(), "--target chatgpt") || !strings.Contains(err.Error(), "Install/detect a supported client") {
 		t.Fatalf("zero-client guidance = %v", err)
 	}
 	state, stateErr := fixture.store.Load()

--- a/cli/plugin-kit-ai/internal/agentpluginscli/directory_rollout_semantics_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/directory_rollout_semantics_test.go
@@ -323,7 +323,7 @@ func TestInteractiveSharedSurfaceAddRequiresSignedPeerEligibilityBeforeAcquisiti
 			rollout.directory.bundle.Snapshot.Distributions[0].ReleasePolicies[0].Targets = []domain.DirectoryTarget{{
 				Client: test.selected, Scopes: []domain.InstallScope{domain.ScopeUser}, Delivery: delivery,
 			}}
-			if _, _, err := rollout.cli.executeInput(true, test.input, "add", "rollout-demo"); err == nil || !strings.Contains(err.Error(), "missing "+string(test.missing)) {
+			if stdout, _, err := rollout.cli.executeInput(true, test.input, "add", "rollout-demo"); err == nil || !strings.Contains(stdout, "the catalog has no compatible release") {
 				t.Fatalf("interactive %s selection accepted incomplete peer policy: %v", test.selected, err)
 			}
 			state, err := rollout.cli.store.Load()
@@ -351,7 +351,7 @@ func TestInteractiveDirectoryAddOffersOnlyOneCompleteSignedTargetSet(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(stdout, "Skipped installed clients that this package cannot install together: codex") {
+	if !strings.Contains(stdout, "Skipped (not installed in this attempt): codex: the catalog has no compatible release") {
 		t.Fatalf("package-aware Directory output = %q", stdout)
 	}
 	if rollout.acquirer.verifiedCalls != 1 {
@@ -393,7 +393,7 @@ func TestInteractiveDirectoryAddSkipsTargetThatCannotPassActivationPreflight(t *
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(stdout, "Skipped installed clients that this package cannot install together: kiro") {
+	if !strings.Contains(stdout, "Skipped (not installed in this attempt): kiro: this CLI cannot automatically check MCP connections") {
 		t.Fatalf("activation-aware Directory output = %q", stdout)
 	}
 	if strings.Contains(stdout, "Detected supported clients (all selected by default)") {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/interactive_targets.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/interactive_targets.go
@@ -28,11 +28,10 @@ func promptCompatibleDetectedTargets(ctx context.Context, cmd *cobra.Command, ap
 		return selection, all, nil, err
 	}
 
-	compatible, preloaded, err := app.compatibleDetectedTargets(ctx, source, detected)
+	compatible, skipped, preloaded, err := app.compatibleDetectedTargets(ctx, source, detected)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	skipped := subtractDetectedClients(detected, compatible)
 	selection, all, err := promptTargetChoices(cmd, app, compatible, skipped, clients)
 	if err != nil {
 		if preloaded != nil && preloaded.cleanup != nil {
@@ -68,46 +67,53 @@ func subtractDetectedClients(all, selected []domain.DetectedClient) []domain.Det
 	return result
 }
 
-func (app App) compatibleDetectedTargets(ctx context.Context, source string, detected []domain.DetectedClient) ([]domain.DetectedClient, *loadedPackage, error) {
+// targetSkip contains only installer-owned guidance, never raw planner/provider errors.
+type targetSkip struct {
+	Client domain.ClientID
+	Reason string
+}
+
+func skippedTargets(clients []domain.DetectedClient, reason string) []targetSkip {
+	var skipped []targetSkip
+	for _, client := range clients {
+		skipped = append(skipped, targetSkip{Client: client.ClientID, Reason: strings.ReplaceAll(reason, "--target", "--target "+string(client.ClientID))})
+	}
+	return skipped
+}
+
+func (app App) compatibleDetectedTargets(ctx context.Context, source string, detected []domain.DetectedClient) ([]domain.DetectedClient, []targetSkip, *loadedPackage, error) {
+	candidates := detected
+	var skipped []targetSkip
 	switch {
 	case strings.HasPrefix(source, "discovery:"):
 		compatible, err := app.compatibleDiscoveryTargets(ctx, source, detected)
-		return compatible, nil, err
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		skipped = skippedTargets(subtractDetectedClients(detected, compatible), "not listed as compatible in the signed Discovery record; inspect this client separately with --target")
+		return compatible, skipped, nil, nil
 	case isDirectorySelector(source):
 		compatible, err := app.compatibleDirectoryTargets(ctx, source, detected)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
-		loaded, err := app.loadPackageFor(
-			ctx,
-			source,
-			withDetectedClients(app.addResolutionRequest(source, detectedClientIDs(compatible)), detectedClientMap(detected)),
-		)
-		if err != nil {
-			return nil, nil, err
+		skipped = skippedTargets(subtractDetectedClients(detected, compatible), "the catalog has no compatible release for this combination of clients and system; check this client separately with --target")
+		candidates = compatible
+		if len(candidates) == 0 {
+			return nil, skipped, nil, nil
 		}
-		compatible = app.compatibleLoadedTargets(ctx, loaded, compatible)
-		if len(compatible) == 0 {
-			if loaded.cleanup != nil {
-				_ = loaded.cleanup()
-			}
-			return nil, nil, fmt.Errorf("the package cannot be installed automatically in any detected supported client; use --target to inspect a specific client")
-		}
-		return compatible, &loaded, nil
-	default:
-		loaded, err := app.loadPackageFor(ctx, source, app.addResolutionRequest(source, nil))
-		if err != nil {
-			return nil, nil, err
-		}
-		compatible := app.compatibleLoadedTargets(ctx, loaded, detected)
-		if len(compatible) == 0 {
-			if loaded.cleanup != nil {
-				_ = loaded.cleanup()
-			}
-			return nil, nil, fmt.Errorf("the package cannot be installed in any detected supported client; use --target to inspect a specific client")
-		}
-		return compatible, &loaded, nil
 	}
+	request := app.addResolutionRequest(source, nil)
+	if isDirectorySelector(source) {
+		request = withDetectedClients(app.addResolutionRequest(source, detectedClientIDs(candidates)), detectedClientMap(detected))
+	}
+	loaded, err := app.loadPackageFor(ctx, source, request)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	compatible, rejected := app.compatibleLoadedTargets(ctx, loaded, candidates)
+	skipped = append(skipped, rejected...)
+	return compatible, skipped, &loaded, nil
 }
 
 func (app App) compatibleDiscoveryTargets(ctx context.Context, selector string, detected []domain.DetectedClient) ([]domain.DetectedClient, error) {
@@ -131,9 +137,6 @@ func (app App) compatibleDiscoveryTargets(ctx context.Context, selector string, 
 		if _, ok := allowed[string(client.ClientID)]; ok {
 			compatible = append(compatible, client)
 		}
-	}
-	if len(compatible) == 0 {
-		return nil, fmt.Errorf("discovery package %q cannot be installed in any detected supported client; use --target to inspect a specific client", selector)
 	}
 	return compatible, nil
 }
@@ -169,7 +172,6 @@ func (app App) compatibleDirectoryTargets(ctx context.Context, selector string, 
 	// At most ten clients are supported, so enumerating subsets is bounded to
 	// 1,023 pure resolver calls. This preserves one signed distribution/release
 	// for the complete set instead of combining incompatible per-client picks.
-	var singleTargetErr error
 	for size := len(detected); size >= 1; size-- {
 		var match []domain.DetectedClient
 		forEachDetectedSubset(detected, size, func(candidate []domain.DetectedClient) bool {
@@ -183,9 +185,6 @@ func (app App) compatibleDirectoryTargets(ctx context.Context, selector string, 
 				OS: runtime.GOOS, Architecture: runtime.GOARCH, DependencyIdentity: environment.DependencyIdentity,
 				SchemaVersion: "1.0.0", Operation: operation, Recorded: request.Recorded,
 			})
-			if size == 1 && singleTargetErr == nil && resolveErr != nil {
-				singleTargetErr = resolveErr
-			}
 			if resolveErr == nil {
 				match = append([]domain.DetectedClient(nil), candidate...)
 				return false
@@ -196,10 +195,9 @@ func (app App) compatibleDirectoryTargets(ctx context.Context, selector string, 
 			return match, nil
 		}
 	}
-	if singleTargetErr != nil {
-		return nil, singleTargetErr
-	}
-	return nil, fmt.Errorf("no signed Directory release for %q supports any detected client", selector)
+	// No subset resolved. The caller reports each excluded client and stops
+	// before acquisition; raw resolver diagnostics can contain source details.
+	return nil, nil
 }
 
 func forEachDetectedSubset(values []domain.DetectedClient, size int, visit func([]domain.DetectedClient) bool) {
@@ -227,7 +225,8 @@ func forEachDetectedSubset(values []domain.DetectedClient, size int, visit func(
 	walk(0, 0)
 }
 
-func (app App) compatibleLoadedTargets(ctx context.Context, loaded loadedPackage, detected []domain.DetectedClient) []domain.DetectedClient {
+func (app App) compatibleLoadedTargets(ctx context.Context, loaded loadedPackage, detected []domain.DetectedClient) ([]domain.DetectedClient, []targetSkip) {
+	var skipped []targetSkip
 	clientMap := detectedClientMap(detected)
 	planner := clientplanner.Planner{ManagedRoot: app.ManagedRoot, Detected: clientMap}
 	physicalID := domain.ComputePhysicalArtifactID(loaded.envelope.Manifest.Name, "00000000-0000-4000-8000-000000000000")
@@ -235,10 +234,21 @@ func (app App) compatibleLoadedTargets(ctx context.Context, loaded loadedPackage
 	for _, client := range detected {
 		candidate := cloneLoadedPackage(loaded)
 		if err := prepareLoadedPackageForClient(&candidate, client.ClientID); err != nil {
+			skipped = append(skipped, targetSkip{client.ClientID, "package binding preparation failed; ask the package publisher to check its client mapping"})
 			continue
 		}
 		plan, err := planner.Plan(ctx, candidate.envelope, client, domain.ScopeUser, physicalID)
 		if err != nil || plan.Status == domain.PlanUnsupported {
+			reason := "package is unsupported for this client; ask the package publisher for supported components"
+			if err != nil {
+				reason = "package planning failed; ask the package publisher to check compatibility for this client"
+			}
+			for _, warning := range plan.Warnings {
+				if warning == "chatgpt_app_binding_required" {
+					reason = clientplanner.ChatGPTAppBindingAction
+				}
+			}
+			skipped = append(skipped, targetSkip{client.ClientID, reason})
 			continue
 		}
 		if preflighter, ok := app.Lifecycle.Activator.(interface {
@@ -248,12 +258,17 @@ func (app App) compatibleLoadedTargets(ctx context.Context, loaded loadedPackage
 				Client: client, Plan: plan, BackendExecutable: backendExecutable(client, clientMap), VerifyOnly: true,
 			})
 			if err != nil {
+				reason := "automatic activation/verification preflight failed; resolve this client's verification prerequisites before retrying --target " + string(client.ClientID)
+				if client.ClientID == domain.ClientKiro {
+					reason = "this CLI cannot automatically check MCP connections in your Kiro setup. Nothing was installed in Kiro. Use another listed client, or connect the server in Kiro: https://kiro.dev/docs/mcp/"
+				}
+				skipped = append(skipped, targetSkip{client.ClientID, reason})
 				continue
 			}
 		}
 		compatible = append(compatible, client)
 	}
-	return compatible
+	return compatible, skipped
 }
 
 func detectedClientIDs(clients []domain.DetectedClient) []domain.ClientID {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/target_eligibility_guidance_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/target_eligibility_guidance_test.go
@@ -1,6 +1,7 @@
 package agentpluginscli
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"strings"
@@ -94,11 +95,16 @@ func TestDirectoryZeroChoicesExplainReleaseSelection(t *testing.T) {
 
 func TestPreflightNextActionsDoNotPromiseAutomaticInstallation(t *testing.T) {
 	targets := []addTargetResult{{NextAction: "agentplugins will install and verify the package's global Kiro skills and MCP servers automatically"}}
+	targets[0].Output.NextAction = targets[0].NextAction
 	targets[0].Output.Result.Plan.Status = domain.PlanReady
 	targets[0].Output.Result.Plan.Authentication = domain.AuthenticationNotRequired
 	setPreflightNextActions(targets)
 	if strings.Contains(addGroupNextAction(targets), "automatically") || !strings.Contains(targets[0].NextAction, "nothing was installed") {
 		t.Fatalf("preflight retained the ready-plan promise: %+v", targets)
+	}
+	encoded, err := json.Marshal(targets)
+	if err != nil || strings.Contains(string(encoded), "automatically") || strings.Count(string(encoded), "nothing was installed") != 2 {
+		t.Fatalf("serialized next actions disagree: %s, %v", encoded, err)
 	}
 	targets[0].Output.Result.Plan.Status = domain.PlanUnsupported
 	targets[0].NextAction = "ask the publisher to register the ChatGPT connection"

--- a/cli/plugin-kit-ai/internal/agentpluginscli/target_eligibility_guidance_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/target_eligibility_guidance_test.go
@@ -91,3 +91,19 @@ func TestDirectoryZeroChoicesExplainReleaseSelection(t *testing.T) {
 		t.Fatal("acquired package with no eligible release")
 	}
 }
+
+func TestPreflightNextActionsDoNotPromiseAutomaticInstallation(t *testing.T) {
+	targets := []addTargetResult{{NextAction: "agentplugins will install and verify the package's global Kiro skills and MCP servers automatically"}}
+	targets[0].Output.Result.Plan.Status = domain.PlanReady
+	targets[0].Output.Result.Plan.Authentication = domain.AuthenticationNotRequired
+	setPreflightNextActions(targets)
+	if strings.Contains(addGroupNextAction(targets), "automatically") || !strings.Contains(targets[0].NextAction, "nothing was installed") {
+		t.Fatalf("preflight retained the ready-plan promise: %+v", targets)
+	}
+	targets[0].Output.Result.Plan.Status = domain.PlanUnsupported
+	targets[0].NextAction = "ask the publisher to register the ChatGPT connection"
+	setPreflightNextActions(targets)
+	if targets[0].NextAction != "ask the publisher to register the ChatGPT connection" {
+		t.Fatal("unsupported-package recovery action was lost")
+	}
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/target_eligibility_guidance_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/target_eligibility_guidance_test.go
@@ -1,0 +1,93 @@
+package agentpluginscli
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers"
+)
+
+type deniedEligibilityActivator struct{ providers.Activator }
+
+func (deniedEligibilityActivator) PreflightActivation(request domain.ActivationRequest) error {
+	if request.Client.ClientID == domain.ClientKiro {
+		return errors.New("\x1b[31m/private/profile/secret-token: unsafe verifier")
+	}
+	return nil
+}
+
+func TestSkippedReasonsSurviveZeroSingleAndMultipleChoices(t *testing.T) {
+	for _, count := range []int{0, 1, 2} {
+		t.Run(string(rune('0'+count)), func(t *testing.T) {
+			clients := []domain.DetectedClient{fixtureClient(t, domain.ClientKiro), fixtureClient(t, domain.ClientChatGPT)}
+			if count > 0 {
+				clients = append(clients, fixtureClient(t, domain.ClientCursor))
+			}
+			if count > 1 {
+				clients = append(clients, fixtureClient(t, domain.ClientCodex))
+			}
+			fixture := newCLIFixture(t, clients)
+			fixture.app.Lifecycle.Activator = deniedEligibilityActivator{}
+			plugin := writeCLIPlugin(t)
+			writeCLIMCP(t, plugin)
+			stdout, _, err := fixture.executeInput(true, "\n", "add", plugin, "--dry-run")
+			if (err != nil) != (count == 0) {
+				t.Fatalf("output=%q err=%v", stdout, err)
+			}
+			for _, want := range []string{"kiro: this CLI cannot automatically check MCP connections", "Nothing was installed in Kiro", "chatgpt: this package is not ready for ChatGPT", "registered connection mapping (.app.json)", "You do not need to create this file", "https://developers.openai.com/plugins/build/plugins"} {
+				if !strings.Contains(stdout, want) {
+					t.Fatalf("missing %q: %q", want, stdout)
+				}
+			}
+			for _, bad := range []string{"cannot install together", "/private/", "secret-token", "\x1b[31m"} {
+				if strings.Contains(stdout, bad) {
+					t.Fatalf("unsafe/misleading output: %q", stdout)
+				}
+			}
+			state, loadErr := fixture.store.Load()
+			if loadErr != nil || len(state.Installations) != 0 {
+				t.Fatalf("state=%+v err=%v", state, loadErr)
+			}
+			if entries, readErr := os.ReadDir(fixture.app.ManagedRoot); readErr == nil && len(entries) > 0 {
+				t.Fatalf("staged files: %v", entries)
+			}
+		})
+	}
+}
+
+func TestKiroEligibilityDoesNotGuessFromClientName(t *testing.T) {
+	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientKiro)})
+	fixture.app.Lifecycle.Activator = providers.Activator{Runner: &cliRunOnlyRunner{}}
+	stdout, _, err := fixture.executeInput(true, "\n", "add", writeCLIPlugin(t), "--dry-run")
+	if err != nil || strings.Contains(stdout, "Skipped") {
+		t.Fatalf("skills-only Kiro was rejected: %q %v", stdout, err)
+	}
+}
+
+func TestExplicitKiroPreflightDoesNotSuggestActivatingInstalledConfiguration(t *testing.T) {
+	kiro := fixtureClient(t, domain.ClientKiro)
+	kiro.ExecutablePath = "/test/bin/kiro-cli"
+	fixture := newCLIFixture(t, []domain.DetectedClient{kiro})
+	fixture.app.Lifecycle.Activator = providers.Activator{Runner: &cliRunOnlyRunner{}}
+	plugin := writeCLIPlugin(t)
+	writeCLIMCP(t, plugin)
+	stdout, _, err := fixture.execute(false, "add", plugin, "--target", "kiro", "--dry-run")
+	if err == nil || !strings.Contains(stdout, "Nothing was installed") || strings.Contains(stdout, "Planned action:") {
+		t.Fatalf("output=%q err=%v", stdout, err)
+	}
+}
+
+func TestDirectoryZeroChoicesExplainReleaseSelection(t *testing.T) {
+	rollout := newRolloutDirectoryFixture(t, []domain.ClientID{domain.ClientCursor}, []domain.ClientID{domain.ClientCursor})
+	rollout.cli.app.Detector = staticDetector{clients: []domain.DetectedClient{fixtureClient(t, domain.ClientCodex)}}
+	stdout, _, err := rollout.cli.executeInput(true, "\n", "add", "rollout-demo", "--dry-run")
+	if err == nil || !strings.Contains(stdout, "codex: the catalog has no compatible release") || !strings.Contains(stdout, "--target codex") || strings.Contains(stdout, "verification preflight failed") {
+		t.Fatalf("output=%q err=%v", stdout, err)
+	}
+	if rollout.acquirer.verifiedCalls != 0 {
+		t.Fatal("acquired package with no eligible release")
+	}
+}

--- a/cli/plugin-kit-ai/internal/terminalprompts/adapter_success_contract_test.go
+++ b/cli/plugin-kit-ai/internal/terminalprompts/adapter_success_contract_test.go
@@ -53,11 +53,14 @@ func TestAdapterSuccessContract(t *testing.T) {
 							t.Fatal("confirmation request mutated")
 						}
 					} else {
-						req := prompt.TargetSelectionRequest{Choices: []prompt.TargetChoice{{ID: "cursor", Label: "Cursor"}, {ID: "claude", Label: "Claude"}, {ID: "codex", Label: "Codex"}}, DefaultIDs: append([]domain.ClientID(nil), tc.defaults...), SkippedLabels: []string{"Unsupported fixture"}}
+						req := prompt.TargetSelectionRequest{Choices: []prompt.TargetChoice{{ID: "cursor", Label: "Cursor"}, {ID: "claude", Label: "Claude"}, {ID: "codex", Label: "Codex"}}, DefaultIDs: append([]domain.ClientID(nil), tc.defaults...), SkippedLabels: []string{"kiro: this CLI cannot automatically check MCP connections; retry --target kiro\x1b\u202e"}}
 						before := prompt.TargetSelectionRequest{Choices: append([]prompt.TargetChoice(nil), req.Choices...), DefaultIDs: append([]domain.ClientID(nil), req.DefaultIDs...), SkippedLabels: append([]string(nil), req.SkippedLabels...)}
 						got, err := p.SelectTargets(ctx, req)
 						if err != nil || !reflect.DeepEqual(got.IDs, tc.want) {
 							t.Fatalf("selection = %+v, %v; want %v", got, err, tc.want)
+						}
+						if !strings.Contains(output.String(), "Skipped (not installed in this attempt): kiro: this CLI cannot automatically check MCP connections; retry --target kiro") || strings.Contains(output.String(), "\u202e") {
+							t.Fatalf("missing or unsafe skipped guidance: %q", output.String())
 						}
 						if !reflect.DeepEqual(req, before) {
 							t.Fatal("selection request mutated")

--- a/cli/plugin-kit-ai/internal/terminalprompts/huh.go
+++ b/cli/plugin-kit-ai/internal/terminalprompts/huh.go
@@ -43,7 +43,7 @@ func (p HuhPrompter) SelectTargets(ctx context.Context, r prompt.TargetSelection
 		choices = append(choices, huh.NewOption(prompt.SafeText(c.Label)+" ("+prompt.SafeText(string(c.ID))+")", c.ID))
 	}
 	for _, label := range r.SkippedLabels {
-		if err := promptio.WriteText(p.Output, (terminaltheme.Theme{Enabled: !p.NoColor}).Text(terminaltheme.Warning, "Skipped installed clients that this package cannot install together")+": "+prompt.SafeText(label)+"\n"); err != nil {
+		if err := promptio.WriteText(p.Output, (terminaltheme.Theme{Enabled: !p.NoColor}).Text(terminaltheme.Warning, "Skipped (not installed in this attempt)")+": "+prompt.SafeText(label)+"\n"); err != nil {
 			return prompt.TargetSelectionResult{}, err
 		}
 	}

--- a/cli/plugin-kit-ai/internal/terminalprompts/plain.go
+++ b/cli/plugin-kit-ai/internal/terminalprompts/plain.go
@@ -29,15 +29,8 @@ func (p PlainPrompter) SelectTargets(ctx context.Context, r prompt.TargetSelecti
 		return prompt.TargetSelectionResult{}, err
 	}
 	var b strings.Builder
-	if len(r.SkippedLabels) > 0 {
-		b.WriteString(terminaltheme.For(p.Output).Text(terminaltheme.Warning, "Skipped installed clients that this package cannot install together") + ": ")
-		for i, s := range r.SkippedLabels {
-			if i > 0 {
-				b.WriteString(", ")
-			}
-			b.WriteString(prompt.SafeText(s))
-		}
-		b.WriteByte('\n')
+	for _, label := range r.SkippedLabels {
+		b.WriteString(terminaltheme.For(p.Output).Text(terminaltheme.Warning, "Skipped (not installed in this attempt)") + ": " + prompt.SafeText(label) + "\n")
 	}
 	b.WriteString(terminaltheme.For(p.Output).Text(terminaltheme.Label, "Detected supported clients") + terminaltheme.For(p.Output).Text(terminaltheme.Muted, " (all selected by default)") + ":\n")
 	for i, c := range r.Choices {

--- a/install/integrationctl/agentplugins/planner/planner.go
+++ b/install/integrationctl/agentplugins/planner/planner.go
@@ -16,6 +16,9 @@ type Planner struct {
 	Detected    map[domain.ClientID]domain.DetectedClient
 }
 
+// ChatGPTAppBindingAction describes registration and package-author responsibilities.
+const ChatGPTAppBindingAction = "this package is not ready for ChatGPT. Connect its remote MCP server in ChatGPT Plugins developer mode; full plugin installation also needs the publisher's registered connection mapping (.app.json). You do not need to create this file. Setup: https://developers.openai.com/plugins/build/plugins"
+
 // DetectedPhysicalClient returns a genuinely detected client that can address
 // an installed physical binding. Copilot and VS Code share one backend, so an
 // installed binding owned by either logical client can be maintained through
@@ -126,7 +129,7 @@ func (planner Planner) Plan(
 		plan.Status = domain.PlanUnsupported
 		plan.Activation = domain.ActivationFailed
 		plan.Warnings = appendUnique(plan.Warnings, "chatgpt_app_binding_required")
-		action := "register every remote MCP connection in ChatGPT Developer Mode and provide a valid root .app.json mapping"
+		action := ChatGPTAppBindingAction
 		if len(missingChatGPTApps) > 0 {
 			action += " for: " + strings.Join(missingChatGPTApps, ", ")
 		}


### PR DESCRIPTION
When an installed client cannot accept a package, the selector currently says the clients cannot be installed together and hides the actual reason. Retain the eligibility stage and show a separate, actionable explanation for catalog compatibility, missing ChatGPT connection mappings, and unavailable client verification. Cover plain/rich prompts and zero/one/multiple choices. A failed preflight now says nothing was installed and no longer appends an automatic-install promise from an unaccepted plan.

Eligibility, signed release selection, activation, process containment and JSON structure are preserved. This does not add automatic ChatGPT or macOS Kiro installation.

Validation: affected CLI, terminal prompt and planner package tests; focused no-mutation regressions. Personal-profile Context7 smoke tests succeeded in ChatGPT (registered developer-mode connection) and Kiro 2.20.2 (actual resolve-library-id and query-docs calls). Those are client connectivity evidence, not proof that this CLI installs either integration. Independent review accepted final 33b51e7d after corrections to both error and nested JSON next-action fields. The final CLI package tests passed. Kiro v2 direct MCP calls also passed after temporarily increasing its existing 120 ms startup timeout; the original setting was restored.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-client explanations when targets are skipped during installation.
  * Added clearer guidance for selecting eligible targets, including ChatGPT and Kiro-specific instructions.
  * Added retry-oriented next steps for targets affected by preflight failures.

* **Bug Fixes**
  * Improved handling when no compatible clients remain, avoiding misleading installation or activation guidance.
  * Clarified that nothing was installed when preflight checks fail.

* **Style**
  * Updated skipped-target notices to use clearer wording and display each reason on its own line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->