### PR TITLE
fix(cli): continue installs while ChatGPT setup is pending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Changes after `v1.2.4` land here.
 
 ### Fixed
 
+- A pending ChatGPT registration no longer cancels a multi-client Context7
+  installation. Other selected clients are installed and ChatGPT is reported
+  as a separate setup step with a ChatGPT-only resume command.
 - `agentplugins add` now enters the guided Context7 setup for ChatGPT and Kiro
   automatically. The former `--prepare` flag has been removed, and ChatGPT
   registration guidance is formatted as four short, executable steps.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ npx universal-agent-plugins add context7 --target chatgpt,kiro
 - ChatGPT: the CLI guides you to create a Developer Mode app for
   `https://mcp.context7.com/mcp` with **No authentication**, accepts the
   resulting `asdk_app_...` ID, and prepares a personal marketplace package.
-  You still install that package and select Context7 in a new chat.
+  You still install that package and select Context7 in a new chat. When other
+  clients are selected too, the CLI installs them first and reports ChatGPT as
+  a separate setup step instead of cancelling the whole batch.
 - Kiro: the CLI installs its owned skills and MCP entry while preserving
   unrelated configuration. On macOS and Windows it reports the remaining
   Kiro OAuth/restart step instead of claiming automatic runtime verification.

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
@@ -91,8 +91,9 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 	if err := authorizeSecurityAssessment(cmd, app, opts, &loaded); err != nil {
 		return err
 	}
