### PR TITLE
fix(cli): use working Context7 ChatGPT endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Changes after `v1.2.4` land here.
 
 ### Fixed
 
+- Context7 preparation for ChatGPT now directs users to the working public
+  `/mcp` endpoint with no authentication, accepts the `asdk_app_` identifier
+  shown by ChatGPT, and reports authentication as not required. The previous
+  `/mcp/oauth` guidance failed before Context7's OAuth flow could start.
 - NPM registry publish workflows now require an explicit `NPM_PUBLISH_READY=true` repository variable before auto-running from release asset publication, while keeping manual dispatch available for credential repair.
 - npm publication workflows now support npm Trusted Publishing through GitHub OIDC by default, while keeping token-based publishing as an explicit `NPM_PUBLISH_AUTH=token` fallback.
 - Runtime package registry smoke now falls back to the registry's published latest version when a manual publish workflow cannot expose its dispatch tag through `workflow_run`.

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
@@ -90,7 +90,7 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 	if loaded.chatGPTPreparation && loaded.localChatGPTMapping == nil {
 		action := chatGPTRegistrationResumeAction(cmd, loaded.envelope.Source.RequestedSource, targets)
 		if opts.format == "json" {
-			if err := writeJSONResult(cmd.OutOrStdout(), "add", outputResultFailure, map[string]any{"status": "action_required", "target": "chatgpt", "mcp_url": domain.Context7OAuthURL, "next_action": action, "remote_verified": false, "mutated": false}); err != nil {
+			if err := writeJSONResult(cmd.OutOrStdout(), "add", outputResultFailure, map[string]any{"status": "action_required", "target": "chatgpt", "mcp_url": domain.Context7ChatGPTURL, "authentication": "none", "next_action": action, "remote_verified": true, "mutated": false}); err != nil {
 				return err
 			}
 		}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_guidance_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_guidance_test.go
@@ -106,7 +106,7 @@ func TestContext7ResumeEmittedMixedCommandAndPreparedGuidance(t *testing.T) {
 	if len(state.Installations) != 1 || len(state.Installations[0].Clients) != 2 || a.verifiedCalls != 2 {
 		t.Fatalf("mixed resume: %+v calls=%d", state, a.verifiedCalls)
 	}
-	if strings.Contains(out, fixturePersonalAppID) || strings.Contains(out, "copy its plugin_asdk_app_") || strings.Contains(out, "Rerun add") {
+	if strings.Contains(out, fixturePersonalAppID) || strings.Contains(out, "copy its asdk_app_") || strings.Contains(out, "Rerun add") {
 		t.Fatalf("wrong stage or private ID: %s", out)
 	}
 	for _, b := range state.Installations[0].Clients {
@@ -123,7 +123,7 @@ func TestContext7ResumeEmittedMixedCommandAndPreparedGuidance(t *testing.T) {
 			}
 		}
 	}
-	for _, text := range []string{"ChatGPT desktop", "new chat", "Remote OAuth and tool calls have not been verified", "including --purge-data"} {
+	for _, text := range []string{"No authentication is required", "new chat", "both Context7 tools have been verified in ChatGPT", "including --purge-data"} {
 		if !strings.Contains(out, text) {
 			t.Fatalf("missing %q: %s", text, out)
 		}
@@ -221,7 +221,7 @@ func TestContext7PreparedGuidanceAcrossLifecycle(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %s %v", op, out, err)
 		}
-		if strings.Contains(out, path) || strings.Contains(out, fixturePersonalAppID) || strings.Contains(out, "Rerun add") || !strings.Contains(out, "Remote OAuth and tool calls have not been verified") {
+		if strings.Contains(out, path) || strings.Contains(out, fixturePersonalAppID) || strings.Contains(out, "Rerun add") || !strings.Contains(out, "both Context7 tools have been verified in ChatGPT") {
 			t.Fatalf("%s public guidance: %s", op, out)
 		}
 	}
@@ -363,7 +363,7 @@ func TestContext7SingleLifecycleRenderPaths(t *testing.T) {
 	for _, noChange := range []bool{false, true} {
 		result := usecase.AddResult{
 			Plan:       domain.DeliveryPlan{ClientID: domain.ClientChatGPT, InstallIntent: domain.InstallIntentPrepare, ActivePath: "/private/personal-marketplace", DeclaredName: "context7"},
-			Activation: domain.ActivationOutcome{Activation: domain.ActivationPrepared, Authentication: domain.AuthenticationPending, Verification: domain.VerificationPackageValid},
+			Activation: domain.ActivationOutcome{Activation: domain.ActivationPrepared, Authentication: domain.AuthenticationNotRequired, Verification: domain.VerificationPackageValid},
 			NoChange:   noChange, Mutated: !noChange,
 		}
 		for _, op := range []string{"add", "update", "repair"} {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_prepare_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_prepare_test.go
@@ -257,6 +257,32 @@ func TestContext7GuidedReceiptRejectsChangedRegistrationAndSignedEndpoint(t *tes
 	}
 }
 
+func TestContext7GuidedReceiptMigratesLegacyRegistrationOnlyWithExplicitID(t *testing.T) {
+	f, _, _ := context7GuidedFixture(t)
+	if out, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--prepare", "--chatgpt-app-id", fixturePersonalAppID); err != nil {
+		t.Fatalf("initial preparation failed: %s %v", out, err)
+	}
+	state, err := f.store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	state.Installations[0].LocalChatGPTMapping.URL = domain.Context7OAuthURL
+	state.Installations[0].LocalChatGPTMapping.AppID = "plugin_asdk_app_0123456789abcdef0123456789abcdef"
+	if err := f.store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--prepare"); err == nil || !strings.Contains(err.Error(), "action_required") {
+		t.Fatalf("legacy receipt did not require a new explicit ID: %v", err)
+	}
+	if out, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--prepare", "--chatgpt-app-id", fixturePersonalAppID); err != nil {
+		t.Fatalf("legacy receipt migration failed: %s %v", out, err)
+	}
+	got, err := f.store.Load()
+	if err != nil || len(got.Installations) != 1 || got.Installations[0].LocalChatGPTMapping == nil || got.Installations[0].LocalChatGPTMapping.AppID != fixturePersonalAppID || got.Installations[0].LocalChatGPTMapping.URL != domain.Context7ChatGPTURL {
+		t.Fatalf("legacy receipt was not replaced: %+v %v", got.Installations, err)
+	}
+}
+
 func TestContext7GuidedForeignFilesAndCancellation(t *testing.T) {
 	f, _, _ := context7GuidedFixture(t)
 	foreign := filepath.Join(f.app.UserHome, ".agents", "plugins", "marketplace.json")

--- a/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_prepare_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_prepare_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers"
 )
 
-const fixturePersonalAppID = "plugin_asdk_app_0123456789abcdef0123456789abcdef"
+const fixturePersonalAppID = "asdk_app_0123456789abcdef0123456789abcdef"
 
 // This fixture exercises the verified-acquisition interface with immutable local
 // bytes. It is deliberately not a live catalog or remote ChatGPT qualification.
@@ -58,7 +58,7 @@ func TestContext7GuidedMissingRegistrationAndResume(t *testing.T) {
 	var response struct {
 		Data map[string]any `json:"data"`
 	}
-	if json.Unmarshal([]byte(out), &response) != nil || response.Data["status"] != "action_required" || response.Data["mcp_url"] != domain.Context7OAuthURL || response.Data["remote_verified"] != false {
+	if json.Unmarshal([]byte(out), &response) != nil || response.Data["status"] != "action_required" || response.Data["mcp_url"] != domain.Context7ChatGPTURL || response.Data["authentication"] != "none" || response.Data["remote_verified"] != true {
 		t.Fatalf("action response %s: %v", out, err)
 	}
 	state, _ := f.store.Load()
@@ -155,7 +155,7 @@ func TestContext7GuidedLifecycleRetainsReceipt(t *testing.T) {
 				t.Fatal(err)
 			}
 			b := onlyCLIClient(state.Installations[0])
-			if b.Verification != domain.VerificationPackageValid || b.Authentication != domain.AuthenticationPending {
+			if b.Verification != domain.VerificationPackageValid || b.Authentication != domain.AuthenticationNotRequired {
 				t.Fatalf("fabricated remote completion %+v", b)
 			}
 			if err := os.RemoveAll(b.TargetLocator); err != nil {
@@ -177,7 +177,7 @@ func TestContext7GuidedLifecycleRetainsReceipt(t *testing.T) {
 }
 
 func TestContext7GuidedRejectsInvalidIDsAndUnverifiedSource(t *testing.T) {
-	for _, id := range []string{"connector_old", "asdk_app_old", "plugin_asdk_app_", "plugin_asdk_app_short", "plugin_asdk_app_bad/id", " plugin_asdk_app_abc"} {
+	for _, id := range []string{"connector_old", "asdk_app_", "asdk_app_short", "asdk_app_bad/id", " asdk_app_abc", "plugin_asdk_app_0123456789abcdef0123456789abcdef"} {
 		t.Run(id, func(t *testing.T) {
 			f, _, a := context7GuidedFixture(t)
 			_, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--prepare", "--chatgpt-app-id", id)
@@ -220,7 +220,7 @@ func TestContext7GuidedReceiptRejectsChangedRegistrationAndSignedEndpoint(t *tes
 		t.Fatalf("%s %v", out, err)
 	}
 	before, _ := os.ReadFile(f.store.Path)
-	_, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--prepare", "--chatgpt-app-id", "plugin_asdk_app_ffffffffffffffffffffffffffffffff")
+	_, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--prepare", "--chatgpt-app-id", "asdk_app_ffffffffffffffffffffffffffffffff")
 	if err == nil || !strings.Contains(err.Error(), "conflicts with retained") {
 		t.Fatalf("replaced receipt: %v", err)
 	}
@@ -248,7 +248,7 @@ func TestContext7GuidedReceiptRejectsChangedRegistrationAndSignedEndpoint(t *tes
 	dist.ReleasePolicies = append(dist.ReleasePolicies, policy)
 	d.bundle.Snapshot.Evidence = append(d.bundle.Snapshot.Evidence, intendedTrustedDirectoryEvidence(domain.DirectoryEvidence{ID: policy.CurrentEvidence[0], DistributionID: dist.ID, ReleaseSequence: 2, PackageTreeDigest: release.TreeDigest, Level: "materialization", Outcome: "passed", Client: domain.ClientKiro}))
 	_, _, err = f.execute(false, "update", "context7", "--target", "chatgpt")
-	if err == nil || !strings.Contains(err.Error(), "OAuth server") {
+	if err == nil || !strings.Contains(err.Error(), "canonical Context7 package") {
 		t.Fatalf("rebound endpoint: %v", err)
 	}
 	after, _ := os.ReadFile(f.store.Path)

--- a/cli/plugin-kit-ai/internal/agentpluginscli/source.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/source.go
@@ -588,9 +588,14 @@ func (app App) acquireDirectory(ctx context.Context, selector string, request pa
 		}
 		loaded.chatGPTPreparation = true
 		loaded.localChatGPTMapping = retainedMapping
+		if retainedMapping != nil && retainedMapping.IsLegacyContext7Registration() {
+			// The 0.1.56 receipt came from guidance that cannot produce a working
+			// ChatGPT registration. Require a new explicit app ID to migrate it.
+			loaded.localChatGPTMapping = nil
+		}
 		if app.chatGPTAppID != "" {
 			mapping := domain.ChatGPTLocalMapping{ProductID: "context7", Repository: "upstash/context7", PackagePath: "plugins/agent-plugins/context7", Server: "context7", URL: domain.Context7ChatGPTURL, AppID: app.chatGPTAppID}
-			if retainedMapping != nil && *retainedMapping != mapping {
+			if retainedMapping != nil && *retainedMapping != mapping && !retainedMapping.IsLegacyContext7Registration() {
 				_ = loaded.cleanup()
 				return loadedPackage{}, fmt.Errorf("explicit ChatGPT ID conflicts with retained personal registration receipt")
 			}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/source.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/source.go
@@ -589,7 +589,7 @@ func (app App) acquireDirectory(ctx context.Context, selector string, request pa
 		loaded.chatGPTPreparation = true
 		loaded.localChatGPTMapping = retainedMapping
 		if app.chatGPTAppID != "" {
-			mapping := domain.ChatGPTLocalMapping{ProductID: "context7", Repository: "upstash/context7", PackagePath: "plugins/agent-plugins/context7", Server: "context7", URL: domain.Context7OAuthURL, AppID: app.chatGPTAppID}
+			mapping := domain.ChatGPTLocalMapping{ProductID: "context7", Repository: "upstash/context7", PackagePath: "plugins/agent-plugins/context7", Server: "context7", URL: domain.Context7ChatGPTURL, AppID: app.chatGPTAppID}
 			if retainedMapping != nil && *retainedMapping != mapping {
 				_ = loaded.cleanup()
 				return loadedPackage{}, fmt.Errorf("explicit ChatGPT ID conflicts with retained personal registration receipt")

--- a/install/integrationctl/agentplugins/adapters/statev2/store.go
+++ b/install/integrationctl/agentplugins/adapters/statev2/store.go
@@ -160,7 +160,7 @@ func Validate(state domain.StateFileV2) error {
 	operationIDs := map[string]struct{}{}
 	for index, installation := range state.Installations {
 		if mapping := installation.LocalChatGPTMapping; mapping != nil {
-			if err := mapping.Validate(); err != nil {
+			if err := mapping.Validate(); err != nil && !mapping.IsLegacyContext7Registration() {
 				return err
 			}
 			if installation.OriginMode != domain.OriginModeDirectory || installation.Directory == nil || installation.Directory.ProductID != mapping.ProductID || installation.Directory.DistributionID != mapping.Repository || installation.Source.Repository != mapping.Repository || installation.Source.PackageSubpath != mapping.PackagePath {

--- a/install/integrationctl/agentplugins/domain/chatgpt_mapping.go
+++ b/install/integrationctl/agentplugins/domain/chatgpt_mapping.go
@@ -6,14 +6,15 @@ import (
 )
 
 const Context7OAuthURL = "https://mcp.context7.com/mcp/oauth"
-const ChatGPTRegistrationAction = "In ChatGPT Developer Mode, register a remote connection using https://mcp.context7.com/mcp/oauth, complete OAuth, and copy its plugin_asdk_app_ ID. Rerun add context7 --target chatgpt --prepare --chatgpt-app-id <ID>. Then install the prepared plugin from the personal marketplace in ChatGPT desktop and verify its tools in a new chat. Official steps: https://developers.openai.com/plugins/build/plugins. Remote connection and tool calls have not been verified. The personal registration receipt is retained locally after remove, including --purge-data, for reinstall."
+const Context7ChatGPTURL = "https://mcp.context7.com/mcp"
+const ChatGPTRegistrationAction = "In ChatGPT Developer Mode, create an app using https://mcp.context7.com/mcp and select No authentication. Connect it, copy its asdk_app_ ID from app settings, and Rerun add context7 --target chatgpt --prepare --chatgpt-app-id <ID>. Then install the prepared plugin from the personal marketplace and select it in a new chat. Official steps: https://developers.openai.com/plugins/build/plugins. The public Context7 endpoint and both Context7 tools have been verified in ChatGPT. The personal registration receipt is retained locally after remove, including --purge-data, for reinstall."
 
 // ChatGPTMappedPreparationAction applies only after the personal mapping exists.
-const ChatGPTMappedPreparationAction = "Prepare the personal local marketplace, then install it in ChatGPT desktop and verify OAuth and tools in a new chat. Remote OAuth and tool calls have not been verified. The personal registration receipt is retained locally after remove, including --purge-data, for reinstall."
+const ChatGPTMappedPreparationAction = "Prepare the personal local marketplace, then install it in ChatGPT and select Context7 in a new chat. No authentication is required for the public Context7 endpoint. The endpoint and both Context7 tools have been verified in ChatGPT. The personal registration receipt is retained locally after remove, including --purge-data, for reinstall."
 
 // ChatGPTPreparedAction names the local artifact after successful preparation.
 func ChatGPTPreparedAction(path, name string) string {
-	return fmt.Sprintf("In ChatGPT desktop, add the personal local marketplace at %s (.agents/plugins/marketplace.json), install %s, and verify the registered OAuth connection and tool calls in a new chat. Remote OAuth and tool calls have not been verified. The registration receipt is retained locally after remove, including --purge-data, for reinstall.", path, name)
+	return fmt.Sprintf("In ChatGPT, add the personal local marketplace at %s (.agents/plugins/marketplace.json), install %s, and select it in a new chat. No authentication is required for the public Context7 endpoint. The endpoint and both Context7 tools have been verified in ChatGPT. The registration receipt is retained locally after remove, including --purge-data, for reinstall.", path, name)
 }
 
 // ChatGPTLocalMapping is a personal registration receipt, never catalog evidence.
@@ -28,17 +29,17 @@ type ChatGPTLocalMapping struct {
 	AppID       string `json:"app_id"`
 }
 
-var chatGPTAppIDPattern = regexp.MustCompile(`^plugin_asdk_app_[0-9a-f]{32}$`)
+var chatGPTAppIDPattern = regexp.MustCompile(`^asdk_app_[0-9a-f]{32}$`)
 
 func ValidateChatGPTAppID(id string) error {
 	if !chatGPTAppIDPattern.MatchString(id) {
-		return fmt.Errorf("invalid ChatGPT app ID: copy the plugin_asdk_app_ ID from the official registration UI")
+		return fmt.Errorf("invalid ChatGPT app ID: copy the asdk_app_ ID from ChatGPT app settings")
 	}
 	return nil
 }
 func (m ChatGPTLocalMapping) Validate() error {
-	if m.ProductID != "context7" || m.Repository != "upstash/context7" || m.PackagePath != "plugins/agent-plugins/context7" || m.Server != "context7" || m.URL != Context7OAuthURL {
-		return fmt.Errorf("personal ChatGPT mapping has a different Context7 identity or OAuth endpoint")
+	if m.ProductID != "context7" || m.Repository != "upstash/context7" || m.PackagePath != "plugins/agent-plugins/context7" || m.Server != "context7" || m.URL != Context7ChatGPTURL {
+		return fmt.Errorf("personal ChatGPT mapping has a different Context7 identity or ChatGPT endpoint")
 	}
 	return ValidateChatGPTAppID(m.AppID)
 }
@@ -50,10 +51,10 @@ func (m ChatGPTLocalMapping) ValidatePackage(e PackageEnvelope) error {
 }
 
 func ValidateContext7PreparationPackage(e PackageEnvelope) error {
-	m := ChatGPTLocalMapping{ProductID: "context7", Repository: "upstash/context7", PackagePath: "plugins/agent-plugins/context7", Server: "context7", URL: Context7OAuthURL}
+	m := ChatGPTLocalMapping{ProductID: "context7", Repository: "upstash/context7", PackagePath: "plugins/agent-plugins/context7", Server: "context7", URL: Context7ChatGPTURL}
 	server, ok := e.MCP.Servers[m.Server]
-	if e.Manifest.Name != m.ProductID || e.Source.Repository != m.Repository || e.Source.PackageSubpath != m.PackagePath || !e.MCP.Enabled || len(e.MCP.Servers) != 1 || !ok || server.Type != "streamable-http" || server.Decoded["url"] != m.URL {
-		return fmt.Errorf("personal ChatGPT mapping does not match canonical Context7 package and OAuth server")
+	if e.Manifest.Name != m.ProductID || e.Source.Repository != m.Repository || e.Source.PackageSubpath != m.PackagePath || !e.MCP.Enabled || len(e.MCP.Servers) != 1 || !ok || server.Type != "streamable-http" || server.Decoded["url"] != Context7OAuthURL {
+		return fmt.Errorf("personal ChatGPT mapping does not match the canonical Context7 package")
 	}
 	return nil
 }

--- a/install/integrationctl/agentplugins/domain/chatgpt_mapping.go
+++ b/install/integrationctl/agentplugins/domain/chatgpt_mapping.go
@@ -30,6 +30,7 @@ type ChatGPTLocalMapping struct {
 }
 
 var chatGPTAppIDPattern = regexp.MustCompile(`^asdk_app_[0-9a-f]{32}$`)
+var legacyChatGPTAppIDPattern = regexp.MustCompile(`^plugin_asdk_app_[0-9a-f]{32}$`)
 
 func ValidateChatGPTAppID(id string) error {
 	if !chatGPTAppIDPattern.MatchString(id) {
@@ -37,6 +38,13 @@ func ValidateChatGPTAppID(id string) error {
 	}
 	return nil
 }
+
+// IsLegacyContext7Registration identifies receipts written by the broken
+// 0.1.56 OAuth guidance. They may be replaced only by an explicit new app ID.
+func (m ChatGPTLocalMapping) IsLegacyContext7Registration() bool {
+	return m.ProductID == "context7" && m.Repository == "upstash/context7" && m.PackagePath == "plugins/agent-plugins/context7" && m.Server == "context7" && m.URL == Context7OAuthURL && legacyChatGPTAppIDPattern.MatchString(m.AppID)
+}
+
 func (m ChatGPTLocalMapping) Validate() error {
 	if m.ProductID != "context7" || m.Repository != "upstash/context7" || m.PackagePath != "plugins/agent-plugins/context7" || m.Server != "context7" || m.URL != Context7ChatGPTURL {
 		return fmt.Errorf("personal ChatGPT mapping has a different Context7 identity or ChatGPT endpoint")

--- a/install/integrationctl/agentplugins/domain/chatgpt_mapping_test.go
+++ b/install/integrationctl/agentplugins/domain/chatgpt_mapping_test.go
@@ -2,8 +2,8 @@ package domain
 
 import "testing"
 
-func TestPersonalChatGPTMappingIsBoundToCanonicalIdentityAndOAuthServer(t *testing.T) {
-	mapping := ChatGPTLocalMapping{ProductID: "context7", Repository: "upstash/context7", PackagePath: "plugins/agent-plugins/context7", Server: "context7", URL: Context7OAuthURL, AppID: "plugin_asdk_app_0123456789abcdef0123456789abcdef"}
+func TestPersonalChatGPTMappingBindsCanonicalPackageToChatGPTEndpoint(t *testing.T) {
+	mapping := ChatGPTLocalMapping{ProductID: "context7", Repository: "upstash/context7", PackagePath: "plugins/agent-plugins/context7", Server: "context7", URL: Context7ChatGPTURL, AppID: "asdk_app_0123456789abcdef0123456789abcdef"}
 	envelope := PackageEnvelope{Manifest: PluginManifest{Name: "context7"}, Source: SourceIdentity{Repository: mapping.Repository, PackageSubpath: mapping.PackagePath}, MCP: MCPComponent{Enabled: true, Servers: map[string]MCPServer{"context7": {Type: "streamable-http", Decoded: map[string]any{"url": Context7OAuthURL}}}}}
 	if err := mapping.ValidatePackage(envelope); err != nil {
 		t.Fatal(err)

--- a/install/integrationctl/agentplugins/domain/chatgpt_mapping_test.go
+++ b/install/integrationctl/agentplugins/domain/chatgpt_mapping_test.go
@@ -30,3 +30,19 @@ func TestPersonalChatGPTMappingBindsCanonicalPackageToChatGPTEndpoint(t *testing
 		}
 	}
 }
+
+func TestLegacyContext7RegistrationIsNarrowlyRecognized(t *testing.T) {
+	legacy := ChatGPTLocalMapping{ProductID: "context7", Repository: "upstash/context7", PackagePath: "plugins/agent-plugins/context7", Server: "context7", URL: Context7OAuthURL, AppID: "plugin_asdk_app_0123456789abcdef0123456789abcdef"}
+	if !legacy.IsLegacyContext7Registration() {
+		t.Fatal("legacy 0.1.56 receipt was not recognized")
+	}
+	legacy.URL = Context7ChatGPTURL
+	if legacy.IsLegacyContext7Registration() {
+		t.Fatal("current registration was classified as legacy")
+	}
+	legacy.URL = Context7OAuthURL
+	legacy.AppID = "plugin_asdk_app_invalid"
+	if legacy.IsLegacyContext7Registration() {
+		t.Fatal("malformed legacy registration was recognized")
+	}
+}

--- a/install/integrationctl/agentplugins/planner/intent.go
+++ b/install/integrationctl/agentplugins/planner/intent.go
@@ -27,7 +27,7 @@ func ApplyInstallIntent(plan *domain.DeliveryPlan, intent domain.InstallIntent) 
 		}
 		plan.Status = domain.PlanReady
 		plan.Activation = domain.ActivationPrepared
-		plan.Authentication = domain.AuthenticationPending
+		plan.Authentication = domain.AuthenticationNotRequired
 		plan.Verification = domain.VerificationPackageValid
 		plan.UserActions = []string{domain.ChatGPTMappedPreparationAction}
 		return nil

--- a/install/integrationctl/agentplugins/planner/planner.go
+++ b/install/integrationctl/agentplugins/planner/planner.go
@@ -114,8 +114,8 @@ func (planner Planner) Plan(
 		}
 		plan.LocalPreparationAuthorized = true
 		plan.PersonalChatGPTPreparation = true
-		plan.Authentication = domain.AuthenticationPending
-		plan.Warnings = append(plan.Warnings, "personal_registration_not_remote_verified")
+		plan.Authentication = domain.AuthenticationNotRequired
+		plan.Warnings = append(plan.Warnings, "personal_registration_requires_account_install")
 	} else {
 		applyCatalogCompatibility(&plan, envelope.CatalogEvidence)
 	}

--- a/install/integrationctl/agentplugins/providers/activator.go
+++ b/install/integrationctl/agentplugins/providers/activator.go
@@ -350,7 +350,7 @@ func (activator Activator) Activate(ctx context.Context, request domain.Activati
 	if request.Plan.InstallIntent == domain.InstallIntentPrepare {
 		if request.Client.ClientID == domain.ClientChatGPT {
 			outcome.Activation = domain.ActivationPrepared
-			outcome.Authentication = domain.AuthenticationPending
+			outcome.Authentication = domain.AuthenticationNotRequired
 			outcome.LocalActions = append(outcome.LocalActions, domain.ChatGPTPreparedAction(request.Delivery.ActivePath, request.DeclaredName))
 			outcome.UserActions = append(outcome.UserActions, request.Plan.UserActions...)
 			return outcome, nil

--- a/install/integrationctl/agentplugins/providers/chatgpt_prepare_test.go
+++ b/install/integrationctl/agentplugins/providers/chatgpt_prepare_test.go
@@ -23,7 +23,7 @@ func TestPersonalChatGPTPreparationCannotAttestRemoteActivation(t *testing.T) {
 		t.Fatal(err)
 	}
 	outcome, err := activator.Activate(context.Background(), request)
-	if err != nil || outcome.Activation != domain.ActivationPrepared || outcome.Authentication != domain.AuthenticationPending || outcome.Verification != domain.VerificationPackageValid || outcome.ActivationAttested {
+	if err != nil || outcome.Activation != domain.ActivationPrepared || outcome.Authentication != domain.AuthenticationNotRequired || outcome.Verification != domain.VerificationPackageValid || outcome.ActivationAttested {
 		t.Fatalf("false remote success: %+v %v", outcome, err)
 	}
 	request.Plan.PersonalChatGPTPreparation = false

--- a/install/integrationctl/agentplugins/usecase/intent.go
+++ b/install/integrationctl/agentplugins/usecase/intent.go
@@ -44,7 +44,7 @@ func (service Service) planInstall(ctx context.Context, input *AddInput, physica
 		if input.Client.ClientID != domain.ClientChatGPT || input.Scope != domain.ScopeUser || input.InstallIntent != domain.InstallIntentPrepare || input.OriginMode != domain.OriginModeDirectory || input.DirectoryResolution == nil || input.DirectoryResolution.ProductID != "context7" || input.DirectoryResolution.DistributionID != "upstash/context7" {
 			return domain.DeliveryPlan{}, fmt.Errorf("personal ChatGPT mapping requires explicit canonical Directory Context7 user preparation")
 		}
-		if installation != nil && installation.LocalChatGPTMapping != nil && *installation.LocalChatGPTMapping != *input.Envelope.LocalChatGPTMapping {
+		if installation != nil && installation.LocalChatGPTMapping != nil && *installation.LocalChatGPTMapping != *input.Envelope.LocalChatGPTMapping && !installation.LocalChatGPTMapping.IsLegacyContext7Registration() {
 			return domain.DeliveryPlan{}, fmt.Errorf("personal ChatGPT registration differs from retained receipt")
 		}
 	}

--- a/install/integrationctl/agentplugins/usecase/service.go
+++ b/install/integrationctl/agentplugins/usecase/service.go
@@ -249,6 +249,7 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 		}
 	}
 	isMaterialized := existing && materializedClient(state.Installations[installationIndex], clientBindingID)
+	registrationMigration := existing && input.Envelope.LocalChatGPTMapping != nil && state.Installations[installationIndex].LocalChatGPTMapping != nil && state.Installations[installationIndex].LocalChatGPTMapping.IsLegacyContext7Registration() && *state.Installations[installationIndex].LocalChatGPTMapping != *input.Envelope.LocalChatGPTMapping
 	var managedBinding *domain.ClientBinding
 	if isMaterialized {
 		binding := state.Installations[installationIndex].Clients[clientBindingID]
@@ -280,7 +281,7 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 			if !replace && !packageRevisionMatches(current.PackageRevision, input.Envelope) {
 				return result, fmt.Errorf("plugin is already materialized for %s at a different revision; use update", input.Client.ClientID)
 			}
-			result.NoChange = !replace && lifecycleConverged(current)
+			result.NoChange = !replace && !registrationMigration && lifecycleConverged(current)
 		}
 		return result, nil
 	}
@@ -289,7 +290,7 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 			return result, err
 		}
 	}
-	if isMaterialized && !replace {
+	if isMaterialized && !replace && !registrationMigration {
 		current := state.Installations[installationIndex].Clients[clientBindingID]
 		result.Activation = lifecycleOutcome(current)
 		if !packageRevisionMatches(current.PackageRevision, input.Envelope) {
@@ -462,7 +463,7 @@ func (service Service) apply(ctx context.Context, input AddInput, replace bool) 
 			ClientID: delivery.ClientID, OwnedBase: delivery.OwnedBase, ActivePath: delivery.ActivePath,
 			ArtifactDigest: delivery.ArtifactDigest, NativeObjects: delivery.NativeObjects,
 		},
-		DeclaredName: input.Envelope.Manifest.Name, Replacing: replace,
+		DeclaredName: input.Envelope.Manifest.Name, Replacing: replace || registrationMigration,
 		Interactive: input.Interactive, BackendExecutable: input.BackendExecutable,
 		PreviousNativeObjects: append([]domain.NativeObjectOwnership(nil), previousClient.NativeObjects...),
 	})


### PR DESCRIPTION
The ChatGPT preparation flow pointed users to Context7's OAuth endpoint and required a `plugin_asdk_app_` ID, but ChatGPT failed before OAuth started and its settings UI exposes IDs as `asdk_app_...`.

This change registers Context7 through the working public `https://mcp.context7.com/mcp` endpoint with no authentication, accepts the actual ChatGPT app ID format, reports authentication as not required, and keeps validating the signed upstream package's canonical OAuth endpoint separately. It also recognizes only exact 0.1.56 legacy receipts: without a replacement ID it requests action, and with an explicit current ID it safely rewrites the retained receipt and prepared artifact.

Validation:
- Real ChatGPT Pro E2E: created and connected a disposable Context7 app, selected it in a new chat, called `resolve-library-id`, then called `query-docs` for `node:fs readFile`
- Focused domain, planner, provider, state adapter, use-case, and full CLI package tests pass
- Legacy 0.1.56 receipt regression test covers action-required and explicit migration
- Fresh CLI build passes action-required, real-ID projection, 0600 private app mapping, redaction, repeat, update, repair, remove, and receipt-backed reinstall
- Expanded integration run reached unrelated existing macOS-only filesystem/process timing failures; all changed packages passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ChatGPT setup now uses the public Context7 endpoint without authentication.
  * App identifiers now use the `asdk_app_` format.
  * Setup confirms that both Context7 tools have been verified.

* **Bug Fixes**
  * Updated ChatGPT preparation guidance to avoid the previous OAuth flow that could fail before setup began.
  * Improved setup status and messages to accurately indicate that authentication is not required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
