### PR TITLE
docs: document Context7 support in ChatGPT and Kiro

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,26 @@ The CLI finds compatible agents installed on your computer.
 2. Follow any activation or sign-in instructions printed by the CLI.
 3. Start a new agent session and try the plugin.
 
+For the verified Context7 setup in ChatGPT and Kiro:
+
+```bash
+npx universal-agent-plugins add context7 --target chatgpt,kiro --prepare
+```
+
+- ChatGPT: the CLI guides you to create a Developer Mode app for
+  `https://mcp.context7.com/mcp` with **No authentication**, accepts the
+  resulting `asdk_app_...` ID, and prepares a personal marketplace package.
+  You still install that package and select Context7 in a new chat.
+- Kiro: the CLI installs its owned skills and MCP entry while preserving
+  unrelated configuration. On macOS and Windows it reports the remaining
+  Kiro OAuth/restart step instead of claiming automatic runtime verification.
+
+The same retained installation supports repeat add, update, repair, remove,
+and reinstall. ChatGPT availability still depends on an account or workspace
+where Developer Mode and custom apps are enabled.
+
+See the [real Context7 ChatGPT and Kiro E2E evidence](docs/CONTEXT7_CHATGPT_KIRO_E2E.md).
+
 <details>
 <summary>Installation details</summary>
 
@@ -125,11 +145,11 @@ The CLI has adapters for:
 | Client | Delivery |
 | --- | --- |
 | <img src="landing/public/client-icons/openai.svg" width="24" height="24" alt="" align="middle"> Codex | managed package or OpenAI compatibility package |
-| <img src="landing/public/client-icons/openai.svg" width="24" height="24" alt="" align="middle"> ChatGPT | registered app/binding where the package provides one |
+| <img src="landing/public/client-icons/openai.svg" width="24" height="24" alt="" align="middle"> ChatGPT | verified publisher app binding, or guided personal Context7 app and marketplace preparation |
 | <img src="landing/public/client-icons/cursor.svg" width="24" height="24" alt="" align="middle"> Cursor | native Agent Plugin and MCP/skills projection |
 | <img src="landing/public/client-icons/github-copilot.svg" width="24" height="24" alt="" align="middle"> GitHub Copilot CLI | native plugin and managed marketplace path |
 | <img src="landing/public/client-icons/vscode.svg" width="24" height="24" alt="" align="middle"> VS Code | prepared Copilot-compatible package |
-| <img src="landing/public/client-icons/kiro.svg" width="24" height="24" alt="" align="middle"> Kiro | native folder and Power import guidance |
+| <img src="landing/public/client-icons/kiro.svg" width="24" height="24" alt="" align="middle"> Kiro | managed skills and MCP configuration; client OAuth/restart when required |
 | <img src="landing/public/client-icons/claude.svg" width="24" height="24" alt="" align="middle"> Claude Code | client-specific skills/MCP projection |
 | <img src="landing/public/client-icons/gemini.svg" width="24" height="24" alt="" align="middle"> Gemini CLI | client-specific configuration projection |
 | <picture><source media="(prefers-color-scheme: dark)" srcset="assets/client-icons/opencode-dark.svg"><img src="landing/public/client-icons/opencode.svg" width="24" height="24" alt="" align="middle"></picture> OpenCode | client-specific configuration projection |
@@ -185,6 +205,9 @@ agentplugins info context7
 
 # Install in specific agents
 agentplugins add context7 --target codex,cursor,kiro
+
+# Prepare Context7 for ChatGPT and Kiro
+agentplugins add context7 --target chatgpt,kiro --prepare
 
 # Manage an installed plugin
 agentplugins update context7 --target codex,cursor

