### PR TITLE
feat(cli): make guided client setup automatic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Changes after `v1.2.4` land here.
 
 ### Fixed
 
+- `agentplugins add` now enters the guided Context7 setup for ChatGPT and Kiro
+  automatically. The former `--prepare` flag has been removed, and ChatGPT
+  registration guidance is formatted as four short, executable steps.
 - Context7 preparation for ChatGPT now directs users to the working public
   `/mcp` endpoint with no authentication, accepts the `asdk_app_` identifier
   shown by ChatGPT, and reports authentication as not required. The previous

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The CLI finds compatible agents installed on your computer.
 For the verified Context7 setup in ChatGPT and Kiro:
 
 ```bash
-npx universal-agent-plugins add context7 --target chatgpt,kiro --prepare
+npx universal-agent-plugins add context7 --target chatgpt,kiro
 ```
 
 - ChatGPT: the CLI guides you to create a Developer Mode app for
@@ -207,7 +207,7 @@ agentplugins info context7
 agentplugins add context7 --target codex,cursor,kiro
 
 # Prepare Context7 for ChatGPT and Kiro
-agentplugins add context7 --target chatgpt,kiro --prepare
+agentplugins add context7 --target chatgpt,kiro
 
 # Manage an installed plugin
 agentplugins update context7 --target codex,cursor

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add.go
@@ -39,34 +39,16 @@ func newAddCommand(app App, opts *options) *cobra.Command {
 				return err
 			}
 			opts.installIntents = make(map[domain.ClientID]domain.InstallIntent)