-	if loaded.chatGPTPreparation && loaded.localChatGPTMapping == nil {
-		action := chatGPTRegistrationResumeAction(cmd, loaded.envelope.Source.RequestedSource, targets)
+	deferredChatGPT := loaded.chatGPTPreparation && loaded.localChatGPTMapping == nil && containsClientID(targets, domain.ClientChatGPT)
+	if deferredChatGPT && len(targets) == 1 {
+		action := chatGPTRegistrationResumeAction(cmd, loaded.envelope.Source.RequestedSource, []domain.ClientID{domain.ClientChatGPT})
 		if opts.format == "json" {
 			if err := writeJSONResult(cmd.OutOrStdout(), "add", outputResultFailure, map[string]any{"status": "action_required", "target": "chatgpt", "mcp_url": domain.Context7ChatGPTURL, "authentication": "none", "next_action": action, "remote_verified": true, "mutated": false}); err != nil {
 				return err
@@ -100,14 +101,18 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 		}
 		return fmt.Errorf("action_required: %s", action)
 	}
-	if len(targets) == 1 {
+	executionTargets := targets
+	if deferredChatGPT {
+		executionTargets = withoutClientID(targets, domain.ClientChatGPT)
+	}
+	if len(executionTargets) == 1 && !deferredChatGPT {
 		selectedOptions := *opts
-		selectedOptions.target = string(targets[0])
+		selectedOptions.target = string(executionTargets[0])
 		if activationComplete || authComplete {
 			return runAddLoaded(ctx, cmd, app, &selectedOptions, loaded, activationComplete, authComplete, clients, needsInstallConfirmation)
 		}
 		if state, err := app.StateStore.Load(); err == nil {
-			if installation, ok := locallyMatchedInstallation(state, loaded.envelope.Manifest.Name); ok && installationHasTarget(installation, targets[0], string(domain.ScopeUser)) {
+			if installation, ok := locallyMatchedInstallation(state, loaded.envelope.Manifest.Name); ok && installationHasTarget(installation, executionTargets[0], string(domain.ScopeUser)) {
 				return runAddLoaded(ctx, cmd, app, &selectedOptions, loaded, false, false, clients, needsInstallConfirmation)
 			}
 		}
@@ -120,7 +125,7 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 		Directory: cloneDirectoryOrigin(loaded.directory),
 		DryRun:    opts.dryRun, Targets: make([]addTargetResult, 0, len(targets)),
 	}
-	selected, detected, err := preflightSelectedTargets(ctx, app, targets, clients, false)
+	selected, detected, err := preflightSelectedTargets(ctx, app, executionTargets, clients, false)
 	if err != nil {
 		return err
 	}
@@ -166,6 +171,9 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 		return fmt.Errorf("group preflight failed; no target was changed (selected targets: %v): %w%s", targets, err, addGroupNextAction(combined.Targets))
 	}
 	if opts.dryRun {
+		if deferredChatGPT {
+			appendDeferredChatGPT(&combined, cmd, loaded)
+		}
 		return renderAddMultiResult(cmd, opts, combined, loaded.envelope)
 	}
 	if needsInstallConfirmation {
@@ -217,6 +225,11 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 		_ = renderAddMultiResult(cmd, opts, combined, loaded.envelope)
 		return err
 	}
+	if deferredChatGPT {
+		// The manual ChatGPT registration is intentionally outside the atomic
+		// local-client group. Report it after every installable peer succeeds.
+		appendDeferredChatGPT(&combined, cmd, loaded)
+	}
 	if err := renderAddMultiResult(cmd, opts, combined, loaded.envelope); err != nil {
 		return err
 	}
@@ -227,6 +240,35 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 		return resumeInteractiveLifecycle(ctx, cmd, service, input, inputs[0].Envelope, applied.Targets[0])
 	}
 	return nil
+}
+
+func containsClientID(targets []domain.ClientID, wanted domain.ClientID) bool {
+	for _, target := range targets {
+		if target == wanted {
+			return true
+		}
+	}
+	return false
+}
+
+func withoutClientID(targets []domain.ClientID, excluded domain.ClientID) []domain.ClientID {
+	filtered := make([]domain.ClientID, 0, len(targets))
+	for _, target := range targets {
+		if target != excluded {
+			filtered = append(filtered, target)
+		}
+	}
+	return filtered
+}
+
+func appendDeferredChatGPT(result *addMultiResult, cmd *cobra.Command, loaded loadedPackage) {
+	action := chatGPTRegistrationResumeAction(cmd, loaded.envelope.Source.RequestedSource, []domain.ClientID{domain.ClientChatGPT})
+	result.Status = "completed_with_action_required"
+	if result.DryRun {
+		result.Status = "planned_with_action_required"
+	}
+	result.Targets = append(result.Targets, addTargetResult{Target: string(domain.ClientChatGPT), Status: "action_required", NextAction: action})
+	result.setTargetProof(domain.ClientChatGPT, "not_run")
 }
 
 func newAddAcquisitionProof(loaded loadedPackage) (addAcquisitionProof, error) {
@@ -394,6 +436,12 @@ func renderAddMultiResult(cmd *cobra.Command, opts *options, result addMultiResu
 		return err
 	}
 	for _, target := range result.Targets {
+		if target.Status == "action_required" {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  %s: setup required\n    Next: %s\n", target.Target, target.NextAction); err != nil {
+				return err
+			}
+			continue
+		}
 		if err := renderOpenCodeRuntimeNotice(cmd.OutOrStdout(), target.Output.Result); err != nil {
 			return err
 		}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_guidance.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_guidance.go
@@ -13,9 +13,6 @@ import (
 // echo a personal ID; the only added value is a registration placeholder.
 func chatGPTRegistrationResumeAction(cmd *cobra.Command, source string, targets []domain.ClientID) string {
 	targetOption := strings.Join(clientIDStrings(targets), ",")
-	if cmd.Flags().Changed("target") {
-		targetOption, _ = cmd.Flags().GetString("target")
-	}
 	args := []string{"add", quoteResumeArgument(source), "--target", quoteResumeArgument(targetOption)}
 	cmd.Flags().Visit(func(flag *pflag.Flag) {
 		switch flag.Name {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_guidance_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_guidance_test.go
@@ -48,7 +48,7 @@ func TestContext7InteractivePreparationChoice(t *testing.T) {
 
 func emittedRegistrationCommand(t *testing.T, action string) string {
 	t.Helper()
-	_, command, ok := strings.Cut(action, "3. Run: npx universal-agent-plugins ")
+	_, command, ok := strings.Cut(action, "2. Resume: npx universal-agent-plugins ")
 	if !ok {
 		t.Fatalf("missing resume command: %s", action)
 	}
@@ -63,20 +63,31 @@ func TestContext7ResumeEmittedMixedCommandAndPreparedGuidance(t *testing.T) {
 	f, d, a := context7GuidedFixture(t)
 	before, _ := json.Marshal(d.bundle)
 	out, _, err := f.execute(false, "add", "context7-alias", "--target", "kiro,chatgpt", "--format", "json", "--scope", "user", "--plain", "--security-details", "--no-color")
-	if err == nil {
-		t.Fatal("expected registration")
+	if err != nil {
+		t.Fatalf("peer installation: %s %v", out, err)
 	}
 	var response struct {
-		Data map[string]any `json:"data"`
+		Data struct {
+			Targets []addTargetResult `json:"targets"`
+		} `json:"data"`
 	}
 	if err := json.Unmarshal([]byte(out), &response); err != nil {
 		t.Fatal(err)
 	}
-	command := emittedRegistrationCommand(t, response.Data["next_action"].(string))
-	for _, flag := range []string{"context7-alias", "kiro,chatgpt", "--format=json", "--scope=user", "--plain=true", "--security-details=true", "--no-color=true"} {
+	action := ""
+	for _, target := range response.Data.Targets {
+		if target.Target == string(domain.ClientChatGPT) {
+			action = target.NextAction
+		}
+	}
+	command := emittedRegistrationCommand(t, action)
+	for _, flag := range []string{"context7-alias", "--target chatgpt", "--format=json", "--scope=user", "--plain=true", "--security-details=true", "--no-color=true"} {
 		if !strings.Contains(command, flag) {
 			t.Fatalf("lost %s: %s", flag, command)
 		}
+	}
+	if strings.Contains(command, "kiro") {
+		t.Fatalf("resume must not reinstall completed peers: %s", command)
 	}
 	out, _, err = f.execute(false, strings.Fields(command)...)
 	if err != nil {
@@ -161,10 +172,10 @@ func TestContext7InteractiveSelectionOnlyAppliesSelectedIntent(t *testing.T) {
 			}
 			out, _, err := f.executeInput(true, "", "add", "context7", "--plain")
 			if chooseChatGPT {
-				if err == nil || !strings.Contains(err.Error(), "action_required") {
+				if err != nil || !strings.Contains(out, "chatgpt: setup required") {
 					t.Fatalf("%s %v", out, err)
 				}
-				command := emittedRegistrationCommand(t, err.Error())
+				command := emittedRegistrationCommand(t, out)
 				out, _, err = f.execute(false, strings.Fields(command)...)
 			}
 			if err != nil {
@@ -312,24 +323,33 @@ func TestContext7GuidedSelectionKeepsEligibleCodex(t *testing.T) {
 			if len(request.Choices) != 3 {
 				t.Fatalf("prepare choices: %+v", request)
 			}
-			return prompt.TargetSelectionResult{IDs: []domain.ClientID{domain.ClientKiro, domain.ClientChatGPT}}, nil
+			return prompt.TargetSelectionResult{IDs: []domain.ClientID{domain.ClientCodex, domain.ClientKiro, domain.ClientChatGPT}}, nil
 		},
 		confirmFn: func() (prompt.ConfirmationResult, error) { return prompt.ConfirmationResult{Accepted: true}, nil },
 	}
 	out, _, err := f.executeInput(true, "", "add", "context7", "--plain")
-	if err == nil || !strings.Contains(err.Error(), "action_required") {
+	if err != nil || !strings.Contains(out, "chatgpt: setup required") {
 		t.Fatalf("registration: %s %v", out, err)
 	}
-	command := emittedRegistrationCommand(t, err.Error())
-	if strings.Contains(command, "codex") || !strings.Contains(command, "chatgpt,kiro") {
+	command := emittedRegistrationCommand(t, out)
+	if strings.Contains(command, "codex") || strings.Contains(command, "kiro") || !strings.Contains(command, "--target chatgpt") {
 		t.Fatal(command)
+	}
+	state, _ := f.store.Load()
+	if len(state.Installations) != 1 || len(state.Installations[0].Clients) != 2 {
+		t.Fatalf("peer installation state: %+v", state)
+	}
+	for _, target := range []domain.ClientID{domain.ClientCodex, domain.ClientKiro} {
+		if !installationHasTarget(state.Installations[0], target, string(domain.ScopeUser)) {
+			t.Fatalf("%s peer missing from installation state: %+v", target, state)
+		}
 	}
 	out, _, err = f.execute(false, strings.Fields(command)...)
 	if err != nil {
 		t.Fatalf("resume %s: %s %v", command, out, err)
 	}
-	state, _ := f.store.Load()
-	if len(state.Installations) != 1 || len(state.Installations[0].Clients) != 2 {
+	state, _ = f.store.Load()
+	if len(state.Installations) != 1 || len(state.Installations[0].Clients) != 3 {
 		t.Fatalf("resume state: %+v", state)
 	}
 }

--- a/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_prepare_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_prepare_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/providers"
 )
 
-const fixturePersonalAppID = "asdk_app_0123456789abcdef0123456789abcdef"
+const fixturePersonalAppID = "plugin_asdk_app_0123456789abcdef0123456789abcdef"
 
 // This fixture exercises the verified-acquisition interface with immutable local
 // bytes. It is deliberately not a live catalog or remote ChatGPT qualification.
@@ -180,7 +180,7 @@ func TestContext7GuidedLifecycleRetainsReceipt(t *testing.T) {
 }
 
 func TestContext7GuidedRejectsInvalidIDsAndUnverifiedSource(t *testing.T) {
-	for _, id := range []string{"connector_old", "asdk_app_", "asdk_app_short", "asdk_app_bad/id", " asdk_app_abc", "plugin_asdk_app_0123456789abcdef0123456789abcdef"} {
+	for _, id := range []string{"connector_old", "asdk_app_", "asdk_app_short", "asdk_app_bad/id", " asdk_app_abc", "plugin_asdk_app_"} {
 		t.Run(id, func(t *testing.T) {
 			f, _, a := context7GuidedFixture(t)
 			_, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--chatgpt-app-id", id)

--- a/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_prepare_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_prepare_test.go
@@ -52,24 +52,27 @@ func context7GuidedFixture(t *testing.T) (cliFixture, *fixedDirectoryClient, *lo
 func TestContext7GuidedMissingRegistrationAndResume(t *testing.T) {
 	f, directory, acquirer := context7GuidedFixture(t)
 	out, _, err := f.execute(false, "add", "context7", "--target", "kiro,chatgpt", "--format", "json")
-	if err == nil {
-		t.Fatal("missing registration must require action")
+	if err != nil {
+		t.Fatalf("install peers before ChatGPT setup: %s %v", out, err)
 	}
 	var response struct {
 		Data map[string]any `json:"data"`
 	}
-	if json.Unmarshal([]byte(out), &response) != nil || response.Data["status"] != "action_required" || response.Data["mcp_url"] != domain.Context7ChatGPTURL || response.Data["authentication"] != "none" || response.Data["remote_verified"] != true {
+	if json.Unmarshal([]byte(out), &response) != nil || response.Data["status"] != "completed_with_action_required" || response.Data["succeeded"] != float64(1) || !strings.Contains(out, `"target":"chatgpt"`) || !strings.Contains(out, `"status":"action_required"`) {
 		t.Fatalf("action response %s: %v", out, err)
 	}
 	state, _ := f.store.Load()
-	if len(state.Installations) != 0 {
-		t.Fatal("missing registration mutated state")
+	if len(state.Installations) != 1 || len(state.Installations[0].Clients) != 1 {
+		t.Fatalf("peer installation state: %+v", state)
+	}
+	if !installationHasTarget(state.Installations[0], domain.ClientKiro, string(domain.ScopeUser)) {
+		t.Fatalf("Kiro peer missing from installation state: %+v", state)
 	}
 	if acquirer.verifiedCalls != 1 || acquirer.directGitCalls != 0 || acquirer.localCalls != 0 {
 		t.Fatalf("acquisition %#v", acquirer)
 	}
 	before, _ := json.Marshal(directory.bundle)
-	out, _, err = f.execute(false, "add", "context7", "--target", "kiro,chatgpt", "--chatgpt-app-id", fixturePersonalAppID, "--format", "json")
+	out, _, err = f.execute(false, "add", "context7", "--target", "chatgpt", "--chatgpt-app-id", fixturePersonalAppID, "--format", "json")
 	if err != nil {
 		t.Fatalf("resume: %s %v", out, err)
 	}

--- a/install/integrationctl/agentplugins/domain/chatgpt_mapping.go
+++ b/install/integrationctl/agentplugins/domain/chatgpt_mapping.go
@@ -7,7 +7,7 @@ import (
 
 const Context7OAuthURL = "https://mcp.context7.com/mcp/oauth"
 const Context7ChatGPTURL = "https://mcp.context7.com/mcp"
-const ChatGPTRegistrationAction = "ChatGPT setup required:\n1. In Developer Mode, create and connect an app for https://mcp.context7.com/mcp with No authentication.\n2. Copy its asdk_app_ ID from app settings.\n3. Run: npx universal-agent-plugins add context7 --target chatgpt --chatgpt-app-id <ID>\n4. Install Context7 from your personal marketplace and select it in a new chat.\nGuide: https://developers.openai.com/plugins/build/plugins"
+const ChatGPTRegistrationAction = "ChatGPT needs setup:\n1. Create a Developer Mode app for https://mcp.context7.com/mcp (No authentication) and copy its asdk_app_ ID.\n2. Resume: npx universal-agent-plugins add context7 --target chatgpt --chatgpt-app-id <ID>\n3. Install Context7 from Personal marketplace and select it in a new chat.\nGuide: https://developers.openai.com/plugins/build/plugins"
 
 // ChatGPTMappedPreparationAction applies only after the personal mapping exists.
 const ChatGPTMappedPreparationAction = "Install Context7 from your personal marketplace in ChatGPT, then select it in a new chat."

--- a/install/integrationctl/agentplugins/domain/chatgpt_mapping.go
+++ b/install/integrationctl/agentplugins/domain/chatgpt_mapping.go
@@ -7,7 +7,7 @@ import (
 
 const Context7OAuthURL = "https://mcp.context7.com/mcp/oauth"
 const Context7ChatGPTURL = "https://mcp.context7.com/mcp"
-const ChatGPTRegistrationAction = "ChatGPT needs setup:\n1. Create a Developer Mode app for https://mcp.context7.com/mcp (No authentication) and copy its asdk_app_ ID.\n2. Resume: npx universal-agent-plugins add context7 --target chatgpt --chatgpt-app-id <ID>\n3. Install Context7 from Personal marketplace and select it in a new chat.\nGuide: https://developers.openai.com/plugins/build/plugins"
+const ChatGPTRegistrationAction = "ChatGPT needs setup:\n1. Create a Developer Mode app for https://mcp.context7.com/mcp (No authentication) and copy its plugin_asdk_app ID.\n2. Resume: npx universal-agent-plugins add context7 --target chatgpt --chatgpt-app-id <ID>\n3. Install Context7 from Personal marketplace and select it in a new chat.\nGuide: https://developers.openai.com/plugins/build/plugins"
 
 // ChatGPTMappedPreparationAction applies only after the personal mapping exists.
 const ChatGPTMappedPreparationAction = "Install Context7 from your personal marketplace in ChatGPT, then select it in a new chat."
@@ -29,12 +29,12 @@ type ChatGPTLocalMapping struct {
 	AppID       string `json:"app_id"`
 }
 
-var chatGPTAppIDPattern = regexp.MustCompile(`^asdk_app_[0-9a-f]{32}$`)
+var chatGPTAppIDPattern = regexp.MustCompile(`^(?:plugin_)?asdk_app_[0-9a-f]{32}$`)
 var legacyChatGPTAppIDPattern = regexp.MustCompile(`^plugin_asdk_app_[0-9a-f]{32}$`)
 
 func ValidateChatGPTAppID(id string) error {
 	if !chatGPTAppIDPattern.MatchString(id) {
-		return fmt.Errorf("invalid ChatGPT app ID: copy the asdk_app_ ID from ChatGPT app settings")
+		return fmt.Errorf("invalid ChatGPT app ID: copy the plugin_asdk_app ID from ChatGPT app settings")
 	}
 	return nil
 }


### PR DESCRIPTION
Selecting ChatGPT without an existing personal app ID stopped the whole Context7 batch before any local client was installed. The CLI now installs every ready peer, reports ChatGPT as a separate setup step, and generates a resume command that targets only ChatGPT.

The ChatGPT-only flow still returns `action_required`, because no local installation can replace registration inside the user's ChatGPT account. Guidance is shorter, and README/CHANGELOG describe the batch behavior.

Validation:
- `go test ./internal/agentpluginscli -count=1`
- focused default-selection E2E proves Codex and Kiro are installed before ChatGPT registration, then ChatGPT resumes into the same installation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Multi-client installations no longer stop when ChatGPT requires additional setup. Other selected clients complete installation, while ChatGPT is reported separately.
  * ChatGPT resume commands now target only the remaining ChatGPT setup, excluding clients already installed.
  * Interactive setup now clearly identifies targets requiring follow-up action.

* **Documentation**
  * Updated ChatGPT and Kiro setup guidance to explain the separate setup flow for multi-client installations.
  * Streamlined ChatGPT Developer Mode instructions and resume guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->