--- a/docs/CONTEXT7_CHATGPT_KIRO_E2E.md
+++ b/docs/CONTEXT7_CHATGPT_KIRO_E2E.md
@@ -1,0 +1,25 @@
+# Context7 ChatGPT and Kiro E2E evidence
+
+The 2026-09-10 Context7 qualification covers the guided client paths shipped in
+`universal-agent-plugins@0.1.57`. The public release is bound to commit
+`6af7f412cb4a35d2e623fcba110f1fe53d9a2a5d`.
+
+| Client | Real client evidence | Supported boundary |
+| --- | --- | --- |
+| ChatGPT | In a real Pro profile, a disposable Developer Mode app connected to `https://mcp.context7.com/mcp` with no authentication. A new chat explicitly selected it and successfully called `resolve-library-id` and `query-docs`. | The CLI validates the real `asdk_app_...` ID and prepares a personal marketplace package. App creation, marketplace installation, and selection remain visible ChatGPT steps. Availability depends on the account/workspace. |
+| Kiro | In real Kiro v3 on macOS, Context7 completed OAuth, loaded after restart, and successfully called `resolve-library-id` and `query-docs` from the installed `context7` server. | The CLI owns only its skill and MCP entries. macOS and Windows use preparation plus an explicit OAuth/restart action; automatic ACP runtime verification is limited to Linux hosts with proven containment support. |
+
+The final release candidate also passed isolated add, repeat add, update,
+repair, remove, and receipt-backed reinstall for ChatGPT. The legacy 0.1.56
+receipt path was reproduced: it requires a new explicit ID and then migrates
+the retained receipt without exposing the private ID in JSON or stderr. The
+exact 0.1.57 release pipeline passed native configuration lifecycle proofs on
+macOS, Linux, and Windows for amd64 and arm64.
+
+Private app IDs, account details, OAuth values, and conversation URLs are
+intentionally excluded from this public evidence.
+
+The older immutable multi-client lifecycle record remains in
+[AGENTPLUGINS_CLIENT_E2E.md](AGENTPLUGINS_CLIENT_E2E.md). It is preserved
+byte-for-byte because published npm release manifests cryptographically bind
+that historical evidence.

--- a/docs/PLUGIN_KIT_AI_AUTHORING.md
+++ b/docs/PLUGIN_KIT_AI_AUTHORING.md
@@ -68,7 +68,9 @@ runtime behavior.
 The following matrix describes the current release source. New client support
 is available through `npx` once a release containing this source is published.
 The exact package, source revisions, commands, and limitations are recorded in
-the [isolated client E2E evidence](docs/AGENTPLUGINS_CLIENT_E2E.md).
+the [isolated client E2E evidence](AGENTPLUGINS_CLIENT_E2E.md). Current real
+Context7 client calls are recorded in [Context7 ChatGPT and Kiro E2E
+evidence](CONTEXT7_CHATGPT_KIRO_E2E.md).
 
 | Client | Evidence |
 | --- | --- |
@@ -77,6 +79,8 @@ the [isolated client E2E evidence](docs/AGENTPLUGINS_CLIENT_E2E.md).
 | OpenCode | OpenCode 1.18.4: real isolated configuration and the same exact-source lifecycle |
 | Cline | Real locally detected client; isolated native configuration and exact-source lifecycle; no client runtime or login |
 | Windsurf | Real locally detected configuration and exact-source lifecycle; no client runtime or login |
+| ChatGPT | Real Pro-profile Context7 app registration with the public no-auth endpoint, followed by successful `resolve-library-id` and `query-docs` calls |
+| Kiro | Real Kiro v3 Context7 OAuth, restart, and successful `resolve-library-id` and `query-docs` calls; exact release CI separately covers native configuration lifecycle |
 
 `search` combines the reviewed Directory with a separately signed Discovery
 Index. Unreviewed results use publisher-qualified `discovery:owner/repo//path`
@@ -114,8 +118,8 @@ authentication as pending or cancelled.
 Kiro skills are installed directly into the documented global skills path.
 For packages with MCP servers, agentplugins atomically merges only its owned
 entries into Kiro's global `mcp.json`, preserving unrelated user configuration,
-then checks supported Kiro CLI versions through a bounded structured ACP v1
-initialize/session handshake.
+then checks supported Kiro CLI versions. The normal automatic lane uses a
+bounded structured ACP v1 initialize/session handshake.
 It sends no prompt or model/tool turn and does not inject package endpoints;
 Kiro must load its installed native configuration and report connected servers
 with enabled tools. The verifier drains a bounded quiet settlement window,
@@ -123,10 +127,11 @@ rejects EOF, partial bytes, or trailing contradictions, then stops and reaps the
 long-lived ACP process through supervised containment. Automatic Kiro ACP
 verification is available only on Linux after capability preflight proves
 delegated cgroup v2 creation, atomic CLONE_INTO_CGROUP placement, and