-			if opts.prepare {
-				targets, err := parseTargetOption(opts.target)
-				if err != nil {
-					return err
-				}
-				if len(targets) == 0 {
-					if !app.Terminal || opts.format != "human" {
-						return fmt.Errorf("--prepare requires --target kiro and/or chatgpt in automated mode")
-					}
-					targets = []domain.ClientID{domain.ClientKiro, domain.ClientChatGPT}
-				}
-				for _, target := range targets {
-					if target != domain.ClientKiro && target != domain.ClientChatGPT {
-						return fmt.Errorf("--prepare requires --target kiro and/or chatgpt (Context7 only)")
-					}
-					opts.installIntents[target] = domain.InstallIntentPrepare
-					if target == domain.ClientChatGPT {
-						app.chatGPTPreparation = true
-					}
-				}
-				if app.chatGPTPreparation && (opts.scope != "user" || !isDirectorySelector(args[0])) {
-					return fmt.Errorf("ChatGPT preparation requires the signed Context7 Directory source and user scope")
-				}
+			requestedTargets, err := parseTargetOption(opts.target)
+			if err != nil {
+				return err
 			}
+			opts.installIntents, err = app.addLifecycleIntents(cmd.Context(), args[0], opts.scope, opts.installIntents, requestedTargets)
+			if err != nil {
+				return err
+			}
+			app.chatGPTPreparation = opts.installIntents[domain.ClientChatGPT] == domain.InstallIntentPrepare
 			if opts.chatGPTAppID != "" {
-				if !app.chatGPTPreparation {
-					return fmt.Errorf("--chatgpt-app-id requires --prepare --target chatgpt")
-				}
 				if err := domain.ValidateChatGPTAppID(opts.chatGPTAppID); err != nil {
 					return err
 				}
@@ -77,10 +59,6 @@ func newAddCommand(app App, opts *options) *cobra.Command {
 			if !targetProvided && app.Terminal && opts.format == "human" {
 				var err error
 				app, err = withPrompter(cmd, app, opts)
-				if err != nil {
-					return err
-				}
-				opts.installIntents, err = app.addLifecycleIntents(cmd.Context(), args[0], opts.scope, opts.installIntents)
 				if err != nil {
 					return err
 				}
@@ -103,11 +81,7 @@ func newAddCommand(app App, opts *options) *cobra.Command {
 					preloaded.chatGPTPreparation = false
 					preloaded.localChatGPTMapping = nil
 				}
-				intents, err := app.addLifecycleIntents(cmd.Context(), args[0], opts.scope, opts.installIntents)
-				if err != nil {
-					return err
-				}
-				detectedClients, err = detectSelectedTargetsForLifecycleResolution(cmd.Context(), app.Detector, automaticInstallTargets(targets, intents), detectedClients, !opts.dryRun && isDirectorySelector(args[0]))
+				detectedClients, err = detectSelectedTargetsForLifecycleResolution(cmd.Context(), app.Detector, automaticInstallTargets(targets, opts.installIntents), detectedClients, !opts.dryRun && isDirectorySelector(args[0]))
 				if err != nil {
 					return fmt.Errorf("detect selected AI clients: %w", err)
 				}
@@ -141,7 +115,6 @@ func newAddCommand(app App, opts *options) *cobra.Command {
 		},
 	}
 	command.Flags().StringVar(&opts.chatGPTAppID, "chatgpt-app-id", "", "personal Context7 registration ID copied from ChatGPT Developer Mode")
-	command.Flags().BoolVar(&opts.prepare, "prepare", false, "prepare Kiro configuration and/or Context7 ChatGPT personal marketplace; authenticate and verify tools in the client")
 	command.Flags().BoolVar(&activationComplete, "activation-complete", false, "attest that manual client activation is complete")
 	command.Flags().BoolVar(&authComplete, "auth-complete", false, "attest that required authentication is complete or none is required after review")
 	return command
@@ -172,6 +145,14 @@ func runAddWithClients(ctx context.Context, cmd *cobra.Command, app App, opts *o
 }
 
 func runAddLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *options, loaded loadedPackage, activationComplete, authComplete bool, clients []domain.DetectedClient, needsInstallConfirmation bool) error {
+	targets, err := parseTargetOption(opts.target)
+	if err != nil {
+		return err
+	}
+	applyLoadedGuidedIntents(opts, loaded, targets)
+	if opts.chatGPTAppID != "" && !loaded.chatGPTPreparation {
+		return fmt.Errorf("--chatgpt-app-id requires the signed Context7 Directory source and --target chatgpt")
+	}
 	if err := authorizeSecurityAssessment(cmd, app, opts, &loaded); err != nil {
 		return err
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
@@ -84,6 +84,10 @@ func runAddManyWithClients(ctx context.Context, cmd *cobra.Command, app App, opt
 }
 
 func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *options, loaded loadedPackage, targets []domain.ClientID, activationComplete, authComplete bool, clients []domain.DetectedClient, needsInstallConfirmation bool) error {
+	applyLoadedGuidedIntents(opts, loaded, targets)
+	if opts.chatGPTAppID != "" && !loaded.chatGPTPreparation {
+		return fmt.Errorf("--chatgpt-app-id requires the signed Context7 Directory source and --target chatgpt")
+	}
 	if err := authorizeSecurityAssessment(cmd, app, opts, &loaded); err != nil {
 		return err
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/app.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/app.go
@@ -67,7 +67,6 @@ type App struct {
 
 type options struct {
 	chatGPTAppID        string
-	prepare             bool
 	installIntents      map[domain.ClientID]domain.InstallIntent
 	color               terminaltheme.Policy
 	target              string

--- a/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_guidance.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_guidance.go
@@ -16,16 +16,16 @@ func chatGPTRegistrationResumeAction(cmd *cobra.Command, source string, targets 
 	if cmd.Flags().Changed("target") {
 		targetOption, _ = cmd.Flags().GetString("target")
 	}
-	args := []string{"add", quoteResumeArgument(source), "--target", quoteResumeArgument(targetOption), "--prepare"}
+	args := []string{"add", quoteResumeArgument(source), "--target", quoteResumeArgument(targetOption)}
 	cmd.Flags().Visit(func(flag *pflag.Flag) {
 		switch flag.Name {
-		case "target", "prepare", "chatgpt-app-id":
+		case "target", "chatgpt-app-id":
 			return
 		}
 		args = append(args, "--"+flag.Name+"="+quoteResumeArgument(flag.Value.String()))
 	})
 	args = append(args, "--chatgpt-app-id", "<ID>")
-	return strings.Replace(domain.ChatGPTRegistrationAction, "add context7 --target chatgpt --prepare --chatgpt-app-id <ID>", strings.Join(args, " "), 1)
+	return strings.Replace(domain.ChatGPTRegistrationAction, "add context7 --target chatgpt --chatgpt-app-id <ID>", strings.Join(args, " "), 1)
 }
 
 func clientIDStrings(targets []domain.ClientID) []string {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_guidance_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_guidance_test.go
@@ -16,63 +16,43 @@ import (
 )
 
 func TestContext7InteractivePreparationChoice(t *testing.T) {
-	for _, explicit := range []bool{false, true} {
-		t.Run(map[bool]string{false: "ordinary-ineligible", true: "requested"}[explicit], func(t *testing.T) {
-			f, d, a := context7GuidedFixture(t)
-			f.app.Detector = staticDetector{clients: []domain.DetectedClient{fixtureClient(t, domain.ClientChatGPT)}}
-			before, _ := json.Marshal(d.bundle)
-			args := []string{"add", "context7-alias", "--plain"}
-			if explicit {
-				args = append(args, "--prepare")
-			}
-			out, _, err := f.executeInput(true, "\n", args...)
-			if !explicit {
-				if err == nil || strings.Contains(out, "prepare personal marketplace") || a.verifiedCalls != 0 || a.directGitCalls != 0 || a.localCalls != 0 {
-					t.Fatalf("ordinary add entered preparation: %s %v acquisition=%+v", out, err, a)
-				}
-				state, _ := f.store.Load()
-				after, _ := json.Marshal(d.bundle)
-				if len(state.Installations) != 0 || string(before) != string(after) {
-					t.Fatal("ordinary add mutated state or signed metadata")
-				}
-				return
-			}
-
-			if err == nil || !strings.Contains(err.Error(), "action_required") || !strings.Contains(out, "prepare personal marketplace") {
-				t.Fatalf("choice/guidance: %s %v", out, err)
-			}
-			if a.verifiedCalls != 1 || a.directGitCalls != 0 || a.localCalls != 0 {
-				t.Fatalf("acquisition: %+v", a)
-			}
-			state, _ := f.store.Load()
-			after, _ := json.Marshal(d.bundle)
-			if len(state.Installations) != 0 || string(before) != string(after) {
-				t.Fatal("registration changed state or signed metadata")
-			}
-			command := emittedRegistrationCommand(t, err.Error())
-			if !strings.Contains(command, "context7-alias") {
-				t.Fatal(command)
-			}
-			out, _, err = f.execute(false, strings.Fields(command)...)
-			if err != nil {
-				t.Fatalf("resume %s: %s %v", command, out, err)
-			}
-			state, _ = f.store.Load()
-			b := onlyCLIClient(state.Installations[0])
-			if b.ClientID != "chatgpt" || b.InstallIntent != domain.InstallIntentPrepare || b.Activation != domain.ActivationPrepared {
-				t.Fatalf("intent not retained: %+v", b)
-			}
-		})
+	f, d, a := context7GuidedFixture(t)
+	f.app.Detector = staticDetector{clients: []domain.DetectedClient{fixtureClient(t, domain.ClientChatGPT)}}
+	before, _ := json.Marshal(d.bundle)
+	out, _, err := f.executeInput(true, "\n", "add", "context7-alias", "--plain")
+	if err == nil || !strings.Contains(err.Error(), "action_required") || !strings.Contains(out, "prepare personal marketplace") {
+		t.Fatalf("choice/guidance: %s %v", out, err)
+	}
+	if a.verifiedCalls != 1 || a.directGitCalls != 0 || a.localCalls != 0 {
+		t.Fatalf("acquisition: %+v", a)
+	}
+	state, _ := f.store.Load()
+	after, _ := json.Marshal(d.bundle)
+	if len(state.Installations) != 0 || string(before) != string(after) {
+		t.Fatal("registration changed state or signed metadata")
+	}
+	command := emittedRegistrationCommand(t, err.Error())
+	if !strings.Contains(command, "context7-alias") {
+		t.Fatal(command)
+	}
+	out, _, err = f.execute(false, strings.Fields(command)...)
+	if err != nil {
+		t.Fatalf("resume %s: %s %v", command, out, err)
+	}
+	state, _ = f.store.Load()
+	b := onlyCLIClient(state.Installations[0])
+	if b.ClientID != "chatgpt" || b.InstallIntent != domain.InstallIntentPrepare || b.Activation != domain.ActivationPrepared {
+		t.Fatalf("intent not retained: %+v", b)
 	}
 }
 
 func emittedRegistrationCommand(t *testing.T, action string) string {
 	t.Helper()
-	_, command, ok := strings.Cut(action, "Rerun ")
+	_, command, ok := strings.Cut(action, "3. Run: npx universal-agent-plugins ")
 	if !ok {
-		t.Fatalf("missing rerun: %s", action)
+		t.Fatalf("missing resume command: %s", action)
 	}
-	command, _, ok = strings.Cut(command, ". Then")
+	command, _, ok = strings.Cut(command, "\n")
 	if !ok {
 		t.Fatalf("missing command boundary: %s", action)
 	}
@@ -82,7 +62,7 @@ func emittedRegistrationCommand(t *testing.T, action string) string {
 func TestContext7ResumeEmittedMixedCommandAndPreparedGuidance(t *testing.T) {
 	f, d, a := context7GuidedFixture(t)
 	before, _ := json.Marshal(d.bundle)
-	out, _, err := f.execute(false, "add", "context7-alias", "--target", "kiro,chatgpt", "--prepare", "--format", "json", "--scope", "user", "--plain", "--security-details", "--no-color")
+	out, _, err := f.execute(false, "add", "context7-alias", "--target", "kiro,chatgpt", "--format", "json", "--scope", "user", "--plain", "--security-details", "--no-color")
 	if err == nil {
 		t.Fatal("expected registration")
 	}
@@ -123,7 +103,7 @@ func TestContext7ResumeEmittedMixedCommandAndPreparedGuidance(t *testing.T) {
 			}
 		}
 	}
-	for _, text := range []string{"No authentication is required", "new chat", "both Context7 tools have been verified in ChatGPT", "including --purge-data"} {
+	for _, text := range []string{"personal marketplace", "new chat"} {
 		if !strings.Contains(out, text) {
 			t.Fatalf("missing %q: %s", text, out)
 		}
@@ -149,7 +129,7 @@ func TestContext7InteractivePreparationPolicyGates(t *testing.T) {
 			case "revoked":
 				d.bundle.Snapshot.Distributions[0].ReleasePolicies[0].Status = domain.ReleaseRevoked
 			}
-			out, _, err := f.executeInput(true, "\n", "add", "context7", "--prepare", "--plain")
+			out, _, err := f.executeInput(true, "\n", "add", "context7", "--plain")
 			if err == nil || strings.Contains(out, "prepare personal marketplace") || a.verifiedCalls != 0 {
 				t.Fatalf("gate bypass: %s %v calls=%d", out, err, a.verifiedCalls)
 			}
@@ -179,7 +159,7 @@ func TestContext7InteractiveSelectionOnlyAppliesSelectedIntent(t *testing.T) {
 				},
 				confirmFn: func() (prompt.ConfirmationResult, error) { return prompt.ConfirmationResult{Accepted: true}, nil },
 			}
-			out, _, err := f.executeInput(true, "", "add", "context7", "--prepare", "--plain")
+			out, _, err := f.executeInput(true, "", "add", "context7", "--plain")
 			if chooseChatGPT {
 				if err == nil || !strings.Contains(err.Error(), "action_required") {
 					t.Fatalf("%s %v", out, err)
@@ -207,7 +187,7 @@ func TestContext7InteractiveSelectionOnlyAppliesSelectedIntent(t *testing.T) {
 
 func TestContext7PreparedGuidanceAcrossLifecycle(t *testing.T) {
 	f, _, _ := context7GuidedFixture(t)
-	prepared, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--prepare", "--chatgpt-app-id", fixturePersonalAppID)
+	prepared, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--chatgpt-app-id", fixturePersonalAppID)
 	if err != nil {
 		t.Fatalf("%s %v", prepared, err)
 	}
@@ -221,7 +201,7 @@ func TestContext7PreparedGuidanceAcrossLifecycle(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %s %v", op, out, err)
 		}
-		if strings.Contains(out, path) || strings.Contains(out, fixturePersonalAppID) || strings.Contains(out, "Rerun add") || !strings.Contains(out, "both Context7 tools have been verified in ChatGPT") {
+		if strings.Contains(out, path) || strings.Contains(out, fixturePersonalAppID) || !strings.Contains(out, "personal marketplace") {
 			t.Fatalf("%s public guidance: %s", op, out)
 		}
 	}
@@ -250,7 +230,7 @@ func TestContext7HumanPathsAcrossSingleAndMixedLifecycle(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			out, _, err := f.execute(false, "add", "context7", "--target", targets, "--prepare", "--chatgpt-app-id", fixturePersonalAppID)
+			out, _, err := f.execute(false, "add", "context7", "--target", targets, "--chatgpt-app-id", fixturePersonalAppID)
 			if err != nil {
 				t.Fatalf("initial: %s %v", out, err)
 			}
@@ -302,7 +282,7 @@ func TestContext7HumanPathsAcrossSingleAndMixedLifecycle(t *testing.T) {
 	}
 }
 
-func TestContext7PreparationExcludesEligibleCodexAndResumes(t *testing.T) {
+func TestContext7GuidedSelectionKeepsEligibleCodex(t *testing.T) {
 	f, d, _ := context7GuidedFixture(t)
 	snapshot := &d.bundle.Snapshot
 	policy := &snapshot.Distributions[0].ReleasePolicies[0]
@@ -329,19 +309,14 @@ func TestContext7PreparationExcludesEligibleCodexAndResumes(t *testing.T) {
 	}
 	f.app.Prompter = fakePrompter{
 		selectFn: func(request prompt.TargetSelectionRequest) (prompt.TargetSelectionResult, error) {
-			if len(request.Choices) != 2 {
+			if len(request.Choices) != 3 {
 				t.Fatalf("prepare choices: %+v", request)
-			}
-			for _, choice := range request.Choices {
-				if choice.ID != domain.ClientKiro && choice.ID != domain.ClientChatGPT {
-					t.Fatalf("unsupported preparation choice: %+v", choice)
-				}
 			}
 			return prompt.TargetSelectionResult{IDs: []domain.ClientID{domain.ClientKiro, domain.ClientChatGPT}}, nil
 		},
 		confirmFn: func() (prompt.ConfirmationResult, error) { return prompt.ConfirmationResult{Accepted: true}, nil },
 	}
-	out, _, err := f.executeInput(true, "", "add", "context7", "--prepare", "--plain")
+	out, _, err := f.executeInput(true, "", "add", "context7", "--plain")
 	if err == nil || !strings.Contains(err.Error(), "action_required") {
 		t.Fatalf("registration: %s %v", out, err)
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_prepare_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_prepare_test.go
@@ -51,7 +51,7 @@ func context7GuidedFixture(t *testing.T) (cliFixture, *fixedDirectoryClient, *lo
 
 func TestContext7GuidedMissingRegistrationAndResume(t *testing.T) {
 	f, directory, acquirer := context7GuidedFixture(t)
-	out, _, err := f.execute(false, "add", "context7", "--target", "kiro,chatgpt", "--prepare", "--format", "json")
+	out, _, err := f.execute(false, "add", "context7", "--target", "kiro,chatgpt", "--format", "json")
 	if err == nil {
 		t.Fatal("missing registration must require action")
 	}
@@ -69,7 +69,7 @@ func TestContext7GuidedMissingRegistrationAndResume(t *testing.T) {
 		t.Fatalf("acquisition %#v", acquirer)
 	}
 	before, _ := json.Marshal(directory.bundle)
-	out, _, err = f.execute(false, "add", "context7", "--target", "kiro,chatgpt", "--prepare", "--chatgpt-app-id", fixturePersonalAppID, "--format", "json")
+	out, _, err = f.execute(false, "add", "context7", "--target", "kiro,chatgpt", "--chatgpt-app-id", fixturePersonalAppID, "--format", "json")
 	if err != nil {
 		t.Fatalf("resume: %s %v", out, err)
 	}
@@ -145,7 +145,7 @@ func TestContext7GuidedLifecycleRetainsReceipt(t *testing.T) {
 					t.Fatalf("%v: %s %v", args, out, err)
 				}
 			}
-			run("add", "context7", "--target", "chatgpt", "--prepare", "--chatgpt-app-id", fixturePersonalAppID)
+			run("add", "context7", "--target", "chatgpt", "--chatgpt-app-id", fixturePersonalAppID)
 			run("add", "context7-alias", "--target", "chatgpt")
 			run("update", "context7", "--target", "chatgpt")
 			run("repair", "context7", "--target", "chatgpt")
@@ -180,7 +180,7 @@ func TestContext7GuidedRejectsInvalidIDsAndUnverifiedSource(t *testing.T) {
 	for _, id := range []string{"connector_old", "asdk_app_", "asdk_app_short", "asdk_app_bad/id", " asdk_app_abc", "plugin_asdk_app_0123456789abcdef0123456789abcdef"} {
 		t.Run(id, func(t *testing.T) {
 			f, _, a := context7GuidedFixture(t)
-			_, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--prepare", "--chatgpt-app-id", id)
+			_, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--chatgpt-app-id", id)
 			if err == nil || a.verifiedCalls != 0 {
 				t.Fatalf("invalid ID reached acquisition: %v", err)
 			}
@@ -202,7 +202,7 @@ func TestContext7GuidedRejectsInvalidIDsAndUnverifiedSource(t *testing.T) {
 			case "mixed-peer":
 				d.bundle.Snapshot.Distributions[0].ReleasePolicies[0].Targets[0].Scopes = []domain.InstallScope{domain.ScopeProject}
 			}
-			_, _, err := f.execute(false, "add", "context7", "--target", "kiro,chatgpt", "--prepare", "--chatgpt-app-id", fixturePersonalAppID)
+			_, _, err := f.execute(false, "add", "context7", "--target", "kiro,chatgpt", "--chatgpt-app-id", fixturePersonalAppID)
 			if err == nil {
 				t.Fatal("accepted invalid source")
 			}
@@ -216,11 +216,11 @@ func TestContext7GuidedRejectsInvalidIDsAndUnverifiedSource(t *testing.T) {
 
 func TestContext7GuidedReceiptRejectsChangedRegistrationAndSignedEndpoint(t *testing.T) {
 	f, d, a := context7GuidedFixture(t)
-	if out, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--prepare", "--chatgpt-app-id", fixturePersonalAppID); err != nil {
+	if out, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--chatgpt-app-id", fixturePersonalAppID); err != nil {
 		t.Fatalf("%s %v", out, err)
 	}
 	before, _ := os.ReadFile(f.store.Path)
-	_, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--prepare", "--chatgpt-app-id", "asdk_app_ffffffffffffffffffffffffffffffff")
+	_, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--chatgpt-app-id", "asdk_app_ffffffffffffffffffffffffffffffff")
 	if err == nil || !strings.Contains(err.Error(), "conflicts with retained") {
 		t.Fatalf("replaced receipt: %v", err)
 	}
@@ -259,7 +259,7 @@ func TestContext7GuidedReceiptRejectsChangedRegistrationAndSignedEndpoint(t *tes
 
 func TestContext7GuidedReceiptMigratesLegacyRegistrationOnlyWithExplicitID(t *testing.T) {
 	f, _, _ := context7GuidedFixture(t)
-	if out, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--prepare", "--chatgpt-app-id", fixturePersonalAppID); err != nil {
+	if out, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--chatgpt-app-id", fixturePersonalAppID); err != nil {
 		t.Fatalf("initial preparation failed: %s %v", out, err)
 	}
 	state, err := f.store.Load()
@@ -271,10 +271,10 @@ func TestContext7GuidedReceiptMigratesLegacyRegistrationOnlyWithExplicitID(t *te
 	if err := f.store.Save(state); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--prepare"); err == nil || !strings.Contains(err.Error(), "action_required") {
+	if _, _, err := f.execute(false, "add", "context7", "--target", "chatgpt"); err == nil || !strings.Contains(err.Error(), "action_required") {
 		t.Fatalf("legacy receipt did not require a new explicit ID: %v", err)
 	}
-	if out, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--prepare", "--chatgpt-app-id", fixturePersonalAppID); err != nil {
+	if out, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--chatgpt-app-id", fixturePersonalAppID); err != nil {
 		t.Fatalf("legacy receipt migration failed: %s %v", out, err)
 	}
 	got, err := f.store.Load()
@@ -296,7 +296,7 @@ func TestContext7GuidedForeignFilesAndCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	command := NewRoot(f.app)
-	command.SetArgs([]string{"add", "context7", "--target", "chatgpt", "--prepare", "--chatgpt-app-id", fixturePersonalAppID})
+	command.SetArgs([]string{"add", "context7", "--target", "chatgpt", "--chatgpt-app-id", fixturePersonalAppID})
 	if err := command.ExecuteContext(ctx); err == nil {
 		t.Fatal("cancelled command completed")
 	}
@@ -305,7 +305,7 @@ func TestContext7GuidedForeignFilesAndCancellation(t *testing.T) {
 		t.Fatalf("cancel mutated state %+v %v", state, err)
 	}
 	for _, args := range [][]string{
-		{"add", "context7", "--target", "chatgpt", "--prepare", "--chatgpt-app-id", fixturePersonalAppID},
+		{"add", "context7", "--target", "chatgpt", "--chatgpt-app-id", fixturePersonalAppID},
 		{"remove", "context7", "--target", "chatgpt", "--external-uninstalled", "--purge-data"},
 	} {
 		if out, _, err := f.execute(false, args...); err != nil {
@@ -320,7 +320,7 @@ func TestContext7GuidedForeignFilesAndCancellation(t *testing.T) {
 
 func TestContext7GuidedMixedUpdateUsesOneNewImmutableRelease(t *testing.T) {
 	f, d, a := context7GuidedFixture(t)
-	if out, _, err := f.execute(false, "add", "context7", "--target", "kiro,chatgpt", "--prepare", "--chatgpt-app-id", fixturePersonalAppID); err != nil {
+	if out, _, err := f.execute(false, "add", "context7", "--target", "kiro,chatgpt", "--chatgpt-app-id", fixturePersonalAppID); err != nil {
 		t.Fatalf("%s %v", out, err)
 	}
 	raw, err := os.ReadFile(filepath.Join(a.root, "plugin.json"))
@@ -374,13 +374,13 @@ func TestContext7GuidedMixedUpdateUsesOneNewImmutableRelease(t *testing.T) {
 func TestContext7GuidedDoesNotBypassSignatureOrScope(t *testing.T) {
 	f, d, a := context7GuidedFixture(t)
 	d.err = fmt.Errorf("signed Directory signature verification failed")
-	out, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--prepare", "--format", "json")
+	out, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--format", "json")
 	if err == nil || a.verifiedCalls != 0 || strings.Contains(out, "action_required") {
 		t.Fatalf("signature failure hidden: %s %v", out, err)
 	}
 	for _, args := range [][]string{
-		{"add", a.root, "--target", "chatgpt", "--prepare"},
-		{"add", "context7", "--target", "chatgpt", "--prepare", "--scope", "project"},
+		{"add", a.root, "--target", "chatgpt"},
+		{"add", "context7", "--target", "chatgpt", "--scope", "project"},
 		{"add", "context7", "--target", "chatgpt", "--chatgpt-app-id", fixturePersonalAppID},
 	} {
 		if _, _, err := f.execute(false, args...); err == nil {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -822,7 +822,7 @@ func TestMissingManagedStdioRuntimeFailsAutomaticActivationPreflightWithoutMutat
 	}
 }
 
-func TestKiroMissingDuplexFailsLifecyclePreflightWithoutMutation(t *testing.T) {
+func TestKiroGuidedSetupDoesNotRequireDuplexRunner(t *testing.T) {
 	t.Parallel()
 	client := fixtureClient(t, domain.ClientKiro)
 	client.ExecutablePath = "/test/bin/kiro-cli"
@@ -832,30 +832,30 @@ func TestKiroMissingDuplexFailsLifecyclePreflightWithoutMutation(t *testing.T) {
 	plugin := writeCLIPlugin(t)
 	writeCLIMCP(t, plugin)
 
-	_, _, err := fixture.execute(false, "add", plugin, "--target", string(domain.ClientKiro))
-	if err == nil || !strings.Contains(err.Error(), "requires an ACP duplex process runner") {
-		t.Fatalf("duplex preflight error = %v", err)
+	out, _, err := fixture.execute(false, "add", plugin, "--target", string(domain.ClientKiro))
+	if err != nil || !strings.Contains(out, "Runtime connections have not been verified") {
+		t.Fatalf("guided setup = %q %v", out, err)
 	}
 	state, loadErr := fixture.store.Load()
 	if loadErr != nil {
 		t.Fatal(loadErr)
 	}
-	if len(state.Installations) != 0 || runner.calls != 0 {
-		t.Fatalf("duplex preflight mutated state or invoked Kiro: state=%+v calls=%d", state, runner.calls)
+	if len(state.Installations) != 1 || onlyCLIClient(state.Installations[0]).InstallIntent != domain.InstallIntentPrepare || runner.calls != 0 {
+		t.Fatalf("guided setup did not persist preparation safely: state=%+v calls=%d", state, runner.calls)
 	}
 	_, _, retryErr := fixture.execute(false, "add", plugin, "--target", string(domain.ClientKiro))
-	if retryErr == nil || !strings.Contains(retryErr.Error(), "requires an ACP duplex process runner") {
-		t.Fatalf("duplex preflight retry = %v", retryErr)
+	if retryErr != nil {
+		t.Fatalf("guided setup retry = %v", retryErr)
 	}
 	state, loadErr = fixture.store.Load()
 	if loadErr != nil {
 		t.Fatal(loadErr)
 	}
-	if len(state.Installations) != 0 || runner.calls != 0 {
-		t.Fatalf("duplex retry entered verify-only or mutated: state=%+v calls=%d", state, runner.calls)
+	if len(state.Installations) != 1 || runner.calls != 0 {
+		t.Fatalf("guided retry invoked Kiro or lost state: state=%+v calls=%d", state, runner.calls)
 	}
-	if _, statErr := os.Stat(client.ConfigRoot); !os.IsNotExist(statErr) {
-		t.Fatalf("duplex preflight created Kiro package/config root %q: %v", client.ConfigRoot, statErr)
+	if _, statErr := os.Stat(filepath.Join(client.ConfigRoot, "settings", "mcp.json")); statErr != nil {
+		t.Fatalf("guided setup did not create Kiro MCP config: %v", statErr)
 	}
 }
 

--- a/cli/plugin-kit-ai/internal/agentpluginscli/directory_rollout_semantics_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/directory_rollout_semantics_test.go
@@ -359,7 +359,7 @@ func TestInteractiveDirectoryAddOffersOnlyOneCompleteSignedTargetSet(t *testing.
 	}
 }
 
-func TestInteractiveDirectoryAddOffersKiroPreparationWhenAutomaticPreflightFails(t *testing.T) {
+func TestInteractiveDirectoryAddOffersKiroGuidedPreparation(t *testing.T) {
 	rollout := newRolloutDirectoryFixture(t,
 		[]domain.ClientID{domain.ClientCursor, domain.ClientKiro},
 		[]domain.ClientID{domain.ClientCursor, domain.ClientKiro})

--- a/cli/plugin-kit-ai/internal/agentpluginscli/interactive_targets.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/interactive_targets.go
@@ -84,20 +84,6 @@ func skippedTargets(clients []domain.DetectedClient, reason string) []targetSkip
 func (app App) compatibleDetectedTargets(ctx context.Context, source string, detected []domain.DetectedClient, intents ...map[domain.ClientID]domain.InstallIntent) ([]domain.DetectedClient, []targetSkip, *loadedPackage, error) {
 	candidates := detected
 	var skipped []targetSkip
-	// The registration resume command applies --prepare to the entire selection.
-	// Keep its target grammar and the menu aligned, even for eligible peers.
-	if app.chatGPTPreparation || (len(intents) > 0 && intents[0][domain.ClientChatGPT] == domain.InstallIntentPrepare) {
-		var allowed []domain.DetectedClient
-		for _, client := range detected {
-			if client.ClientID == domain.ClientKiro || client.ClientID == domain.ClientChatGPT {
-				allowed = append(allowed, client)
-			} else {
-				skipped = append(skipped, targetSkip{client.ClientID, "--prepare supports only Kiro and ChatGPT; install this client separately without --prepare"})
-			}
-		}
-		detected = allowed
-		candidates = allowed
-	}
 
 	switch {
 	case strings.HasPrefix(source, "discovery:"):
@@ -178,6 +164,13 @@ func (app App) compatibleDirectoryTargets(ctx context.Context, selector string, 
 	resolveSelector := selector
 	if request.Selector != "" {
 		resolveSelector = request.Selector
+	}
+	if productID, productErr := directorySelectorProductID(bundle.Snapshot, resolveSelector); productErr == nil && productID == "context7" && len(intents) > 0 {
+		if intents[0] == nil {
+			intents[0] = make(map[domain.ClientID]domain.InstallIntent)
+		}
+		intents[0][domain.ClientChatGPT] = domain.InstallIntentPrepare
+		intents[0][domain.ClientKiro] = domain.InstallIntentPrepare
 	}
 	clients := detectedClientMap(detected)
 	environment := directoryEnvironment(clients)

--- a/cli/plugin-kit-ai/internal/agentpluginscli/kiro_prepare_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/kiro_prepare_test.go
@@ -21,7 +21,7 @@ func TestKiroPrepareCLIPlainAndJSON(t *testing.T) {
 			fixture.app.Lifecycle.Activator = providers.Activator{}
 			plugin := writeCLIPlugin(t)
 			writeCLIMCP(t, plugin)
-			out, _, err := fixture.execute(false, "add", plugin, "--target", "kiro", "--prepare", "--format", format)
+			out, _, err := fixture.execute(false, "add", plugin, "--target", "kiro", "--format", format)
 			if err != nil {
 				t.Fatalf("%s: %v", out, err)
 			}
@@ -63,19 +63,15 @@ func TestKiroPrepareCLIPlainAndJSON(t *testing.T) {
 	}
 }
 
-func TestPrepareRejectsInvalidTargetsBeforeAcquisition(t *testing.T) {
-	for _, target := range []string{"cursor", "kiro,cursor", ""} {
-		t.Run(target, func(t *testing.T) {
-			fixture := newCLIFixture(t, nil)
-			_, _, err := fixture.execute(false, "add", "context7", "--target", target, "--prepare")
-			if err == nil || !strings.Contains(err.Error(), "--prepare requires --target kiro") {
-				t.Fatalf("invalid target: %v", err)
-			}
-			state, _ := fixture.store.Load()
-			if len(state.Installations) != 0 {
-				t.Fatal("mutated")
-			}
-		})
+func TestPrepareFlagWasRemoved(t *testing.T) {
+	fixture := newCLIFixture(t, nil)
+	_, _, err := fixture.execute(false, "add", "context7", "--target", "kiro", "--prepare")
+	if err == nil || !strings.Contains(err.Error(), "unknown flag: --prepare") {
+		t.Fatalf("removed flag accepted: %v", err)
+	}
+	state, _ := fixture.store.Load()
+	if len(state.Installations) != 0 {
+		t.Fatal("mutated")
 	}
 }
 
@@ -138,7 +134,7 @@ func TestPreparedLifecycleVersionDetectionNeverLaunchesKiro(t *testing.T) {
 	fixture := newCLIFixture(t, []domain.DetectedClient{kiro})
 	plugin := writeCLIPlugin(t)
 	writeCLIMCP(t, plugin)
-	if out, _, err := fixture.execute(false, "add", plugin, "--target", "kiro", "--prepare"); err != nil {
+	if out, _, err := fixture.execute(false, "add", plugin, "--target", "kiro"); err != nil {
 		t.Fatalf("%s: %v", out, err)
 	}
 	detector := &observedProbingDetector{clients: []domain.DetectedClient{kiro, fixtureClient(t, domain.ClientCursor)}}
@@ -189,8 +185,10 @@ func TestKiroPreparationUsesNormalDirectoryResolution(t *testing.T) {
 			if err := loaded.cleanup(); err != nil {
 				t.Fatal(err)
 			}
+			rollout.directory.bundle.Snapshot.Products[0].ID = "context7"
+			rollout.directory.bundle.Snapshot.Distributions[0].ProductID = "context7"
 			rollout.directory.bundle.Snapshot.Products[0].Aliases = append(rollout.directory.bundle.Snapshot.Products[0].Aliases, "context7")
-			out, _, err := rollout.cli.execute(false, "add", "context7", "--target", "kiro", "--prepare", "--format", "json")
+			out, _, err := rollout.cli.execute(false, "add", "context7", "--target", "kiro", "--format", "json")
 			if !supported {
 				if err == nil || rollout.acquirer.verifiedCalls != 0 {
 					t.Fatalf("bypassed compatibility: %s %v", out, err)

--- a/cli/plugin-kit-ai/internal/agentpluginscli/prepare.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/prepare.go
@@ -3,6 +3,7 @@ package agentpluginscli
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/ports"
@@ -66,7 +67,10 @@ func lifecycleInstallIntents(installation domain.Installation, scope string, exp
 
 // Resolve Directory aliases to the retained product before any executable
 // detection, just as acquisition does before choosing a release.
-func (app App) addLifecycleIntents(ctx context.Context, source, scope string, explicit map[domain.ClientID]domain.InstallIntent) (map[domain.ClientID]domain.InstallIntent, error) {
+func (app App) addLifecycleIntents(ctx context.Context, source, scope string, explicit map[domain.ClientID]domain.InstallIntent, targetSets ...[]domain.ClientID) (map[domain.ClientID]domain.InstallIntent, error) {
+	if explicit == nil {
+		explicit = make(map[domain.ClientID]domain.InstallIntent)
+	}
 	if app.StateStore == nil {
 		return explicit, nil
 	}
@@ -75,7 +79,13 @@ func (app App) addLifecycleIntents(ctx context.Context, source, scope string, ex
 		return nil, err
 	}
 	installation, _ := locallyMatchedInstallation(state, source)
-	if isDirectorySelector(source) && app.DirectoryClient != nil && len(state.Installations) > 0 {
+	needsGuidedResolution := strings.Contains(strings.ToLower(source), "context7") && (len(targetSets) == 0 || len(targetSets[0]) == 0)
+	if !needsGuidedResolution && len(targetSets) > 0 {
+		for _, target := range targetSets[0] {
+			needsGuidedResolution = needsGuidedResolution || strings.Contains(strings.ToLower(source), "context7") && (target == domain.ClientKiro || target == domain.ClientChatGPT)
+		}
+	}
+	if isDirectorySelector(source) && app.DirectoryClient != nil && (len(state.Installations) > 0 || needsGuidedResolution) {
 		bundle, err := app.DirectoryClient.Load(ctx, installedDirectoryFloor(state))
 		if err != nil {
 			return nil, err
@@ -84,21 +94,41 @@ func (app App) addLifecycleIntents(ctx context.Context, source, scope string, ex
 		if err != nil && !errors.Is(err, domain.ErrDirectoryNotFound) {
 			return nil, err
 		}
-		installation, _, err = retainedDirectoryInstallation(state, source, productID)
-		if err != nil {
-			return nil, err
+		if err == nil && productID == "context7" {
+			explicit[domain.ClientKiro] = domain.InstallIntentPrepare
+			explicit[domain.ClientChatGPT] = domain.InstallIntentPrepare
+		}
+		if len(state.Installations) > 0 {
+			installation, _, err = retainedDirectoryInstallation(state, source, productID)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	return lifecycleInstallIntents(installation, scope, explicit), nil
 }
 
-func preflightAddTargets(ctx context.Context, app App, opts *options, source string, targets []domain.ClientID, clients []domain.DetectedClient) ([]domain.DetectedClient, map[domain.ClientID]domain.DetectedClient, error) {
-	intents, err := app.addLifecycleIntents(ctx, source, opts.scope, opts.installIntents)
-	if err != nil {
-		return nil, nil, err
+// Direct packages are already loaded before this decision, so only packages
+// with useful Kiro components enter the guided preparation lane.
+func applyLoadedGuidedIntents(opts *options, loaded loadedPackage, targets []domain.ClientID) {
+	if opts.installIntents == nil {
+		opts.installIntents = make(map[domain.ClientID]domain.InstallIntent)
 	}
-	opts.installIntents = intents
-	return preflightSelectedTargets(ctx, app, targets, clients, !opts.dryRun && isDirectorySelector(source), intents)
+	if (loaded.origin != domain.OriginModeDirect && loaded.envelope.Manifest.Name != "context7") || (!loaded.envelope.MCP.Enabled && len(loaded.envelope.Skills) == 0) {
+		return
+	}
+	for _, target := range targets {
+		if target == domain.ClientKiro && opts.installIntents[target] == "" {
+			opts.installIntents[target] = domain.InstallIntentPrepare
+		}
+		if target == domain.ClientChatGPT && loaded.chatGPTPreparation {
+			opts.installIntents[target] = domain.InstallIntentPrepare
+		}
+	}
+}
+
+func preflightAddTargets(ctx context.Context, app App, opts *options, source string, targets []domain.ClientID, clients []domain.DetectedClient) ([]domain.DetectedClient, map[domain.ClientID]domain.DetectedClient, error) {
+	return preflightSelectedTargets(ctx, app, targets, clients, !opts.dryRun && isDirectorySelector(source), opts.installIntents)
 }
 
 func automaticInstallTargets(targets []domain.ClientID, intents map[domain.ClientID]domain.InstallIntent) []domain.ClientID {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/review_regression_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/review_regression_test.go
@@ -72,7 +72,7 @@ func TestReviewUnrelatedPreparationPreservesAutomaticDirectoryGate(t *testing.T)
 	}
 	writeCLIMCP(t, plugin)
 	r.cli.app.Lifecycle.Activator = providers.Activator{}
-	if out, _, err := r.cli.execute(false, "add", plugin, "--target", "kiro", "--prepare"); err != nil {
+	if out, _, err := r.cli.execute(false, "add", plugin, "--target", "kiro"); err != nil {
 		t.Fatalf("prepare: %s %v", out, err)
 	}
 	if err := check(); err == nil {
@@ -113,7 +113,7 @@ func TestUnrelatedRetainedPreparationPreservesAutomaticDirectoryGate(t *testing.
 	}
 	writeCLIMCP(t, plugin)
 	r.cli.app.Lifecycle.Activator = providers.Activator{}
-	if out, _, err := r.cli.execute(false, "add", plugin, "--target", "kiro", "--prepare"); err != nil {
+	if out, _, err := r.cli.execute(false, "add", plugin, "--target", "kiro"); err != nil {
 		t.Fatalf("prepare: %s %v", out, err)
 	}
 	check()
@@ -154,7 +154,7 @@ func TestUnrelatedPreparationPreservesAutomaticUpdateAndRepairEvidence(t *testin
 	// Seed a recorded native binding with disposable preparation, then model a
 	// historical automatic binding. Every command below must fail at resolution,
 	// before acquisition or activation can execute a client.
-	if out, _, err := r.cli.execute(false, "add", "rollout-demo", "--target", "kiro", "--prepare"); err != nil {
+	if out, _, err := r.cli.execute(false, "add", "rollout-demo", "--target", "kiro"); err != nil {
 		t.Fatalf("seed: %s %v", out, err)
 	}
 	state, err := r.cli.store.Load()
@@ -211,7 +211,7 @@ func TestUnrelatedPreparationPreservesAutomaticUpdateAndRepairEvidence(t *testin
 		t.Fatal(err)
 	}
 
-	if out, _, err := r.cli.execute(false, "add", plugin, "--target", "kiro", "--prepare"); err != nil {
+	if out, _, err := r.cli.execute(false, "add", plugin, "--target", "kiro"); err != nil {
 		t.Fatalf("prepare: %s %v", out, err)
 	}
 	check()

--- a/cli/plugin-kit-ai/internal/agentpluginscli/source.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/source.go
@@ -482,6 +482,7 @@ func (app App) acquireDirectory(ctx context.Context, selector string, request pa
 	if request.Selector != "" {
 		resolveSelector = request.Selector
 	}
+	productID, _ := directorySelectorProductID(bundle.Snapshot, resolveSelector)
 	affectedTargets := expandAffectedSurfaceTargets(request.Targets)
 	resolveRequest := domain.DirectoryResolveRequest{
 		Selector: resolveSelector, Targets: affectedTargets, Scope: domain.ScopeUser,
@@ -494,7 +495,7 @@ func (app App) acquireDirectory(ctx context.Context, selector string, request pa
 	installation, _ := locallyMatchedInstallation(state, resolveSelector)
 	intents := lifecycleInstallIntents(installation, "user", nil)
 	for _, target := range affectedTargets {
-		if target == domain.ClientChatGPT && (app.chatGPTPreparation || intents[target] == domain.InstallIntentPrepare) {
+		if target == domain.ClientChatGPT && (productID == "context7" || app.chatGPTPreparation || intents[target] == domain.InstallIntentPrepare) {
 			preparingChatGPT = true
 		}
 	}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/target_eligibility_guidance_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/target_eligibility_guidance_test.go
@@ -68,7 +68,7 @@ func TestKiroEligibilityDoesNotGuessFromClientName(t *testing.T) {
 	}
 }
 
-func TestExplicitKiroPreflightDoesNotSuggestActivatingInstalledConfiguration(t *testing.T) {
+func TestExplicitKiroUsesGuidedPreparation(t *testing.T) {
 	kiro := fixtureClient(t, domain.ClientKiro)
 	kiro.ExecutablePath = "/test/bin/kiro-cli"
 	fixture := newCLIFixture(t, []domain.DetectedClient{kiro})
@@ -76,7 +76,7 @@ func TestExplicitKiroPreflightDoesNotSuggestActivatingInstalledConfiguration(t *
 	plugin := writeCLIPlugin(t)
 	writeCLIMCP(t, plugin)
 	stdout, _, err := fixture.execute(false, "add", plugin, "--target", "kiro", "--dry-run")
-	if err == nil || !strings.Contains(stdout, "Nothing was installed") || strings.Contains(stdout, "Planned action:") {
+	if err != nil || strings.Contains(stdout, "Nothing was installed") || !strings.Contains(stdout, "Planned action: After preparation") {
 		t.Fatalf("output=%q err=%v", stdout, err)
 	}
 }

--- a/docs/PLUGIN_KIT_AI_AUTHORING.md
+++ b/docs/PLUGIN_KIT_AI_AUTHORING.md
@@ -127,8 +127,8 @@ rejects EOF, partial bytes, or trailing contradictions, then stops and reaps the
 long-lived ACP process through supervised containment. Automatic Kiro ACP
 verification is available only on Linux after capability preflight proves
 delegated cgroup v2 creation, atomic CLONE_INTO_CGROUP placement, and
-cgroup.kill. On macOS, Windows, and Linux hosts without that containment,
-`--prepare` installs the owned Kiro skills and MCP configuration without
+cgroup.kill. On macOS, Windows, and Linux hosts without that containment, the guided lane
+installs the owned Kiro skills and MCP configuration without
 claiming a connected runtime. It reports the exact OAuth/restart step and keeps
 the lifecycle receipt for update, repair, remove, and reinstall. Failure to
 start ACP
@@ -146,10 +146,11 @@ ChatGPT packages with a verified publisher app binding are prepared directly.
 Canonical Directory Context7 also has a guided personal-registration path:
 
 ```bash
-npx universal-agent-plugins add context7 --target chatgpt --prepare
+npx universal-agent-plugins add context7 --target chatgpt
 ```
 
-The first run prints the public `https://mcp.context7.com/mcp` endpoint and
+The CLI selects this guided lane automatically. The first run prints the public
+`https://mcp.context7.com/mcp` endpoint and
 requires **No authentication**. After the user creates and connects the app in
 ChatGPT Developer Mode, the CLI accepts its `asdk_app_...` ID and prepares a
 personal marketplace package. The ID stays in private installer state and is

--- a/install/integrationctl/agentplugins/domain/chatgpt_mapping.go
+++ b/install/integrationctl/agentplugins/domain/chatgpt_mapping.go
@@ -7,14 +7,14 @@ import (
 
 const Context7OAuthURL = "https://mcp.context7.com/mcp/oauth"
 const Context7ChatGPTURL = "https://mcp.context7.com/mcp"
-const ChatGPTRegistrationAction = "In ChatGPT Developer Mode, create an app using https://mcp.context7.com/mcp and select No authentication. Connect it, copy its asdk_app_ ID from app settings, and Rerun add context7 --target chatgpt --prepare --chatgpt-app-id <ID>. Then install the prepared plugin from the personal marketplace and select it in a new chat. Official steps: https://developers.openai.com/plugins/build/plugins. The public Context7 endpoint and both Context7 tools have been verified in ChatGPT. The personal registration receipt is retained locally after remove, including --purge-data, for reinstall."
+const ChatGPTRegistrationAction = "ChatGPT setup required:\n1. In Developer Mode, create and connect an app for https://mcp.context7.com/mcp with No authentication.\n2. Copy its asdk_app_ ID from app settings.\n3. Run: npx universal-agent-plugins add context7 --target chatgpt --chatgpt-app-id <ID>\n4. Install Context7 from your personal marketplace and select it in a new chat.\nGuide: https://developers.openai.com/plugins/build/plugins"
 
 // ChatGPTMappedPreparationAction applies only after the personal mapping exists.
-const ChatGPTMappedPreparationAction = "Prepare the personal local marketplace, then install it in ChatGPT and select Context7 in a new chat. No authentication is required for the public Context7 endpoint. The endpoint and both Context7 tools have been verified in ChatGPT. The personal registration receipt is retained locally after remove, including --purge-data, for reinstall."
+const ChatGPTMappedPreparationAction = "Install Context7 from your personal marketplace in ChatGPT, then select it in a new chat."
 
 // ChatGPTPreparedAction names the local artifact after successful preparation.
 func ChatGPTPreparedAction(path, name string) string {
-	return fmt.Sprintf("In ChatGPT, add the personal local marketplace at %s (.agents/plugins/marketplace.json), install %s, and select it in a new chat. No authentication is required for the public Context7 endpoint. The endpoint and both Context7 tools have been verified in ChatGPT. The registration receipt is retained locally after remove, including --purge-data, for reinstall.", path, name)
+	return fmt.Sprintf("ChatGPT: add the personal marketplace at %s (.agents/plugins/marketplace.json), install %s, then select it in a new chat.", path, name)
 }
 
 // ChatGPTLocalMapping is a personal registration receipt, never catalog evidence.

--- a/npm/agentplugins/README.md
+++ b/npm/agentplugins/README.md
@@ -26,7 +26,7 @@ verified scripts in the [project README](https://github.com/777genius/universal-
 For the verified Context7 setup in ChatGPT and Kiro:
 
 ```bash
-npx universal-agent-plugins add context7 --target chatgpt,kiro --prepare
+npx universal-agent-plugins add context7 --target chatgpt,kiro
 ```
 
 For ChatGPT, follow the printed Developer Mode steps, use
@@ -76,7 +76,7 @@ npx universal-agent-plugins info context7
 npx universal-agent-plugins add context7 --target codex,cursor,kiro
 
 # Prepare Context7 for ChatGPT and Kiro
-npx universal-agent-plugins add context7 --target chatgpt,kiro --prepare
+npx universal-agent-plugins add context7 --target chatgpt,kiro
 
 # Manage installed plugins
 npx universal-agent-plugins update context7 --target codex,cursor


### PR DESCRIPTION
`add context7` previously required users to discover and pass `--prepare`, then returned a long single-paragraph ChatGPT instruction. The CLI now selects the guided ChatGPT and Kiro preparation intent automatically, preserves other compatible clients in interactive selection, and rejects the removed flag.

ChatGPT action-required output is now four short steps with the exact endpoint, authentication choice, app ID location, executable resume command, and final marketplace action. README, npm README, authoring documentation, and changelog use the flag-free command.

Validation:
- `go test ./cli/plugin-kit-ai/internal/agentpluginscli ./install/integrationctl/agentplugins/domain`
- focused repository contract tests
- local release-style binary: `add --help` has no `--prepare`
- isolated live Directory run reaches the new four-step ChatGPT action-required output without `--prepare`
- broader integrationctl packages passed except known unrelated macOS POSIX case-collision and `/dev/fd` cleanup tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `agentplugins add` now automatically guides Context7 setup for ChatGPT and Kiro when selected as targets.
  - Kiro setup no longer requires a duplex runtime connection and can complete with runtime verification pending.
  - ChatGPT registration guidance now provides four concise, executable steps.

- **Bug Fixes**
  - Improved Context7 target detection and preparation across direct and directory-based installations.
  - Added clearer validation for ChatGPT app IDs and supported sources.

- **Documentation**
  - Updated README and authoring examples to use the streamlined commands without `--prepare`.
  - Refreshed ChatGPT setup instructions and lifecycle messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->