### PR TITLE
feat(cli): prepare Kiro integrations without automatic activation

### DIFF
--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -12,6 +12,7 @@ import (
 	"github.com/777genius/plugin-kit-ai/cli/internal/promptio"
 	"github.com/777genius/plugin-kit-ai/cli/internal/terminaltheme"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	clientplanner "github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/planner"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/ports"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/usecase"
 	"github.com/spf13/cobra"
@@ -37,6 +38,17 @@ func newAddCommand(app App, opts *options) *cobra.Command {
 			if err := validateCommonOptions(opts); err != nil {
 				return err
 			}
+			opts.installIntents = make(map[domain.ClientID]domain.InstallIntent)
+			if opts.prepare {
+				targets, err := parseTargetOption(opts.target)
+				if err != nil {
+					return err
+				}
+				if len(targets) != 1 || targets[0] != domain.ClientKiro {
+					return fmt.Errorf("--prepare requires --target kiro; prepare other targets in separate commands")
+				}
+				opts.installIntents[domain.ClientKiro] = domain.InstallIntentPrepare
+			}
 			var detectedClients []domain.DetectedClient
 			targetProvided := cmd.Flags().Changed("target") && strings.TrimSpace(opts.target) != ""
 			if !targetProvided && app.Terminal && opts.format == "human" {
@@ -45,7 +57,7 @@ func newAddCommand(app App, opts *options) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				selection, clients, preloaded, err := promptCompatibleDetectedTargets(cmd.Context(), cmd, app, args[0])
+				selection, clients, preloaded, err := promptCompatibleDetectedTargets(cmd.Context(), cmd, app, args[0], opts.installIntents)
 				if err != nil {
 					return err
 				}
@@ -54,7 +66,7 @@ func newAddCommand(app App, opts *options) *cobra.Command {
 				}
 				detectedClients = clients
 				targets := selection
-				detectedClients, err = detectSelectedTargetsForLifecycleResolution(cmd.Context(), app.Detector, targets, detectedClients, !opts.dryRun && isDirectorySelector(args[0]))
+				detectedClients, err = detectSelectedTargetsForLifecycleResolution(cmd.Context(), app.Detector, automaticInstallTargets(targets, opts.installIntents), detectedClients, !opts.dryRun && isDirectorySelector(args[0]))
 				if err != nil {
 					return fmt.Errorf("detect selected AI clients: %w", err)
 				}
@@ -87,6 +99,7 @@ func newAddCommand(app App, opts *options) *cobra.Command {
 			return runAddManyWithClients(cmd.Context(), cmd, app, opts, args[0], targets, activationComplete, authComplete, detectedClients)
 		},
 	}
+	command.Flags().BoolVar(&opts.prepare, "prepare", false, "prepare owned Kiro configuration without launching Kiro; authenticate and verify tools in Kiro")
 	command.Flags().BoolVar(&activationComplete, "activation-complete", false, "attest that manual client activation is complete")
 	command.Flags().BoolVar(&authComplete, "auth-complete", false, "attest that required authentication is complete or none is required after review")
 	return command
@@ -132,7 +145,8 @@ func runAddLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *option
 	}
 	service := lifecycleService(app, detectedMap)
 	input := usecase.AddInput{
-		Envelope: loaded.envelope, Client: selected, Scope: domain.InstallScope(opts.scope),
+		InstallIntent: opts.installIntents[selected.ClientID],
+		Envelope:      loaded.envelope, Client: selected, Scope: domain.InstallScope(opts.scope),
 		DryRun: opts.dryRun, Confirmed: false, Interactive: app.Terminal,
 		Hints: loaded.hints, BackendExecutable: backendExecutable(selected, detectedMap),
 		ActivationComplete: activationComplete, AuthComplete: authComplete,
@@ -256,7 +270,7 @@ func promptTargetChoices(cmd *cobra.Command, app App, detected []domain.Detected
 // retain the read-only observations rather than falling back to executing every
 // discovered client binary.
 func detectSelectedTargetsForLifecycleResolution(ctx context.Context, detector ports.ClientDetector, targets []domain.ClientID, detected []domain.DetectedClient, probeVersion bool) ([]domain.DetectedClient, error) {
-	if !probeVersion {
+	if !probeVersion || len(targets) == 0 {
 		return detected, nil
 	}
 	if targeted, ok := detector.(ports.TargetedVersionProbingClientDetector); ok {
@@ -273,6 +287,9 @@ func resumeInteractiveLifecycle(
 	envelope domain.PackageEnvelope,
 	current usecase.AddResult,
 ) error {
+	if current.Plan.InstallIntent == domain.InstallIntentPrepare {
+		return nil
+	}
 	if current.Activation.Activation != domain.ActivationActive || current.Activation.Verification != domain.VerificationInstalled {
 		complete, err := promptYesNo(cmd.Context(), cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(), "Have you completed activation and verified the plugin is enabled in the client? [y/N]")
 		if err != nil {
@@ -534,6 +551,10 @@ func renderAddResultErrorWithSecurity(writer io.Writer, format string, envelope 
 	if err := renderOpenCodeRuntimeNotice(writer, result); err != nil {
 		return err
 	}
+	if result.NoChange && result.Plan.InstallIntent == domain.InstallIntentPrepare {
+		_, err := fmt.Fprintln(writer, "Owned Kiro configuration remains prepared. No changes made.\nNext: "+clientplanner.KiroPrepareAction)
+		return err
+	}
 	if result.NoChange {
 		_, _ = fmt.Fprintln(writer, terminaltheme.For(writer).Text(terminaltheme.Muted, "Already installed and lifecycle verification is complete. No changes made."))
 		return nil
@@ -642,6 +663,9 @@ func nextLocalLifecycleAction(result usecase.AddResult) string {
 }
 
 func lifecycleAction(result usecase.AddResult, includePrivate bool) string {
+	if result.Plan.InstallIntent == domain.InstallIntentPrepare {
+		return clientplanner.KiroPrepareAction
+	}
 	action := ""
 	if includePrivate && len(result.Activation.LocalActions) > 0 {
 		action = result.Activation.LocalActions[0]

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -66,7 +66,11 @@ func newAddCommand(app App, opts *options) *cobra.Command {
 				}
 				detectedClients = clients
 				targets := selection
-				detectedClients, err = detectSelectedTargetsForLifecycleResolution(cmd.Context(), app.Detector, automaticInstallTargets(targets, opts.installIntents), detectedClients, !opts.dryRun && isDirectorySelector(args[0]))
+				intents, err := app.addLifecycleIntents(cmd.Context(), args[0], opts.scope, opts.installIntents)
+				if err != nil {
+					return err
+				}
+				detectedClients, err = detectSelectedTargetsForLifecycleResolution(cmd.Context(), app.Detector, automaticInstallTargets(targets, intents), detectedClients, !opts.dryRun && isDirectorySelector(args[0]))
 				if err != nil {
 					return fmt.Errorf("detect selected AI clients: %w", err)
 				}
@@ -114,7 +118,7 @@ func runAddWithClients(ctx context.Context, cmd *cobra.Command, app App, opts *o
 	if err != nil {
 		return err
 	}
-	_, detected, err := preflightSelectedTargets(ctx, app, targets, clients, !opts.dryRun && isDirectorySelector(source))
+	_, detected, err := preflightAddTargets(ctx, app, opts, source, targets, clients)
 	if err != nil {
 		return err
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
@@ -68,7 +68,7 @@ func runAddMany(ctx context.Context, cmd *cobra.Command, app App, opts *options,
 }
 
 func runAddManyWithClients(ctx context.Context, cmd *cobra.Command, app App, opts *options, source string, targets []domain.ClientID, activationComplete, authComplete bool, clients []domain.DetectedClient) error {
-	_, detected, err := preflightSelectedTargets(ctx, app, targets, clients, !opts.dryRun && isDirectorySelector(source) && len(opts.installIntents) == 0)
+	_, detected, err := preflightAddTargets(ctx, app, opts, source, targets, clients)
 	if err != nil {
 		return err
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
@@ -68,7 +68,7 @@ func runAddMany(ctx context.Context, cmd *cobra.Command, app App, opts *options,
 }
 
 func runAddManyWithClients(ctx context.Context, cmd *cobra.Command, app App, opts *options, source string, targets []domain.ClientID, activationComplete, authComplete bool, clients []domain.DetectedClient) error {
-	_, detected, err := preflightSelectedTargets(ctx, app, targets, clients, !opts.dryRun && isDirectorySelector(source))
+	_, detected, err := preflightSelectedTargets(ctx, app, targets, clients, !opts.dryRun && isDirectorySelector(source) && len(opts.installIntents) == 0)
 	if err != nil {
 		return err
 	}
@@ -120,7 +120,8 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 			return fmt.Errorf("preflight target %s: %w; no target was changed", client.ClientID, err)
 		}
 		input := usecase.AddInput{
-			Envelope: clientPackage.envelope, Client: client, Scope: domain.ScopeUser,
+			InstallIntent: opts.installIntents[client.ClientID],
+			Envelope:      clientPackage.envelope, Client: client, Scope: domain.ScopeUser,
 			DryRun: true, Interactive: app.Terminal, Hints: clientPackage.hints,
 			BackendExecutable:  backendExecutable(client, detected),
 			ActivationComplete: activationComplete, AuthComplete: authComplete,

--- a/cli/plugin-kit-ai/internal/agentpluginscli/app.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/app.go
@@ -64,6 +64,8 @@ type App struct {
 }
 
 type options struct {
+	prepare             bool
+	installIntents      map[domain.ClientID]domain.InstallIntent
 	color               terminaltheme.Policy
 	target              string
 	scope               string

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -937,7 +937,7 @@ func TestInteractiveAddSkipsDetectedClientThatPackageCannotServe(t *testing.T) {
 	}
 }
 
-func TestInteractiveAddSkipsDetectedClientThatCannotPassActivationPreflight(t *testing.T) {
+func TestInteractiveAddOffersKiroPreparationWhenAutomaticPreflightFails(t *testing.T) {
 	t.Parallel()
 	kiro := fixtureClient(t, domain.ClientKiro)
 	kiro.ExecutablePath = "/test/bin/kiro-cli"
@@ -952,11 +952,11 @@ func TestInteractiveAddSkipsDetectedClientThatCannotPassActivationPreflight(t *t
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(stdout, "Skipped (not installed in this attempt): kiro") {
+	if !strings.Contains(stdout, "prepare configuration; automatic MCP verification unavailable") {
 		t.Fatalf("activation-aware interactive output = %q", stdout)
 	}
-	if strings.Contains(stdout, "Detected supported clients (all selected by default)") {
-		t.Fatalf("single preflight-capable target unexpectedly prompted for multiple clients: %q", stdout)
+	if !strings.Contains(stdout, "Detected supported clients (all selected by default)") {
+		t.Fatalf("preparation-capable target unexpectedly prompted for multiple clients: %q", stdout)
 	}
 	state, loadErr := fixture.store.Load()
 	if loadErr != nil {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/directory_rollout_semantics_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/directory_rollout_semantics_test.go
@@ -359,7 +359,7 @@ func TestInteractiveDirectoryAddOffersOnlyOneCompleteSignedTargetSet(t *testing.
 	}
 }
 
-func TestInteractiveDirectoryAddSkipsTargetThatCannotPassActivationPreflight(t *testing.T) {
+func TestInteractiveDirectoryAddOffersKiroPreparationWhenAutomaticPreflightFails(t *testing.T) {
 	rollout := newRolloutDirectoryFixture(t,
 		[]domain.ClientID{domain.ClientCursor, domain.ClientKiro},
 		[]domain.ClientID{domain.ClientCursor, domain.ClientKiro})
@@ -393,11 +393,11 @@ func TestInteractiveDirectoryAddSkipsTargetThatCannotPassActivationPreflight(t *
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(stdout, "Skipped (not installed in this attempt): kiro: this CLI cannot automatically check MCP connections") {
+	if !strings.Contains(stdout, "prepare configuration; automatic MCP verification unavailable") {
 		t.Fatalf("activation-aware Directory output = %q", stdout)
 	}
-	if strings.Contains(stdout, "Detected supported clients (all selected by default)") {
-		t.Fatalf("single preflight-capable Directory target unexpectedly prompted: %q", stdout)
+	if !strings.Contains(stdout, "Detected supported clients (all selected by default)") {
+		t.Fatalf("preparation-capable Directory target unexpectedly prompted: %q", stdout)
 	}
 	if rollout.acquirer.verifiedCalls != 1 {
 		t.Fatalf("Directory package acquired %d times, want exactly once", rollout.acquirer.verifiedCalls)

--- a/cli/plugin-kit-ai/internal/agentpluginscli/engine_boundary.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/engine_boundary.go
@@ -71,7 +71,7 @@ func runSwitch(ctx context.Context, cmd *cobra.Command, app App, opts *options, 
 	targetIDs := installationTargets(installation, string(domain.ScopeUser))
 	var detected map[domain.ClientID]domain.DetectedClient
 	if len(targetIDs) > 0 {
-		_, detected, err = preflightSelectedTargets(ctx, app, targetIDs, nil, !opts.dryRun && isDirectorySelector(source))
+		_, detected, err = preflightSelectedTargets(ctx, app, targetIDs, nil, !opts.dryRun && isDirectorySelector(source), lifecycleInstallIntents(installation, opts.scope, nil))
 		if err != nil {
 			return err
 		}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/interactive_targets.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/interactive_targets.go
@@ -17,7 +17,7 @@ import (
 // turning ambient client detection into an unsafe all-or-nothing guess. It
 // first narrows the installed clients to one complete target set that the
 // selected package can actually serve, then asks the user to confirm it.
-func promptCompatibleDetectedTargets(ctx context.Context, cmd *cobra.Command, app App, source string) ([]domain.ClientID, []domain.DetectedClient, *loadedPackage, error) {
+func promptCompatibleDetectedTargets(ctx context.Context, cmd *cobra.Command, app App, source string, intents ...map[domain.ClientID]domain.InstallIntent) ([]domain.ClientID, []domain.DetectedClient, *loadedPackage, error) {
 	clients, err := app.Detector.Detect(ctx)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("detect AI clients: %w", err)
@@ -28,7 +28,7 @@ func promptCompatibleDetectedTargets(ctx context.Context, cmd *cobra.Command, ap
 		return selection, all, nil, err
 	}
 
-	compatible, skipped, preloaded, err := app.compatibleDetectedTargets(ctx, source, detected)
+	compatible, skipped, preloaded, err := app.compatibleDetectedTargets(ctx, source, detected, intents...)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -81,7 +81,7 @@ func skippedTargets(clients []domain.DetectedClient, reason string) []targetSkip
 	return skipped
 }
 
-func (app App) compatibleDetectedTargets(ctx context.Context, source string, detected []domain.DetectedClient) ([]domain.DetectedClient, []targetSkip, *loadedPackage, error) {
+func (app App) compatibleDetectedTargets(ctx context.Context, source string, detected []domain.DetectedClient, intents ...map[domain.ClientID]domain.InstallIntent) ([]domain.DetectedClient, []targetSkip, *loadedPackage, error) {
 	candidates := detected
 	var skipped []targetSkip
 	switch {
@@ -111,7 +111,7 @@ func (app App) compatibleDetectedTargets(ctx context.Context, source string, det
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	compatible, rejected := app.compatibleLoadedTargets(ctx, loaded, candidates)
+	compatible, rejected := app.compatibleLoadedTargets(ctx, loaded, candidates, intents...)
 	skipped = append(skipped, rejected...)
 	return compatible, skipped, &loaded, nil
 }
@@ -225,11 +225,25 @@ func forEachDetectedSubset(values []domain.DetectedClient, size int, visit func(
 	walk(0, 0)
 }
 
-func (app App) compatibleLoadedTargets(ctx context.Context, loaded loadedPackage, detected []domain.DetectedClient) ([]domain.DetectedClient, []targetSkip) {
+func (app App) compatibleLoadedTargets(ctx context.Context, loaded loadedPackage, detected []domain.DetectedClient, intents ...map[domain.ClientID]domain.InstallIntent) ([]domain.DetectedClient, []targetSkip) {
 	var skipped []targetSkip
 	clientMap := detectedClientMap(detected)
 	planner := clientplanner.Planner{ManagedRoot: app.ManagedRoot, Detected: clientMap}
 	physicalID := domain.ComputePhysicalArtifactID(loaded.envelope.Manifest.Name, "00000000-0000-4000-8000-000000000000")
+	if len(intents) > 0 && intents[0] != nil && app.StateStore != nil {
+		if state, err := app.StateStore.Load(); err == nil {
+			if installation, ok := locallyMatchedInstallation(state, loaded.envelope.Manifest.Name); ok {
+				for _, binding := range installation.Clients {
+					if binding.InstallIntent == domain.InstallIntentPrepare {
+						intents[0][domain.ClientID(binding.ClientID)] = binding.InstallIntent
+					}
+				}
+				for _, preference := range installation.InstallPreferences {
+					intents[0][preference.ClientID] = preference.InstallIntent
+				}
+			}
+		}
+	}
 	compatible := make([]domain.DetectedClient, 0, len(detected))
 	for _, client := range detected {
 		candidate := cloneLoadedPackage(loaded)
@@ -251,6 +265,13 @@ func (app App) compatibleLoadedTargets(ctx context.Context, loaded loadedPackage
 			skipped = append(skipped, targetSkip{client.ClientID, reason})
 			continue
 		}
+		if len(intents) > 0 && intents[0][client.ClientID] == domain.InstallIntentPrepare {
+			if err := clientplanner.ApplyInstallIntent(&plan, domain.InstallIntentPrepare); err != nil {
+				skipped = append(skipped, targetSkip{client.ClientID, "persisted preparation cannot serve this package"})
+				continue
+			}
+			client.DisplayName += " (prepare configuration; authenticate and verify tools in Kiro)"
+		}
 		if preflighter, ok := app.Lifecycle.Activator.(interface {
 			PreflightActivation(domain.ActivationRequest) error
 		}); ok {
@@ -259,6 +280,17 @@ func (app App) compatibleLoadedTargets(ctx context.Context, loaded loadedPackage
 			})
 			if err != nil {
 				reason := "automatic activation/verification preflight failed; resolve this client's verification prerequisites before retrying --target " + string(client.ClientID)
+				if client.ClientID == domain.ClientKiro && len(intents) > 0 && intents[0] != nil {
+					if prepareErr := clientplanner.ApplyInstallIntent(&plan, domain.InstallIntentPrepare); prepareErr == nil {
+						prepareErr = preflighter.PreflightActivation(domain.ActivationRequest{Client: client, Plan: plan, VerifyOnly: true})
+						if prepareErr == nil {
+							intents[0][client.ClientID] = domain.InstallIntentPrepare
+							client.DisplayName += " (prepare configuration; automatic MCP verification unavailable; authenticate and verify tools in Kiro)"
+							compatible = append(compatible, client)
+							continue
+						}
+					}
+				}
 				if client.ClientID == domain.ClientKiro {
 					reason = "this CLI cannot automatically check MCP connections in your Kiro setup. Nothing was installed in Kiro. Use another listed client, or connect the server in Kiro: https://kiro.dev/docs/mcp/"
 				}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/kiro_prepare_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/kiro_prepare_test.go
@@ -1,0 +1,221 @@
+package agentpluginscli
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers"
+)
+
+func TestKiroPrepareCLIPlainAndJSON(t *testing.T) {
+	for _, format := range []string{"human", "json"} {
+		t.Run(format, func(t *testing.T) {
+			client := fixtureClient(t, domain.ClientKiro)
+			client.ExecutablePath = "/fixture/kiro-cli"
+			fixture := newCLIFixture(t, []domain.DetectedClient{client})
+			fixture.app.Lifecycle.Activator = providers.Activator{}
+			plugin := writeCLIPlugin(t)
+			writeCLIMCP(t, plugin)
+			out, _, err := fixture.execute(false, "add", plugin, "--target", "kiro", "--prepare", "--format", format)
+			if err != nil {
+				t.Fatalf("%s: %v", out, err)
+			}
+			if !strings.Contains(out, "prepared") || !strings.Contains(out, "Runtime connections have not been verified") {
+				t.Fatalf("missing honest guidance: %s", out)
+			}
+			if format == "json" {
+				var response struct {
+					Data addMultiResult `json:"data"`
+				}
+				if err := json.Unmarshal([]byte(out), &response); err != nil {
+					t.Fatal(err)
+				}
+				if len(response.Data.Targets) != 1 {
+					t.Fatalf("missing target: %s", out)
+				}
+				result := response.Data.Targets[0].Output.Result
+				if result.Plan.InstallIntent != domain.InstallIntentPrepare || result.Activation.Activation != domain.ActivationPrepared || result.Activation.Verification != domain.VerificationPackageValid || result.Activation.ActivationAttested {
+					t.Fatalf("false JSON claim: %s", out)
+				}
+			}
+			state, err := fixture.store.Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, binding := range state.Installations[0].Clients {
+				if binding.InstallIntent != domain.InstallIntentPrepare {
+					t.Fatal("lost intent")
+				}
+			}
+			out, _, err = fixture.execute(false, "add", plugin, "--target", "kiro", "--format", format)
+			if err != nil || !strings.Contains(out, "prepared") {
+				t.Fatalf("repeat %s: %v", out, err)
+			}
+			if _, err := os.Stat(filepath.Join(client.ConfigRoot, "settings", "mcp.json")); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestPrepareRejectsInvalidTargetsBeforeAcquisition(t *testing.T) {
+	for _, target := range []string{"cursor", "kiro,cursor", "chatgpt", ""} {
+		t.Run(target, func(t *testing.T) {
+			fixture := newCLIFixture(t, nil)
+			_, _, err := fixture.execute(false, "add", "context7", "--target", target, "--prepare")
+			if err == nil || !strings.Contains(err.Error(), "--prepare requires --target kiro") {
+				t.Fatalf("invalid target: %v", err)
+			}
+			state, _ := fixture.store.Load()
+			if len(state.Installations) != 0 {
+				t.Fatal("mutated")
+			}
+		})
+	}
+}
+
+func TestDetectedKiroOffersExplicitPreparationWithoutChangingOtherTargets(t *testing.T) {
+	kiro := fixtureClient(t, domain.ClientKiro)
+	kiro.ExecutablePath = "/fixture/kiro-cli"
+	cursor := fixtureClient(t, domain.ClientCursor)
+	fixture := newCLIFixture(t, []domain.DetectedClient{kiro, cursor})
+	plugin := writeCLIPlugin(t)
+	writeCLIMCP(t, plugin)
+	loaded, err := fixture.app.loadPackageFor(context.Background(), plugin, fixture.app.addResolutionRequest(plugin, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.cleanup != nil {
+		defer loaded.cleanup()
+	}
+	intents := map[domain.ClientID]domain.InstallIntent{}
+	eligible, skipped := fixture.app.compatibleLoadedTargets(context.Background(), loaded, []domain.DetectedClient{kiro, cursor}, intents)
+	if len(eligible) != 2 || len(skipped) != 0 || intents[domain.ClientKiro] != domain.InstallIntentPrepare || intents[domain.ClientCursor] != "" {
+		t.Fatalf("selection: %+v %+v %+v", eligible, skipped, intents)
+	}
+	if !strings.Contains(eligible[0].DisplayName, "prepare configuration") {
+		t.Fatalf("unlabelled preparation: %+v", eligible)
+	}
+}
+
+func TestInteractiveKiroPreparationPersistsThroughConfirmedSelection(t *testing.T) {
+	kiro := fixtureClient(t, domain.ClientKiro)
+	kiro.ExecutablePath = "/fixture/kiro-cli"
+	cursor := fixtureClient(t, domain.ClientCursor)
+	fixture := newCLIFixture(t, []domain.DetectedClient{kiro, cursor})
+	plugin := writeCLIPlugin(t)
+	writeCLIMCP(t, plugin)
+	out, _, err := fixture.executeInput(true, "\ny\n", "add", plugin, "--plain")
+	if err != nil {
+		t.Fatalf("%s: %v", out, err)
+	}
+	state, err := fixture.store.Load()
+	if err != nil || len(state.Installations) != 1 {
+		t.Fatalf("state %+v: %v; %s", state, err, out)
+	}
+	for _, binding := range state.Installations[0].Clients {
+		if binding.ClientID == string(domain.ClientKiro) {
+			if binding.InstallIntent != domain.InstallIntentPrepare {
+				t.Fatal("Kiro was not prepared")
+			}
+		} else if binding.InstallIntent != "" {
+			t.Fatal("other target intent changed")
+		}
+	}
+	if len(state.Installations[0].Clients) != 2 {
+		t.Fatalf("missing selected target: %s", out)
+	}
+}
+
+func TestPreparedLifecycleVersionDetectionNeverLaunchesKiro(t *testing.T) {
+	kiro := fixtureClient(t, domain.ClientKiro)
+	kiro.ExecutablePath = "/fixture/kiro-cli"
+	fixture := newCLIFixture(t, []domain.DetectedClient{kiro})
+	plugin := writeCLIPlugin(t)
+	writeCLIMCP(t, plugin)
+	if out, _, err := fixture.execute(false, "add", plugin, "--target", "kiro", "--prepare"); err != nil {
+		t.Fatalf("%s: %v", out, err)
+	}
+	detector := &observedProbingDetector{clients: []domain.DetectedClient{kiro, fixtureClient(t, domain.ClientCursor)}}
+	fixture.app.Detector = detector
+	if _, err := fixture.app.detectForLifecycle(context.Background(), true); err != nil {
+		t.Fatal(err)
+	}
+	if detector.probeCalls != 0 || len(detector.targets) != 1 || detector.targets[0] != domain.ClientCursor {
+		t.Fatalf("unsafe version probes: %+v", detector)
+	}
+}
+
+// This exercises the normal Directory boundary with disposable fixture data;
+// it does not attest the live catalog or contact the OAuth endpoint.
+func TestKiroPreparationUsesNormalDirectoryResolution(t *testing.T) {
+	for _, supported := range []bool{true, false} {
+		t.Run(map[bool]string{true: "supported", false: "unsupported"}[supported], func(t *testing.T) {
+			targets := []domain.ClientID{domain.ClientCursor}
+			if supported {
+				targets = append(targets, domain.ClientKiro)
+			}
+			rollout := newRolloutDirectoryFixture(t, targets, targets)
+			kiro := fixtureClient(t, domain.ClientKiro)
+			kiro.ExecutablePath = "/fixture/kiro-cli"
+			detector := &observedProbingDetector{clients: []domain.DetectedClient{kiro}}
+			rollout.cli.app.Detector = detector
+			const mcp = `{"$schema":"https://agent-plugins.org/schemas/1.0.0/mcp.schema.json","mcpServers":{"docs":{"type":"streamable-http","url":"https://mcp.context7.com/mcp/oauth"}}}`
+			if err := os.WriteFile(filepath.Join(rollout.v1.root, "mcp.json"), []byte(mcp), 0600); err != nil {
+				t.Fatal(err)
+			}
+			loaded, err := rollout.cli.app.acquireLocal(context.Background(), rollout.v1.root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			release := &rollout.directory.bundle.Snapshot.Distributions[0].Releases[0]
+			release.TreeDigest = loaded.envelope.TreeDigest
+			release.ManifestDigest = loaded.envelope.ManifestDigest
+			for i := range rollout.directory.bundle.Snapshot.Evidence {
+				evidence := &rollout.directory.bundle.Snapshot.Evidence[i]
+				if evidence.ReleaseSequence == 1 {
+					evidence.PackageTreeDigest = release.TreeDigest
+				}
+			}
+			if err := loaded.cleanup(); err != nil {
+				t.Fatal(err)
+			}
+			rollout.directory.bundle.Snapshot.Products[0].Aliases = append(rollout.directory.bundle.Snapshot.Products[0].Aliases, "context7")
+			out, _, err := rollout.cli.execute(false, "add", "context7", "--target", "kiro", "--prepare", "--format", "json")
+			if !supported {
+				if err == nil || rollout.acquirer.verifiedCalls != 0 {
+					t.Fatalf("bypassed compatibility: %s %v", out, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("%s: %v", out, err)
+			}
+			if rollout.acquirer.verifiedCalls != 1 || rollout.acquirer.directGitCalls != 0 || detector.probeCalls != 0 || detector.targetedCalls != 0 {
+				t.Fatalf("wrong acquisition/probes: %+v %+v", rollout.acquirer, detector)
+			}
+			state, err := rollout.cli.store.Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if state.Installations[0].OriginMode != domain.OriginModeDirectory || state.Installations[0].Source.ResolvedRevision != rollout.v1.revision {
+				t.Fatal("lost exact Directory origin")
+			}
+			body, err := os.ReadFile(filepath.Join(kiro.ConfigRoot, "settings", "mcp.json"))
+			if err != nil || !strings.Contains(string(body), "https://mcp.context7.com/mcp/oauth") {
+				t.Fatalf("OAuth URL changed: %s %v", body, err)
+			}
+			if out, _, err := rollout.cli.execute(false, "repair", "demo", "--target", "kiro", "--format", "json"); err != nil {
+				t.Fatalf("repair %s: %v", out, err)
+			}
+			if detector.probeCalls != 0 || detector.targetedCalls != 0 {
+				t.Fatal("prepared repair executed Kiro version probe")
+			}
+		})
+	}
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/kiro_prepare_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/kiro_prepare_test.go
@@ -143,7 +143,11 @@ func TestPreparedLifecycleVersionDetectionNeverLaunchesKiro(t *testing.T) {
 	}
 	detector := &observedProbingDetector{clients: []domain.DetectedClient{kiro, fixtureClient(t, domain.ClientCursor)}}
 	fixture.app.Detector = detector
-	if _, err := fixture.app.detectForLifecycle(context.Background(), true); err != nil {
+	intents, err := fixture.app.addLifecycleIntents(context.Background(), plugin, string(domain.ScopeUser), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fixture.app.detectForLifecycle(context.Background(), true, intents); err != nil {
 		t.Fatal(err)
 	}
 	if detector.probeCalls != 0 || len(detector.targets) != 1 || detector.targets[0] != domain.ClientCursor {
@@ -215,6 +219,23 @@ func TestKiroPreparationUsesNormalDirectoryResolution(t *testing.T) {
 			}
 			if detector.probeCalls != 0 || detector.targetedCalls != 0 {
 				t.Fatal("prepared repair executed Kiro version probe")
+			}
+			// A new alias must recover the same binding intent before probing.
+			rollout.directory.bundle.Snapshot.Distributions[0].Releases = rollout.directory.bundle.Snapshot.Distributions[0].Releases[:1]
+			rollout.directory.bundle.Snapshot.Distributions[0].ReleasePolicies = rollout.directory.bundle.Snapshot.Distributions[0].ReleasePolicies[:1]
+			rollout.directory.bundle.Snapshot.Products[0].Aliases = append(rollout.directory.bundle.Snapshot.Products[0].Aliases, "new-context-alias")
+			for _, args := range [][]string{
+				{"add", "new-context-alias", "--target", "kiro"},
+				{"update", "demo", "--target", "kiro"},
+				{"remove", "demo", "--target", "kiro"},
+				{"add", "new-context-alias", "--target", "kiro"},
+			} {
+				if out, _, err := rollout.cli.execute(false, args...); err != nil {
+					t.Fatalf("%v: %s %v", args, out, err)
+				}
+				if detector.probeCalls != 0 || detector.targetedCalls != 0 {
+					t.Fatalf("prepared operation %v executed Kiro version probe", args)
+				}
 			}
 		})
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/preflight.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/preflight.go
@@ -21,9 +21,13 @@ func detectClientsForLifecycleResolution(ctx context.Context, detector ports.Cli
 // before any package or Directory work begins. ChatGPT is the sole synthetic
 // client: signed compatibility may authorize preparing its local package even
 // though the remote product cannot be detected locally.
-func preflightSelectedTargets(ctx context.Context, app App, targets []domain.ClientID, clients []domain.DetectedClient, probeVersion bool) ([]domain.DetectedClient, map[domain.ClientID]domain.DetectedClient, error) {
+func preflightSelectedTargets(ctx context.Context, app App, targets []domain.ClientID, clients []domain.DetectedClient, probeVersion bool, operationIntents ...map[domain.ClientID]domain.InstallIntent) ([]domain.DetectedClient, map[domain.ClientID]domain.DetectedClient, error) {
 	if clients == nil {
-		detected, err := app.detectForLifecycle(ctx, probeVersion)
+		var intents map[domain.ClientID]domain.InstallIntent
+		if len(operationIntents) > 0 {
+			intents = operationIntents[0]
+		}
+		detected, err := app.detectForLifecycle(ctx, probeVersion, intents)
 		if err != nil {
 			return nil, nil, fmt.Errorf("detect AI clients: %w", err)
 		}
@@ -77,7 +81,7 @@ func preflightInstalledBindings(bindingTargets []domain.ClientID, detected map[d
 }
 
 func resolveInstalledBindingTargets(ctx context.Context, app App, bindingTargets []domain.ClientID, probeVersion bool) ([]domain.ClientID, error) {
-	clients, err := app.detectForLifecycle(ctx, probeVersion)
+	clients, err := app.detectForLifecycle(ctx, probeVersion, nil)
 	if err != nil {
 		return nil, fmt.Errorf("detect AI clients: %w", err)
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/preflight.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/preflight.go
@@ -23,7 +23,7 @@ func detectClientsForLifecycleResolution(ctx context.Context, detector ports.Cli
 // though the remote product cannot be detected locally.
 func preflightSelectedTargets(ctx context.Context, app App, targets []domain.ClientID, clients []domain.DetectedClient, probeVersion bool) ([]domain.DetectedClient, map[domain.ClientID]domain.DetectedClient, error) {
 	if clients == nil {
-		detected, err := detectClientsForLifecycleResolution(ctx, app.Detector, probeVersion)
+		detected, err := app.detectForLifecycle(ctx, probeVersion)
 		if err != nil {
 			return nil, nil, fmt.Errorf("detect AI clients: %w", err)
 		}
@@ -77,7 +77,7 @@ func preflightInstalledBindings(bindingTargets []domain.ClientID, detected map[d
 }
 
 func resolveInstalledBindingTargets(ctx context.Context, app App, bindingTargets []domain.ClientID, probeVersion bool) ([]domain.ClientID, error) {
-	clients, err := detectClientsForLifecycleResolution(ctx, app.Detector, probeVersion)
+	clients, err := app.detectForLifecycle(ctx, probeVersion)
 	if err != nil {
 		return nil, fmt.Errorf("detect AI clients: %w", err)
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/prepare.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/prepare.go
@@ -2,59 +2,102 @@ package agentpluginscli
 
 import (
 	"context"
+	"errors"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/ports"
 )
 
-// Retained preparation must not launch Kiro even for version discovery. Other
-// clients may still supply their versions for normal Directory resolution.
-func (app App) detectForLifecycle(ctx context.Context, probeVersion bool) ([]domain.DetectedClient, error) {
-	if probeVersion && app.StateStore != nil {
-		state, err := app.StateStore.Load()
+// Only the current operation's effective Kiro intent may suppress execution.
+// Ordinary resolution retains the detector's normal version discovery behavior.
+func (app App) detectForLifecycle(ctx context.Context, probeVersion bool, intents map[domain.ClientID]domain.InstallIntent) ([]domain.DetectedClient, error) {
+	if !probeVersion || intents[domain.ClientKiro] != domain.InstallIntentPrepare {
+		return detectClientsForLifecycleResolution(ctx, app.Detector, probeVersion)
+	}
+	clients, err := app.Detector.Detect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var targets []domain.ClientID
+	for _, client := range clients {
+		if client.ClientID != domain.ClientKiro && client.Status == domain.DetectionDetected {
+			targets = append(targets, client.ClientID)
+		}
+	}
+	if targeted, ok := app.Detector.(ports.TargetedVersionProbingClientDetector); ok && len(targets) > 0 {
+		probed, err := targeted.DetectTargetsWithVersionProbe(ctx, targets)
 		if err != nil {
 			return nil, err
 		}
-		prepared := false
-		for _, installation := range state.Installations {
-			for _, binding := range installation.Clients {
-				prepared = prepared || binding.InstallIntent == domain.InstallIntentPrepare
+		for i, client := range clients {
+			if client.ClientID == domain.ClientKiro {
+				continue
 			}
-			for _, preference := range installation.InstallPreferences {
-				prepared = prepared || preference.InstallIntent == domain.InstallIntentPrepare
-			}
-		}
-		if prepared {
-			clients, err := app.Detector.Detect(ctx)
-			if err != nil {
-				return nil, err
-			}
-			var targets []domain.ClientID
-			for _, client := range clients {
-				if client.ClientID != domain.ClientKiro && client.Status == domain.DetectionDetected {
-					targets = append(targets, client.ClientID)
+			for _, updated := range probed {
+				if updated.ClientID == client.ClientID {
+					clients[i] = updated
 				}
 			}
-			if targeted, ok := app.Detector.(ports.TargetedVersionProbingClientDetector); ok && len(targets) > 0 {
-				probed, err := targeted.DetectTargetsWithVersionProbe(ctx, targets)
-				if err != nil {
-					return nil, err
-				}
-				for i, client := range clients {
-					if client.ClientID == domain.ClientKiro {
-						continue
-					}
-					for _, updated := range probed {
-						if updated.ClientID == client.ClientID {
-							clients[i] = updated
-						}
-					}
-				}
-			}
-			return clients, nil
 		}
 	}
-	return detectClientsForLifecycleResolution(ctx, app.Detector, probeVersion)
+	return clients, nil
+}
+
+// Match the same client and scope as lifecycle planning, including preferences
+// left after removal. Do not infer intent from another installation or scope.
+func lifecycleInstallIntents(installation domain.Installation, scope string, explicit map[domain.ClientID]domain.InstallIntent) map[domain.ClientID]domain.InstallIntent {
+	intents := make(map[domain.ClientID]domain.InstallIntent)
+	for client, intent := range explicit {
+		intents[client] = intent
+	}
+	for _, preference := range installation.InstallPreferences {
+		if string(preference.Scope) == scope && intents[preference.ClientID] == "" {
+			intents[preference.ClientID] = preference.InstallIntent
+		}
+	}
+	for _, binding := range installation.Clients {
+		client := domain.ClientID(binding.ClientID)
+		if binding.Scope == scope && intents[client] == "" {
+			intents[client] = binding.InstallIntent
+		}
+	}
+	return intents
+}
+
+// Resolve Directory aliases to the retained product before any executable
+// detection, just as acquisition does before choosing a release.
+func (app App) addLifecycleIntents(ctx context.Context, source, scope string, explicit map[domain.ClientID]domain.InstallIntent) (map[domain.ClientID]domain.InstallIntent, error) {
+	if app.StateStore == nil {
+		return explicit, nil
+	}
+	state, err := app.StateStore.Load()
+	if err != nil {
+		return nil, err
+	}
+	installation, _ := locallyMatchedInstallation(state, source)
+	if isDirectorySelector(source) && app.DirectoryClient != nil && len(state.Installations) > 0 {
+		bundle, err := app.DirectoryClient.Load(ctx, installedDirectoryFloor(state))
+		if err != nil {
+			return nil, err
+		}
+		productID, err := directorySelectorProductID(bundle.Snapshot, source)
+		if err != nil && !errors.Is(err, domain.ErrDirectoryNotFound) {
+			return nil, err
+		}
+		installation, _, err = retainedDirectoryInstallation(state, source, productID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return lifecycleInstallIntents(installation, scope, explicit), nil
+}
+
+func preflightAddTargets(ctx context.Context, app App, opts *options, source string, targets []domain.ClientID, clients []domain.DetectedClient) ([]domain.DetectedClient, map[domain.ClientID]domain.DetectedClient, error) {
+	intents, err := app.addLifecycleIntents(ctx, source, opts.scope, opts.installIntents)
+	if err != nil {
+		return nil, nil, err
+	}
+	return preflightSelectedTargets(ctx, app, targets, clients, !opts.dryRun && isDirectorySelector(source), intents)
 }
 
 func automaticInstallTargets(targets []domain.ClientID, intents map[domain.ClientID]domain.InstallIntent) []domain.ClientID {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/prepare.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/prepare.go
@@ -1,0 +1,68 @@
+package agentpluginscli
+
+import (
+	"context"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/ports"
+)
+
+// Retained preparation must not launch Kiro even for version discovery. Other
+// clients may still supply their versions for normal Directory resolution.
+func (app App) detectForLifecycle(ctx context.Context, probeVersion bool) ([]domain.DetectedClient, error) {
+	if probeVersion && app.StateStore != nil {
+		state, err := app.StateStore.Load()
+		if err != nil {
+			return nil, err
+		}
+		prepared := false
+		for _, installation := range state.Installations {
+			for _, binding := range installation.Clients {
+				prepared = prepared || binding.InstallIntent == domain.InstallIntentPrepare
+			}
+			for _, preference := range installation.InstallPreferences {
+				prepared = prepared || preference.InstallIntent == domain.InstallIntentPrepare
+			}
+		}
+		if prepared {
+			clients, err := app.Detector.Detect(ctx)
+			if err != nil {
+				return nil, err
+			}
+			var targets []domain.ClientID
+			for _, client := range clients {
+				if client.ClientID != domain.ClientKiro && client.Status == domain.DetectionDetected {
+					targets = append(targets, client.ClientID)
+				}
+			}
+			if targeted, ok := app.Detector.(ports.TargetedVersionProbingClientDetector); ok && len(targets) > 0 {
+				probed, err := targeted.DetectTargetsWithVersionProbe(ctx, targets)
+				if err != nil {
+					return nil, err
+				}
+				for i, client := range clients {
+					if client.ClientID == domain.ClientKiro {
+						continue
+					}
+					for _, updated := range probed {
+						if updated.ClientID == client.ClientID {
+							clients[i] = updated
+						}
+					}
+				}
+			}
+			return clients, nil
+		}
+	}
+	return detectClientsForLifecycleResolution(ctx, app.Detector, probeVersion)
+}
+
+func automaticInstallTargets(targets []domain.ClientID, intents map[domain.ClientID]domain.InstallIntent) []domain.ClientID {
+	var automatic []domain.ClientID
+	for _, target := range targets {
+		if intents[target] == domain.InstallIntentAutomatic {
+			automatic = append(automatic, target)
+		}
+	}
+	return automatic
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/read.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/read.go
@@ -20,6 +20,7 @@ import (
 )
 
 type publicClient struct {
+	InstallIntent             domain.InstallIntent           `json:"install_intent,omitempty"`
 	BindingID                 string                         `json:"-"`
 	ClientID                  string                         `json:"client_id"`
 	Scope                     string                         `json:"scope"`
@@ -537,8 +538,9 @@ func publicInstallationView(installation domain.Installation, includeAbsent bool
 		affectedSurfaces := append([]string(nil), client.AffectedSurfaces...)
 		sort.Strings(affectedSurfaces)
 		value.Clients = append(value.Clients, publicClient{
-			BindingID: client.ClientBindingID,
-			ClientID:  client.ClientID, Scope: client.Scope, Materialization: client.Materialization,
+			InstallIntent: client.InstallIntent,
+			BindingID:     client.ClientBindingID,
+			ClientID:      client.ClientID, Scope: client.Scope, Materialization: client.Materialization,
 			Activation: client.Activation, Authentication: client.Authentication,
 			Policy: client.Policy, Verification: client.Verification,
 			PackageRevision:  publicPackageRevision(client.PackageRevision),

--- a/cli/plugin-kit-ai/internal/agentpluginscli/read_reconciliation.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/read_reconciliation.go
@@ -23,7 +23,17 @@ func reconcileInstalledInfo(ctx context.Context, app App, installation domain.In
 	for _, target := range targets {
 		selected[target] = true
 	}
-	clients, err := detectClientsForInfoReconciliation(ctx, app.Detector, targets)
+	probeTargets := append([]domain.ClientID(nil), targets...)
+	for _, binding := range installation.Clients {
+		if binding.InstallIntent == domain.InstallIntentPrepare {
+			for i := len(probeTargets) - 1; i >= 0; i-- {
+				if probeTargets[i] == domain.ClientID(binding.ClientID) {
+					probeTargets = append(probeTargets[:i], probeTargets[i+1:]...)
+				}
+			}
+		}
+	}
+	clients, err := detectClientsForInfoReconciliation(ctx, app.Detector, probeTargets)
 	if err != nil {
 		return err
 	}
@@ -120,7 +130,7 @@ func detectClientsForInfoReconciliation(ctx context.Context, detector ports.Clie
 		probeTargets = append(probeTargets, target)
 	}
 	sort.Slice(probeTargets, func(i, j int) bool { return probeTargets[i] < probeTargets[j] })
-	if targeted, ok := detector.(ports.TargetedVersionProbingClientDetector); ok {
+	if targeted, ok := detector.(ports.TargetedVersionProbingClientDetector); ok && len(probeTargets) > 0 {
 		return targeted.DetectTargetsWithVersionProbe(ctx, probeTargets)
 	}
 	return detector.Detect(ctx)
@@ -153,7 +163,8 @@ func reconcileClientIdentity(ctx context.Context, app App, installation domain.I
 		return result
 	}
 	plan := domain.DeliveryPlan{
-		ClientID: bindingClient.ClientID, Scope: domain.InstallScope(binding.Scope), DeclaredName: installation.DeclaredName,
+		InstallIntent: binding.InstallIntent,
+		ClientID:      bindingClient.ClientID, Scope: domain.InstallScope(binding.Scope), DeclaredName: installation.DeclaredName,
 		DeclaredVersion:    declaredVersion,
 		PhysicalArtifactID: expectedArtifact, TargetAnchor: target.TargetAnchor, TargetRoot: target.TargetRoot, ActivePath: target.ActivePath,
 		NativeRegistryRoot: observerClient.ConfigRoot, NativeRegistryExecutable: observerClient.ExecutablePath,

--- a/cli/plugin-kit-ai/internal/agentpluginscli/repair_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/repair_multi.go
@@ -88,7 +88,7 @@ func runRepairMany(ctx context.Context, cmd *cobra.Command, app App, opts *optio
 			requests[key] = &request
 		}
 	}
-	_, detected, err := preflightSelectedTargets(ctx, app, targets, nil, !opts.dryRun && installation.OriginMode == domain.OriginModeDirectory)
+	_, detected, err := preflightSelectedTargets(ctx, app, targets, nil, !opts.dryRun && installation.OriginMode == domain.OriginModeDirectory, lifecycleInstallIntents(installation, opts.scope, nil))
 	if err != nil {
 		return err
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/review_regression_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/review_regression_test.go
@@ -1,0 +1,222 @@
+package agentpluginscli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers"
+)
+
+type reviewVersionDetector struct{ client domain.DetectedClient }
+
+func (d reviewVersionDetector) Detect(context.Context) ([]domain.DetectedClient, error) {
+	c := d.client
+	c.Version = ""
+	return []domain.DetectedClient{c}, nil
+}
+func (d reviewVersionDetector) DetectWithVersionProbe(context.Context) ([]domain.DetectedClient, error) {
+	c := d.client
+	c.Version = "fixture-client"
+	return []domain.DetectedClient{c}, nil
+}
+func (d reviewVersionDetector) DetectTargetsWithVersionProbe(ctx context.Context, targets []domain.ClientID) ([]domain.DetectedClient, error) {
+	for _, target := range targets {
+		if target == domain.ClientKiro {
+			return d.DetectWithVersionProbe(ctx)
+		}
+	}
+	return d.Detect(ctx)
+}
+
+func TestReviewUnrelatedPreparationPreservesAutomaticDirectoryGate(t *testing.T) {
+	r := newRolloutDirectoryFixture(t, []domain.ClientID{domain.ClientKiro}, []domain.ClientID{domain.ClientKiro})
+	kiro := fixtureClient(t, domain.ClientKiro)
+	r.cli.app.Detector = reviewVersionDetector{client: kiro}
+	snapshot := &r.directory.bundle.Snapshot
+	failed := intendedTrustedDirectoryEvidence(domain.DirectoryEvidence{
+		ID: "failed/runtime/kiro", DistributionID: "owner/rollout", ReleaseSequence: 1,
+		PackageTreeDigest: r.v1.tree, Level: "runtime", Outcome: "failed", Client: domain.ClientKiro,
+		InstallerVersion: r.cli.app.Version,
+	})
+	snapshot.Evidence = append(snapshot.Evidence, failed)
+	snapshot.Distributions[0].ReleasePolicies[0].CurrentEvidence = append(snapshot.Distributions[0].ReleasePolicies[0].CurrentEvidence, failed.ID)
+	check := func() error {
+		_, clients, err := preflightSelectedTargets(context.Background(), r.cli.app, []domain.ClientID{domain.ClientKiro}, nil, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		loaded, err := r.cli.app.loadPackageFor(context.Background(), "rollout-demo", withDetectedClients(r.cli.app.addResolutionRequest("rollout-demo", []domain.ClientID{domain.ClientKiro}), clients))
+		if loaded.cleanup != nil {
+			defer loaded.cleanup()
+		}
+		t.Logf("automatic version=%q resolution=%v", clients[domain.ClientKiro].Version, err)
+		if clients[domain.ClientKiro].Version != "fixture-client" {
+			t.Fatalf("lost automatic Kiro version: %+v", clients)
+		}
+		return err
+	}
+	if err := check(); err == nil || !strings.Contains(err.Error(), "evidence") {
+		t.Fatalf("fixture must initially reject current failed evidence: %v", err)
+	}
+	plugin := writeCLIPlugin(t)
+	body, err := os.ReadFile(filepath.Join(plugin, "plugin.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(plugin, "plugin.json"), []byte(strings.ReplaceAll(string(body), `"demo"`, `"unrelated"`)), 0600); err != nil {
+		t.Fatal(err)
+	}
+	writeCLIMCP(t, plugin)
+	r.cli.app.Lifecycle.Activator = providers.Activator{}
+	if out, _, err := r.cli.execute(false, "add", plugin, "--target", "kiro", "--prepare"); err != nil {
+		t.Fatalf("prepare: %s %v", out, err)
+	}
+	if err := check(); err == nil {
+		t.Fatal("unrelated prepared installation suppressed automatic Kiro version and bypassed current failed Directory evidence")
+	}
+}
+
+func TestUnrelatedRetainedPreparationPreservesAutomaticDirectoryGate(t *testing.T) {
+	r := newRolloutDirectoryFixture(t, []domain.ClientID{domain.ClientKiro}, []domain.ClientID{domain.ClientKiro})
+	r.cli.app.Detector = reviewVersionDetector{client: fixtureClient(t, domain.ClientKiro)}
+	failed := intendedTrustedDirectoryEvidence(domain.DirectoryEvidence{
+		ID: "failed/runtime/kiro", DistributionID: "owner/rollout", ReleaseSequence: 1,
+		PackageTreeDigest: r.v1.tree, Level: "runtime", Outcome: "failed", Client: domain.ClientKiro,
+		InstallerVersion: r.cli.app.Version,
+	})
+	snapshot := &r.directory.bundle.Snapshot
+	snapshot.Evidence = append(snapshot.Evidence, failed)
+	snapshot.Distributions[0].ReleasePolicies[0].CurrentEvidence = append(snapshot.Distributions[0].ReleasePolicies[0].CurrentEvidence, failed.ID)
+	check := func() {
+		t.Helper()
+		calls := r.acquirer.verifiedCalls
+		out, _, err := r.cli.execute(false, "add", "rollout-demo", "--target", "kiro")
+		if err == nil || !strings.Contains(err.Error(), "current trusted runtime evidence failed for kiro") {
+			t.Fatalf("automatic Directory evidence gate: %s %v", out, err)
+		}
+		if r.acquirer.verifiedCalls != calls {
+			t.Fatal("failed evidence reached acquisition")
+		}
+	}
+	check()
+	plugin := writeCLIPlugin(t)
+	body, err := os.ReadFile(filepath.Join(plugin, "plugin.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(plugin, "plugin.json"), []byte(strings.ReplaceAll(string(body), `"demo"`, `"unrelated"`)), 0600); err != nil {
+		t.Fatal(err)
+	}
+	writeCLIMCP(t, plugin)
+	r.cli.app.Lifecycle.Activator = providers.Activator{}
+	if out, _, err := r.cli.execute(false, "add", plugin, "--target", "kiro", "--prepare"); err != nil {
+		t.Fatalf("prepare: %s %v", out, err)
+	}
+	check()
+	if out, _, err := r.cli.execute(false, "remove", "unrelated", "--target", "kiro"); err != nil {
+		t.Fatalf("remove: %s %v", out, err)
+	}
+	state, err := r.cli.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Installations) != 1 || len(state.Installations[0].InstallPreferences) != 1 || state.Installations[0].InstallPreferences[0].InstallIntent != domain.InstallIntentPrepare {
+		t.Fatalf("missing retained preparation: %+v", state)
+	}
+	check()
+}
+
+func TestUnrelatedPreparationPreservesAutomaticUpdateAndRepairEvidence(t *testing.T) {
+	r := newRolloutDirectoryFixture(t, []domain.ClientID{domain.ClientKiro}, []domain.ClientID{domain.ClientKiro})
+	r.cli.app.Detector = reviewVersionDetector{client: fixtureClient(t, domain.ClientKiro)}
+	writeCLIMCP(t, r.v1.root)
+	loaded, err := r.cli.app.acquireLocal(context.Background(), r.v1.root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.v1.tree = loaded.envelope.TreeDigest
+	release := &r.directory.bundle.Snapshot.Distributions[0].Releases[0]
+	release.TreeDigest = r.v1.tree
+	release.ManifestDigest = loaded.envelope.ManifestDigest
+	for i := range r.directory.bundle.Snapshot.Evidence {
+		evidence := &r.directory.bundle.Snapshot.Evidence[i]
+		if evidence.ReleaseSequence == 1 {
+			evidence.PackageTreeDigest = r.v1.tree
+		}
+	}
+	if err := loaded.cleanup(); err != nil {
+		t.Fatal(err)
+	}
+	// Seed a recorded native binding with disposable preparation, then model a
+	// historical automatic binding. Every command below must fail at resolution,
+	// before acquisition or activation can execute a client.
+	if out, _, err := r.cli.execute(false, "add", "rollout-demo", "--target", "kiro", "--prepare"); err != nil {
+		t.Fatalf("seed: %s %v", out, err)
+	}
+	state, err := r.cli.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, binding := range state.Installations[0].Clients {
+		binding.InstallIntent = domain.InstallIntentAutomatic
+		state.Installations[0].Clients[key] = binding
+	}
+	if err := r.cli.store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+	// Keep update on the installed release so both commands evaluate its evidence.
+	snapshot := &r.directory.bundle.Snapshot
+	snapshot.Distributions[0].Releases = snapshot.Distributions[0].Releases[:1]
+	snapshot.Distributions[0].ReleasePolicies = snapshot.Distributions[0].ReleasePolicies[:1]
+	failed := intendedTrustedDirectoryEvidence(domain.DirectoryEvidence{
+		ID: "failed/runtime/kiro", DistributionID: "owner/rollout", ReleaseSequence: 1,
+		PackageTreeDigest: r.v1.tree, Level: "runtime", Outcome: "failed", Client: domain.ClientKiro,
+		InstallerVersion: r.cli.app.Version,
+	})
+	snapshot.Evidence = append(snapshot.Evidence, failed)
+	snapshot.Distributions[0].ReleasePolicies[0].CurrentEvidence = append(snapshot.Distributions[0].ReleasePolicies[0].CurrentEvidence, failed.ID)
+	check := func() {
+		t.Helper()
+		for _, operation := range []string{"update", "repair"} {
+			calls := r.acquirer.verifiedCalls
+			out, _, err := r.cli.execute(false, operation, "demo", "--target", "kiro")
+			if err == nil || !strings.Contains(err.Error(), "current trusted runtime evidence failed for kiro") {
+				t.Fatalf("%s gate: %s %v", operation, out, err)
+			}
+			if r.acquirer.verifiedCalls != calls {
+				t.Fatal("failed evidence reached acquisition")
+			}
+		}
+	}
+	check()
+	plugin := writeCLIPlugin(t)
+	body, err := os.ReadFile(filepath.Join(plugin, "plugin.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(plugin, "plugin.json"), []byte(strings.ReplaceAll(string(body), `"demo"`, `"unrelated"`)), 0600); err != nil {
+		t.Fatal(err)
+	}
+	writeCLIMCP(t, plugin)
+	mcpPath := filepath.Join(plugin, "mcp.json")
+	mcp, err := os.ReadFile(mcpPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mcpPath, []byte(strings.ReplaceAll(string(mcp), `"demo"`, `"unrelated"`)), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if out, _, err := r.cli.execute(false, "add", plugin, "--target", "kiro", "--prepare"); err != nil {
+		t.Fatalf("prepare: %s %v", out, err)
+	}
+	check()
+	if out, _, err := r.cli.execute(false, "remove", "unrelated", "--target", "kiro"); err != nil {
+		t.Fatalf("remove: %s %v", out, err)
+	}
+	check()
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/update_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/update_multi.go
@@ -87,7 +87,7 @@ func prepareUpdateMany(ctx context.Context, app App, opts *options, installation
 		}
 	}
 	allTargets := installationTargets(installation, opts.scope)
-	_, detected, err := preflightSelectedTargets(ctx, app, targets, nil, probeVersion && installation.OriginMode == domain.OriginModeDirectory)
+	_, detected, err := preflightSelectedTargets(ctx, app, targets, nil, probeVersion && installation.OriginMode == domain.OriginModeDirectory, lifecycleInstallIntents(installation, opts.scope, nil))
 	if err != nil {
 		return nil, err
 	}

--- a/install/integrationctl/agentplugins/adapters/statev2/intent_test.go
+++ b/install/integrationctl/agentplugins/adapters/statev2/intent_test.go
@@ -1,0 +1,55 @@
+package statev2
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+func TestInstallIntentStateRoundtripAndValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name, client string
+		intent       domain.InstallIntent
+		valid        bool
+	}{
+		{"historical empty", "kiro", "", true}, {"prepared", "kiro", domain.InstallIntentPrepare, true},
+		{"unknown", "kiro", "automatic", false}, {"malformed", "kiro", "PREPARE", false}, {"unsupported target", "codex", domain.InstallIntentPrepare, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := Store{Path: filepath.Join(t.TempDir(), "state.json")}
+			installation := validInstallation("00000000-0000-4000-8000-000000000001", "source", "demo-id")
+			for key, binding := range installation.Clients {
+				binding.ClientID = tc.client
+				binding.InstallIntent = tc.intent
+				installation.Clients[key] = binding
+			}
+			state := domain.StateFileV2{SchemaVersion: domain.StateSchemaVersion, Installations: []domain.Installation{installation}}
+			err := store.Save(state)
+			if (err == nil) != tc.valid {
+				t.Fatalf("Save: %v", err)
+			}
+			// Exercise the on-disk decoder separately from Save's validation.
+			body, err := json.Marshal(state)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(store.Path, body, 0600); err != nil {
+				t.Fatal(err)
+			}
+			loaded, err := store.Load()
+			if (err == nil) != tc.valid {
+				t.Fatalf("Load: %v", err)
+			}
+			if tc.valid {
+				for _, binding := range loaded.Installations[0].Clients {
+					if binding.InstallIntent != tc.intent {
+						t.Fatalf("intent: %q", binding.InstallIntent)
+					}
+				}
+			}
+		})
+	}
+}

--- a/install/integrationctl/agentplugins/adapters/statev2/store.go
+++ b/install/integrationctl/agentplugins/adapters/statev2/store.go
@@ -203,6 +203,17 @@ func Validate(state domain.StateFileV2) error {
 		default:
 			return fmt.Errorf("%s origin_mode must be directory or direct", prefix)
 		}
+		preferences := map[string]bool{}
+		for _, preference := range installation.InstallPreferences {
+			if err := preference.InstallIntent.Validate(preference.ClientID); err != nil {
+				return err
+			}
+			key := string(preference.ClientID) + ":" + string(preference.Scope)
+			if preference.InstallIntent != domain.InstallIntentPrepare || preference.Scope != domain.ScopeUser || preferences[key] {
+				return fmt.Errorf("invalid or duplicate install preference %q", key)
+			}
+			preferences[key] = true
+		}
 		if installation.DataRetained && len(installation.Clients) != 0 {
 			return fmt.Errorf("%s data_retained installation must have no client bindings", prefix)
 		}
@@ -251,6 +262,12 @@ func Validate(state domain.StateFileV2) error {
 				return fmt.Errorf("duplicate client_binding_id %q", client.ClientBindingID)
 			}
 			clientBindingIDs[client.ClientBindingID] = struct{}{}
+			if client.InstallIntent == domain.InstallIntentPrepare && client.Scope != string(domain.ScopeUser) {
+				return fmt.Errorf("prepare binding requires user scope")
+			}
+			if err := client.InstallIntent.Validate(domain.ClientID(client.ClientID)); err != nil {
+				return err
+			}
 			if strings.TrimSpace(client.ClientID) == "" || strings.TrimSpace(client.TargetLocator) == "" {
 				return fmt.Errorf("%s client binding %q is incomplete", prefix, client.ClientBindingID)
 			}

--- a/install/integrationctl/agentplugins/domain/clients.go
+++ b/install/integrationctl/agentplugins/domain/clients.go
@@ -190,6 +190,7 @@ type ComponentDecision struct {
 }
 
 type DeliveryPlan struct {
+	InstallIntent      InstallIntent       `json:"install_intent,omitempty"`
 	ClientID           ClientID            `json:"client_id"`
 	Scope              InstallScope        `json:"scope"`
 	Status             PlanStatus          `json:"status"`

--- a/install/integrationctl/agentplugins/domain/install_intent.go
+++ b/install/integrationctl/agentplugins/domain/install_intent.go
@@ -1,0 +1,50 @@
+package domain
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// InstallIntent is persisted per binding. Empty historical state means automatic.
+type InstallIntent string
+
+const (
+	InstallIntentAutomatic InstallIntent = ""
+	InstallIntentPrepare   InstallIntent = "prepare"
+)
+
+func (intent InstallIntent) Validate(client ClientID) error {
+	switch intent {
+	case InstallIntentAutomatic:
+		return nil
+	case InstallIntentPrepare:
+		if client == ClientKiro {
+			return nil
+		}
+	}
+	return fmt.Errorf("unsupported install intent %q for client %s", intent, client)
+}
+
+// InstallPreference retains user intent after owned artifacts are removed. It
+// carries no ownership or runtime verification evidence.
+type InstallPreference struct {
+	ClientID      ClientID      `json:"client_id"`
+	Scope         InstallScope  `json:"scope"`
+	InstallIntent InstallIntent `json:"install_intent"`
+}
+
+func (intent *InstallIntent) UnmarshalJSON(data []byte) error {
+	var value *string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	if value == nil {
+		return fmt.Errorf("install intent must be a string")
+	}
+	switch InstallIntent(*value) {
+	case InstallIntentAutomatic, InstallIntentPrepare:
+		*intent = InstallIntent(*value)
+		return nil
+	}
+	return fmt.Errorf("unsupported install intent %q", *value)
+}

--- a/install/integrationctl/agentplugins/domain/install_intent_test.go
+++ b/install/integrationctl/agentplugins/domain/install_intent_test.go
@@ -1,0 +1,21 @@
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestInstallIntentRejectsMalformedJSON(t *testing.T) {
+	for _, raw := range []string{`null`, `true`, `42`, `{}`, `"automatic"`, `" prepare"`, `"PREPARE"`} {
+		var binding ClientBinding
+		if err := json.Unmarshal([]byte(`{"install_intent":`+raw+`}`), &binding); err == nil {
+			t.Fatalf("accepted %s", raw)
+		}
+	}
+	for _, raw := range []string{`{}`, `{"install_intent":""}`, `{"install_intent":"prepare"}`} {
+		var binding ClientBinding
+		if err := json.Unmarshal([]byte(raw), &binding); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/install/integrationctl/agentplugins/domain/state.go
+++ b/install/integrationctl/agentplugins/domain/state.go
@@ -159,6 +159,7 @@ type ClientPackageRevision struct {
 }
 
 type ClientBinding struct {
+	InstallIntent    InstallIntent           `json:"install_intent,omitempty"`
 	ClientBindingID  string                  `json:"client_binding_id"`
 	ClientID         string                  `json:"client_id"`
 	Scope            string                  `json:"scope"`
@@ -207,19 +208,20 @@ type DataReceipt struct {
 }
 
 type Installation struct {
-	InstallationID   string                   `json:"installation_id"`
-	DeclaredName     string                   `json:"declared_name"`
-	Source           SourceBinding            `json:"source"`
-	Package          PackageBinding           `json:"package"`
-	OriginMode       OriginMode               `json:"origin_mode,omitempty"`
-	Directory        *DirectoryOrigin         `json:"directory,omitempty"`
-	OperationGroupID string                   `json:"operation_group_id,omitempty"`
-	DataReceipts     map[string]DataReceipt   `json:"data_receipts,omitempty"`
-	DataRetained     bool                     `json:"data_retained,omitempty"`
-	Clients          map[string]ClientBinding `json:"clients"`
-	NeedsRebind      bool                     `json:"needs_rebind,omitempty"`
-	CreatedAt        string                   `json:"created_at"`
-	UpdatedAt        string                   `json:"updated_at"`
+	InstallPreferences []InstallPreference      `json:"install_preferences,omitempty"`
+	InstallationID     string                   `json:"installation_id"`
+	DeclaredName       string                   `json:"declared_name"`
+	Source             SourceBinding            `json:"source"`
+	Package            PackageBinding           `json:"package"`
+	OriginMode         OriginMode               `json:"origin_mode,omitempty"`
+	Directory          *DirectoryOrigin         `json:"directory,omitempty"`
+	OperationGroupID   string                   `json:"operation_group_id,omitempty"`
+	DataReceipts       map[string]DataReceipt   `json:"data_receipts,omitempty"`
+	DataRetained       bool                     `json:"data_retained,omitempty"`
+	Clients            map[string]ClientBinding `json:"clients"`
+	NeedsRebind        bool                     `json:"needs_rebind,omitempty"`
+	CreatedAt          string                   `json:"created_at"`
+	UpdatedAt          string                   `json:"updated_at"`
 }
 
 type StateFileV2 struct {

--- a/install/integrationctl/agentplugins/planner/intent.go
+++ b/install/integrationctl/agentplugins/planner/intent.go
@@ -7,7 +7,7 @@ import (
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 )
 
-const KiroPrepareAction = "Kiro native configuration is prepared; open or restart Kiro, review the MCP servers and complete authentication in Kiro on first connection when prompted, then verify their tools in Kiro. Runtime connections have not been verified."
+const KiroPrepareAction = "After preparation, open or restart Kiro, review the MCP servers and complete authentication in Kiro on first connection when prompted, then verify their tools in Kiro. Runtime connections have not been verified."
 
 // ApplyInstallIntent retains all package and Directory compatibility decisions.
 func ApplyInstallIntent(plan *domain.DeliveryPlan, intent domain.InstallIntent) error {

--- a/install/integrationctl/agentplugins/planner/intent.go
+++ b/install/integrationctl/agentplugins/planner/intent.go
@@ -1,0 +1,32 @@
+package planner
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+const KiroPrepareAction = "Kiro native configuration is prepared; open or restart Kiro, review the MCP servers and complete authentication in Kiro on first connection when prompted, then verify their tools in Kiro. Runtime connections have not been verified."
+
+// ApplyInstallIntent retains all package and Directory compatibility decisions.
+func ApplyInstallIntent(plan *domain.DeliveryPlan, intent domain.InstallIntent) error {
+	if err := intent.Validate(plan.ClientID); err != nil {
+		return err
+	}
+	if intent == domain.InstallIntentPrepare && plan.Scope != domain.ScopeUser {
+		return fmt.Errorf("Kiro preparation supports user scope only")
+	}
+	plan.InstallIntent = intent
+	if intent != domain.InstallIntentPrepare || plan.Status == domain.PlanUnsupported {
+		return nil
+	}
+	if strings.TrimSpace(plan.NativeRegistryRoot) == "" || !hasOnlyKiroNativeComponents(plan.Components) {
+		return fmt.Errorf("Kiro preparation requires a native config root and supported skills or MCP servers")
+	}
+	plan.Status = domain.PlanReady
+	plan.Activation = domain.ActivationPrepared
+	plan.Verification = domain.VerificationPackageValid
+	plan.UserActions = []string{KiroPrepareAction}
+	return nil
+}

--- a/install/integrationctl/agentplugins/planner/intent_test.go
+++ b/install/integrationctl/agentplugins/planner/intent_test.go
@@ -1,0 +1,34 @@
+package planner
+
+import (
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"testing"
+)
+
+func TestPreparationCannotOverrideUnsupportedPackage(t *testing.T) {
+	plan := domain.DeliveryPlan{ClientID: domain.ClientKiro, Scope: domain.ScopeUser, Status: domain.PlanUnsupported}
+	if err := ApplyInstallIntent(&plan, domain.InstallIntentPrepare); err != nil {
+		t.Fatal(err)
+	}
+	if plan.Status != domain.PlanUnsupported {
+		t.Fatal("preparation bypassed compatibility")
+	}
+}
+
+func TestPreparationRequiresSupportedNativeUserTarget(t *testing.T) {
+	for _, tc := range []struct {
+		client domain.ClientID
+		scope  domain.InstallScope
+		root   string
+		kind   domain.ComponentKind
+	}{
+		{domain.ClientChatGPT, domain.ScopeUser, "native", domain.ComponentMCPServer},
+		{domain.ClientKiro, domain.ScopeProject, "native", domain.ComponentMCPServer},
+		{domain.ClientKiro, domain.ScopeUser, "", domain.ComponentMCPServer},
+	} {
+		plan := domain.DeliveryPlan{ClientID: tc.client, Scope: tc.scope, NativeRegistryRoot: tc.root, Components: []domain.ComponentDecision{{Kind: tc.kind, Support: domain.SupportPrepared}}}
+		if err := ApplyInstallIntent(&plan, domain.InstallIntentPrepare); err == nil {
+			t.Fatalf("accepted %+v", tc)
+		}
+	}
+}

--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -54,6 +54,9 @@ func committedNativeDeactivationCleanup(outcome *domain.DeactivationOutcome, err
 // CLI for this exact request. Runtime preflight consumes this same predicate so
 // it cannot drift from the provider's activation paths.
 func (activator Activator) AutomaticallyActivates(request domain.ActivationRequest) bool {
+	if request.Plan.InstallIntent != domain.InstallIntentAutomatic {
+		return false
+	}
 	switch request.Client.ClientID {
 	case domain.ClientCline:
 		return strings.TrimSpace(request.Client.ConfigRoot) != "" && openCodeNativeComponents(request.Plan.Components)
@@ -77,6 +80,15 @@ func (activator Activator) AutomaticallyActivates(request domain.ActivationReque
 // PreflightActivation rejects lifecycle configurations that would otherwise
 // discover a missing required capability only after native client mutation.
 func (activator Activator) PreflightActivation(request domain.ActivationRequest) error {
+	if err := request.Plan.InstallIntent.Validate(request.Client.ClientID); err != nil {
+		return err
+	}
+	if request.Plan.InstallIntent == domain.InstallIntentPrepare {
+		if request.Plan.Scope != domain.ScopeUser || strings.TrimSpace(request.Client.ConfigRoot) == "" || !kiroNativeComponents(request.Plan.Components) {
+			return fmt.Errorf("Kiro preparation requires native configuration and supported components")
+		}
+		return nil
+	}
 	if request.Client.ClientID == domain.ClientClaude {
 		_, err := prepareClaudeActivationProbe(request)
 		return err
@@ -328,6 +340,19 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 		Authentication: request.Plan.Authentication,
 		Policy:         domain.PolicyAllowed,
 		Verification:   domain.VerificationPackageValid,
+	}
+	if request.Plan.InstallIntent == domain.InstallIntentPrepare {
+		if request.VerifyOnly {
+			err = verifyKiroNativeObjects(request.Client.ConfigRoot, request.Delivery.NativeObjects, false)
+		} else {
+			err = activateKiroNative(ctx, request)
+		}
+		if err != nil {
+			return failedActivation(outcome, "repair the managed Kiro native configuration", err)
+		}
+		outcome.Activation = domain.ActivationPrepared
+		outcome.UserActions = append(outcome.UserActions, request.Plan.UserActions...)
+		return outcome, nil
 	}
 	if request.ActivationComplete && !activator.AutomaticallyActivates(request) {
 		outcome.Activation = domain.ActivationActive

--- a/install/integrationctl/agentplugins/usecase/group.go
+++ b/install/integrationctl/agentplugins/usecase/group.go
@@ -126,6 +126,11 @@ type plannedGroupTarget struct {
 }
 
 func (service Service) applyGroup(ctx context.Context, input GroupInput, replace bool) (GroupResult, error) {
+	for _, target := range append(append([]AddInput(nil), input.Targets...), input.CompatibilityChecks...) {
+		if err := target.InstallIntent.Validate(target.Client.ClientID); err != nil {
+			return GroupResult{}, err
+		}
+	}
 	if len(input.Targets) == 0 {
 		return GroupResult{}, fmt.Errorf("at least one target is required")
 	}
@@ -244,7 +249,7 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 		if target.DistributionSuspended && normalizedOriginMode(target.OriginMode) == domain.OriginModeDirectory && !input.Repair {
 			return result, fmt.Errorf("suspended distribution blocks group add/update")
 		}
-		plan, err := service.Planner.Plan(ctx, target.Envelope, target.Client, target.Scope, domain.ComputePhysicalArtifactID(target.Envelope.Manifest.Name, installationID))
+		plan, err := service.planInstall(ctx, &target, domain.ComputePhysicalArtifactID(target.Envelope.Manifest.Name, installationID), installationIfExisting(state, installationIndex, existing))
 		if err != nil {
 			return result, err
 		}
@@ -355,7 +360,7 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 			if check.Envelope.TreeDigest != first.Envelope.TreeDigest || check.Envelope.ManifestDigest != first.Envelope.ManifestDigest {
 				return result, fmt.Errorf("compatibility preflight must use the update candidate bytes")
 			}
-			plan, err := service.Planner.Plan(ctx, check.Envelope, check.Client, check.Scope, domain.ComputePhysicalArtifactID(check.Envelope.Manifest.Name, installationID))
+			plan, err := service.planInstall(ctx, &check, domain.ComputePhysicalArtifactID(check.Envelope.Manifest.Name, installationID), installationIfExisting(state, installationIndex, existing))
 			if err != nil {
 				return result, err
 			}

--- a/install/integrationctl/agentplugins/usecase/intent.go
+++ b/install/integrationctl/agentplugins/usecase/intent.go
@@ -1,0 +1,45 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/planner"
+)
+
+// planInstall resolves intent before any activation preflight, including grouped
+// compatibility checks. An omitted flag retains even an absent binding's intent.
+func (service Service) planInstall(ctx context.Context, input *AddInput, physicalID string, installation *domain.Installation) (domain.DeliveryPlan, error) {
+	if err := input.InstallIntent.Validate(input.Client.ClientID); err != nil {
+		return domain.DeliveryPlan{}, err
+	}
+	if installation != nil {
+		if input.InstallIntent == "" {
+			for _, preference := range installation.InstallPreferences {
+				if preference.ClientID == input.Client.ClientID && preference.Scope == input.Scope {
+					input.InstallIntent = preference.InstallIntent
+				}
+			}
+		}
+		for _, binding := range installation.Clients {
+			if binding.ClientID != string(input.Client.ClientID) || binding.Scope != string(input.Scope) {
+				continue
+			}
+			if err := binding.InstallIntent.Validate(input.Client.ClientID); err != nil {
+				return domain.DeliveryPlan{}, err
+			}
+			if input.InstallIntent != "" && input.InstallIntent != binding.InstallIntent && binding.Materialization != domain.MaterializationAbsent {
+				return domain.DeliveryPlan{}, fmt.Errorf("install intent differs from the persisted binding; remove the binding before changing mode")
+			}
+			if input.InstallIntent == "" {
+				input.InstallIntent = binding.InstallIntent
+			}
+		}
+	}
+	plan, err := service.Planner.Plan(ctx, input.Envelope, input.Client, input.Scope, physicalID)
+	if err == nil {
+		err = planner.ApplyInstallIntent(&plan, input.InstallIntent)
+	}
+	return plan, err
+}

--- a/install/integrationctl/agentplugins/usecase/kiro_prepare_test.go
+++ b/install/integrationctl/agentplugins/usecase/kiro_prepare_test.go
@@ -1,0 +1,224 @@
+package usecase
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers"
+	legacyports "github.com/777genius/plugin-kit-ai/install/integrationctl/ports"
+)
+
+type prepareNoDuplexRunner struct{ calls int }
+
+func (r *prepareNoDuplexRunner) Run(context.Context, legacyports.Command) (legacyports.CommandResult, error) {
+	r.calls++
+	return legacyports.CommandResult{}, nil
+}
+
+func kiroPrepareInput(t *testing.T, client domain.DetectedClient) AddInput {
+	t.Helper()
+	input := addInput(t, client, "https://example.test/kiro-prepare")
+	const server = `{"type":"streamable-http","url":"https://mcp.context7.com/mcp/oauth"}`
+	body := []byte(`{"mcpServers":{"docs":` + server + `}}`)
+	if err := os.WriteFile(filepath.Join(input.Envelope.SnapshotRoot, "mcp.json"), body, 0600); err != nil {
+		t.Fatal(err)
+	}
+	input.Envelope.MCP = domain.MCPComponent{Present: true, Enabled: true, Raw: body, Servers: map[string]domain.MCPServer{"docs": {Name: "docs", Type: "streamable-http", Raw: []byte(server), Decoded: map[string]any{"type": "streamable-http", "url": "https://mcp.context7.com/mcp/oauth"}}}}
+	input.Envelope.Inventory.MCPPresent = true
+	input.Envelope.Inventory.MCPEnabled = true
+	input.Envelope.Inventory.MCPServers = []string{"docs"}
+	input.BackendExecutable = "/fixture/kiro-cli"
+	input.Confirmed = true
+	return input
+}
+
+func TestKiroExplicitPreparationLifecycleWithoutDuplex(t *testing.T) {
+	for _, purge := range []bool{false, true} {
+		t.Run(map[bool]string{false: "retain data", true: "purge data"}[purge], func(t *testing.T) {
+			service, store, _ := serviceFixture(t)
+			runner := &prepareNoDuplexRunner{}
+			service.Activator = providers.Activator{Runner: runner}
+			service.NativeObserver = providers.NativeIdentityObserver{Stager: service.Stager, Runner: runner}
+			client := domain.DetectedClient{ClientID: domain.ClientKiro, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".kiro")}
+			input := kiroPrepareInput(t, client)
+			if _, err := service.Add(context.Background(), input); err == nil || !strings.Contains(err.Error(), "duplex") {
+				t.Fatalf("automatic preflight: %v", err)
+			}
+			state, err := store.Load()
+			if err != nil || len(state.Installations) != 0 {
+				t.Fatalf("automatic mutated state: %+v %v", state, err)
+			}
+			if _, err := os.Stat(client.ConfigRoot); !os.IsNotExist(err) {
+				t.Fatalf("automatic wrote config: %v", err)
+			}
+			config := filepath.Join(client.ConfigRoot, "settings", "mcp.json")
+			if err := os.MkdirAll(filepath.Dir(config), 0700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(config, []byte(`{"mcpServers":{"foreign":{"url":"https://foreign.test/mcp"}},"custom":42}`), 0600); err != nil {
+				t.Fatal(err)
+			}
+			input.InstallIntent = domain.InstallIntentPrepare
+			check := func(result AddResult, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if result.Plan.InstallIntent != domain.InstallIntentPrepare || result.Activation.Activation != domain.ActivationPrepared || result.Activation.Verification != domain.VerificationPackageValid || result.Activation.ActivationAttested {
+					t.Fatalf("false lifecycle claim: %+v", result)
+				}
+				state, err := store.Load()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if onlyBinding(state.Installations[0]).InstallIntent != domain.InstallIntentPrepare {
+					t.Fatal("lost persisted preparation")
+				}
+				body, err := os.ReadFile(config)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var doc map[string]any
+				if err := json.Unmarshal(body, &doc); err != nil {
+					t.Fatal(err)
+				}
+				servers := doc["mcpServers"].(map[string]any)
+				if len(servers) != 2 || servers["foreign"].(map[string]any)["url"] != "https://foreign.test/mcp" || servers["docs"].(map[string]any)["url"] != "https://mcp.context7.com/mcp/oauth" || doc["custom"] != float64(42) {
+					t.Fatalf("config damaged: %s", body)
+				}
+				if runner.calls != 0 {
+					t.Fatalf("executed %d client commands", runner.calls)
+				}
+			}
+			check(service.Add(context.Background(), input))
+			input.InstallIntent = ""
+			input.ActivationComplete = true
+			check(service.Add(context.Background(), input))
+			input.ActivationComplete = false
+			setEnvelopeVersion(t, &input.Envelope, "2.0.0", "sha256:prepare-v2", "sha256:prepare-manifest-v2")
+			input.OperationID = "prepare-update"
+			check(service.Update(context.Background(), input))
+			input.OperationID = "prepare-repair"
+			check(service.Repair(context.Background(), input))
+			state, _ = store.Load()
+			if err := os.RemoveAll(onlyBinding(state.Installations[0]).TargetLocator); err != nil {
+				t.Fatal(err)
+			}
+			input.OperationID = "prepare-rematerialize"
+			check(service.Repair(context.Background(), input))
+			removed, err := service.RemoveGroup(context.Background(), RemoveGroupInput{Selector: input.InstallationID, Targets: []RemoveInput{{Client: client, Scope: domain.ScopeUser}}, OperationGroupID: "prepare-remove", Confirmed: true, PurgeData: purge})
+			if err != nil || !removed.Mutated {
+				t.Fatalf("remove: %+v %v", removed, err)
+			}
+			body, _ := os.ReadFile(config)
+			if strings.Contains(string(body), `"docs"`) || !strings.Contains(string(body), `"foreign"`) {
+				t.Fatalf("remove damaged foreign config: %s", body)
+			}
+			input.OperationID = "prepare-reinstall"
+			check(service.Add(context.Background(), input))
+			before, _ := os.ReadFile(config)
+			changed := strings.ReplaceAll(string(before), "https://mcp.context7.com/mcp/oauth", "https://changed.test/mcp")
+			if err := os.WriteFile(config, []byte(changed), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := service.Add(context.Background(), input); err == nil {
+				t.Fatal("repeat accepted modified owned entry")
+			}
+			if _, err := service.Repair(context.Background(), input); err == nil {
+				t.Fatal("repair accepted modified owned entry")
+			}
+			after, _ := os.ReadFile(config)
+			if string(after) != changed {
+				t.Fatal("overwrote modified entry")
+			}
+		})
+	}
+}
+
+func TestPreparedKiroGroupedMaintenanceRetainsPerTargetIntent(t *testing.T) {
+	service, store, cursor := serviceFixture(t)
+	runner := &prepareNoDuplexRunner{}
+	service.Activator = providers.Activator{Runner: runner}
+	service.NativeObserver = providers.NativeIdentityObserver{Stager: service.Stager, Runner: runner}
+	kiro := domain.DetectedClient{ClientID: domain.ClientKiro, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".kiro")}
+	input := kiroPrepareInput(t, kiro)
+	input.InstallIntent = domain.InstallIntentPrepare
+	peer := input
+	peer.Client = cursor
+	peer.InstallIntent = ""
+	peer.BackendExecutable = ""
+	check := func(result GroupResult, err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, target := range result.Targets {
+			if target.Plan.ClientID == domain.ClientKiro && (target.Plan.InstallIntent != domain.InstallIntentPrepare || target.Activation.Activation != domain.ActivationPrepared || target.Activation.Verification != domain.VerificationPackageValid) {
+				t.Fatalf("group lost intent: %+v", target)
+			}
+		}
+		state, err := store.Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, binding := range state.Installations[0].Clients {
+			if binding.ClientID == string(domain.ClientKiro) {
+				if binding.InstallIntent != domain.InstallIntentPrepare {
+					t.Fatal("lost persisted intent")
+				}
+			} else if binding.InstallIntent != "" {
+				t.Fatal("changed other target mode")
+			}
+		}
+		if runner.calls != 0 {
+			t.Fatal("group launched client")
+		}
+	}
+	check(service.AddGroup(context.Background(), GroupInput{Targets: []AddInput{input, peer}, OperationGroupID: "prepare-group-add", Confirmed: true}))
+	input.InstallIntent = ""
+	setEnvelopeVersion(t, &input.Envelope, "2.0.0", "sha256:group-prepare-v2", "sha256:group-prepare-manifest-v2")
+	peer.Envelope = input.Envelope
+	check(service.UpdateGroup(context.Background(), GroupInput{Targets: []AddInput{input, peer}, CompatibilityChecks: []AddInput{input, peer}, OperationGroupID: "prepare-group-update", Confirmed: true}))
+	check(service.RepairGroup(context.Background(), GroupInput{Targets: []AddInput{input, peer}, OperationGroupID: "prepare-group-repair", Confirmed: true}))
+}
+
+func TestPreparationRejectsForeignNameAndInvalidIntentBeforeMutation(t *testing.T) {
+	for _, invalid := range []bool{false, true} {
+		t.Run(map[bool]string{false: "foreign name", true: "invalid intent"}[invalid], func(t *testing.T) {
+			service, store, _ := serviceFixture(t)
+			runner := &prepareNoDuplexRunner{}
+			service.Activator = providers.Activator{Runner: runner}
+			service.NativeObserver = providers.NativeIdentityObserver{Stager: service.Stager, Runner: runner}
+			client := domain.DetectedClient{ClientID: domain.ClientKiro, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".kiro")}
+			input := kiroPrepareInput(t, client)
+			input.InstallIntent = domain.InstallIntentPrepare
+			if invalid {
+				input.InstallIntent = "typo"
+			}
+			config := filepath.Join(client.ConfigRoot, "settings", "mcp.json")
+			if err := os.MkdirAll(filepath.Dir(config), 0700); err != nil {
+				t.Fatal(err)
+			}
+			const foreign = `{"mcpServers":{"docs":{"url":"https://foreign.test/mcp"}}}`
+			if err := os.WriteFile(config, []byte(foreign), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := service.Add(context.Background(), input); err == nil {
+				t.Fatal("accepted foreign ownership or invalid intent")
+			}
+			state, err := store.Load()
+			if err != nil || len(state.Installations) != 0 {
+				t.Fatalf("mutated state %+v %v", state, err)
+			}
+			body, _ := os.ReadFile(config)
+			if string(body) != foreign || runner.calls != 0 {
+				t.Fatal("changed foreign configuration or launched client")
+			}
+		})
+	}
+}

--- a/install/integrationctl/agentplugins/usecase/remove.go
+++ b/install/integrationctl/agentplugins/usecase/remove.go
@@ -193,6 +193,19 @@ func (service Service) prepareRemovedBindingsState(ctx context.Context, state do
 			return state, nil, nil, fmt.Errorf("removed binding state is not authoritative")
 		}
 		removed = append(removed, client)
+		if client.InstallIntent != domain.InstallIntentAutomatic {
+			preference := domain.InstallPreference{ClientID: domain.ClientID(client.ClientID), Scope: domain.InstallScope(client.Scope), InstallIntent: client.InstallIntent}
+			found := false
+			for i, previous := range installation.InstallPreferences {
+				if previous.ClientID == preference.ClientID && previous.Scope == preference.Scope {
+					installation.InstallPreferences[i] = preference
+					found = true
+				}
+			}
+			if !found {
+				installation.InstallPreferences = append(installation.InstallPreferences, preference)
+			}
+		}
 		delete(installation.Clients, clientKey)
 	}
 	active := 0
@@ -234,7 +247,13 @@ func (service Service) prepareRemovedBindingsState(ctx context.Context, state do
 				receipts = append(receipts, receipt)
 			}
 			sort.Slice(receipts, func(i, j int) bool { return receipts[i].DataReceiptID < receipts[j].DataReceiptID })
-			state.Installations = append(state.Installations[:installationIndex], state.Installations[installationIndex+1:]...)
+			if len(installation.InstallPreferences) > 0 {
+				installation.DataRetained = false
+				installation.DataReceipts = nil
+				state.Installations[installationIndex] = installation
+			} else {
+				state.Installations = append(state.Installations[:installationIndex], state.Installations[installationIndex+1:]...)
+			}
 			return state, receipts, createdData, nil
 		}
 		installation.DataRetained = true
@@ -297,7 +316,14 @@ func (service Service) PurgeRetainedData(ctx context.Context, selector string, c
 	if err != nil {
 		return err
 	}
-	state.Installations = append(state.Installations[:index], state.Installations[index+1:]...)
+	if len(installation.InstallPreferences) > 0 {
+		retained := installation
+		retained.DataRetained = false
+		retained.DataReceipts = nil
+		state.Installations[index] = retained
+	} else {
+		state.Installations = append(state.Installations[:index], state.Installations[index+1:]...)
+	}
 	receipts := make([]domain.DataReceipt, 0, len(installation.DataReceipts))
 	for _, receipt := range installation.DataReceipts {
 		receipts = append(receipts, receipt)

--- a/install/integrationctl/agentplugins/usecase/repair.go
+++ b/install/integrationctl/agentplugins/usecase/repair.go
@@ -17,6 +17,9 @@ import (
 // resolved package. It never uses a persisted target until that target has
 // been matched to the target resolver's current safe result.
 func (service Service) Repair(ctx context.Context, input AddInput) (AddResult, error) {
+	if err := input.InstallIntent.Validate(input.Client.ClientID); err != nil {
+		return AddResult{}, err
+	}
 	if input.OriginMode == "" && input.DirectoryResolution != nil {
 		input.OriginMode = domain.OriginModeDirectory
 	}
@@ -49,11 +52,14 @@ func (service Service) Repair(ctx context.Context, input AddInput) (AddResult, e
 		return AddResult{}, fmt.Errorf("resolved repair source identity does not match the selected installation")
 	}
 	physicalID := domain.ComputePhysicalArtifactID(installation.DeclaredName, installation.InstallationID)
-	plan, err := service.Planner.Plan(ctx, input.Envelope, input.Client, input.Scope, physicalID)
+	plan, err := service.planInstall(ctx, &input, physicalID, &installation)
 	if err != nil {
 		return AddResult{}, err
 	}
 	result := AddResult{InstallationID: installation.InstallationID, Plan: plan}
+	if err := service.preflightActivation(input, plan); err != nil {
+		return result, err
+	}
 	if err := service.preflightTargetComponents(ctx, input, &plan, &installation, true, false); err != nil {
 		result.Plan = plan
 		return result, err

--- a/install/integrationctl/agentplugins/usecase/service.go
+++ b/install/integrationctl/agentplugins/usecase/service.go
@@ -70,6 +70,7 @@ type pluginDataAwareStager interface {
 }
 
 type AddInput struct {
+	InstallIntent      domain.InstallIntent
 	Envelope           domain.PackageEnvelope
 	Client             domain.DetectedClient
 	Scope              domain.InstallScope
@@ -115,6 +116,9 @@ func (service Service) Update(ctx context.Context, input AddInput) (AddResult, e
 }
 
 func (service Service) apply(ctx context.Context, input AddInput, replace bool) (AddResult, error) {
+	if err := input.InstallIntent.Validate(input.Client.ClientID); err != nil {
+		return AddResult{}, err
+	}
 	if input.OriginMode == "" && input.DirectoryResolution != nil {
 		input.OriginMode = domain.OriginModeDirectory
 	}
@@ -201,7 +205,7 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 		}
 	}
 	physicalID := domain.ComputePhysicalArtifactID(input.Envelope.Manifest.Name, installationID)
-	plan, err := service.Planner.Plan(ctx, input.Envelope, input.Client, input.Scope, physicalID)
+	plan, err := service.planInstall(ctx, &input, physicalID, installationIfExisting(state, installationIndex, existing))
 	if err != nil {
 		return AddResult{}, err
 	}
@@ -494,6 +498,9 @@ func (service Service) stagePackage(ctx context.Context, envelope domain.Package
 }
 
 func lifecycleConverged(client domain.ClientBinding) bool {
+	if client.InstallIntent == domain.InstallIntentPrepare {
+		return client.Materialization == domain.MaterializationMaterialized && client.Activation == domain.ActivationPrepared && client.Verification == domain.VerificationPackageValid
+	}
 	authComplete := client.Authentication == domain.AuthenticationNotRequired || client.Authentication == domain.AuthenticationComplete
 	return client.Materialization == domain.MaterializationMaterialized &&
 		client.Activation == domain.ActivationActive &&
@@ -768,7 +775,7 @@ func (service Service) verifyClientReadOnly(ctx context.Context, input AddInput,
 			return domain.ActivationOutcome{}, nil
 		}
 	case domain.ClientKiro:
-		if !strings.Contains(strings.ToLower(input.BackendExecutable), "kiro") {
+		if input.InstallIntent != domain.InstallIntentPrepare && !strings.Contains(strings.ToLower(input.BackendExecutable), "kiro") {
 			return domain.ActivationOutcome{}, nil
 		}
 	default:
@@ -858,6 +865,7 @@ func upsertPreparedInstallation(
 		bindingClientID = previousClient.ClientID
 	}
 	installation.Clients[clientBindingID] = domain.ClientBinding{
+		InstallIntent:   input.InstallIntent,
 		ClientBindingID: clientBindingID, ClientID: bindingClientID, Scope: string(input.Scope),
 		TargetLocator: plan.ActivePath, PhysicalArtifact: plan.PhysicalArtifactID,
 		Materialization: domain.MaterializationStaged, Activation: domain.ActivationPrepared,


### PR DESCRIPTION
Kiro MCP installation currently stops on macOS when automatic ACP containment is unavailable. This adds explicit `add context7 --target kiro --prepare`: the installer writes and reads back its owned native configuration while reporting prepared, runtime-unverified state. The automatic path retains its containment checks.

Preparation intent survives repeat add, update, repair and removal/reinstall. Interactive selection offers preparation with an explicit label. Foreign entries and user-modified owned entries remain protected. Version-probe suppression is scoped to the current installation, so unrelated automatic operations still enforce version-specific Directory evidence. The package OAuth endpoint is preserved.

Validation: six affected Go package suites passed. The corrected CLI suite passed 256 tests; independent review accepted exact head `58ec1b5046152c4942b799b231704768d37e1b6c` with additional focused checks. All 27 CI checks passed on that head. Real macOS testing of the signed catalog Context7 package passed add, repeat add, update, repair, remove and reinstall; removal cleared the owned MCP entry and reinstall retained preparation intent.

OAuth runtime qualification remains incomplete: Kiro v2 reports an issuer-validation error after browser authentication, and the v3 check has not established tools from this installed connection. This PR delivers local preparation and honest next actions; it does not claim remote tool verification, ChatGPT support or a published release.