-cgroup.kill. macOS, Windows, and Linux hosts without every required proof fail
-preflight before any MCP mutation. On those hosts, use Kiro's documented manual
-skill and MCP configuration paths; that workflow is outside this automatic CLI
-path. Failure to start ACP
+cgroup.kill. On macOS, Windows, and Linux hosts without that containment,
+`--prepare` installs the owned Kiro skills and MCP configuration without
+claiming a connected runtime. It reports the exact OAuth/restart step and keeps
+the lifecycle receipt for update, repair, remove, and reinstall. Failure to
+start ACP
 after a supported preflight may still leave a manual verification action. This
 is activation evidence, not a runtime tool E2E claim.
 Once the ACP process starts, companion-launch failure (including a missing
@@ -136,6 +141,20 @@ failures; the managed package remains committed for explicit repair and is
 never reported active.
 Verification is reported for the exact plugin, client, runtime, and OAuth
 evidence available—not as a claim that every combination has been tested.
+
+ChatGPT packages with a verified publisher app binding are prepared directly.
+Canonical Directory Context7 also has a guided personal-registration path:
+
+```bash
+npx universal-agent-plugins add context7 --target chatgpt --prepare
+```
+
+The first run prints the public `https://mcp.context7.com/mcp` endpoint and
+requires **No authentication**. After the user creates and connects the app in
+ChatGPT Developer Mode, the CLI accepts its `asdk_app_...` ID and prepares a
+personal marketplace package. The ID stays in private installer state and is
+not emitted in structured output. Installing the marketplace package and
+selecting Context7 in a new chat remain explicit ChatGPT actions.
 
 `universal-agent-plugins` is an independent community installer, not an official
 OpenAI CLI.

--- a/landing/data/clients.ts
+++ b/landing/data/clients.ts
@@ -29,12 +29,14 @@ export const clientLandingPages: ClientLandingPage[] = [
     slug: 'chatgpt',
     name: 'ChatGPT',
     icon: 'openai.svg',
-    note: 'Verified ChatGPT connections',
+    note: 'Verified app bindings and guided Context7 setup',
     status: 'Setup in app',
     intro:
       'Prepare compatible Agent Plugins 1.0 for ChatGPT while keeping app activation and account consent inside ChatGPT.',
-    delivery: 'The CLI validates and prepares the compatible package or registered app binding.',
-    activation: 'Complete the final app activation or sign-in step in ChatGPT when prompted.',
+    delivery:
+      'The CLI validates publisher app bindings and can prepare a personal marketplace package for Context7 using its public no-auth MCP endpoint.',
+    activation:
+      'Create or connect the app in Developer Mode, install the prepared personal plugin, and select it in a new chat.',
   },
   {
     id: 'cursor',
@@ -82,14 +84,14 @@ export const clientLandingPages: ClientLandingPage[] = [
     slug: 'kiro',
     name: 'Kiro',
     icon: 'kiro.svg',
-    note: 'Native folder package',
+    note: 'Managed skills and MCP configuration',
     status: 'Supported',
     intro:
       'Install Agent Plugins 1.0 for Kiro from the same portable package used by other AI agents.',
     delivery:
-      "The CLI prepares Kiro's native folder package with the compatible plugin components.",
+      'The CLI installs its owned Kiro skills and MCP entries while preserving unrelated global configuration.',
     activation:
-      'Follow the printed import or activation hint when Kiro requires a final client-side step.',
+      'Complete the printed OAuth or restart step. macOS and Windows preparation does not claim automatic runtime verification.',
   },
   {
     id: 'claude',
@@ -168,7 +170,9 @@ export const clients: ClientTarget[] = clientLandingPages.map(
 );
 
 // Shell consumers can use this contract with clients[] without importing message JSON.
-export function clientPresentationKey(id: ClientTarget['id']): `registryUi.clients.${ClientTarget['id']}` {
+export function clientPresentationKey(
+  id: ClientTarget['id'],
+): `registryUi.clients.${ClientTarget['id']}` {
   return `registryUi.clients.${id}`;
 }
 

--- a/landing/locales/en.json
+++ b/landing/locales/en.json
@@ -727,11 +727,11 @@
         "activation": "Follow any activation hint printed by the CLI, then start a new Codex session."
       },
       "chatgpt": {
-        "note": "Verified ChatGPT connections",
+        "note": "Verified app bindings and guided Context7 setup",
         "status": "Setup in app",
         "intro": "Prepare compatible Agent Plugins 1.0 for ChatGPT while keeping app activation and account consent inside ChatGPT.",
-        "delivery": "The CLI validates and prepares the compatible package or registered app binding.",
-        "activation": "Complete the final app activation or sign-in step in ChatGPT when prompted."
+        "delivery": "The CLI validates publisher app bindings and can prepare a personal marketplace package for Context7 using its public no-auth MCP endpoint.",
+        "activation": "Create or connect the app in Developer Mode, install the prepared personal plugin, and select it in a new chat."
       },
       "cursor": {
         "note": "Native Agent Plugin package",
@@ -755,11 +755,11 @@
         "activation": "If automatic activation is unavailable, follow the exact setting or import path printed by the CLI."
       },
       "kiro": {
-        "note": "Native folder package",
+        "note": "Managed skills and MCP configuration",
         "status": "Supported",
         "intro": "Install Agent Plugins 1.0 for Kiro from the same portable package used by other AI agents.",
-        "delivery": "The CLI prepares Kiro's native folder package with the compatible plugin components.",
-        "activation": "Follow the printed import or activation hint when Kiro requires a final client-side step."
+        "delivery": "The CLI installs its owned Kiro skills and MCP entries while preserving unrelated global configuration.",
+        "activation": "Complete the printed OAuth or restart step. macOS and Windows preparation does not claim automatic runtime verification."
       },
       "claude": {
         "note": "Managed MCP configuration",

--- a/npm/agentplugins/README.md
+++ b/npm/agentplugins/README.md
@@ -23,6 +23,22 @@ verified scripts in the [project README](https://github.com/777genius/universal-
 3. Follow any activation or sign-in instruction printed by the CLI.
 4. Start a new agent session and use the plugin.
 
+For the verified Context7 setup in ChatGPT and Kiro:
+
+```bash
+npx universal-agent-plugins add context7 --target chatgpt,kiro --prepare
+```
+
+For ChatGPT, follow the printed Developer Mode steps, use
+`https://mcp.context7.com/mcp` with **No authentication**, and rerun the
+printed command with the `asdk_app_...` ID. The CLI then prepares the personal
+marketplace package; installing it and selecting Context7 remain visible
+ChatGPT steps. For Kiro, the CLI manages its owned skills and MCP entry while
+preserving unrelated configuration, then reports any OAuth or restart step.
+macOS and Windows preparation does not claim automatic runtime verification.
+
+See the [real Context7 ChatGPT and Kiro E2E evidence](https://github.com/777genius/universal-agent-plugins/blob/main/docs/CONTEXT7_CHATGPT_KIRO_E2E.md).
+
 [Browse 2,500+ plugins](https://777genius.github.io/universal-agent-plugins/plugins/)
 
 ## What it does
@@ -58,6 +74,9 @@ npx universal-agent-plugins info context7
 
 # Install in specific agents
 npx universal-agent-plugins add context7 --target codex,cursor,kiro
+
+# Prepare Context7 for ChatGPT and Kiro
+npx universal-agent-plugins add context7 --target chatgpt,kiro --prepare
 
 # Manage installed plugins
 npx universal-agent-plugins update context7 --target codex,cursor


### PR DESCRIPTION
Context7 support for ChatGPT and Kiro is now documented with the exact guided setup shipped in `universal-agent-plugins@0.1.57`. The README, npm README, authoring guide, and website explain the remaining client-side activation steps and link to sanitized real-client E2E evidence.

Validation:
- `npm test` in `npm/agentplugins` - 61 passed, 2 skipped
- landing registry and shell i18n tests - 14 passed
- landing locale consistency check - passed
- Prettier check for changed landing files - passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added setup guidance for connecting Context7 with ChatGPT and Kiro using the guided preparation command.
  - Documented ChatGPT Developer Mode configuration and Kiro OAuth/restart activation steps.
  - Added end-to-end verification evidence and updated supported-client documentation.
  - Refreshed client descriptions to clarify setup, activation, and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->