### PR TITLE
feat(cli): guide Context7 setup for ChatGPT

### DIFF
--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -44,10 +44,30 @@ func newAddCommand(app App, opts *options) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				if len(targets) != 1 || targets[0] != domain.ClientKiro {
-					return fmt.Errorf("--prepare requires --target kiro; prepare other targets in separate commands")
+				if len(targets) == 0 {
+					return fmt.Errorf("--prepare requires --target kiro and/or chatgpt")
 				}
-				opts.installIntents[domain.ClientKiro] = domain.InstallIntentPrepare
+				for _, target := range targets {
+					if target != domain.ClientKiro && target != domain.ClientChatGPT {
+						return fmt.Errorf("--prepare requires --target kiro and/or chatgpt (Context7 only)")
+					}
+					opts.installIntents[target] = domain.InstallIntentPrepare
+					if target == domain.ClientChatGPT {
+						app.chatGPTPreparation = true
+					}
+				}
+				if app.chatGPTPreparation && (opts.scope != "user" || !isDirectorySelector(args[0])) {
+					return fmt.Errorf("ChatGPT preparation requires the signed Context7 Directory source and user scope")
+				}
+			}
+			if opts.chatGPTAppID != "" {
+				if !app.chatGPTPreparation {
+					return fmt.Errorf("--chatgpt-app-id requires --prepare --target chatgpt")
+				}
+				if err := domain.ValidateChatGPTAppID(opts.chatGPTAppID); err != nil {
+					return err
+				}
+				app.chatGPTAppID = opts.chatGPTAppID
 			}
 			var detectedClients []domain.DetectedClient
 			targetProvided := cmd.Flags().Changed("target") && strings.TrimSpace(opts.target) != ""
@@ -103,7 +123,8 @@ func newAddCommand(app App, opts *options) *cobra.Command {
 			return runAddManyWithClients(cmd.Context(), cmd, app, opts, args[0], targets, activationComplete, authComplete, detectedClients)
 		},
 	}
-	command.Flags().BoolVar(&opts.prepare, "prepare", false, "prepare owned Kiro configuration without launching Kiro; authenticate and verify tools in Kiro")
+	command.Flags().StringVar(&opts.chatGPTAppID, "chatgpt-app-id", "", "personal Context7 registration ID copied from ChatGPT Developer Mode")
+	command.Flags().BoolVar(&opts.prepare, "prepare", false, "prepare Kiro configuration and/or Context7 ChatGPT personal marketplace; authenticate and verify tools in the client")
 	command.Flags().BoolVar(&activationComplete, "activation-complete", false, "attest that manual client activation is complete")
 	command.Flags().BoolVar(&authComplete, "auth-complete", false, "attest that required authentication is complete or none is required after review")
 	return command
@@ -556,7 +577,11 @@ func renderAddResultErrorWithSecurity(writer io.Writer, format string, envelope 
 		return err
 	}
 	if result.NoChange && result.Plan.InstallIntent == domain.InstallIntentPrepare {
-		_, err := fmt.Fprintln(writer, "Owned Kiro configuration remains prepared. No changes made.\nNext: "+clientplanner.KiroPrepareAction)
+		message := "Owned Kiro configuration remains prepared. No changes made."
+		if result.Plan.ClientID == domain.ClientChatGPT {
+			message = "Owned ChatGPT package remains prepared. Remote connection and tool calls have not been verified."
+		}
+		_, err := fmt.Fprintln(writer, message+"\nNext: "+nextLifecycleAction(result))
 		return err
 	}
 	if result.NoChange {
@@ -668,6 +693,12 @@ func nextLocalLifecycleAction(result usecase.AddResult) string {
 
 func lifecycleAction(result usecase.AddResult, includePrivate bool) string {
 	if result.Plan.InstallIntent == domain.InstallIntentPrepare {
+		if result.Plan.ClientID == domain.ClientChatGPT {
+			if includePrivate && len(result.Activation.LocalActions) > 0 {
+				return result.Activation.LocalActions[0]
+			}
+			return domain.ChatGPTRegistrationAction
+		}
 		return clientplanner.KiroPrepareAction
 	}
 	action := ""

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -45,7 +45,10 @@ func newAddCommand(app App, opts *options) *cobra.Command {
 					return err
 				}
 				if len(targets) == 0 {
-					return fmt.Errorf("--prepare requires --target kiro and/or chatgpt")
+					if !app.Terminal || opts.format != "human" {
+						return fmt.Errorf("--prepare requires --target kiro and/or chatgpt in automated mode")
+					}
+					targets = []domain.ClientID{domain.ClientKiro, domain.ClientChatGPT}
 				}
 				for _, target := range targets {
 					if target != domain.ClientKiro && target != domain.ClientChatGPT {
@@ -86,6 +89,16 @@ func newAddCommand(app App, opts *options) *cobra.Command {
 				}
 				detectedClients = clients
 				targets := selection
+				selectedChatGPT := false
+				for _, target := range targets {
+					if target == domain.ClientChatGPT {
+						selectedChatGPT = true
+					}
+				}
+				if preloaded != nil && !selectedChatGPT {
+					preloaded.chatGPTPreparation = false
+					preloaded.localChatGPTMapping = nil
+				}
 				intents, err := app.addLifecycleIntents(cmd.Context(), args[0], opts.scope, opts.installIntents)
 				if err != nil {
 					return err
@@ -261,7 +274,8 @@ func promptTargetChoices(cmd *cobra.Command, app App, detected []domain.Detected
 			return nil, nil, err
 		}
 	}
-	if len(detected) <= 1 {
+	personalPreparationChoice := len(detected) == 1 && detected[0].ClientID == domain.ClientChatGPT && strings.Contains(detected[0].DisplayName, "prepare personal marketplace")
+	if len(detected) <= 1 && !personalPreparationChoice {
 		for _, label := range request.SkippedLabels {
 			if _, err := fmt.Fprintln(reviewWriter(cmd, app), "Skipped (not installed in this attempt): "+label); err != nil {
 				return nil, nil, err
@@ -694,10 +708,17 @@ func nextLocalLifecycleAction(result usecase.AddResult) string {
 func lifecycleAction(result usecase.AddResult, includePrivate bool) string {
 	if result.Plan.InstallIntent == domain.InstallIntentPrepare {
 		if result.Plan.ClientID == domain.ClientChatGPT {
-			if includePrivate && len(result.Activation.LocalActions) > 0 {
-				return result.Activation.LocalActions[0]
+			if includePrivate && result.Activation.Activation == domain.ActivationPrepared {
+				if len(result.Activation.LocalActions) > 0 {
+					return result.Activation.LocalActions[0]
+				}
+				if result.Plan.ActivePath != "" {
+					// Personal preparation explicitly exposes its usable marketplace path,
+					// but never the private registration receipt or ID.
+					return domain.ChatGPTPreparedAction(result.Plan.ActivePath, result.Plan.DeclaredName)
+				}
 			}
-			return domain.ChatGPTRegistrationAction
+			return domain.ChatGPTMappedPreparationAction
 		}
 		return clientplanner.KiroPrepareAction
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -80,6 +80,10 @@ func newAddCommand(app App, opts *options) *cobra.Command {
 				if err != nil {
 					return err
 				}
+				opts.installIntents, err = app.addLifecycleIntents(cmd.Context(), args[0], opts.scope, opts.installIntents)
+				if err != nil {
+					return err
+				}
 				selection, clients, preloaded, err := promptCompatibleDetectedTargets(cmd.Context(), cmd, app, args[0], opts.installIntents)
 				if err != nil {
 					return err
@@ -595,7 +599,7 @@ func renderAddResultErrorWithSecurity(writer io.Writer, format string, envelope 
 		if result.Plan.ClientID == domain.ClientChatGPT {
 			message = "Owned ChatGPT package remains prepared. Remote connection and tool calls have not been verified."
 		}
-		_, err := fmt.Fprintln(writer, message+"\nNext: "+nextLifecycleAction(result))
+		_, err := fmt.Fprintln(writer, message+"\nNext: "+nextLocalLifecycleAction(result))
 		return err
 	}
 	if result.NoChange {
@@ -756,4 +760,12 @@ func lifecycleAction(result usecase.AddResult, includePrivate bool) string {
 func fullyInstalled(outcome domain.ActivationOutcome) bool {
 	authComplete := outcome.Authentication == domain.AuthenticationNotRequired || outcome.Authentication == domain.AuthenticationComplete
 	return outcome.Activation == domain.ActivationActive && outcome.Verification == domain.VerificationInstalled && authComplete
+}
+
+// Preserve group preflight guidance unless a prepared personal marketplace exists.
+func localTargetLifecycleAction(result usecase.AddResult, publicAction string) string {
+	if result.Plan.ClientID == domain.ClientChatGPT && result.Plan.InstallIntent == domain.InstallIntentPrepare && result.Activation.Activation == domain.ActivationPrepared {
+		return nextLocalLifecycleAction(result)
+	}
+	return publicAction
 }

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
@@ -87,6 +87,14 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 	if err := authorizeSecurityAssessment(cmd, app, opts, &loaded); err != nil {
 		return err
 	}
+	if loaded.chatGPTPreparation && loaded.localChatGPTMapping == nil {
+		if opts.format == "json" {
+			if err := writeJSONResult(cmd.OutOrStdout(), "add", outputResultFailure, map[string]any{"status": "action_required", "target": "chatgpt", "mcp_url": domain.Context7OAuthURL, "next_action": domain.ChatGPTRegistrationAction, "remote_verified": false, "mutated": false}); err != nil {
+				return err
+			}
+		}
+		return fmt.Errorf("action_required: %s", domain.ChatGPTRegistrationAction)
+	}
 	if len(targets) == 1 {
 		selectedOptions := *opts
 		selectedOptions.target = string(targets[0])

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
@@ -397,7 +397,7 @@ func renderAddMultiResult(cmd *cobra.Command, opts *options, result addMultiResu
 			return err
 		}
 		if target.NextAction != "" && !fullyInstalled(target.Output.Result.Activation) {
-			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "    Next: %s\n", target.NextAction); err != nil {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "    Next: %s\n", localTargetLifecycleAction(target.Output.Result, target.NextAction)); err != nil {
 				return err
 			}
 		}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
@@ -88,12 +88,13 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 		return err
 	}
 	if loaded.chatGPTPreparation && loaded.localChatGPTMapping == nil {
+		action := chatGPTRegistrationResumeAction(cmd, loaded.envelope.Source.RequestedSource, targets)
 		if opts.format == "json" {
-			if err := writeJSONResult(cmd.OutOrStdout(), "add", outputResultFailure, map[string]any{"status": "action_required", "target": "chatgpt", "mcp_url": domain.Context7OAuthURL, "next_action": domain.ChatGPTRegistrationAction, "remote_verified": false, "mutated": false}); err != nil {
+			if err := writeJSONResult(cmd.OutOrStdout(), "add", outputResultFailure, map[string]any{"status": "action_required", "target": "chatgpt", "mcp_url": domain.Context7OAuthURL, "next_action": action, "remote_verified": false, "mutated": false}); err != nil {
 				return err
 			}
 		}
-		return fmt.Errorf("action_required: %s", domain.ChatGPTRegistrationAction)
+		return fmt.Errorf("action_required: %s", action)
 	}
 	if len(targets) == 1 {
 		selectedOptions := *opts

--- a/cli/plugin-kit-ai/internal/agentpluginscli/app.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/app.go
@@ -37,9 +37,11 @@ type SourceAcquirer interface {
 }
 
 type App struct {
-	Prompter      prompt.Prompter
-	PromptFactory func(io.Reader, io.Writer, io.Writer, bool, bool) (prompt.Prompter, io.Writer, error)
-	reviewOutput  io.Writer
+	chatGPTPreparation bool
+	chatGPTAppID       string
+	Prompter           prompt.Prompter
+	PromptFactory      func(io.Reader, io.Writer, io.Writer, bool, bool) (prompt.Prompter, io.Writer, error)
+	reviewOutput       io.Writer
 
 	Version             string
 	UserHome            string
@@ -64,6 +66,7 @@ type App struct {
 }
 
 type options struct {
+	chatGPTAppID        string
 	prepare             bool
 	installIntents      map[domain.ClientID]domain.InstallIntent
 	color               terminaltheme.Policy

--- a/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_guidance.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_guidance.go
@@ -1,0 +1,46 @@
+package agentpluginscli
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// Rebuild the actual request, including selected interactive targets. Never
+// echo a personal ID; the only added value is a registration placeholder.
+func chatGPTRegistrationResumeAction(cmd *cobra.Command, source string, targets []domain.ClientID) string {
+	targetOption := strings.Join(clientIDStrings(targets), ",")
+	if cmd.Flags().Changed("target") {
+		targetOption, _ = cmd.Flags().GetString("target")
+	}
+	args := []string{"add", quoteResumeArgument(source), "--target", quoteResumeArgument(targetOption), "--prepare"}
+	cmd.Flags().Visit(func(flag *pflag.Flag) {
+		switch flag.Name {
+		case "target", "prepare", "chatgpt-app-id":
+			return
+		}
+		args = append(args, "--"+flag.Name+"="+quoteResumeArgument(flag.Value.String()))
+	})
+	args = append(args, "--chatgpt-app-id", "<ID>")
+	return strings.Replace(domain.ChatGPTRegistrationAction, "add context7 --target chatgpt --prepare --chatgpt-app-id <ID>", strings.Join(args, " "), 1)
+}
+
+func clientIDStrings(targets []domain.ClientID) []string {
+	values := make([]string, len(targets))
+	for i, target := range targets {
+		values[i] = string(target)
+	}
+	return values
+}
+
+func quoteResumeArgument(value string) string {
+	if value != "" && strings.IndexFunc(value, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r) && !strings.ContainsRune("_./:@,+-=", r)
+	}) == -1 {
+		return value
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_guidance_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_guidance_test.go
@@ -1,7 +1,10 @@
 package agentpluginscli
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,11 +12,12 @@ import (
 
 	"github.com/777genius/plugin-kit-ai/cli/internal/agentpluginscli/prompt"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/usecase"
 )
 
 func TestContext7InteractivePreparationChoice(t *testing.T) {
 	for _, explicit := range []bool{false, true} {
-		t.Run(map[bool]string{false: "offered", true: "requested"}[explicit], func(t *testing.T) {
+		t.Run(map[bool]string{false: "ordinary-ineligible", true: "requested"}[explicit], func(t *testing.T) {
 			f, d, a := context7GuidedFixture(t)
 			f.app.Detector = staticDetector{clients: []domain.DetectedClient{fixtureClient(t, domain.ClientChatGPT)}}
 			before, _ := json.Marshal(d.bundle)
@@ -22,6 +26,18 @@ func TestContext7InteractivePreparationChoice(t *testing.T) {
 				args = append(args, "--prepare")
 			}
 			out, _, err := f.executeInput(true, "\n", args...)
+			if !explicit {
+				if err == nil || strings.Contains(out, "prepare personal marketplace") || a.verifiedCalls != 0 || a.directGitCalls != 0 || a.localCalls != 0 {
+					t.Fatalf("ordinary add entered preparation: %s %v acquisition=%+v", out, err, a)
+				}
+				state, _ := f.store.Load()
+				after, _ := json.Marshal(d.bundle)
+				if len(state.Installations) != 0 || string(before) != string(after) {
+					t.Fatal("ordinary add mutated state or signed metadata")
+				}
+				return
+			}
+
 			if err == nil || !strings.Contains(err.Error(), "action_required") || !strings.Contains(out, "prepare personal marketplace") {
 				t.Fatalf("choice/guidance: %s %v", out, err)
 			}
@@ -207,6 +223,170 @@ func TestContext7PreparedGuidanceAcrossLifecycle(t *testing.T) {
 		}
 		if strings.Contains(out, path) || strings.Contains(out, fixturePersonalAppID) || strings.Contains(out, "Rerun add") || !strings.Contains(out, "Remote OAuth and tool calls have not been verified") {
 			t.Fatalf("%s public guidance: %s", op, out)
+		}
+	}
+}
+
+func TestContext7HumanPathsAcrossSingleAndMixedLifecycle(t *testing.T) {
+	for _, targets := range []string{"chatgpt", "kiro,chatgpt"} {
+		t.Run(targets, func(t *testing.T) {
+			f, _, _ := context7GuidedFixture(t)
+			check := func(out string) {
+				t.Helper()
+				state, err := f.store.Load()
+				if err != nil {
+					t.Fatal(err)
+				}
+				path := ""
+				for _, b := range state.Installations[0].Clients {
+					if b.ClientID == "chatgpt" {
+						path = b.TargetLocator
+					}
+				}
+				if path == "" || !strings.Contains(out, path) || strings.Contains(out, fixturePersonalAppID) {
+					t.Fatalf("missing usable path or leaked ID: %s", out)
+				}
+				if _, err := os.Stat(filepath.Join(path, ".agents", "plugins", "marketplace.json")); err != nil {
+					t.Fatal(err)
+				}
+			}
+			out, _, err := f.execute(false, "add", "context7", "--target", targets, "--prepare", "--chatgpt-app-id", fixturePersonalAppID)
+			if err != nil {
+				t.Fatalf("initial: %s %v", out, err)
+			}
+			check(out)
+			for _, op := range []string{"add", "update", "repair"} {
+				t.Run(op, func(t *testing.T) {
+					out, _, err := f.execute(false, op, "context7", "--target", targets)
+					if err != nil {
+						t.Fatalf("%s: %s %v", op, out, err)
+					}
+					check(out)
+					out, _, err = f.execute(false, op, "context7", "--target", targets, "--format", "json")
+					if err != nil {
+						t.Fatalf("json: %s %v", out, err)
+					}
+					state, _ := f.store.Load()
+					for _, b := range state.Installations[0].Clients {
+						encoded, _ := json.Marshal(b.TargetLocator)
+						if b.TargetLocator != "" && strings.Contains(out, strings.Trim(string(encoded), "\"")) {
+							t.Fatalf("private path in JSON: %s", out)
+						}
+					}
+					if strings.Contains(out, fixturePersonalAppID) {
+						t.Fatalf("private ID in JSON: %s", out)
+					}
+				})
+			}
+
+			state, _ := f.store.Load()
+			for _, b := range state.Installations[0].Clients {
+				if b.ClientID == "chatgpt" {
+					if err := os.RemoveAll(b.TargetLocator); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			out, _, err = f.execute(false, "repair", "context7", "--target", targets)
+			if err != nil {
+				t.Fatalf("repair missing marketplace: %s %v", out, err)
+			}
+			check(out)
+			f.app.Detector = staticDetector{clients: []domain.DetectedClient{fixtureClient(t, domain.ClientChatGPT)}}
+			out, _, err = f.executeInput(true, "\n", "add", "context7-alias", "--plain")
+			if err != nil {
+				t.Fatalf("retained interactive intent: %s %v", out, err)
+			}
+			check(out)
+		})
+	}
+}
+
+func TestContext7PreparationExcludesEligibleCodexAndResumes(t *testing.T) {
+	f, d, _ := context7GuidedFixture(t)
+	snapshot := &d.bundle.Snapshot
+	policy := &snapshot.Distributions[0].ReleasePolicies[0]
+	policy.Targets = append(policy.Targets, domain.DirectoryTarget{Client: domain.ClientCodex, Scopes: []domain.InstallScope{domain.ScopeUser}, Delivery: "managed", Authentication: domain.AuthenticationRequirementRequired})
+	policy.CurrentEvidence = append(policy.CurrentEvidence, "materialized/codex")
+	evidence := snapshot.Evidence[0]
+	evidence.ID, evidence.Client = "materialized/codex", domain.ClientCodex
+	snapshot.Evidence = append(snapshot.Evidence, evidence)
+	f.app.Detector = staticDetector{clients: []domain.DetectedClient{fixtureClient(t, domain.ClientCodex), fixtureClient(t, domain.ClientKiro), fixtureClient(t, domain.ClientChatGPT)}}
+	// Prove this peer has ordinary signed eligibility before testing preparation.
+	clients := detectedSupportedClients(f.app.Detector.(staticDetector).clients)
+	compatible, err := f.app.compatibleDirectoryTargets(context.Background(), "context7", clients)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, client := range compatible {
+		if client.ClientID == domain.ClientCodex {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("fixture Codex is not ordinarily eligible: %+v", compatible)
+	}
+	f.app.Prompter = fakePrompter{
+		selectFn: func(request prompt.TargetSelectionRequest) (prompt.TargetSelectionResult, error) {
+			if len(request.Choices) != 2 {
+				t.Fatalf("prepare choices: %+v", request)
+			}
+			for _, choice := range request.Choices {
+				if choice.ID != domain.ClientKiro && choice.ID != domain.ClientChatGPT {
+					t.Fatalf("unsupported preparation choice: %+v", choice)
+				}
+			}
+			return prompt.TargetSelectionResult{IDs: []domain.ClientID{domain.ClientKiro, domain.ClientChatGPT}}, nil
+		},
+		confirmFn: func() (prompt.ConfirmationResult, error) { return prompt.ConfirmationResult{Accepted: true}, nil },
+	}
+	out, _, err := f.executeInput(true, "", "add", "context7", "--prepare", "--plain")
+	if err == nil || !strings.Contains(err.Error(), "action_required") {
+		t.Fatalf("registration: %s %v", out, err)
+	}
+	command := emittedRegistrationCommand(t, err.Error())
+	if strings.Contains(command, "codex") || !strings.Contains(command, "chatgpt,kiro") {
+		t.Fatal(command)
+	}
+	out, _, err = f.execute(false, strings.Fields(command)...)
+	if err != nil {
+		t.Fatalf("resume %s: %s %v", command, out, err)
+	}
+	state, _ := f.store.Load()
+	if len(state.Installations) != 1 || len(state.Installations[0].Clients) != 2 {
+		t.Fatalf("resume state: %+v", state)
+	}
+}
+
+func TestContext7SingleLifecycleRenderPaths(t *testing.T) {
+	for _, noChange := range []bool{false, true} {
+		result := usecase.AddResult{
+			Plan:       domain.DeliveryPlan{ClientID: domain.ClientChatGPT, InstallIntent: domain.InstallIntentPrepare, ActivePath: "/private/personal-marketplace", DeclaredName: "context7"},
+			Activation: domain.ActivationOutcome{Activation: domain.ActivationPrepared, Authentication: domain.AuthenticationPending, Verification: domain.VerificationPackageValid},
+			NoChange:   noChange, Mutated: !noChange,
+		}
+		for _, op := range []string{"add", "update", "repair"} {
+			t.Run(fmt.Sprintf("%s/noChange=%t", op, noChange), func(t *testing.T) {
+				for _, format := range []string{"human", "json"} {
+					var out bytes.Buffer
+					var err error
+					switch op {
+					case "add":
+						err = renderAddResult(&out, format, domain.PackageEnvelope{}, result, false)
+					case "update":
+						err = renderUpdateResult(&out, format, domain.PackageEnvelope{}, result, false)
+					case "repair":
+						err = renderRepairResult(&out, format, domain.Installation{}, result, false)
+					}
+					if err != nil {
+						t.Fatal(err)
+					}
+					if strings.Contains(out.String(), result.Plan.ActivePath) != (format == "human") {
+						t.Fatalf("%s path boundary: %s", format, out.String())
+					}
+				}
+			})
 		}
 	}
 }

--- a/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_guidance_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_guidance_test.go
@@ -1,0 +1,212 @@
+package agentpluginscli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/cli/internal/agentpluginscli/prompt"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+)
+
+func TestContext7InteractivePreparationChoice(t *testing.T) {
+	for _, explicit := range []bool{false, true} {
+		t.Run(map[bool]string{false: "offered", true: "requested"}[explicit], func(t *testing.T) {
+			f, d, a := context7GuidedFixture(t)
+			f.app.Detector = staticDetector{clients: []domain.DetectedClient{fixtureClient(t, domain.ClientChatGPT)}}
+			before, _ := json.Marshal(d.bundle)
+			args := []string{"add", "context7-alias", "--plain"}
+			if explicit {
+				args = append(args, "--prepare")
+			}
+			out, _, err := f.executeInput(true, "\n", args...)
+			if err == nil || !strings.Contains(err.Error(), "action_required") || !strings.Contains(out, "prepare personal marketplace") {
+				t.Fatalf("choice/guidance: %s %v", out, err)
+			}
+			if a.verifiedCalls != 1 || a.directGitCalls != 0 || a.localCalls != 0 {
+				t.Fatalf("acquisition: %+v", a)
+			}
+			state, _ := f.store.Load()
+			after, _ := json.Marshal(d.bundle)
+			if len(state.Installations) != 0 || string(before) != string(after) {
+				t.Fatal("registration changed state or signed metadata")
+			}
+			command := emittedRegistrationCommand(t, err.Error())
+			if !strings.Contains(command, "context7-alias") {
+				t.Fatal(command)
+			}
+			out, _, err = f.execute(false, strings.Fields(command)...)
+			if err != nil {
+				t.Fatalf("resume %s: %s %v", command, out, err)
+			}
+			state, _ = f.store.Load()
+			b := onlyCLIClient(state.Installations[0])
+			if b.ClientID != "chatgpt" || b.InstallIntent != domain.InstallIntentPrepare || b.Activation != domain.ActivationPrepared {
+				t.Fatalf("intent not retained: %+v", b)
+			}
+		})
+	}
+}
+
+func emittedRegistrationCommand(t *testing.T, action string) string {
+	t.Helper()
+	_, command, ok := strings.Cut(action, "Rerun ")
+	if !ok {
+		t.Fatalf("missing rerun: %s", action)
+	}
+	command, _, ok = strings.Cut(command, ". Then")
+	if !ok {
+		t.Fatalf("missing command boundary: %s", action)
+	}
+	return strings.ReplaceAll(command, "<ID>", fixturePersonalAppID)
+}
+
+func TestContext7ResumeEmittedMixedCommandAndPreparedGuidance(t *testing.T) {
+	f, d, a := context7GuidedFixture(t)
+	before, _ := json.Marshal(d.bundle)
+	out, _, err := f.execute(false, "add", "context7-alias", "--target", "kiro,chatgpt", "--prepare", "--format", "json", "--scope", "user", "--plain", "--security-details", "--no-color")
+	if err == nil {
+		t.Fatal("expected registration")
+	}
+	var response struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(out), &response); err != nil {
+		t.Fatal(err)
+	}
+	command := emittedRegistrationCommand(t, response.Data["next_action"].(string))
+	for _, flag := range []string{"context7-alias", "kiro,chatgpt", "--format=json", "--scope=user", "--plain=true", "--security-details=true", "--no-color=true"} {
+		if !strings.Contains(command, flag) {
+			t.Fatalf("lost %s: %s", flag, command)
+		}
+	}
+	out, _, err = f.execute(false, strings.Fields(command)...)
+	if err != nil {
+		t.Fatalf("emitted command: %s %v", out, err)
+	}
+	state, _ := f.store.Load()
+	if len(state.Installations) != 1 || len(state.Installations[0].Clients) != 2 || a.verifiedCalls != 2 {
+		t.Fatalf("mixed resume: %+v calls=%d", state, a.verifiedCalls)
+	}
+	if strings.Contains(out, fixturePersonalAppID) || strings.Contains(out, "copy its plugin_asdk_app_") || strings.Contains(out, "Rerun add") {
+		t.Fatalf("wrong stage or private ID: %s", out)
+	}
+	for _, b := range state.Installations[0].Clients {
+		if b.InstallIntent != domain.InstallIntentPrepare || b.Activation != domain.ActivationPrepared || b.Verification != domain.VerificationPackageValid {
+			t.Fatalf("false completion: %+v", b)
+		}
+		if b.ClientID == "chatgpt" {
+			if _, err := os.Stat(filepath.Join(b.TargetLocator, ".agents", "plugins", "marketplace.json")); err != nil {
+				t.Fatal(err)
+			}
+			encodedPath, _ := json.Marshal(b.TargetLocator)
+			if strings.Contains(out, strings.Trim(string(encodedPath), "\"")) {
+				t.Fatalf("public JSON leaked marketplace path: %s", out)
+			}
+		}
+	}
+	for _, text := range []string{"ChatGPT desktop", "new chat", "Remote OAuth and tool calls have not been verified", "including --purge-data"} {
+		if !strings.Contains(out, text) {
+			t.Fatalf("missing %q: %s", text, out)
+		}
+	}
+	after, _ := json.Marshal(d.bundle)
+	if string(before) != string(after) {
+		t.Fatal("changed signed metadata")
+	}
+}
+
+func TestContext7InteractivePreparationPolicyGates(t *testing.T) {
+	for _, kind := range []string{"signature", "source", "scope", "revoked"} {
+		t.Run(kind, func(t *testing.T) {
+			f, d, a := context7GuidedFixture(t)
+			f.app.Detector = staticDetector{clients: []domain.DetectedClient{fixtureClient(t, domain.ClientChatGPT)}}
+			switch kind {
+			case "signature":
+				d.err = os.ErrPermission
+			case "source":
+				d.bundle.Snapshot.Distributions[0].Releases[0].PackageSource.Repository = "other/context7"
+			case "scope":
+				d.bundle.Snapshot.Distributions[0].ReleasePolicies[0].Targets = append(d.bundle.Snapshot.Distributions[0].ReleasePolicies[0].Targets, domain.DirectoryTarget{Client: domain.ClientChatGPT, Scopes: []domain.InstallScope{domain.ScopeProject}, Delivery: "managed"})
+			case "revoked":
+				d.bundle.Snapshot.Distributions[0].ReleasePolicies[0].Status = domain.ReleaseRevoked
+			}
+			out, _, err := f.executeInput(true, "\n", "add", "context7", "--prepare", "--plain")
+			if err == nil || strings.Contains(out, "prepare personal marketplace") || a.verifiedCalls != 0 {
+				t.Fatalf("gate bypass: %s %v calls=%d", out, err, a.verifiedCalls)
+			}
+			state, _ := f.store.Load()
+			if len(state.Installations) != 0 {
+				t.Fatal("mutated")
+			}
+		})
+	}
+}
+
+func TestContext7InteractiveSelectionOnlyAppliesSelectedIntent(t *testing.T) {
+	for _, chooseChatGPT := range []bool{false, true} {
+		t.Run(map[bool]string{false: "kiro-only", true: "mixed"}[chooseChatGPT], func(t *testing.T) {
+			f, _, a := context7GuidedFixture(t)
+			f.app.Detector = staticDetector{clients: []domain.DetectedClient{fixtureClient(t, domain.ClientChatGPT), fixtureClient(t, domain.ClientKiro)}}
+			f.app.Prompter = fakePrompter{
+				selectFn: func(request prompt.TargetSelectionRequest) (prompt.TargetSelectionResult, error) {
+					if len(request.Choices) != 2 {
+						t.Fatalf("lost eligible peer: %+v", request)
+					}
+					ids := []domain.ClientID{domain.ClientKiro}
+					if chooseChatGPT {
+						ids = append(ids, domain.ClientChatGPT)
+					}
+					return prompt.TargetSelectionResult{IDs: ids}, nil
+				},
+				confirmFn: func() (prompt.ConfirmationResult, error) { return prompt.ConfirmationResult{Accepted: true}, nil },
+			}
+			out, _, err := f.executeInput(true, "", "add", "context7", "--prepare", "--plain")
+			if chooseChatGPT {
+				if err == nil || !strings.Contains(err.Error(), "action_required") {
+					t.Fatalf("%s %v", out, err)
+				}
+				command := emittedRegistrationCommand(t, err.Error())
+				out, _, err = f.execute(false, strings.Fields(command)...)
+			}
+			if err != nil {
+				t.Fatalf("%s %v", out, err)
+			}
+			state, _ := f.store.Load()
+			want := 1
+			if chooseChatGPT {
+				want = 2
+			}
+			if len(state.Installations) != 1 || len(state.Installations[0].Clients) != want || a.verifiedCalls != want {
+				t.Fatalf("unexpected selected outcome: %+v calls=%d", state, a.verifiedCalls)
+			}
+			if !chooseChatGPT && state.Installations[0].LocalChatGPTMapping != nil {
+				t.Fatal("unselected registration retained")
+			}
+		})
+	}
+}
+
+func TestContext7PreparedGuidanceAcrossLifecycle(t *testing.T) {
+	f, _, _ := context7GuidedFixture(t)
+	prepared, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--prepare", "--chatgpt-app-id", fixturePersonalAppID)
+	if err != nil {
+		t.Fatalf("%s %v", prepared, err)
+	}
+	state, _ := f.store.Load()
+	path := onlyCLIClient(state.Installations[0]).TargetLocator
+	if !strings.Contains(prepared, path) || strings.Contains(prepared, fixturePersonalAppID) || strings.Contains(prepared, "Rerun add") {
+		t.Fatalf("initial human guidance: %s", prepared)
+	}
+	for _, op := range []string{"add", "update", "repair"} {
+		out, _, err := f.execute(false, op, "context7", "--target", "chatgpt", "--format", "json")
+		if err != nil {
+			t.Fatalf("%s: %s %v", op, out, err)
+		}
+		if strings.Contains(out, path) || strings.Contains(out, fixturePersonalAppID) || strings.Contains(out, "Rerun add") || !strings.Contains(out, "Remote OAuth and tool calls have not been verified") {
+			t.Fatalf("%s public guidance: %s", op, out)
+		}
+	}
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_prepare_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_prepare_test.go
@@ -323,7 +323,8 @@ func TestContext7GuidedMixedUpdateUsesOneNewImmutableRelease(t *testing.T) {
 	dist.ReleasePolicies = append(dist.ReleasePolicies, policy)
 	d.bundle.Snapshot.Evidence = append(d.bundle.Snapshot.Evidence, intendedTrustedDirectoryEvidence(domain.DirectoryEvidence{ID: policy.CurrentEvidence[0], DistributionID: dist.ID, ReleaseSequence: 2, PackageTreeDigest: release.TreeDigest, Level: "materialization", Outcome: "passed", Client: domain.ClientKiro}))
 	beforeCalls := a.verifiedCalls
-	if out, _, err := f.execute(false, "update", "context7", "--target", "kiro,chatgpt"); err != nil {
+	out, _, err := f.execute(false, "update", "context7", "--target", "kiro,chatgpt")
+	if err != nil {
 		t.Fatalf("%s %v", out, err)
 	}
 	state, err := f.store.Load()
@@ -337,6 +338,9 @@ func TestContext7GuidedMixedUpdateUsesOneNewImmutableRelease(t *testing.T) {
 	for _, b := range i.Clients {
 		if b.PackageRevision == nil || b.PackageRevision.TreeDigest != release.TreeDigest || b.PackageRevision.ResolvedRevision != release.PackageSource.Revision || b.InstallIntent != domain.InstallIntentPrepare || b.Activation != domain.ActivationPrepared {
 			t.Fatalf("mixed update not same revision: %+v", b)
+		}
+		if b.ClientID == "chatgpt" && (!strings.Contains(out, b.TargetLocator) || strings.Contains(out, fixturePersonalAppID)) {
+			t.Fatalf("updated human path: %s", out)
 		}
 	}
 }

--- a/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_prepare_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_prepare_test.go
@@ -1,0 +1,359 @@
+package agentpluginscli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/adapters/directoryv1"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers"
+)
+
+const fixturePersonalAppID = "plugin_asdk_app_0123456789abcdef0123456789abcdef"
+
+// This fixture exercises the verified-acquisition interface with immutable local
+// bytes. It is deliberately not a live catalog or remote ChatGPT qualification.
+func context7GuidedFixture(t *testing.T) (cliFixture, *fixedDirectoryClient, *localBackedSourceAcquirer) {
+	t.Helper()
+	kiro := fixtureClient(t, domain.ClientKiro)
+	f := newCLIFixture(t, []domain.DetectedClient{kiro})
+	f.app.Lifecycle.NativeObserver = providers.NativeIdentityObserver{Stager: providers.Stager{}}
+	root := writeCLIPlugin(t)
+	manifest, err := os.ReadFile(filepath.Join(root, "plugin.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "plugin.json"), []byte(strings.ReplaceAll(string(manifest), `"demo"`, `"context7"`)), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "mcp.json"), []byte(`{"$schema":"https://agent-plugins.org/schemas/1.0.0/mcp.schema.json","mcpServers":{"context7":{"type":"streamable-http","url":"https://mcp.context7.com/mcp/oauth"}}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := f.app.acquireLocal(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer loaded.cleanup()
+	release := domain.DirectoryRelease{Sequence: 1, PackageVersion: "1.0.0", ManifestName: "context7", AgentPluginsSchema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json", PackageSource: domain.DirectorySource{Repository: "upstash/context7", Path: "plugins/agent-plugins/context7", Revision: strings.Repeat("a", 40)}, TreeDigestAlgorithm: domain.TreeDigestAlgorithm, TreeDigest: loaded.envelope.TreeDigest, ManifestDigest: loaded.envelope.ManifestDigest, Components: []string{"mcp"}, PublishedAt: "2026-08-21T00:00:00Z"}
+	policy := domain.DirectoryReleasePolicy{ReleaseSequence: 1, Status: domain.ReleaseActive, MinimumInstallerVersion: "0.1.0", Targets: []domain.DirectoryTarget{{Client: domain.ClientKiro, Scopes: []domain.InstallScope{domain.ScopeUser}, Delivery: "managed", Authentication: domain.AuthenticationRequirementRequired}}, CurrentEvidence: []string{"materialized/kiro"}}
+	snapshot := domain.DirectorySnapshot{SnapshotSchemaVersion: 1, Sequence: 17, SourceCommit: strings.Repeat("b", 40), Products: []domain.DirectoryProduct{{SchemaVersion: 1, ID: "context7", ManifestName: "context7", Aliases: []string{"context7", "context7-alias"}, DefaultDistribution: "upstash/context7", Distributions: []string{"upstash/context7"}}}, Distributions: []domain.DirectoryDistribution{{SchemaVersion: 1, ID: "upstash/context7", ProductID: "context7", Kind: domain.DistributionUpstream, Status: domain.DistributionActive, Releases: []domain.DirectoryRelease{release}, ReleasePolicies: []domain.DirectoryReleasePolicy{policy}}}, Evidence: []domain.DirectoryEvidence{intendedTrustedDirectoryEvidence(domain.DirectoryEvidence{ID: "materialized/kiro", DistributionID: "upstash/context7", ReleaseSequence: 1, PackageTreeDigest: release.TreeDigest, Level: "materialization", Outcome: "passed", Client: domain.ClientKiro})}}
+	directory := &fixedDirectoryClient{bundle: directoryv1.VerifiedBundle{Snapshot: snapshot, Digest: "sha256:" + strings.Repeat("c", 64)}}
+	acquirer := &localBackedSourceAcquirer{delegate: f.app.SourceAcquirer, root: root}
+	f.app.DirectoryClient, f.app.SourceAcquirer = directory, acquirer
+	return f, directory, acquirer
+}
+
+func TestContext7GuidedMissingRegistrationAndResume(t *testing.T) {
+	f, directory, acquirer := context7GuidedFixture(t)
+	out, _, err := f.execute(false, "add", "context7", "--target", "kiro,chatgpt", "--prepare", "--format", "json")
+	if err == nil {
+		t.Fatal("missing registration must require action")
+	}
+	var response struct {
+		Data map[string]any `json:"data"`
+	}
+	if json.Unmarshal([]byte(out), &response) != nil || response.Data["status"] != "action_required" || response.Data["mcp_url"] != domain.Context7OAuthURL || response.Data["remote_verified"] != false {
+		t.Fatalf("action response %s: %v", out, err)
+	}
+	state, _ := f.store.Load()
+	if len(state.Installations) != 0 {
+		t.Fatal("missing registration mutated state")
+	}
+	if acquirer.verifiedCalls != 1 || acquirer.directGitCalls != 0 || acquirer.localCalls != 0 {
+		t.Fatalf("acquisition %#v", acquirer)
+	}
+	before, _ := json.Marshal(directory.bundle)
+	out, _, err = f.execute(false, "add", "context7", "--target", "kiro,chatgpt", "--prepare", "--chatgpt-app-id", fixturePersonalAppID, "--format", "json")
+	if err != nil {
+		t.Fatalf("resume: %s %v", out, err)
+	}
+	after, _ := json.Marshal(directory.bundle)
+	if string(before) != string(after) {
+		t.Fatal("mutated signed Directory")
+	}
+	if acquirer.verifiedCalls != 2 {
+		t.Fatal("mixed preparation did not acquire exactly once")
+	}
+	state, err = f.store.Load()
+	if err != nil || len(state.Installations) != 1 {
+		t.Fatalf("state %+v %v", state, err)
+	}
+	i := state.Installations[0]
+	if i.LocalChatGPTMapping == nil || i.LocalChatGPTMapping.AppID != fixturePersonalAppID || len(i.Clients) != 2 {
+		t.Fatalf("receipt %+v", i)
+	}
+	for _, b := range i.Clients {
+		if b.InstallIntent != domain.InstallIntentPrepare || b.Activation != domain.ActivationPrepared || b.Verification != domain.VerificationPackageValid {
+			t.Fatalf("false completion %+v", b)
+		}
+		if b.PackageRevision != nil && b.PackageRevision.CatalogEvidence != nil {
+			if _, ok := b.PackageRevision.CatalogEvidence.Compatibility["chatgpt"]; ok {
+				t.Fatal("invented signed ChatGPT compatibility")
+			}
+		}
+		if b.ClientID == "chatgpt" {
+			raw, err := os.ReadFile(filepath.Join(b.TargetLocator, ".app.json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(raw) != `{"apps":{"context7":{"id":"`+fixturePersonalAppID+`"}}}` {
+				t.Fatalf("projection %s", raw)
+			}
+			info, _ := os.Stat(filepath.Join(b.TargetLocator, ".app.json"))
+			if info.Mode().Perm() != 0600 {
+				t.Fatalf("app mode %v", info.Mode())
+			}
+			m := readCLIObject(t, filepath.Join(b.TargetLocator, ".codex-plugin", "plugin.json"))
+			mcp := readCLIObject(t, filepath.Join(b.TargetLocator, ".mcp.json"))
+			servers := mcp["mcpServers"].(map[string]any)
+			if len(servers) != 1 || servers["context7"].(map[string]any)["url"] != domain.Context7OAuthURL {
+				t.Fatalf("OAuth endpoint changed: %+v", mcp)
+			}
+			marketplace := readCLIObject(t, filepath.Join(b.TargetLocator, ".agents", "plugins", "marketplace.json"))
+			plugins := marketplace["plugins"].([]any)
+			if len(plugins) != 1 || plugins[0].(map[string]any)["name"] != "context7" {
+				t.Fatalf("personal marketplace %+v", marketplace)
+			}
+			if m["apps"] != "./.app.json" {
+				t.Fatalf("manifest %+v", m)
+			}
+		}
+	}
+	if _, err := os.Stat(filepath.Join(acquirer.root, ".app.json")); !os.IsNotExist(err) {
+		t.Fatal("source package was modified")
+	}
+	info, _ := os.Stat(f.store.Path)
+	if info.Mode().Perm() != 0600 {
+		t.Fatal("personal receipt is not private")
+	}
+}
+
+func TestContext7GuidedLifecycleRetainsReceipt(t *testing.T) {
+	for _, purge := range []bool{false, true} {
+		t.Run(map[bool]string{false: "retain-data", true: "purge-data"}[purge], func(t *testing.T) {
+			f, _, _ := context7GuidedFixture(t)
+			run := func(args ...string) {
+				t.Helper()
+				out, _, err := f.execute(false, args...)
+				if err != nil {
+					t.Fatalf("%v: %s %v", args, out, err)
+				}
+			}
+			run("add", "context7", "--target", "chatgpt", "--prepare", "--chatgpt-app-id", fixturePersonalAppID)
+			run("add", "context7-alias", "--target", "chatgpt")
+			run("update", "context7", "--target", "chatgpt")
+			run("repair", "context7", "--target", "chatgpt")
+			run("add", "context7", "--target", "chatgpt", "--activation-complete", "--auth-complete")
+			state, err := f.store.Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			b := onlyCLIClient(state.Installations[0])
+			if b.Verification != domain.VerificationPackageValid || b.Authentication != domain.AuthenticationPending {
+				t.Fatalf("fabricated remote completion %+v", b)
+			}
+			if err := os.RemoveAll(b.TargetLocator); err != nil {
+				t.Fatal(err)
+			}
+			run("repair", "context7", "--target", "chatgpt")
+			args := []string{"remove", "context7", "--target", "chatgpt", "--external-uninstalled"}
+			if purge {
+				args = append(args, "--purge-data")
+			}
+			run(args...)
+			state, err = f.store.Load()
+			if err != nil || len(state.Installations) != 1 || state.Installations[0].LocalChatGPTMapping == nil {
+				t.Fatalf("receipt lost: %+v %v", state, err)
+			}
+			run("add", "context7", "--target", "chatgpt")
+		})
+	}
+}
+
+func TestContext7GuidedRejectsInvalidIDsAndUnverifiedSource(t *testing.T) {
+	for _, id := range []string{"connector_old", "asdk_app_old", "plugin_asdk_app_", "plugin_asdk_app_short", "plugin_asdk_app_bad/id", " plugin_asdk_app_abc"} {
+		t.Run(id, func(t *testing.T) {
+			f, _, a := context7GuidedFixture(t)
+			_, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--prepare", "--chatgpt-app-id", id)
+			if err == nil || a.verifiedCalls != 0 {
+				t.Fatalf("invalid ID reached acquisition: %v", err)
+			}
+		})
+	}
+	for _, kind := range []string{"tree", "manifest", "endpoint", "identity", "mixed-peer"} {
+		t.Run(kind, func(t *testing.T) {
+			f, d, a := context7GuidedFixture(t)
+			switch kind {
+			case "tree":
+				d.bundle.Snapshot.Distributions[0].Releases[0].TreeDigest = "sha256:" + strings.Repeat("d", 64)
+			case "manifest":
+				d.bundle.Snapshot.Distributions[0].Releases[0].ManifestDigest = "sha256:" + strings.Repeat("d", 64)
+			case "endpoint":
+				raw, _ := os.ReadFile(filepath.Join(a.root, "mcp.json"))
+				os.WriteFile(filepath.Join(a.root, "mcp.json"), []byte(strings.ReplaceAll(string(raw), domain.Context7OAuthURL, "https://mcp.context7.com/mcp")), 0600)
+			case "identity":
+				d.bundle.Snapshot.Distributions[0].Releases[0].PackageSource.Repository = "other/context7"
+			case "mixed-peer":
+				d.bundle.Snapshot.Distributions[0].ReleasePolicies[0].Targets[0].Scopes = []domain.InstallScope{domain.ScopeProject}
+			}
+			_, _, err := f.execute(false, "add", "context7", "--target", "kiro,chatgpt", "--prepare", "--chatgpt-app-id", fixturePersonalAppID)
+			if err == nil {
+				t.Fatal("accepted invalid source")
+			}
+			state, _ := f.store.Load()
+			if len(state.Installations) != 0 {
+				t.Fatal("mutated")
+			}
+		})
+	}
+}
+
+func TestContext7GuidedReceiptRejectsChangedRegistrationAndSignedEndpoint(t *testing.T) {
+	f, d, a := context7GuidedFixture(t)
+	if out, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--prepare", "--chatgpt-app-id", fixturePersonalAppID); err != nil {
+		t.Fatalf("%s %v", out, err)
+	}
+	before, _ := os.ReadFile(f.store.Path)
+	_, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--prepare", "--chatgpt-app-id", "plugin_asdk_app_ffffffffffffffffffffffffffffffff")
+	if err == nil || !strings.Contains(err.Error(), "conflicts with retained") {
+		t.Fatalf("replaced receipt: %v", err)
+	}
+	raw, _ := os.ReadFile(filepath.Join(a.root, "mcp.json"))
+	if err := os.WriteFile(filepath.Join(a.root, "mcp.json"), []byte(strings.ReplaceAll(string(raw), domain.Context7OAuthURL, "https://mcp.context7.com/mcp")), 0600); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := f.app.acquireLocal(context.Background(), a.root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer loaded.cleanup()
+	// A newly signed release can change bytes, but cannot silently rebind a
+	// personal registration to a different endpoint, even with valid digests.
+	dist := &d.bundle.Snapshot.Distributions[0]
+	release := dist.Releases[0]
+	release.Sequence = 2
+	release.PackageSource.Revision = strings.Repeat("d", 40)
+	release.TreeDigest = loaded.envelope.TreeDigest
+	release.ManifestDigest = loaded.envelope.ManifestDigest
+	policy := dist.ReleasePolicies[0]
+	policy.ReleaseSequence = 2
+	policy.CurrentEvidence = []string{"materialized/kiro/2"}
+	dist.Releases = append(dist.Releases, release)
+	dist.ReleasePolicies = append(dist.ReleasePolicies, policy)
+	d.bundle.Snapshot.Evidence = append(d.bundle.Snapshot.Evidence, intendedTrustedDirectoryEvidence(domain.DirectoryEvidence{ID: policy.CurrentEvidence[0], DistributionID: dist.ID, ReleaseSequence: 2, PackageTreeDigest: release.TreeDigest, Level: "materialization", Outcome: "passed", Client: domain.ClientKiro}))
+	_, _, err = f.execute(false, "update", "context7", "--target", "chatgpt")
+	if err == nil || !strings.Contains(err.Error(), "OAuth server") {
+		t.Fatalf("rebound endpoint: %v", err)
+	}
+	after, _ := os.ReadFile(f.store.Path)
+	if string(before) != string(after) {
+		t.Fatal("failed update changed receipt/state")
+	}
+}
+
+func TestContext7GuidedForeignFilesAndCancellation(t *testing.T) {
+	f, _, _ := context7GuidedFixture(t)
+	foreign := filepath.Join(f.app.UserHome, ".agents", "plugins", "marketplace.json")
+	if err := os.MkdirAll(filepath.Dir(foreign), 0700); err != nil {
+		t.Fatal(err)
+	}
+	content := []byte(`{"name":"foreign-authoring","plugins":[]}`)
+	if err := os.WriteFile(foreign, content, 0600); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	command := NewRoot(f.app)
+	command.SetArgs([]string{"add", "context7", "--target", "chatgpt", "--prepare", "--chatgpt-app-id", fixturePersonalAppID})
+	if err := command.ExecuteContext(ctx); err == nil {
+		t.Fatal("cancelled command completed")
+	}
+	state, err := f.store.Load()
+	if err != nil || len(state.Installations) != 0 {
+		t.Fatalf("cancel mutated state %+v %v", state, err)
+	}
+	for _, args := range [][]string{
+		{"add", "context7", "--target", "chatgpt", "--prepare", "--chatgpt-app-id", fixturePersonalAppID},
+		{"remove", "context7", "--target", "chatgpt", "--external-uninstalled", "--purge-data"},
+	} {
+		if out, _, err := f.execute(false, args...); err != nil {
+			t.Fatalf("%v: %s %v", args, out, err)
+		}
+	}
+	actual, err := os.ReadFile(foreign)
+	if err != nil || string(actual) != string(content) {
+		t.Fatalf("foreign authoring changed %s %v", actual, err)
+	}
+}
+
+func TestContext7GuidedMixedUpdateUsesOneNewImmutableRelease(t *testing.T) {
+	f, d, a := context7GuidedFixture(t)
+	if out, _, err := f.execute(false, "add", "context7", "--target", "kiro,chatgpt", "--prepare", "--chatgpt-app-id", fixturePersonalAppID); err != nil {
+		t.Fatalf("%s %v", out, err)
+	}
+	raw, err := os.ReadFile(filepath.Join(a.root, "plugin.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(a.root, "plugin.json"), []byte(strings.ReplaceAll(string(raw), "1.0.0\"", "2.0.0\"")), 0600); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := f.app.acquireLocal(context.Background(), a.root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer loaded.cleanup()
+	dist := &d.bundle.Snapshot.Distributions[0]
+	release := dist.Releases[0]
+	release.Sequence = 2
+	release.PackageVersion = "2.0.0"
+	release.PackageSource.Revision = strings.Repeat("d", 40)
+	release.TreeDigest = loaded.envelope.TreeDigest
+	release.ManifestDigest = loaded.envelope.ManifestDigest
+	policy := dist.ReleasePolicies[0]
+	policy.ReleaseSequence = 2
+	policy.CurrentEvidence = []string{"materialized/kiro/2"}
+	dist.Releases = append(dist.Releases, release)
+	dist.ReleasePolicies = append(dist.ReleasePolicies, policy)
+	d.bundle.Snapshot.Evidence = append(d.bundle.Snapshot.Evidence, intendedTrustedDirectoryEvidence(domain.DirectoryEvidence{ID: policy.CurrentEvidence[0], DistributionID: dist.ID, ReleaseSequence: 2, PackageTreeDigest: release.TreeDigest, Level: "materialization", Outcome: "passed", Client: domain.ClientKiro}))
+	beforeCalls := a.verifiedCalls
+	if out, _, err := f.execute(false, "update", "context7", "--target", "kiro,chatgpt"); err != nil {
+		t.Fatalf("%s %v", out, err)
+	}
+	state, err := f.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	i := state.Installations[0]
+	if a.verifiedCalls != beforeCalls+1 || i.Directory.DesiredReleaseSequence != 2 || i.LocalChatGPTMapping == nil || i.LocalChatGPTMapping.AppID != fixturePersonalAppID {
+		t.Fatalf("mixed update receipt %+v calls %d", i, a.verifiedCalls)
+	}
+	for _, b := range i.Clients {
+		if b.PackageRevision == nil || b.PackageRevision.TreeDigest != release.TreeDigest || b.PackageRevision.ResolvedRevision != release.PackageSource.Revision || b.InstallIntent != domain.InstallIntentPrepare || b.Activation != domain.ActivationPrepared {
+			t.Fatalf("mixed update not same revision: %+v", b)
+		}
+	}
+}
+
+func TestContext7GuidedDoesNotBypassSignatureOrScope(t *testing.T) {
+	f, d, a := context7GuidedFixture(t)
+	d.err = fmt.Errorf("signed Directory signature verification failed")
+	out, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--prepare", "--format", "json")
+	if err == nil || a.verifiedCalls != 0 || strings.Contains(out, "action_required") {
+		t.Fatalf("signature failure hidden: %s %v", out, err)
+	}
+	for _, args := range [][]string{
+		{"add", a.root, "--target", "chatgpt", "--prepare"},
+		{"add", "context7", "--target", "chatgpt", "--prepare", "--scope", "project"},
+		{"add", "context7", "--target", "chatgpt", "--chatgpt-app-id", fixturePersonalAppID},
+	} {
+		if _, _, err := f.execute(false, args...); err == nil {
+			t.Fatalf("accepted invalid preparation request %v", args)
+		}
+	}
+}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_prepare_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_prepare_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -105,7 +106,7 @@ func TestContext7GuidedMissingRegistrationAndResume(t *testing.T) {
 				t.Fatalf("projection %s", raw)
 			}
 			info, _ := os.Stat(filepath.Join(b.TargetLocator, ".app.json"))
-			if info.Mode().Perm() != 0600 {
+			if runtime.GOOS != "windows" && info.Mode().Perm() != 0600 {
 				t.Fatalf("app mode %v", info.Mode())
 			}
 			m := readCLIObject(t, filepath.Join(b.TargetLocator, ".codex-plugin", "plugin.json"))
@@ -128,7 +129,7 @@ func TestContext7GuidedMissingRegistrationAndResume(t *testing.T) {
 		t.Fatal("source package was modified")
 	}
 	info, _ := os.Stat(f.store.Path)
-	if info.Mode().Perm() != 0600 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0600 {
 		t.Fatal("personal receipt is not private")
 	}
 }

--- a/cli/plugin-kit-ai/internal/agentpluginscli/interactive_targets.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/interactive_targets.go
@@ -84,6 +84,21 @@ func skippedTargets(clients []domain.DetectedClient, reason string) []targetSkip
 func (app App) compatibleDetectedTargets(ctx context.Context, source string, detected []domain.DetectedClient, intents ...map[domain.ClientID]domain.InstallIntent) ([]domain.DetectedClient, []targetSkip, *loadedPackage, error) {
 	candidates := detected
 	var skipped []targetSkip
+	// The registration resume command applies --prepare to the entire selection.
+	// Keep its target grammar and the menu aligned, even for eligible peers.
+	if app.chatGPTPreparation || (len(intents) > 0 && intents[0][domain.ClientChatGPT] == domain.InstallIntentPrepare) {
+		var allowed []domain.DetectedClient
+		for _, client := range detected {
+			if client.ClientID == domain.ClientKiro || client.ClientID == domain.ClientChatGPT {
+				allowed = append(allowed, client)
+			} else {
+				skipped = append(skipped, targetSkip{client.ClientID, "--prepare supports only Kiro and ChatGPT; install this client separately without --prepare"})
+			}
+		}
+		detected = allowed
+		candidates = allowed
+	}
+
 	switch {
 	case strings.HasPrefix(source, "discovery:"):
 		compatible, err := app.compatibleDiscoveryTargets(ctx, source, detected)
@@ -97,7 +112,7 @@ func (app App) compatibleDetectedTargets(ctx context.Context, source string, det
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		skipped = skippedTargets(subtractDetectedClients(detected, compatible), "the catalog has no compatible release for this combination of clients and system; check this client separately with --target")
+		skipped = append(skipped, skippedTargets(subtractDetectedClients(detected, compatible), "the catalog has no compatible release for this combination of clients and system; check this client separately with --target")...)
 		candidates = compatible
 		if len(candidates) == 0 {
 			return nil, skipped, nil, nil
@@ -192,7 +207,7 @@ func (app App) compatibleDirectoryTargets(ctx context.Context, selector string, 
 			preparing := false
 			// Ordinary eligibility wins unless preparation was requested. Only
 			// the bounded Context7 purpose can offer an additional choice.
-			if (resolveErr != nil || app.chatGPTPreparation) && len(intents) > 0 && intents[0] != nil {
+			if len(intents) > 0 && intents[0][domain.ClientChatGPT] == domain.InstallIntentPrepare {
 				hasChatGPT := false
 				var peers []domain.ClientID
 				for _, target := range targets {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/interactive_targets.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/interactive_targets.go
@@ -93,7 +93,7 @@ func (app App) compatibleDetectedTargets(ctx context.Context, source string, det
 		skipped = skippedTargets(subtractDetectedClients(detected, compatible), "not listed as compatible in the signed Discovery record; inspect this client separately with --target")
 		return compatible, skipped, nil, nil
 	case isDirectorySelector(source):
-		compatible, err := app.compatibleDirectoryTargets(ctx, source, detected)
+		compatible, err := app.compatibleDirectoryTargets(ctx, source, detected, intents...)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -102,6 +102,9 @@ func (app App) compatibleDetectedTargets(ctx context.Context, source string, det
 		if len(candidates) == 0 {
 			return nil, skipped, nil, nil
 		}
+	}
+	if len(intents) > 0 && intents[0][domain.ClientChatGPT] == domain.InstallIntentPrepare {
+		app.chatGPTPreparation = true
 	}
 	request := app.addResolutionRequest(source, nil)
 	if isDirectorySelector(source) {
@@ -141,7 +144,7 @@ func (app App) compatibleDiscoveryTargets(ctx context.Context, selector string, 
 	return compatible, nil
 }
 
-func (app App) compatibleDirectoryTargets(ctx context.Context, selector string, detected []domain.DetectedClient) ([]domain.DetectedClient, error) {
+func (app App) compatibleDirectoryTargets(ctx context.Context, selector string, detected []domain.DetectedClient, intents ...map[domain.ClientID]domain.InstallIntent) ([]domain.DetectedClient, error) {
 	if app.DirectoryClient == nil || app.StateStore == nil {
 		return nil, fmt.Errorf("signed Directory dependencies are unavailable; use a direct local or exact full-SHA source")
 	}
@@ -170,7 +173,7 @@ func (app App) compatibleDirectoryTargets(ctx context.Context, selector string, 
 	}
 
 	// At most ten clients are supported, so enumerating subsets is bounded to
-	// 1,023 pure resolver calls. This preserves one signed distribution/release
+	// 1,023 subsets, each with bounded pure resolver checks. This preserves one signed distribution/release
 	// for the complete set instead of combining incompatible per-client picks.
 	for size := len(detected); size >= 1; size-- {
 		var match []domain.DetectedClient
@@ -179,13 +182,55 @@ func (app App) compatibleDirectoryTargets(ctx context.Context, selector string, 
 			for index, client := range candidate {
 				targets[index] = client.ClientID
 			}
-			_, resolveErr := domain.ResolveDirectory(bundle.Snapshot, domain.DirectoryResolveRequest{
+			resolveRequest := domain.DirectoryResolveRequest{
 				Selector: resolveSelector, Targets: targets, Scope: domain.ScopeUser,
 				InstallerVersion: app.Version, ClientVersions: environment.ClientVersions,
 				OS: runtime.GOOS, Architecture: runtime.GOARCH, DependencyIdentity: environment.DependencyIdentity,
 				SchemaVersion: "1.0.0", Operation: operation, Recorded: request.Recorded,
-			})
+			}
+			_, resolveErr := domain.ResolveDirectory(bundle.Snapshot, resolveRequest)
+			preparing := false
+			// Ordinary eligibility wins unless preparation was requested. Only
+			// the bounded Context7 purpose can offer an additional choice.
+			if (resolveErr != nil || app.chatGPTPreparation) && len(intents) > 0 && intents[0] != nil {
+				hasChatGPT := false
+				var peers []domain.ClientID
+				for _, target := range targets {
+					if target == domain.ClientChatGPT {
+						hasChatGPT = true
+					} else {
+						peers = append(peers, target)
+					}
+				}
+				if hasChatGPT {
+					preparation := resolveRequest
+					preparation.Targets = []domain.ClientID{domain.ClientChatGPT}
+					preparation.Purpose = domain.DirectoryResolveContext7ChatGPTPreparation
+					selection, prepErr := domain.ResolveDirectory(bundle.Snapshot, preparation)
+					if prepErr == nil && len(peers) > 0 {
+						peerRequest := resolveRequest
+						peerRequest.Targets = peers
+						peerRequest.Selector = selection.DistributionID
+						peerRequest.Operation = domain.DirectoryNewTarget
+						peerRequest.Recorded = &domain.RecordedDirectoryRelease{
+							ProductID: selection.ProductID, DistributionID: selection.DistributionID, ReleaseSequence: selection.ReleaseSequence,
+							Repository: selection.Source.Repository, ResolvedRevision: selection.Source.Revision, Path: selection.Source.Path,
+							TreeDigestAlgorithm: selection.TreeDigestAlgorithm, TreeDigest: selection.TreeDigest, ManifestDigest: selection.ManifestDigest,
+						}
+						peer, err := domain.ResolveDirectory(bundle.Snapshot, peerRequest)
+						prepErr = err
+						if err == nil && (peer.DistributionID != selection.DistributionID || peer.ReleaseSequence != selection.ReleaseSequence || peer.TreeDigest != selection.TreeDigest) {
+							prepErr = fmt.Errorf("preparation peers require the same immutable release")
+						}
+					}
+					resolveErr = prepErr
+					preparing = prepErr == nil
+				}
+			}
 			if resolveErr == nil {
+				if preparing {
+					intents[0][domain.ClientChatGPT] = domain.InstallIntentPrepare
+				}
 				match = append([]domain.DetectedClient(nil), candidate...)
 				return false
 			}
@@ -247,6 +292,13 @@ func (app App) compatibleLoadedTargets(ctx context.Context, loaded loadedPackage
 	compatible := make([]domain.DetectedClient, 0, len(detected))
 	for _, client := range detected {
 		candidate := cloneLoadedPackage(loaded)
+		if client.ClientID == domain.ClientChatGPT && loaded.chatGPTPreparation && loaded.localChatGPTMapping == nil {
+			// Acquisition already verified source policy, immutable bytes and
+			// endpoint. Registration is the next step, before any mutation.
+			client.DisplayName += " (prepare personal marketplace; register in ChatGPT, then install and verify tools)"
+			compatible = append(compatible, client)
+			continue
+		}
 		if err := prepareLoadedPackageForClient(&candidate, client.ClientID); err != nil {
 			skipped = append(skipped, targetSkip{client.ClientID, "package binding preparation failed; ask the package publisher to check its client mapping"})
 			continue
@@ -270,7 +322,11 @@ func (app App) compatibleLoadedTargets(ctx context.Context, loaded loadedPackage
 				skipped = append(skipped, targetSkip{client.ClientID, "persisted preparation cannot serve this package"})
 				continue
 			}
-			client.DisplayName += " (prepare configuration; authenticate and verify tools in Kiro)"
+			if client.ClientID == domain.ClientChatGPT {
+				client.DisplayName += " (prepare personal marketplace; install and verify tools in ChatGPT)"
+			} else {
+				client.DisplayName += " (prepare configuration; authenticate and verify tools in Kiro)"
+			}
 		}
 		if preflighter, ok := app.Lifecycle.Activator.(interface {
 			PreflightActivation(domain.ActivationRequest) error

--- a/cli/plugin-kit-ai/internal/agentpluginscli/kiro_prepare_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/kiro_prepare_test.go
@@ -64,7 +64,7 @@ func TestKiroPrepareCLIPlainAndJSON(t *testing.T) {
 }
 
 func TestPrepareRejectsInvalidTargetsBeforeAcquisition(t *testing.T) {
-	for _, target := range []string{"cursor", "kiro,cursor", "chatgpt", ""} {
+	for _, target := range []string{"cursor", "kiro,cursor", ""} {
 		t.Run(target, func(t *testing.T) {
 			fixture := newCLIFixture(t, nil)
 			_, _, err := fixture.execute(false, "add", "context7", "--target", target, "--prepare")

--- a/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/lifecycle.go
@@ -180,6 +180,13 @@ func renderRepairResult(writer io.Writer, format string, installation domain.Ins
 	if err := renderOpenCodeRuntimeNotice(writer, result); err != nil {
 		return err
 	}
+	if !dryRun {
+		if action := localTargetLifecycleAction(result, ""); action != "" {
+			if _, err := fmt.Fprintf(writer, "Next: %s\n", action); err != nil {
+				return err
+			}
+		}
+	}
 	if result.NoChange {
 		_, err := fmt.Fprintln(writer, "Managed package digest is valid. No repair was needed.")
 		return err
@@ -776,6 +783,11 @@ func renderUpdateResult(writer io.Writer, format string, envelope domain.Package
 		return err
 	}
 	if result.NoChange {
+		if action := localTargetLifecycleAction(result, ""); action != "" {
+			if _, err := fmt.Fprintf(writer, "Next: %s\n", action); err != nil {
+				return err
+			}
+		}
 		_, _ = fmt.Fprintln(writer, "Already up to date. No changes made.")
 		return nil
 	}
@@ -800,7 +812,7 @@ func renderUpdateResult(writer io.Writer, format string, envelope domain.Package
 			_, _ = fmt.Fprintln(writer, "Package updated. Activation is not complete yet.")
 		}
 	}
-	if action := nextLifecycleAction(result); action != "" && !fullyInstalled(result.Activation) {
+	if action := nextLocalLifecycleAction(result); action != "" && !fullyInstalled(result.Activation) {
 		_, _ = fmt.Fprintf(writer, "Next: %s\n", action)
 	}
 	return nil

--- a/cli/plugin-kit-ai/internal/agentpluginscli/prepare.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/prepare.go
@@ -97,6 +97,7 @@ func preflightAddTargets(ctx context.Context, app App, opts *options, source str
 	if err != nil {
 		return nil, nil, err
 	}
+	opts.installIntents = intents
 	return preflightSelectedTargets(ctx, app, targets, clients, !opts.dryRun && isDirectorySelector(source), intents)
 }
 

--- a/cli/plugin-kit-ai/internal/agentpluginscli/repair_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/repair_multi.go
@@ -215,7 +215,7 @@ func renderRepairMultiResult(cmd *cobra.Command, opts *options, result repairMul
 			return err
 		}
 		if target.NextAction != "" {
-			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "    Next: %s\n", target.NextAction); err != nil {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "    Next: %s\n", localTargetLifecycleAction(target.Output.Result, target.NextAction)); err != nil {
 				return err
 			}
 		}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/source.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/source.go
@@ -34,6 +34,8 @@ type loadedPackage struct {
 	directory             *domain.DirectoryOrigin
 	distributionSuspended bool
 	releaseRevoked        bool
+	localChatGPTMapping   *domain.ChatGPTLocalMapping
+	chatGPTPreparation    bool
 	directorySelection    *domain.DirectorySelection
 	cleanup               func() error
 }
@@ -487,6 +489,20 @@ func (app App) acquireDirectory(ctx context.Context, selector string, request pa
 		DependencyIdentity: environment.DependencyIdentity,
 		SchemaVersion:      "1.0.0", Operation: operation, Recorded: request.Recorded,
 	}
+	preparingChatGPT := false
+	var retainedMapping *domain.ChatGPTLocalMapping
+	installation, _ := locallyMatchedInstallation(state, resolveSelector)
+	intents := lifecycleInstallIntents(installation, "user", nil)
+	for _, target := range affectedTargets {
+		if target == domain.ClientChatGPT && (app.chatGPTPreparation || intents[target] == domain.InstallIntentPrepare) {
+			preparingChatGPT = true
+		}
+	}
+	if preparingChatGPT {
+		resolveRequest.Purpose = domain.DirectoryResolveContext7ChatGPTPreparation
+		resolveRequest.Targets = []domain.ClientID{domain.ClientChatGPT}
+		retainedMapping = installation.LocalChatGPTMapping
+	}
 	selection, err := domain.ResolveDirectory(bundle.Snapshot, resolveRequest)
 	if err != nil {
 		return loadedPackage{}, err
@@ -541,6 +557,51 @@ func (app App) acquireDirectory(ctx context.Context, selector string, request pa
 			return loadedPackage{}, fmt.Errorf("acquired exact Directory release failed compatibility recheck: %w", err)
 		}
 		return loadedPackage{}, fmt.Errorf("acquired exact Directory release changed during compatibility recheck")
+	}
+	// The preparation resolver intentionally accepts exactly ChatGPT. Compose
+	// mixed requests by checking peers against its exact immutable selection with
+	// normal signed eligibility; never acquire another target's substitute package.
+	if preparingChatGPT {
+		var peers []domain.ClientID
+		for _, target := range affectedTargets {
+			if target != domain.ClientChatGPT {
+				peers = append(peers, target)
+			}
+		}
+		if len(peers) > 0 {
+			peerRequest := exactRequest
+			peerRequest.Purpose = ""
+			peerRequest.Targets = peers
+			peer, peerErr := domain.ResolveDirectory(bundle.Snapshot, peerRequest)
+			if peerErr != nil || peer.DistributionID != selection.DistributionID || peer.ReleaseSequence != selection.ReleaseSequence || peer.TreeDigest != selection.TreeDigest {
+				_ = loaded.cleanup()
+				return loadedPackage{}, fmt.Errorf("mixed preparation peers must qualify the same immutable Context7 release: %v", peerErr)
+			}
+		}
+		if err := domain.ValidateContext7PreparationPackage(loaded.envelope); err != nil {
+			_ = loaded.cleanup()
+			return loadedPackage{}, err
+		}
+		if loaded.envelope.App.Present || loaded.envelope.App.Declared {
+			_ = loaded.cleanup()
+			return loadedPackage{}, fmt.Errorf("refuse personal registration for a publisher-mapped package")
+		}
+		loaded.chatGPTPreparation = true
+		loaded.localChatGPTMapping = retainedMapping
+		if app.chatGPTAppID != "" {
+			mapping := domain.ChatGPTLocalMapping{ProductID: "context7", Repository: "upstash/context7", PackagePath: "plugins/agent-plugins/context7", Server: "context7", URL: domain.Context7OAuthURL, AppID: app.chatGPTAppID}
+			if retainedMapping != nil && *retainedMapping != mapping {
+				_ = loaded.cleanup()
+				return loadedPackage{}, fmt.Errorf("explicit ChatGPT ID conflicts with retained personal registration receipt")
+			}
+			loaded.localChatGPTMapping = &mapping
+		}
+		if loaded.localChatGPTMapping != nil {
+			if err := loaded.localChatGPTMapping.ValidatePackage(loaded.envelope); err != nil {
+				_ = loaded.cleanup()
+				return loadedPackage{}, err
+			}
+		}
 	}
 	loaded.distributionSuspended = distribution.Status == domain.DistributionSuspended
 	loaded.releaseRevoked = policy.Status == domain.ReleaseRevoked || snapshotRevokes(bundle.Snapshot, selection)
@@ -872,6 +933,28 @@ func cloneCatalogCompatibility(source map[string]domain.CatalogCompatibility) ma
 
 func prepareLoadedPackageForClient(loaded *loadedPackage, clientID domain.ClientID) error {
 	if loaded == nil || clientID != domain.ClientChatGPT {
+		return nil
+	}
+	if loaded.chatGPTPreparation {
+		if loaded.localChatGPTMapping == nil {
+			return fmt.Errorf("action_required: %s", domain.ChatGPTRegistrationAction)
+		}
+		mapping := *loaded.localChatGPTMapping
+		if err := mapping.ValidatePackage(loaded.envelope); err != nil {
+			return err
+		}
+		if loaded.envelope.App.Present || loaded.envelope.App.Declared {
+			return fmt.Errorf("refuse to replace publisher app mapping with personal registration")
+		}
+		raw, err := json.Marshal(map[string]any{"apps": map[string]any{mapping.Server: map[string]string{"id": mapping.AppID}}})
+		if err != nil {
+			return err
+		}
+		entryRaw, _ := json.Marshal(map[string]string{"id": mapping.AppID})
+		loaded.envelope.LocalChatGPTMapping = &mapping
+		loaded.envelope.App = domain.AppComponent{Present: true, Declared: true, Enabled: true, Raw: raw, Bindings: map[string]domain.AppBinding{mapping.Server: {Alias: mapping.Server, ID: mapping.AppID, Raw: entryRaw}}}
+		loaded.envelope.Inventory.AppPresent = true
+		loaded.envelope.Inventory.AppBindings = []string{mapping.Server}
 		return nil
 	}
 	compatibility, ok := loaded.hints.Compatibility[string(domain.ClientChatGPT)]

--- a/cli/plugin-kit-ai/internal/agentpluginscli/source_directory_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/source_directory_test.go
@@ -679,6 +679,7 @@ func (acquirer *localBackedSourceAcquirer) AcquireGitHubVerified(ctx context.Con
 		return domain.PackageSnapshot{}, err
 	}
 	if snapshot.TreeDigest != digest {
+		_ = packagedigest.Remove(snapshot)
 		return domain.PackageSnapshot{}, fmt.Errorf("verified tree digest mismatch")
 	}
 	return snapshot, nil

--- a/cli/plugin-kit-ai/internal/agentpluginscli/update_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/update_multi.go
@@ -361,7 +361,7 @@ func renderUpdateMultiResult(cmd *cobra.Command, opts *options, result updateMul
 			return err
 		}
 		if target.NextAction != "" && !fullyInstalled(target.Output.Result.Activation) {
-			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "    Next: %s\n", target.NextAction); err != nil {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "    Next: %s\n", localTargetLifecycleAction(target.Output.Result, target.NextAction)); err != nil {
 				return err
 			}
 		}

--- a/install/integrationctl/agentplugins/adapters/statev2/store.go
+++ b/install/integrationctl/agentplugins/adapters/statev2/store.go
@@ -159,6 +159,14 @@ func Validate(state domain.StateFileV2) error {
 	clientBindingIDs := map[string]struct{}{}
 	operationIDs := map[string]struct{}{}
 	for index, installation := range state.Installations {
+		if mapping := installation.LocalChatGPTMapping; mapping != nil {
+			if err := mapping.Validate(); err != nil {
+				return err
+			}
+			if installation.OriginMode != domain.OriginModeDirectory || installation.Directory == nil || installation.Directory.ProductID != mapping.ProductID || installation.Directory.DistributionID != mapping.Repository || installation.Source.Repository != mapping.Repository || installation.Source.PackageSubpath != mapping.PackagePath {
+				return fmt.Errorf("personal ChatGPT receipt source does not match installation")
+			}
+		}
 		prefix := fmt.Sprintf("installations[%d]", index)
 		if err := pathpolicy.ValidateLeafID(installation.InstallationID); err != nil {
 			return fmt.Errorf("%s has invalid installation_id: %w", prefix, err)

--- a/install/integrationctl/agentplugins/domain/chatgpt_mapping.go
+++ b/install/integrationctl/agentplugins/domain/chatgpt_mapping.go
@@ -8,6 +8,14 @@ import (
 const Context7OAuthURL = "https://mcp.context7.com/mcp/oauth"
 const ChatGPTRegistrationAction = "In ChatGPT Developer Mode, register a remote connection using https://mcp.context7.com/mcp/oauth, complete OAuth, and copy its plugin_asdk_app_ ID. Rerun add context7 --target chatgpt --prepare --chatgpt-app-id <ID>. Then install the prepared plugin from the personal marketplace in ChatGPT desktop and verify its tools in a new chat. Official steps: https://developers.openai.com/plugins/build/plugins. Remote connection and tool calls have not been verified. The personal registration receipt is retained locally after remove, including --purge-data, for reinstall."
 
+// ChatGPTMappedPreparationAction applies only after the personal mapping exists.
+const ChatGPTMappedPreparationAction = "Prepare the personal local marketplace, then install it in ChatGPT desktop and verify OAuth and tools in a new chat. Remote OAuth and tool calls have not been verified. The personal registration receipt is retained locally after remove, including --purge-data, for reinstall."
+
+// ChatGPTPreparedAction names the local artifact after successful preparation.
+func ChatGPTPreparedAction(path, name string) string {
+	return fmt.Sprintf("In ChatGPT desktop, add the personal local marketplace at %s (.agents/plugins/marketplace.json), install %s, and verify the registered OAuth connection and tool calls in a new chat. Remote OAuth and tool calls have not been verified. The registration receipt is retained locally after remove, including --purge-data, for reinstall.", path, name)
+}
+
 // ChatGPTLocalMapping is a personal registration receipt, never catalog evidence.
 // It is retained in private installer state across remove, including purge-data.
 // Reinstallation revalidates its source and endpoint before projecting it.

--- a/install/integrationctl/agentplugins/domain/chatgpt_mapping.go
+++ b/install/integrationctl/agentplugins/domain/chatgpt_mapping.go
@@ -1,0 +1,51 @@
+package domain
+
+import (
+	"fmt"
+	"regexp"
+)
+
+const Context7OAuthURL = "https://mcp.context7.com/mcp/oauth"
+const ChatGPTRegistrationAction = "In ChatGPT Developer Mode, register a remote connection using https://mcp.context7.com/mcp/oauth, complete OAuth, and copy its plugin_asdk_app_ ID. Rerun add context7 --target chatgpt --prepare --chatgpt-app-id <ID>. Then install the prepared plugin from the personal marketplace in ChatGPT desktop and verify its tools in a new chat. Official steps: https://developers.openai.com/plugins/build/plugins. Remote connection and tool calls have not been verified. The personal registration receipt is retained locally after remove, including --purge-data, for reinstall."
+
+// ChatGPTLocalMapping is a personal registration receipt, never catalog evidence.
+// It is retained in private installer state across remove, including purge-data.
+// Reinstallation revalidates its source and endpoint before projecting it.
+type ChatGPTLocalMapping struct {
+	ProductID   string `json:"product_id"`
+	Repository  string `json:"repository"`
+	PackagePath string `json:"package_path"`
+	Server      string `json:"server"`
+	URL         string `json:"url"`
+	AppID       string `json:"app_id"`
+}
+
+var chatGPTAppIDPattern = regexp.MustCompile(`^plugin_asdk_app_[0-9a-f]{32}$`)
+
+func ValidateChatGPTAppID(id string) error {
+	if !chatGPTAppIDPattern.MatchString(id) {
+		return fmt.Errorf("invalid ChatGPT app ID: copy the plugin_asdk_app_ ID from the official registration UI")
+	}
+	return nil
+}
+func (m ChatGPTLocalMapping) Validate() error {
+	if m.ProductID != "context7" || m.Repository != "upstash/context7" || m.PackagePath != "plugins/agent-plugins/context7" || m.Server != "context7" || m.URL != Context7OAuthURL {
+		return fmt.Errorf("personal ChatGPT mapping has a different Context7 identity or OAuth endpoint")
+	}
+	return ValidateChatGPTAppID(m.AppID)
+}
+func (m ChatGPTLocalMapping) ValidatePackage(e PackageEnvelope) error {
+	if err := m.Validate(); err != nil {
+		return err
+	}
+	return ValidateContext7PreparationPackage(e)
+}
+
+func ValidateContext7PreparationPackage(e PackageEnvelope) error {
+	m := ChatGPTLocalMapping{ProductID: "context7", Repository: "upstash/context7", PackagePath: "plugins/agent-plugins/context7", Server: "context7", URL: Context7OAuthURL}
+	server, ok := e.MCP.Servers[m.Server]
+	if e.Manifest.Name != m.ProductID || e.Source.Repository != m.Repository || e.Source.PackageSubpath != m.PackagePath || !e.MCP.Enabled || len(e.MCP.Servers) != 1 || !ok || server.Type != "streamable-http" || server.Decoded["url"] != m.URL {
+		return fmt.Errorf("personal ChatGPT mapping does not match canonical Context7 package and OAuth server")
+	}
+	return nil
+}

--- a/install/integrationctl/agentplugins/domain/chatgpt_mapping_test.go
+++ b/install/integrationctl/agentplugins/domain/chatgpt_mapping_test.go
@@ -1,0 +1,32 @@
+package domain
+
+import "testing"
+
+func TestPersonalChatGPTMappingIsBoundToCanonicalIdentityAndOAuthServer(t *testing.T) {
+	mapping := ChatGPTLocalMapping{ProductID: "context7", Repository: "upstash/context7", PackagePath: "plugins/agent-plugins/context7", Server: "context7", URL: Context7OAuthURL, AppID: "plugin_asdk_app_0123456789abcdef0123456789abcdef"}
+	envelope := PackageEnvelope{Manifest: PluginManifest{Name: "context7"}, Source: SourceIdentity{Repository: mapping.Repository, PackageSubpath: mapping.PackagePath}, MCP: MCPComponent{Enabled: true, Servers: map[string]MCPServer{"context7": {Type: "streamable-http", Decoded: map[string]any{"url": Context7OAuthURL}}}}}
+	if err := mapping.ValidatePackage(envelope); err != nil {
+		t.Fatal(err)
+	}
+	for _, change := range []func(*PackageEnvelope){
+		func(e *PackageEnvelope) { e.Manifest.Name = "other" },
+		func(e *PackageEnvelope) { e.Source.Repository = "other/context7" },
+		func(e *PackageEnvelope) { e.Source.PackageSubpath = "other" },
+		func(e *PackageEnvelope) { e.MCP.Enabled = false },
+		func(e *PackageEnvelope) {
+			e.MCP.Servers = map[string]MCPServer{"context7": {Type: "streamable-http", Decoded: map[string]any{"url": "https://mcp.context7.com/mcp"}}}
+		},
+		func(e *PackageEnvelope) {
+			e.MCP.Servers = map[string]MCPServer{"context7": {Type: "stdio", Decoded: map[string]any{"url": Context7OAuthURL}}}
+		},
+		func(e *PackageEnvelope) {
+			e.MCP.Servers = map[string]MCPServer{"context7": envelope.MCP.Servers["context7"], "other": {Type: "streamable-http"}}
+		},
+	} {
+		altered := envelope
+		change(&altered)
+		if err := mapping.ValidatePackage(altered); err == nil {
+			t.Fatalf("accepted mismatched package %+v", altered)
+		}
+	}
+}

--- a/install/integrationctl/agentplugins/domain/clients.go
+++ b/install/integrationctl/agentplugins/domain/clients.go
@@ -190,6 +190,8 @@ type ComponentDecision struct {
 }
 
 type DeliveryPlan struct {
+	PersonalChatGPTPreparation bool `json:"-"`
+
 	InstallIntent      InstallIntent       `json:"install_intent,omitempty"`
 	ClientID           ClientID            `json:"client_id"`
 	Scope              InstallScope        `json:"scope"`
@@ -207,7 +209,8 @@ type DeliveryPlan struct {
 	DeclaredVersion          string `json:"-"`
 	NativeRegistryRoot       string `json:"-"`
 	NativeRegistryExecutable string `json:"-"`
-	// LocalPreparationAuthorized records signed package evidence that permits
+	// LocalPreparationAuthorized records validated package evidence or an explicit
+	// personal Context7 registration receipt that permits
 	// creation of the local prepared package even when a remote, manually
 	// activated registry cannot be observed. It is never evidence that the
 	// remote identity is free, activated, authenticated, or verified.

--- a/install/integrationctl/agentplugins/domain/directory.go
+++ b/install/integrationctl/agentplugins/domain/directory.go
@@ -278,6 +278,7 @@ type RecordedDirectoryRelease struct {
 }
 
 type DirectoryResolveRequest struct {
+	Purpose            DirectoryResolvePurpose
 	Selector           string
 	Targets            []ClientID
 	Scope              InstallScope
@@ -324,6 +325,9 @@ var (
 // distribution and one release for the complete target set; acquisition
 // failure is intentionally not a fallback input.
 func ResolveDirectory(snapshot DirectorySnapshot, request DirectoryResolveRequest) (DirectorySelection, error) {
+	if err := validateDirectoryResolvePurpose(request); err != nil {
+		return DirectorySelection{}, err
+	}
 	selector := strings.TrimSpace(request.Selector)
 	if selector == "" {
 		return DirectorySelection{}, fmt.Errorf("%w: empty selector", ErrDirectoryNotFound)
@@ -337,6 +341,13 @@ func ResolveDirectory(snapshot DirectorySnapshot, request DirectoryResolveReques
 	product, qualified, err := findDirectoryProduct(snapshot, selector)
 	if err != nil {
 		return DirectorySelection{}, err
+	}
+	if request.Purpose == DirectoryResolveContext7ChatGPTPreparation {
+		if product.ID != "context7" || product.ManifestName != "context7" || (qualified != "" && qualified != "upstash/context7") ||
+			(request.Recorded != nil && request.Recorded.DistributionID != "upstash/context7") {
+			return DirectorySelection{}, fmt.Errorf("%w: Context7 preparation requires the upstream Context7 product", ErrDirectoryIneligible)
+		}
+		qualified = "upstash/context7"
 	}
 	if request.Recorded != nil {
 		if strings.TrimSpace(request.Recorded.ResolvedRevision) == "" {
@@ -492,6 +503,10 @@ func chooseDirectoryRelease(snapshot DirectorySnapshot, product DirectoryProduct
 		if !ok {
 			continue
 		}
+		if request.Purpose == DirectoryResolveContext7ChatGPTPreparation && !isContext7PreparationSource(distribution, *release) {
+			reasons = append(reasons, eligibilityReason{"invalid_preparation_source", "Context7 preparation requires the canonical upstream source"})
+			continue
+		}
 		exactRecorded := request.Recorded != nil && release.Sequence == request.Recorded.ReleaseSequence
 		// Every recorded operation except an explicit update stays on the exact
 		// immutable release. In particular, re-adding a data-retained installation
@@ -554,17 +569,23 @@ func releaseEligibility(snapshot DirectorySnapshot, product DirectoryProduct, di
 			return &eligibilityReason{"blocking_evidence", "current trusted schema evidence failed"}
 		}
 	}
+	if request.Purpose == DirectoryResolveContext7ChatGPTPreparation && !hasContext7PreparationPromotion(snapshot, distribution, release, policy) {
+		return &eligibilityReason{"upstream_materialization_required", "Context7 preparation requires trusted materialization on a declared supported target"}
+	}
 	for _, target := range directoryEligibilityTargets(request.Targets) {
 		entry := targetByClient(policy.Targets, target)
-		if entry == nil || !containsScope(entry.Scopes, request.Scope) {
-			return &eligibilityReason{"incomplete_targets", "release does not support complete target set; missing " + string(target)}
-		}
-		delivery, supported := ExpectedDirectoryDelivery(target)
-		if !supported || entry.Delivery != delivery {
-			return &eligibilityReason{"incompatible_delivery", fmt.Sprintf("release delivery %q is incompatible with %s; expected %q", entry.Delivery, target, delivery)}
-		}
-		if distribution.Kind == DistributionUpstream && !hasPassedUpstreamMaterialization(snapshot, distribution, release, policy, target) {
-			return &eligibilityReason{"upstream_materialization_required", "upstream release lacks current passed materialization evidence for " + string(target)}
+		// Only absence of signed ChatGPT support can use the source-only lane.
+		if !(entry == nil && request.Purpose == DirectoryResolveContext7ChatGPTPreparation) {
+			if entry == nil || !containsScope(entry.Scopes, request.Scope) {
+				return &eligibilityReason{"incomplete_targets", "release does not support complete target set; missing " + string(target)}
+			}
+			delivery, supported := ExpectedDirectoryDelivery(target)
+			if !supported || entry.Delivery != delivery {
+				return &eligibilityReason{"incompatible_delivery", fmt.Sprintf("release delivery %q is incompatible with %s; expected %q", entry.Delivery, target, delivery)}
+			}
+			if distribution.Kind == DistributionUpstream && !hasPassedUpstreamMaterialization(snapshot, distribution, release, policy, target) {
+				return &eligibilityReason{"upstream_materialization_required", "upstream release lacks current passed materialization evidence for " + string(target)}
+			}
 		}
 		for _, evidenceID := range policy.CurrentEvidence {
 			if e := evidenceByID(snapshot, evidenceID); e != nil && e.HasTrustedEligibilityProvenanceAtSequence(snapshot.Sequence) && directoryEvidenceApplies(*e, distribution, release, target, request) && (e.Level == "materialization" || e.Level == "discovery" || e.Level == "runtime" || e.Level == "oauth") && e.Outcome == "failed" {

--- a/install/integrationctl/agentplugins/domain/directory_context7_preparation.go
+++ b/install/integrationctl/agentplugins/domain/directory_context7_preparation.go
@@ -1,0 +1,41 @@
+package domain
+
+import "fmt"
+
+// DirectoryResolvePurpose distinguishes normal target eligibility from the
+// bounded acquisition of source for local preparation. The zero value retains
+// normal resolution; callers must explicitly opt in after validating intent.
+type DirectoryResolvePurpose string
+
+// DirectoryResolveContext7ChatGPTPreparation permits only source acquisition
+// for Context7 ChatGPT user-scope local preparation, pending mapping validation.
+// Its selection is not signed ChatGPT compatibility or installation authority.
+const DirectoryResolveContext7ChatGPTPreparation DirectoryResolvePurpose = "context7_chatgpt_preparation"
+
+func validateDirectoryResolvePurpose(request DirectoryResolveRequest) error {
+	if request.Purpose == "" {
+		return nil
+	}
+	if request.Purpose != DirectoryResolveContext7ChatGPTPreparation || request.Scope != ScopeUser ||
+		len(request.Targets) != 1 || request.Targets[0] != ClientChatGPT {
+		return fmt.Errorf("%w: invalid Context7 ChatGPT user-scope preparation purpose", ErrDirectoryIneligible)
+	}
+	return nil
+}
+
+func isContext7PreparationSource(distribution DirectoryDistribution, release DirectoryRelease) bool {
+	return distribution.ID == "upstash/context7" && distribution.ProductID == "context7" &&
+		distribution.Kind == DistributionUpstream && release.ManifestName == "context7" &&
+		release.PackageSource.Repository == "upstash/context7" && release.PackageSource.Path == "plugins/agent-plugins/context7"
+}
+
+func hasContext7PreparationPromotion(snapshot DirectorySnapshot, distribution DirectoryDistribution, release DirectoryRelease, policy DirectoryReleasePolicy) bool {
+	for _, target := range policy.Targets {
+		delivery, supported := ExpectedDirectoryDelivery(target.Client)
+		if supported && target.Delivery == delivery && (containsScope(target.Scopes, ScopeUser) || containsScope(target.Scopes, ScopeProject)) &&
+			hasPassedUpstreamMaterialization(snapshot, distribution, release, policy, target.Client) {
+			return true
+		}
+	}
+	return false
+}

--- a/install/integrationctl/agentplugins/domain/directory_context7_preparation_test.go
+++ b/install/integrationctl/agentplugins/domain/directory_context7_preparation_test.go
@@ -1,0 +1,260 @@
+package domain
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func context7PreparationFixture() (DirectorySnapshot, DirectoryResolveRequest) {
+	s := testDirectory()
+	d := s.Distributions[2]
+	d.ID, d.ProductID = "upstash/context7", "context7"
+	d.Releases, d.ReleasePolicies = d.Releases[1:], d.ReleasePolicies[1:]
+	r := &d.Releases[0]
+	r.ManifestName = "context7"
+	r.PackageSource.Repository, r.PackageSource.Path = "upstash/context7", "plugins/agent-plugins/context7"
+	p := &s.Products[0]
+	p.ID, p.ManifestName, p.Aliases = "context7", "context7", nil
+	p.DefaultDistribution, p.Distributions = d.ID, []string{d.ID}
+	s.Distributions = []DirectoryDistribution{d}
+	s.Evidence = s.Evidence[1:]
+	s.Evidence[0].DistributionID = d.ID
+	q := request("context7", ClientChatGPT)
+	q.Purpose = DirectoryResolveContext7ChatGPTPreparation
+	return s, q
+}
+
+func TestResolveDirectoryContext7PreparationSourceOnly(t *testing.T) {
+	s, q := context7PreparationFixture()
+	before, _ := context7PreparationFixture()
+	normal := q
+	normal.Purpose = ""
+	if _, err := ResolveDirectory(s, normal); !errors.Is(err, ErrDirectoryIneligible) || !strings.Contains(err.Error(), "complete target set") {
+		t.Fatalf("normal missing ChatGPT target: %v", err)
+	}
+	for _, selector := range []string{"context7", "upstash/context7"} {
+		q.Selector = selector
+		got, err := ResolveDirectory(s, q)
+		r := s.Distributions[0].Releases[0]
+		if err != nil || got.DistributionID != "upstash/context7" || got.Source != r.PackageSource || got.TreeDigest != r.TreeDigest || got.ManifestDigest != r.ManifestDigest || got.Fallback {
+			t.Fatalf("source selection: %+v %v", got, err)
+		}
+	}
+	if !reflect.DeepEqual(s, before) {
+		t.Fatal("resolution mutated signed metadata")
+	}
+	// A later revision is governed by signed policy/evidence, never a pinned SHA.
+	s.Distributions[0].Releases[0].PackageSource.Revision = strings.Repeat("f", 40)
+	if _, err := ResolveDirectory(s, q); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResolveDirectoryContext7PreparationBoundaries(t *testing.T) {
+	cases := []struct {
+		name   string
+		change func(*DirectorySnapshot, *DirectoryResolveRequest)
+	}{
+		{"unknown purpose", func(s *DirectorySnapshot, q *DirectoryResolveRequest) { q.Purpose = "bypass" }},
+		{"project", func(s *DirectorySnapshot, q *DirectoryResolveRequest) { q.Scope = ScopeProject }},
+		{"implicit scope", func(s *DirectorySnapshot, q *DirectoryResolveRequest) { q.Scope = "" }},
+		{"wrong target", func(s *DirectorySnapshot, q *DirectoryResolveRequest) { q.Targets = []ClientID{ClientCodex} }},
+		{"empty targets", func(s *DirectorySnapshot, q *DirectoryResolveRequest) { q.Targets = nil }},
+		{"mixed targets", func(s *DirectorySnapshot, q *DirectoryResolveRequest) { q.Targets = append(q.Targets, ClientCodex) }},
+		{"product", func(s *DirectorySnapshot, q *DirectoryResolveRequest) { s.Products[0].ID = "other" }},
+		{"product manifest", func(s *DirectorySnapshot, q *DirectoryResolveRequest) { s.Products[0].ManifestName = "other" }},
+		{"distribution", func(s *DirectorySnapshot, q *DirectoryResolveRequest) {
+			s.Distributions[0].ID = "other/context7"
+			s.Products[0].Distributions = []string{"other/context7"}
+			q.Selector = "other/context7"
+		}},
+		{"kind", func(s *DirectorySnapshot, q *DirectoryResolveRequest) {
+			s.Distributions[0].Kind = DistributionCommunity
+		}},
+		{"repository", func(s *DirectorySnapshot, q *DirectoryResolveRequest) {
+			s.Distributions[0].Releases[0].PackageSource.Repository = "other/context7"
+		}},
+		{"path", func(s *DirectorySnapshot, q *DirectoryResolveRequest) {
+			s.Distributions[0].Releases[0].PackageSource.Path = "other"
+		}},
+		{"manifest", func(s *DirectorySnapshot, q *DirectoryResolveRequest) {
+			s.Distributions[0].Releases[0].ManifestName = "other"
+		}},
+		{"missing promotion", func(s *DirectorySnapshot, q *DirectoryResolveRequest) { s.Evidence = nil }},
+		{"untrusted promotion", func(s *DirectorySnapshot, q *DirectoryResolveRequest) { s.Evidence[0].Trust = nil }},
+		{"stale promotion", func(s *DirectorySnapshot, q *DirectoryResolveRequest) {
+			s.Distributions[0].ReleasePolicies[0].CurrentEvidence = nil
+		}},
+		{"wrong digest", func(s *DirectorySnapshot, q *DirectoryResolveRequest) {
+			s.Evidence[0].PackageTreeDigest = "sha256:wrong"
+		}},
+		{"wrong sequence", func(s *DirectorySnapshot, q *DirectoryResolveRequest) { s.Evidence[0].ReleaseSequence++ }},
+		{"wrong evidence distribution", func(s *DirectorySnapshot, q *DirectoryResolveRequest) {
+			s.Evidence[0].DistributionID = "other/context7"
+		}},
+		{"undeclared promotion", func(s *DirectorySnapshot, q *DirectoryResolveRequest) {
+			s.Distributions[0].ReleasePolicies[0].Targets = nil
+		}},
+		{"unsupported promotion", func(s *DirectorySnapshot, q *DirectoryResolveRequest) {
+			s.Distributions[0].ReleasePolicies[0].Targets[0].Client = "unknown"
+			s.Evidence[0].Client = "unknown"
+		}},
+		{"promotion delivery", func(s *DirectorySnapshot, q *DirectoryResolveRequest) {
+			s.Distributions[0].ReleasePolicies[0].Targets[0].Delivery = "wrong"
+		}},
+		{"promotion scope", func(s *DirectorySnapshot, q *DirectoryResolveRequest) {
+			s.Distributions[0].ReleasePolicies[0].Targets[0].Scopes = nil
+		}},
+		{"schema", func(s *DirectorySnapshot, q *DirectoryResolveRequest) {
+			s.Distributions[0].Releases[0].AgentPluginsSchema = "unsupported"
+		}},
+		{"requested schema", func(s *DirectorySnapshot, q *DirectoryResolveRequest) { q.SchemaVersion = "2.0.0" }},
+		{"minimum version", func(s *DirectorySnapshot, q *DirectoryResolveRequest) {
+			s.Distributions[0].ReleasePolicies[0].MinimumInstallerVersion = "99.0.0"
+		}},
+		{"required component", func(s *DirectorySnapshot, q *DirectoryResolveRequest) { q.RequiredComponents = []string{"absent"} }},
+		{"product component", func(s *DirectorySnapshot, q *DirectoryResolveRequest) {
+			s.Distributions[0].Releases[0].Components = nil
+		}},
+		{"declared ChatGPT scope", func(s *DirectorySnapshot, q *DirectoryResolveRequest) {
+			p := &s.Distributions[0].ReleasePolicies[0]
+			p.Targets = append(p.Targets, DirectoryTarget{Client: ClientChatGPT, Scopes: []InstallScope{ScopeProject}, Delivery: "manual_activation"})
+		}},
+		{"declared ChatGPT missing promotion", func(s *DirectorySnapshot, q *DirectoryResolveRequest) {
+			p := &s.Distributions[0].ReleasePolicies[0]
+			p.Targets = append(p.Targets, testPolicy(3, ClientChatGPT).Targets...)
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, q := context7PreparationFixture()
+			tc.change(&s, &q)
+			if got, err := ResolveDirectory(s, q); err == nil {
+				t.Fatalf("accepted: %+v", got)
+			}
+		})
+	}
+}
+
+func TestResolveDirectoryContext7PreparationNegativeEvidence(t *testing.T) {
+	for _, level := range []string{"schema", "materialization", "discovery", "runtime", "oauth"} {
+		t.Run(level, func(t *testing.T) {
+			s, q := context7PreparationFixture()
+			e := testTrustedEvidence(DirectoryEvidence{ID: "failure", DistributionID: "upstash/context7", ReleaseSequence: 3, PackageTreeDigest: s.Distributions[0].Releases[0].TreeDigest, Client: ClientChatGPT, Level: level, Outcome: "failed"})
+			if level == "schema" {
+				e.Client = ""
+			}
+			s.Evidence = append(s.Evidence, e)
+			s.Distributions[0].ReleasePolicies[0].CurrentEvidence = append(s.Distributions[0].ReleasePolicies[0].CurrentEvidence, e.ID)
+			if _, err := ResolveDirectory(s, q); err == nil || !strings.Contains(err.Error(), "evidence failed") {
+				t.Fatalf("negative evidence: %v", err)
+			}
+			if level != "schema" {
+				s.Evidence[1].OS = "different-os"
+				if _, err := ResolveDirectory(s, q); err != nil {
+					t.Fatalf("inapplicable evidence: %v", err)
+				}
+				s.Evidence[1].OS = ""
+			}
+			s.Evidence[1].Trust = nil
+			if _, err := ResolveDirectory(s, q); err != nil {
+				t.Fatalf("untrusted failure: %v", err)
+			}
+		})
+	}
+}
+
+func TestResolveDirectoryContext7PreparationRecordedPolicy(t *testing.T) {
+	for _, op := range []DirectoryOperation{DirectoryInstall, DirectoryNewTarget, DirectoryUpdate, DirectoryRepair, DirectoryRematerialize, DirectoryReproduce, DirectoryRemove} {
+		for _, status := range []string{"active", "suspended", "superseded", "revoked", "top-level revoked"} {
+			for _, recorded := range []bool{false, true} {
+				t.Run(string(op)+"/"+status+"/recorded="+map[bool]string{true: "yes", false: "no"}[recorded], func(t *testing.T) {
+					s, q := context7PreparationFixture()
+					q.Operation = op
+					d := &s.Distributions[0]
+					if recorded {
+						q.Recorded = &RecordedDirectoryRelease{ProductID: "context7", DistributionID: d.ID, ReleaseSequence: 3, ResolvedRevision: d.Releases[0].PackageSource.Revision, TreeDigest: d.Releases[0].TreeDigest}
+					}
+					switch status {
+					case "suspended":
+						d.Status = DistributionSuspended
+					case "superseded":
+						d.ReleasePolicies[0].Status = ReleaseSuperseded
+					case "revoked":
+						d.ReleasePolicies[0].Status = ReleaseRevoked
+					case "top-level revoked":
+						s.Revocations = []DirectoryRevocation{{DistributionID: d.ID, ReleaseSequence: 3}}
+					}
+					// Compare to the existing real resolver on the declared promoted target.
+					normal := q
+					normal.Purpose, normal.Targets = "", []ClientID{ClientCodex}
+					want, wantErr := ResolveDirectory(s, normal)
+					got, err := ResolveDirectory(s, q)
+					if (err == nil) != (wantErr == nil) || (err == nil && !reflect.DeepEqual(got, want)) {
+						t.Fatalf("prep %+v %v; normal %+v %v", got, err, want, wantErr)
+					}
+					if errors.Is(err, ErrDirectoryNoSafeUpdate) != errors.Is(wantErr, ErrDirectoryNoSafeUpdate) {
+						t.Fatalf("changed update error: %v vs %v", err, wantErr)
+					}
+					if recorded {
+						q.Recorded.TreeDigest = "sha256:wrong"
+						if _, err := ResolveDirectory(s, q); err == nil {
+							t.Fatal("recorded digest mismatch accepted")
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestResolveDirectoryContext7PreparationUpdateAndQualifiedIdentity(t *testing.T) {
+	s, q := context7PreparationFixture()
+	d := &s.Distributions[0]
+	q.Recorded = &RecordedDirectoryRelease{ProductID: "context7", DistributionID: d.ID, ReleaseSequence: 3, ResolvedRevision: d.Releases[0].PackageSource.Revision}
+	newer := d.Releases[0]
+	newer.Sequence, newer.PackageVersion = 4, "0.0.1"
+	newer.PackageSource.Revision = strings.Repeat("e", 40)
+	d.Releases = append(d.Releases, newer)
+	policy := testPolicy(4, ClientCodex)
+	policy.CurrentEvidence = []string{"new-promotion"}
+	d.ReleasePolicies = append(d.ReleasePolicies, policy)
+	evidence := s.Evidence[0]
+	evidence.ID, evidence.ReleaseSequence = "new-promotion", 4
+	s.Evidence = append(s.Evidence, evidence)
+	for _, op := range []DirectoryOperation{DirectoryInstall, DirectoryRepair, DirectoryUpdate} {
+		q.Operation = op
+		want := uint64(3)
+		if op == DirectoryUpdate {
+			want = 4
+		}
+		got, err := ResolveDirectory(s, q)
+		if err != nil || got.ReleaseSequence != want {
+			t.Fatalf("%s: %+v %v", op, got, err)
+		}
+	}
+	s.Revocations = []DirectoryRevocation{{DistributionID: d.ID, ReleaseSequence: 3}}
+	if got, err := ResolveDirectory(s, q); err != nil || got.ReleaseSequence != 4 {
+		t.Fatalf("update from revoked: %+v %v", got, err)
+	}
+	// Neither selector qualification nor recorded identity can widen the purpose.
+	other := *d
+	other.ID = "other/context7"
+	s.Distributions = append(s.Distributions, other)
+	s.Products[0].Distributions = append(s.Products[0].Distributions, other.ID)
+	q.Selector = other.ID
+	if _, err := ResolveDirectory(s, q); !errors.Is(err, ErrDirectoryIneligible) {
+		t.Fatalf("wrong qualified selector with upstream record: %v", err)
+	}
+	q.Selector, q.Recorded.DistributionID = "context7", other.ID
+	if _, err := ResolveDirectory(s, q); !errors.Is(err, ErrDirectoryIneligible) {
+		t.Fatalf("wrong recorded distribution: %v", err)
+	}
+	q.Recorded.DistributionID = "upstash/context7"
+	q.Recorded.ResolvedRevision = strings.Repeat("f", 40)
+	if _, err := ResolveDirectory(s, q); err == nil {
+		t.Fatal("changed recorded revision accepted")
+	}
+}

--- a/install/integrationctl/agentplugins/domain/install_intent.go
+++ b/install/integrationctl/agentplugins/domain/install_intent.go
@@ -18,7 +18,7 @@ func (intent InstallIntent) Validate(client ClientID) error {
 	case InstallIntentAutomatic:
 		return nil
 	case InstallIntentPrepare:
-		if client == ClientKiro {
+		if client == ClientKiro || client == ClientChatGPT {
 			return nil
 		}
 	}

--- a/install/integrationctl/agentplugins/domain/state.go
+++ b/install/integrationctl/agentplugins/domain/state.go
@@ -208,6 +208,8 @@ type DataReceipt struct {
 }
 
 type Installation struct {
+	LocalChatGPTMapping *ChatGPTLocalMapping `json:"local_chatgpt_mapping,omitempty"`
+
 	InstallPreferences []InstallPreference      `json:"install_preferences,omitempty"`
 	InstallationID     string                   `json:"installation_id"`
 	DeclaredName       string                   `json:"declared_name"`

--- a/install/integrationctl/agentplugins/domain/types.go
+++ b/install/integrationctl/agentplugins/domain/types.go
@@ -167,6 +167,8 @@ type ComponentInventory struct {
 }
 
 type PackageEnvelope struct {
+	LocalChatGPTMapping *ChatGPTLocalMapping `json:"-"`
+
 	LoaderKind      string             `json:"loader_kind"`
 	FormatID        string             `json:"format_id"`
 	SchemaURI       string             `json:"schema_uri"`

--- a/install/integrationctl/agentplugins/planner/intent.go
+++ b/install/integrationctl/agentplugins/planner/intent.go
@@ -29,7 +29,7 @@ func ApplyInstallIntent(plan *domain.DeliveryPlan, intent domain.InstallIntent) 
 		plan.Activation = domain.ActivationPrepared
 		plan.Authentication = domain.AuthenticationPending
 		plan.Verification = domain.VerificationPackageValid
-		plan.UserActions = []string{domain.ChatGPTRegistrationAction}
+		plan.UserActions = []string{domain.ChatGPTMappedPreparationAction}
 		return nil
 	}
 	if strings.TrimSpace(plan.NativeRegistryRoot) == "" || !hasOnlyKiroNativeComponents(plan.Components) {

--- a/install/integrationctl/agentplugins/planner/intent.go
+++ b/install/integrationctl/agentplugins/planner/intent.go
@@ -15,10 +15,21 @@ func ApplyInstallIntent(plan *domain.DeliveryPlan, intent domain.InstallIntent) 
 		return err
 	}
 	if intent == domain.InstallIntentPrepare && plan.Scope != domain.ScopeUser {
-		return fmt.Errorf("Kiro preparation supports user scope only")
+		return fmt.Errorf("preparation supports user scope only")
 	}
 	plan.InstallIntent = intent
 	if intent != domain.InstallIntentPrepare || plan.Status == domain.PlanUnsupported {
+		return nil
+	}
+	if plan.ClientID == domain.ClientChatGPT {
+		if !plan.PersonalChatGPTPreparation {
+			return fmt.Errorf("ChatGPT preparation requires a validated Context7 personal mapping")
+		}
+		plan.Status = domain.PlanReady
+		plan.Activation = domain.ActivationPrepared
+		plan.Authentication = domain.AuthenticationPending
+		plan.Verification = domain.VerificationPackageValid
+		plan.UserActions = []string{domain.ChatGPTRegistrationAction}
 		return nil
 	}
 	if strings.TrimSpace(plan.NativeRegistryRoot) == "" || !hasOnlyKiroNativeComponents(plan.Components) {

--- a/install/integrationctl/agentplugins/planner/planner.go
+++ b/install/integrationctl/agentplugins/planner/planner.go
@@ -101,7 +101,24 @@ func (planner Planner) Plan(
 	plan.TargetAnchor = target.TargetAnchor
 	plan.ActivePath = target.ActivePath
 	plan.Components = componentDecisions(envelope, capabilities)
-	applyCatalogCompatibility(&plan, envelope.CatalogEvidence)
+	if client.ClientID == domain.ClientChatGPT && envelope.LocalChatGPTMapping != nil {
+		if scope != domain.ScopeUser {
+			return plan, fmt.Errorf("ChatGPT preparation supports user scope only")
+		}
+		if err := envelope.LocalChatGPTMapping.ValidatePackage(envelope); err != nil {
+			return plan, err
+		}
+		binding, ok := envelope.App.Bindings[envelope.LocalChatGPTMapping.Server]
+		if !envelope.App.Enabled || len(envelope.App.Bindings) != 1 || !ok || binding.ID != envelope.LocalChatGPTMapping.AppID {
+			return plan, fmt.Errorf("personal ChatGPT mapping projection does not match receipt")
+		}
+		plan.LocalPreparationAuthorized = true
+		plan.PersonalChatGPTPreparation = true
+		plan.Authentication = domain.AuthenticationPending
+		plan.Warnings = append(plan.Warnings, "personal_registration_not_remote_verified")
+	} else {
+		applyCatalogCompatibility(&plan, envelope.CatalogEvidence)
+	}
 	chatGPTCompatibility, hasChatGPTCompatibility := domain.CatalogCompatibility{}, false
 	if envelope.CatalogEvidence != nil {
 		chatGPTCompatibility, hasChatGPTCompatibility = envelope.CatalogEvidence.Compatibility[string(domain.ClientChatGPT)]

--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -84,6 +84,12 @@ func (activator Activator) PreflightActivation(request domain.ActivationRequest)
 		return err
 	}
 	if request.Plan.InstallIntent == domain.InstallIntentPrepare {
+		if request.Client.ClientID == domain.ClientChatGPT {
+			if request.Plan.Scope != domain.ScopeUser || !request.Plan.PersonalChatGPTPreparation {
+				return fmt.Errorf("ChatGPT preparation requires validated personal mapping")
+			}
+			return nil
+		}
 		if request.Plan.Scope != domain.ScopeUser || strings.TrimSpace(request.Client.ConfigRoot) == "" || !kiroNativeComponents(request.Plan.Components) {
 			return fmt.Errorf("Kiro preparation requires native configuration and supported components")
 		}
@@ -342,6 +348,13 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 		Verification:   domain.VerificationPackageValid,
 	}
 	if request.Plan.InstallIntent == domain.InstallIntentPrepare {
+		if request.Client.ClientID == domain.ClientChatGPT {
+			outcome.Activation = domain.ActivationPrepared
+			outcome.Authentication = domain.AuthenticationPending
+			outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf("In ChatGPT desktop, add the personal local marketplace at %s (.agents/plugins/marketplace.json), install %s, and verify the registered OAuth connection and tool calls in a new chat. The registration receipt is retained locally after remove, including --purge-data, for reinstall.", request.Delivery.ActivePath, request.DeclaredName))
+			outcome.UserActions = append(outcome.UserActions, request.Plan.UserActions...)
+			return outcome, nil
+		}
 		if request.VerifyOnly {
 			err = verifyKiroNativeObjects(request.Client.ConfigRoot, request.Delivery.NativeObjects, false)
 		} else {

--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -351,7 +351,7 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 		if request.Client.ClientID == domain.ClientChatGPT {
 			outcome.Activation = domain.ActivationPrepared
 			outcome.Authentication = domain.AuthenticationPending
-			outcome.LocalActions = append(outcome.LocalActions, fmt.Sprintf("In ChatGPT desktop, add the personal local marketplace at %s (.agents/plugins/marketplace.json), install %s, and verify the registered OAuth connection and tool calls in a new chat. The registration receipt is retained locally after remove, including --purge-data, for reinstall.", request.Delivery.ActivePath, request.DeclaredName))
+			outcome.LocalActions = append(outcome.LocalActions, domain.ChatGPTPreparedAction(request.Delivery.ActivePath, request.DeclaredName))
 			outcome.UserActions = append(outcome.UserActions, request.Plan.UserActions...)
 			return outcome, nil
 		}

--- a/install/integrationctl/agentplugins/providers/chatgpt_prepare_test.go
+++ b/install/integrationctl/agentplugins/providers/chatgpt_prepare_test.go
@@ -1,0 +1,33 @@
+package providers
+
+import (
+	"context"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPersonalChatGPTPreparationCannotAttestRemoteActivation(t *testing.T) {
+	request := domain.ActivationRequest{Client: domain.DetectedClient{ClientID: domain.ClientChatGPT}, Plan: domain.DeliveryPlan{ClientID: domain.ClientChatGPT, Scope: domain.ScopeUser, InstallIntent: domain.InstallIntentPrepare, PersonalChatGPTPreparation: true}, ActivationComplete: true}
+	root := t.TempDir()
+	active := filepath.Join(root, "context7")
+	if err := os.Mkdir(active, 0700); err != nil {
+		t.Fatal(err)
+	}
+	request.DeclaredName = "context7"
+	request.Plan.ActivePath = active
+	request.Delivery = domain.StagedDelivery{ClientID: domain.ClientChatGPT, OwnedBase: root, ActivePath: active}
+	activator := Activator{}
+	if err := activator.PreflightActivation(request); err != nil {
+		t.Fatal(err)
+	}
+	outcome, err := activator.Activate(context.Background(), request)
+	if err != nil || outcome.Activation != domain.ActivationPrepared || outcome.Authentication != domain.AuthenticationPending || outcome.Verification != domain.VerificationPackageValid || outcome.ActivationAttested {
+		t.Fatalf("false remote success: %+v %v", outcome, err)
+	}
+	request.Plan.PersonalChatGPTPreparation = false
+	if err := activator.PreflightActivation(request); err == nil {
+		t.Fatal("unvalidated preparation allowed")
+	}
+}

--- a/install/integrationctl/agentplugins/providers/native_identity.go
+++ b/install/integrationctl/agentplugins/providers/native_identity.go
@@ -203,7 +203,8 @@ func (observer NativeIdentityObserver) inspectNativeRegistry(ctx context.Context
 		}
 	case domain.ClientChatGPT:
 		// ChatGPT's installed-plugin registry is remote and this adapter has no
-		// authenticated read-only API. A signed explicit app binding authorizes
+		// authenticated read-only API. A validated explicit app binding (signed or
+		// a personal Context7 receipt) authorizes
 		// only preparation of a new local package, while an existing ownership
 		// receipt authorizes replacement of that owned local package. Neither is
 		// treated as proof of remote activation or registry availability.

--- a/install/integrationctl/agentplugins/providers/stager.go
+++ b/install/integrationctl/agentplugins/providers/stager.go
@@ -405,7 +405,11 @@ func writeSanitizedApp(root string, envelope domain.PackageEnvelope, plan domain
 		}
 		return nil
 	}
-	return atomicfile.Write(path, append([]byte(nil), envelope.App.Raw...), 0o644)
+	mode := os.FileMode(0o644)
+	if envelope.LocalChatGPTMapping != nil {
+		mode = 0o600
+	}
+	return atomicfile.Write(path, append([]byte(nil), envelope.App.Raw...), mode)
 }
 
 func removeInvalidAndUnsupportedSkills(root string, envelope domain.PackageEnvelope, plan domain.DeliveryPlan) error {

--- a/install/integrationctl/agentplugins/usecase/intent.go
+++ b/install/integrationctl/agentplugins/usecase/intent.go
@@ -37,6 +37,17 @@ func (service Service) planInstall(ctx context.Context, input *AddInput, physica
 			}
 		}
 	}
+	if input.Client.ClientID == domain.ClientChatGPT && input.InstallIntent == domain.InstallIntentPrepare && input.Envelope.LocalChatGPTMapping == nil {
+		return domain.DeliveryPlan{}, fmt.Errorf("ChatGPT preparation requires a personal Context7 registration receipt")
+	}
+	if input.Envelope.LocalChatGPTMapping != nil {
+		if input.Client.ClientID != domain.ClientChatGPT || input.Scope != domain.ScopeUser || input.InstallIntent != domain.InstallIntentPrepare || input.OriginMode != domain.OriginModeDirectory || input.DirectoryResolution == nil || input.DirectoryResolution.ProductID != "context7" || input.DirectoryResolution.DistributionID != "upstash/context7" {
+			return domain.DeliveryPlan{}, fmt.Errorf("personal ChatGPT mapping requires explicit canonical Directory Context7 user preparation")
+		}
+		if installation != nil && installation.LocalChatGPTMapping != nil && *installation.LocalChatGPTMapping != *input.Envelope.LocalChatGPTMapping {
+			return domain.DeliveryPlan{}, fmt.Errorf("personal ChatGPT registration differs from retained receipt")
+		}
+	}
 	plan, err := service.Planner.Plan(ctx, input.Envelope, input.Client, input.Scope, physicalID)
 	if err == nil {
 		err = planner.ApplyInstallIntent(&plan, input.InstallIntent)

--- a/install/integrationctl/agentplugins/usecase/service.go
+++ b/install/integrationctl/agentplugins/usecase/service.go
@@ -859,6 +859,10 @@ func upsertPreparedInstallation(
 			installation.Clients = map[string]domain.ClientBinding{}
 		}
 	}
+	if input.Envelope.LocalChatGPTMapping != nil {
+		mapping := *input.Envelope.LocalChatGPTMapping
+		installation.LocalChatGPTMapping = &mapping
+	}
 	previousClient := installation.Clients[clientBindingID]
 	bindingClientID := string(input.Client.ClientID)
 	if previousClient.ClientID != "" {


### PR DESCRIPTION
Context7 has no packaged ChatGPT account mapping, so the installer previously skipped it with no usable path forward. This adds an explicit guided flow: `add context7 --prepare` offers only Kiro and ChatGPT, requests the personal ChatGPT registration ID when needed, and prepares one verified package for both clients.

The ChatGPT mapping stays in private local state and is bound to the canonical `upstash/context7` package, signed Directory metadata, the exact immutable release, user scope, and `https://mcp.context7.com/mcp/oauth`. Human output shows the usable personal marketplace path; JSON keeps host paths and the personal app ID private. Update, repair, remove and reinstall retain the preparation intent without claiming remote activation.

Validation:

- Final exact-head CI passed 27/27 after the reviewed remediation.
- Independent exact-SHA review at `2db93e9e` returned ACCEPT after reproducing and verifying all three prior P2 fixes.
- Fresh macOS sandbox E2E passed interactive selection, emitted-command resume, mixed Kiro/ChatGPT preparation, repeat, update, repair, JSON privacy and ordinary-add isolation.
- Real Kiro v3 OAuth and Context7 `resolve-library-id` plus `query-docs` tool calls passed in #238.
- Real ChatGPT registration and local preparation passed. Remote OAuth/tool calls remain unverified because the available personal profile is on the Free plan, which current OpenAI documentation does not list for custom MCP apps.

This PR does not publish a release or claim remote ChatGPT activation.
