### PR TITLE
fix(cli): continue batch activation with stable per-target results

### DIFF
--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_group_rendering_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_group_rendering_test.go
@@ -1,10 +1,15 @@
 package agentpluginscli
 
 import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
+	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/usecase"
+	"github.com/spf13/cobra"
 )
 
 func TestSharedGroupHumanReviewIdentifiesLogicalTargets(t *testing.T) {
@@ -50,4 +55,336 @@ func TestGroupCollisionErrorIncludesSelectedTargetContext(t *testing.T) {
 	if loadErr != nil || len(state.Installations) != 0 {
 		t.Fatalf("collision mutated state: %+v, %v", state, loadErr)
 	}
+}
+
+func TestBatchActivationApplySummaryAndExitCodes(t *testing.T) {
+	t.Parallel()
+	t.Run("human summary keeps order and hides technical phases", func(t *testing.T) {
+		result := addMultiResult{
+			Plugin: "demo", Version: "1.0.0", Status: string(usecase.GroupPhaseExternalPartialFailure),
+			Succeeded: 3, Failed: 1, ActionRequired: 2,
+			Targets: []addTargetResult{
+				{Target: "codex", displayName: "OpenAI Codex", Status: string(usecase.GroupTargetExternalCompleted), Output: addResultData{Result: usecase.AddResult{
+					GroupPhase: usecase.GroupTargetExternalCompleted,
+					Activation: domain.ActivationOutcome{Activation: domain.ActivationActive, Authentication: domain.AuthenticationNotRequired, Verification: domain.VerificationInstalled},
+				}}},
+				{Target: "kiro", displayName: "Kiro", Status: string(usecase.GroupTargetExternalCompleted), NextAction: "Restart Kiro and approve the connection.", Output: addResultData{Result: usecase.AddResult{
+					GroupPhase: usecase.GroupTargetExternalCompleted,
+					Activation: domain.ActivationOutcome{Activation: domain.ActivationActive, Authentication: domain.AuthenticationPending, Verification: domain.VerificationInstalled},
+				}}},
+				{Target: "chatgpt", displayName: "ChatGPT", Status: "action_required", NextAction: "Finish ChatGPT setup."},
+				{Target: "claude", displayName: "Claude Code", Status: string(usecase.GroupTargetExternalFailed), RetryCommand: "npx universal-agent-plugins add demo --target claude",
+					Error:  &usecase.GroupTargetFailure{Stage: "activation", Message: "Could not update ~/.claude/config.json: permission denied."},
+					Output: addResultData{Result: usecase.AddResult{GroupPhase: usecase.GroupTargetExternalFailed, Failure: &usecase.GroupTargetFailure{Stage: "activation", Message: "Could not update ~/.claude/config.json: permission denied."}}}},
+			},
+		}
+		var out bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetOut(&out)
+		if err := renderAddMultiResult(cmd, &options{format: "human"}, result, domain.PackageEnvelope{Manifest: domain.PluginManifest{Name: "demo"}}); err != nil {
+			t.Fatal(err)
+		}
+		body := out.String()
+		if !strings.Contains(body, "demo installation finished with issues") || !strings.Contains(body, "Client") || !strings.Contains(body, "Result") {
+			t.Fatalf("summary header missing: %s", body)
+		}
+		for _, want := range []string{"OpenAI Codex", "Installed", "Kiro", "Sign-in required", "ChatGPT", "Setup required", "Claude Code", "Failed"} {
+			if !strings.Contains(body, want) {
+				t.Fatalf("missing %q in %s", want, body)
+			}
+		}
+		if strings.Contains(body, "external_completed") || strings.Contains(body, "external_failed") {
+			t.Fatalf("technical phases leaked: %s", body)
+		}
+		attention := strings.Index(body, "Needs attention")
+		if attention < 0 {
+			t.Fatalf("needs attention missing: %s", body)
+		}
+		detail := body[attention:]
+		if !strings.Contains(detail, "Restart Kiro") || !strings.Contains(detail, "Finish ChatGPT setup.") ||
+			!strings.Contains(detail, "permission denied") || !strings.Contains(detail, "Retry:") ||
+			!strings.Contains(detail, "npx universal-agent-plugins add demo --target claude") {
+			t.Fatalf("attention details = %s", detail)
+		}
+		if strings.Contains(detail, "OpenAI Codex") {
+			t.Fatalf("installed target listed under needs attention: %s", detail)
+		}
+		codexPos := strings.Index(body, "OpenAI Codex")
+		kiroPos := strings.Index(body, "Kiro")
+		chatgptPos := strings.Index(body, "ChatGPT")
+		claudePos := strings.Index(body, "Claude Code")
+		if !(codexPos < kiroPos && kiroPos < chatgptPos && chatgptPos < claudePos) {
+			t.Fatalf("client order broken: %s", body)
+		}
+	})
+	t.Run("long failure keeps two column summary", func(t *testing.T) {
+		long := strings.Repeat("permission denied while writing managed config path ", 8)
+		result := addMultiResult{
+			Plugin: "demo", Status: string(usecase.GroupPhaseExternalPartialFailure), Succeeded: 1, Failed: 1,
+			Targets: []addTargetResult{
+				{Target: "codex", displayName: "Codex", Status: string(usecase.GroupTargetExternalCompleted), Output: addResultData{Result: usecase.AddResult{
+					GroupPhase: usecase.GroupTargetExternalCompleted,
+					Activation: domain.ActivationOutcome{Activation: domain.ActivationActive, Authentication: domain.AuthenticationNotRequired, Verification: domain.VerificationInstalled},
+				}}},
+				{Target: "cursor", displayName: "Cursor", Status: string(usecase.GroupTargetExternalFailed), RetryCommand: "npx universal-agent-plugins add demo --target cursor",
+					Error:  &usecase.GroupTargetFailure{Stage: "activation", Message: long},
+					Output: addResultData{Result: usecase.AddResult{GroupPhase: usecase.GroupTargetExternalFailed}}},
+			},
+		}
+		var out bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetOut(&out)
+		if err := renderAddMultiResult(cmd, &options{format: "human"}, result, domain.PackageEnvelope{Manifest: domain.PluginManifest{Name: "demo"}}); err != nil {
+			t.Fatal(err)
+		}
+		lines := strings.Split(out.String(), "\n")
+		var summaryLines []string
+		for _, line := range lines {
+			if strings.HasPrefix(line, "Codex") || strings.HasPrefix(line, "Cursor") || strings.HasPrefix(line, "Client") {
+				summaryLines = append(summaryLines, line)
+			}
+		}
+		if len(summaryLines) < 3 {
+			t.Fatalf("summary lines = %#v body=%s", summaryLines, out.String())
+		}
+		for _, line := range summaryLines {
+			if strings.Contains(line, "permission denied") {
+				t.Fatalf("long error leaked into summary columns: %q", line)
+			}
+		}
+	})
+	t.Run("quoted retry arguments", func(t *testing.T) {
+		got := batchRetryCommand("demo-plugin", domain.ClientClaude)
+		if got != "npx universal-agent-plugins add demo-plugin --target claude" {
+			t.Fatalf("retry = %q", got)
+		}
+		if got := batchRetryCommand("my plugin", domain.ClientClaude); got != "" {
+			t.Fatalf("unsafe spaced source must omit retry: %q", got)
+		}
+		if got := batchRetryCommand("demo", domain.ClientID("weird target")); got != "" {
+			t.Fatalf("unsafe target must omit retry: %q", got)
+		}
+	})
+	t.Run("action required only keeps exit zero", func(t *testing.T) {
+		fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCodex), fixtureClient(t, domain.ClientCursor)})
+		stdout, _, err := fixture.execute(false, "add", writeCLIPlugin(t), "--target", "codex,cursor", "--format", "json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		var output struct {
+			Data addMultiResult `json:"data"`
+		}
+		if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+			t.Fatal(err)
+		}
+		if output.Data.Failed != 0 || output.Data.Succeeded != 2 {
+			t.Fatalf("success counts = %+v", output.Data)
+		}
+	})
+	t.Run("real failure exit one and continues activation", func(t *testing.T) {
+		fixture := newCLIFixture(t, []domain.DetectedClient{
+			fixtureClient(t, domain.ClientCodex), fixtureClient(t, domain.ClientCursor), fixtureClient(t, domain.ClientKiro),
+		})
+		activator := &failSecondCLIGroupActivator{}
+		fixture.app.Lifecycle.Activator = activator
+		stdout, _, err := fixture.execute(false, "add", writeCLIPlugin(t), "--target", "codex,cursor,kiro")
+		if err == nil || !strings.Contains(err.Error(), "1 of 3 client installations failed; see results above") {
+			t.Fatalf("err = %v", err)
+		}
+		if activator.calls != 3 {
+			t.Fatalf("Activate calls = %d, want 3", activator.calls)
+		}
+		if !strings.Contains(stdout, "Needs attention") || !strings.Contains(stdout, "Failed") || !strings.Contains(stdout, "Installed") {
+			t.Fatalf("human summary = %s", stdout)
+		}
+		if strings.Contains(stdout, "injected grouped activation failure") && strings.Count(stdout, "injected grouped activation failure") > 1 {
+			t.Fatalf("raw failure duplicated after summary: %s", stdout)
+		}
+	})
+	t.Run("dry-run output unchanged shape", func(t *testing.T) {
+		fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCodex), fixtureClient(t, domain.ClientCursor)})
+		stdout, _, err := fixture.execute(false, "add", writeCLIPlugin(t), "--target", "codex,cursor", "--dry-run")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(stdout, "Plugin:") || !strings.Contains(stdout, "Targets:") || !strings.Contains(stdout, "No changes made (dry run).") {
+			t.Fatalf("dry-run changed: %s", stdout)
+		}
+		if strings.Contains(stdout, "Needs attention") || strings.Contains(stdout, "Client  Result") {
+			t.Fatalf("apply summary leaked into dry-run: %s", stdout)
+		}
+	})
+	t.Run("auth pending and not-checked stay action-required", func(t *testing.T) {
+		pending := addTargetResult{Target: "kiro", displayName: "Kiro", Status: string(usecase.GroupTargetExternalCompleted), Output: addResultData{Result: usecase.AddResult{
+			GroupPhase: usecase.GroupTargetExternalCompleted,
+			Activation: domain.ActivationOutcome{Activation: domain.ActivationActive, Authentication: domain.AuthenticationPending, Verification: domain.VerificationInstalled},
+		}}}
+		unchecked := addTargetResult{Target: "codex", displayName: "Codex", Status: string(usecase.GroupTargetExternalCompleted), Output: addResultData{Result: usecase.AddResult{
+			GroupPhase: usecase.GroupTargetExternalCompleted,
+			Activation: domain.ActivationOutcome{Activation: domain.ActivationActive, Authentication: domain.AuthenticationNotChecked, Verification: domain.VerificationInstalled},
+		}}}
+		if classifyBatchPresentation(pending) != batchPresentationSignInRequired {
+			t.Fatalf("pending = %s", classifyBatchPresentation(pending))
+		}
+		if classifyBatchPresentation(unchecked) != batchPresentationSetupRequired {
+			t.Fatalf("not-checked = %s", classifyBatchPresentation(unchecked))
+		}
+		var counts addMultiResult
+		countBatchTarget(&counts, pending)
+		countBatchTarget(&counts, unchecked)
+		if counts.Failed != 0 || counts.Succeeded != 2 || counts.ActionRequired != 2 {
+			t.Fatalf("counts = %+v", counts)
+		}
+	})
+	t.Run("unknown commit and not-attempted retries", func(t *testing.T) {
+		source := "demo-plugin"
+		unknown := addTargetResult{Target: "cursor", displayName: "Cursor", Status: string(usecase.GroupTargetManagedUnknown), Output: addResultData{Result: usecase.AddResult{GroupPhase: usecase.GroupTargetManagedUnknown}}}
+		skipped := addTargetResult{Target: "kiro", displayName: "Kiro", Status: string(usecase.GroupTargetExternalNotAttempted),
+			Error: &usecase.GroupTargetFailure{Stage: "persist", Message: "processing stopped because the operation was canceled"},
+			Output: addResultData{Result: usecase.AddResult{GroupPhase: usecase.GroupTargetExternalNotAttempted}}}
+		if retry := batchRetryCommandFor(unknown, source); retry != "" {
+			t.Fatalf("unknown commit must not get retry: %q", retry)
+		}
+		if retry := batchRetryCommandFor(skipped, source); retry != "npx universal-agent-plugins add demo-plugin --target kiro" {
+			t.Fatalf("not-attempted retry = %q", retry)
+		}
+		result := addMultiResult{Plugin: "demo", Failed: 2, Targets: []addTargetResult{unknown, skipped}}
+		var out bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetOut(&out)
+		if err := renderAddMultiResult(cmd, &options{format: "human"}, result, domain.PackageEnvelope{Manifest: domain.PluginManifest{Name: "demo"}}); err != nil {
+			t.Fatal(err)
+		}
+		body := out.String()
+		if !strings.Contains(body, "Needs attention") || !strings.Contains(body, "Managed commit state is unknown") || !strings.Contains(body, "Not completed") {
+			t.Fatalf("body = %s", body)
+		}
+		if strings.Contains(body, "Retry:\n    npx universal-agent-plugins add demo-plugin --target cursor") {
+			t.Fatalf("unsafe unknown retry present: %s", body)
+		}
+	})
+	t.Run("presentation source omits retry", func(t *testing.T) {
+		if got := batchRetrySource(domain.PackageEnvelope{}, "direct local source"); got != "" {
+			t.Fatalf("presentation source leaked: %q", got)
+		}
+		if got := batchRetryCommandFor(addTargetResult{Target: "cursor", Output: addResultData{Result: usecase.AddResult{GroupPhase: usecase.GroupTargetExternalFailed}}}, ""); got != "" {
+			t.Fatalf("empty source retry = %q", got)
+		}
+		localPath := filepath.Join(t.TempDir(), "plugin")
+		if got := batchRetrySource(domain.PackageEnvelope{Source: domain.SourceIdentity{RequestedSource: localPath}}, "direct local source"); got != "" {
+			t.Fatalf("local absolute path leaked into retry source: %q", got)
+		}
+	})
+	t.Run("json failure status without failed count", func(t *testing.T) {
+		result := addMultiResult{Batch: true, Status: "apply_failed", Plugin: "demo", Version: "1.0.0", Source: "direct local source"}
+		var out bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetOut(&out)
+		if err := renderAddMultiResult(cmd, &options{format: "json"}, result, domain.PackageEnvelope{Manifest: domain.PluginManifest{Name: "demo"}}); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(out.String(), `"result":"failure"`) || strings.Contains(out.String(), `"result":"success"`) {
+			t.Fatalf("json = %s", out.String())
+		}
+	})
+	t.Run("rolled back appears under needs attention", func(t *testing.T) {
+		result := addMultiResult{Plugin: "demo", Failed: 2, Targets: []addTargetResult{
+			{
+				Target: "cursor", displayName: "Cursor", Status: string(usecase.GroupTargetManagedRolledBack),
+				Output: addResultData{Result: usecase.AddResult{GroupPhase: usecase.GroupTargetManagedRolledBack}},
+			},
+			{
+				Target: "kiro", displayName: "Kiro", Status: string(usecase.GroupTargetManagedRolledBack),
+				Output: addResultData{Result: usecase.AddResult{GroupPhase: usecase.GroupTargetManagedRolledBack}},
+			},
+		}}
+		var out bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetOut(&out)
+		if err := renderAddMultiResult(cmd, &options{format: "human"}, result, domain.PackageEnvelope{Manifest: domain.PluginManifest{Name: "demo"}}); err != nil {
+			t.Fatal(err)
+		}
+		body := out.String()
+		if !strings.Contains(body, "Rolled back") || !strings.Contains(body, "Needs attention") || !strings.Contains(body, "rolled back") {
+			t.Fatalf("body = %s", body)
+		}
+	})
+	t.Run("aggregate error excludes deferred chatgpt", func(t *testing.T) {
+		result := addMultiResult{
+			Succeeded: 1, Failed: 1, ActionRequired: 1,
+			Targets: []addTargetResult{
+				{Target: "codex", Status: string(usecase.GroupTargetExternalCompleted), Output: addResultData{Result: usecase.AddResult{GroupPhase: usecase.GroupTargetExternalCompleted}}},
+				{Target: "cursor", Status: string(usecase.GroupTargetExternalFailed), Output: addResultData{Result: usecase.AddResult{GroupPhase: usecase.GroupTargetExternalFailed}}},
+				{Target: "chatgpt", Status: "action_required", NextAction: "Finish ChatGPT setup."},
+			},
+		}
+		err := batchActivationAggregateError(result)
+		if err == nil || err.Error() != "1 of 2 client installations failed; see results above" {
+			t.Fatalf("aggregate = %v", err)
+		}
+	})
+	t.Run("chatgpt-only json is success with action_required", func(t *testing.T) {
+		if batchStatusIndicatesFailure("action_required") {
+			t.Fatal("action_required must not be treated as failure status")
+		}
+		result := map[string]any{"status": "action_required", "target": "chatgpt", "mutated": false}
+		var out bytes.Buffer
+		if err := writeJSONResult(&out, "add", outputResultSuccess, result); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(out.String(), `"result":"success"`) || !strings.Contains(out.String(), `"status":"action_required"`) {
+			t.Fatalf("json = %s", out.String())
+		}
+	})
+	t.Run("deferred chatgpt remains visible when peers fail", func(t *testing.T) {
+		result := addMultiResult{
+			Plugin: "demo", Status: string(usecase.GroupPhaseManagedActivationFailed), Failed: 1, ActionRequired: 1,
+			Targets: []addTargetResult{
+				{Target: "kiro", displayName: "Kiro", Status: string(usecase.GroupTargetExternalFailed),
+					Error: &usecase.GroupTargetFailure{Stage: "activation", Message: "kiro failed"},
+					Output: addResultData{Result: usecase.AddResult{GroupPhase: usecase.GroupTargetExternalFailed}}},
+				{Target: "chatgpt", displayName: "ChatGPT", Status: "action_required", NextAction: "Finish ChatGPT setup."},
+			},
+		}
+		var out bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetOut(&out)
+		if err := renderAddMultiResult(cmd, &options{format: "human"}, result, domain.PackageEnvelope{Manifest: domain.PluginManifest{Name: "demo"}}); err != nil {
+			t.Fatal(err)
+		}
+		body := out.String()
+		if !strings.Contains(body, "ChatGPT") || !strings.Contains(body, "Setup required") || !strings.Contains(body, "Finish ChatGPT setup.") {
+			t.Fatalf("missing deferred chatgpt: %s", body)
+		}
+	})
+	t.Run("multiline failure stays under attention only", func(t *testing.T) {
+		result := addMultiResult{
+			Plugin: "demo", Succeeded: 1, Failed: 1,
+			Targets: []addTargetResult{
+				{Target: "codex", displayName: "Codex", Status: string(usecase.GroupTargetExternalCompleted), Output: addResultData{Result: usecase.AddResult{
+					GroupPhase: usecase.GroupTargetExternalCompleted,
+					Activation: domain.ActivationOutcome{Activation: domain.ActivationActive, Authentication: domain.AuthenticationNotRequired, Verification: domain.VerificationInstalled},
+				}}},
+				{Target: "cursor", displayName: "Cursor", Status: string(usecase.GroupTargetExternalFailed),
+					Error: &usecase.GroupTargetFailure{Stage: "activation", Message: "first line\nsecond line with agentplugins add resume --foo"},
+					Output: addResultData{Result: usecase.AddResult{GroupPhase: usecase.GroupTargetExternalFailed}}},
+			},
+		}
+		var out bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetOut(&out)
+		if err := renderAddMultiResult(cmd, &options{format: "human"}, result, domain.PackageEnvelope{Manifest: domain.PluginManifest{Name: "demo"}}); err != nil {
+			t.Fatal(err)
+		}
+		body := out.String()
+		lines := strings.Split(body, "\n")
+		for _, line := range lines {
+			if strings.HasPrefix(line, "Cursor") && strings.Contains(line, "first line") {
+				t.Fatalf("multiline leaked into summary row: %q", line)
+			}
+		}
+		if !strings.Contains(body, "first line") || !strings.Contains(body, "second line") {
+			t.Fatalf("attention lost multiline detail: %s", body)
+		}
+	})
 }

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_group_rendering_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_group_rendering_test.go
@@ -280,6 +280,12 @@ func TestBatchActivationApplySummaryAndExitCodes(t *testing.T) {
 		if got := batchRetrySource(domain.PackageEnvelope{Source: domain.SourceIdentity{RequestedSource: localPath}}, "", "direct local source"); got != "" {
 			t.Fatalf("local absolute path leaked into retry source: %q", got)
 		}
+		if got := batchRetrySource(domain.PackageEnvelope{Source: domain.SourceIdentity{RequestedSource: "d:/private/plugin"}}, "", "direct local source"); got != "" {
+			t.Fatalf("windows local path leaked into retry source: %q", got)
+		}
+		if !isLocalFilesystemSource("d:/private/plugin") || !isLocalFilesystemSource(`D:\private\plugin`) {
+			t.Fatal("portable windows local paths must be detected")
+		}
 		dir := domain.PackageEnvelope{Source: domain.SourceIdentity{
 			RequestedSource: "context7", Repository: "upstash/context7", PackageSubpath: "plugins/agent-plugins/context7",
 			ResolvedRevision: strings.Repeat("a", 40),

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_group_rendering_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_group_rendering_test.go
@@ -236,19 +236,25 @@ func TestBatchActivationApplySummaryAndExitCodes(t *testing.T) {
 			t.Fatalf("counts = %+v", counts)
 		}
 	})
-	t.Run("unknown commit and not-attempted retries", func(t *testing.T) {
+	t.Run("unknown commit and persist skips omit retry", func(t *testing.T) {
 		source := "demo-plugin"
 		unknown := addTargetResult{Target: "cursor", displayName: "Cursor", Status: string(usecase.GroupTargetManagedUnknown), Output: addResultData{Result: usecase.AddResult{GroupPhase: usecase.GroupTargetManagedUnknown}}}
-		skipped := addTargetResult{Target: "kiro", displayName: "Kiro", Status: string(usecase.GroupTargetExternalNotAttempted),
-			Error: &usecase.GroupTargetFailure{Stage: "persist", Message: "processing stopped because the operation was canceled"},
+		persistSkipped := addTargetResult{Target: "kiro", displayName: "Kiro", Status: string(usecase.GroupTargetExternalNotAttempted),
+			Error:  &usecase.GroupTargetFailure{Stage: "persist", Message: "processing stopped because installation state could not be saved safely"},
+			Output: addResultData{Result: usecase.AddResult{GroupPhase: usecase.GroupTargetExternalNotAttempted}}}
+		canceledSkipped := addTargetResult{Target: "codex", displayName: "Codex", Status: string(usecase.GroupTargetExternalNotAttempted),
+			Error:  &usecase.GroupTargetFailure{Stage: "canceled", Message: "processing stopped because the operation was canceled"},
 			Output: addResultData{Result: usecase.AddResult{GroupPhase: usecase.GroupTargetExternalNotAttempted}}}
 		if retry := batchRetryCommandFor(unknown, source); retry != "" {
 			t.Fatalf("unknown commit must not get retry: %q", retry)
 		}
-		if retry := batchRetryCommandFor(skipped, source); retry != "npx universal-agent-plugins add demo-plugin --target kiro" {
-			t.Fatalf("not-attempted retry = %q", retry)
+		if retry := batchRetryCommandFor(persistSkipped, source); retry != "" {
+			t.Fatalf("persist skip must not get retry: %q", retry)
 		}
-		result := addMultiResult{Plugin: "demo", Failed: 2, Targets: []addTargetResult{unknown, skipped}}
+		if retry := batchRetryCommandFor(canceledSkipped, source); retry != "npx universal-agent-plugins add demo-plugin --target codex" {
+			t.Fatalf("canceled not-attempted retry = %q", retry)
+		}
+		result := addMultiResult{Plugin: "demo", Failed: 2, Targets: []addTargetResult{unknown, persistSkipped}}
 		var out bytes.Buffer
 		cmd := &cobra.Command{}
 		cmd.SetOut(&out)
@@ -256,23 +262,44 @@ func TestBatchActivationApplySummaryAndExitCodes(t *testing.T) {
 			t.Fatal(err)
 		}
 		body := out.String()
-		if !strings.Contains(body, "Needs attention") || !strings.Contains(body, "Managed commit state is unknown") || !strings.Contains(body, "Not completed") {
+		if !strings.Contains(body, "Needs attention") || !strings.Contains(body, "Managed commit state is unknown") || !strings.Contains(body, "doctor before retrying") || !strings.Contains(body, "Not completed") {
 			t.Fatalf("body = %s", body)
 		}
-		if strings.Contains(body, "Retry:\n    npx universal-agent-plugins add demo-plugin --target cursor") {
-			t.Fatalf("unsafe unknown retry present: %s", body)
+		if strings.Contains(body, "Retry:") {
+			t.Fatalf("unsafe persist/unknown retry present: %s", body)
 		}
 	})
-	t.Run("presentation source omits retry", func(t *testing.T) {
-		if got := batchRetrySource(domain.PackageEnvelope{}, "direct local source"); got != "" {
+	t.Run("presentation and github retry sources", func(t *testing.T) {
+		if got := batchRetrySource(domain.PackageEnvelope{}, "", "direct local source"); got != "" {
 			t.Fatalf("presentation source leaked: %q", got)
 		}
 		if got := batchRetryCommandFor(addTargetResult{Target: "cursor", Output: addResultData{Result: usecase.AddResult{GroupPhase: usecase.GroupTargetExternalFailed}}}, ""); got != "" {
 			t.Fatalf("empty source retry = %q", got)
 		}
 		localPath := filepath.Join(t.TempDir(), "plugin")
-		if got := batchRetrySource(domain.PackageEnvelope{Source: domain.SourceIdentity{RequestedSource: localPath}}, "direct local source"); got != "" {
+		if got := batchRetrySource(domain.PackageEnvelope{Source: domain.SourceIdentity{RequestedSource: localPath}}, "", "direct local source"); got != "" {
 			t.Fatalf("local absolute path leaked into retry source: %q", got)
+		}
+		dir := domain.PackageEnvelope{Source: domain.SourceIdentity{
+			RequestedSource: "context7", Repository: "upstash/context7", PackageSubpath: "plugins/agent-plugins/context7",
+			ResolvedRevision: strings.Repeat("a", 40),
+		}}
+		if got := batchRetrySource(dir, domain.OriginModeDirectory, "direct immutable source"); got != "context7" {
+			t.Fatalf("directory retry source = %q", got)
+		}
+		sha := strings.Repeat("b", 40)
+		github := domain.PackageEnvelope{Source: domain.SourceIdentity{
+			Repository: "owner/repo", PackageSubpath: "plugins/demo", ResolvedRevision: sha,
+		}}
+		wantGit := "owner/repo@" + sha + "//plugins/demo"
+		if got := batchRetrySource(github, domain.OriginModeDirect, ""); got != wantGit {
+			t.Fatalf("github retry source = %q, want %q", got, wantGit)
+		}
+		if got := batchRetrySource(domain.PackageEnvelope{Source: domain.SourceIdentity{Repository: "owner/repo", PackageSubpath: "plugins/demo", ResolvedRevision: "moving-head"}}, domain.OriginModeDirect, ""); got != "" {
+			t.Fatalf("mutable github revision leaked: %q", got)
+		}
+		if got := batchRetryCommand("owner/repo@"+sha+"//plugins/demo", domain.ClientKiro); got != "npx universal-agent-plugins add owner/repo@"+sha+"//plugins/demo --target kiro" {
+			t.Fatalf("github retry command = %q", got)
 		}
 	})
 	t.Run("json failure status without failed count", func(t *testing.T) {
@@ -323,6 +350,24 @@ func TestBatchActivationApplySummaryAndExitCodes(t *testing.T) {
 			t.Fatalf("aggregate = %v", err)
 		}
 	})
+	t.Run("single target failure uses apply summary", func(t *testing.T) {
+		result := addMultiResult{Plugin: "demo", Failed: 1, Status: string(usecase.GroupPhaseManagedActivationFailed), Targets: []addTargetResult{{
+			Target: "kiro", displayName: "Kiro", Status: string(usecase.GroupTargetExternalFailed),
+			RetryCommand: "npx universal-agent-plugins add context7 --target kiro",
+			Error:        &usecase.GroupTargetFailure{Stage: "activation", Message: "could not write kiro config"},
+			Output:       addResultData{Result: usecase.AddResult{GroupPhase: usecase.GroupTargetExternalFailed}},
+		}}}
+		var out bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetOut(&out)
+		if err := renderAddMultiResult(cmd, &options{format: "human"}, result, domain.PackageEnvelope{Manifest: domain.PluginManifest{Name: "demo"}}); err != nil {
+			t.Fatal(err)
+		}
+		body := out.String()
+		if strings.Contains(body, "Add: external_failed") || !strings.Contains(body, "Needs attention") || !strings.Contains(body, "could not write kiro config") || !strings.Contains(body, "Retry:") {
+			t.Fatalf("single-target summary = %s", body)
+		}
+	})
 	t.Run("chatgpt-only json is success with action_required", func(t *testing.T) {
 		if batchStatusIndicatesFailure("action_required") {
 			t.Fatal("action_required must not be treated as failure status")
@@ -341,7 +386,7 @@ func TestBatchActivationApplySummaryAndExitCodes(t *testing.T) {
 			Plugin: "demo", Status: string(usecase.GroupPhaseManagedActivationFailed), Failed: 1, ActionRequired: 1,
 			Targets: []addTargetResult{
 				{Target: "kiro", displayName: "Kiro", Status: string(usecase.GroupTargetExternalFailed),
-					Error: &usecase.GroupTargetFailure{Stage: "activation", Message: "kiro failed"},
+					Error:  &usecase.GroupTargetFailure{Stage: "activation", Message: "kiro failed"},
 					Output: addResultData{Result: usecase.AddResult{GroupPhase: usecase.GroupTargetExternalFailed}}},
 				{Target: "chatgpt", displayName: "ChatGPT", Status: "action_required", NextAction: "Finish ChatGPT setup."},
 			},
@@ -366,7 +411,7 @@ func TestBatchActivationApplySummaryAndExitCodes(t *testing.T) {
 					Activation: domain.ActivationOutcome{Activation: domain.ActivationActive, Authentication: domain.AuthenticationNotRequired, Verification: domain.VerificationInstalled},
 				}}},
 				{Target: "cursor", displayName: "Cursor", Status: string(usecase.GroupTargetExternalFailed),
-					Error: &usecase.GroupTargetFailure{Stage: "activation", Message: "first line\nsecond line with agentplugins add resume --foo"},
+					Error:  &usecase.GroupTargetFailure{Stage: "activation", Message: "first line\nsecond line with agentplugins add resume --foo"},
 					Output: addResultData{Result: usecase.AddResult{GroupPhase: usecase.GroupTargetExternalFailed}}},
 			},
 		}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
@@ -238,7 +238,7 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 		return fmt.Errorf("group apply returned %d targets for %d selected clients", len(applied.Targets), len(selected))
 	}
 	combined.Status, combined.Targets, combined.Succeeded, combined.Failed, combined.ActionRequired = string(applied.Phase), combined.Targets[:0], 0, 0, 0
-	sourceArg := batchRetrySource(loaded.envelope, combined.Source)
+	sourceArg := batchRetrySource(loaded.envelope, loaded.origin, combined.Source)
 	for index, result := range applied.Targets {
 		output := newAddResultData(inputs[index].Envelope, result, false)
 		output.OperationID = operationID
@@ -487,11 +487,16 @@ func renderAddMultiResult(cmd *cobra.Command, opts *options, result addMultiResu
 		}
 		return nil
 	}
-	if len(result.Targets) == 1 {
-		return renderAddResult(cmd.OutOrStdout(), "human", envelope, result.Targets[0].Output.Result, result.DryRun)
-	}
 	if result.DryRun {
+		if len(result.Targets) == 1 {
+			return renderAddResult(cmd.OutOrStdout(), "human", envelope, result.Targets[0].Output.Result, true)
+		}
 		return renderAddMultiDryRun(cmd.OutOrStdout(), result)
+	}
+	// Failed single-target applies use the same summary so error detail and retry
+	// guidance stay visible instead of the legacy "Add: external_failed" line.
+	if len(result.Targets) == 1 && result.Failed == 0 && !batchStatusIndicatesFailure(result.Status) {
+		return renderAddResult(cmd.OutOrStdout(), "human", envelope, result.Targets[0].Output.Result, false)
 	}
 	return renderAddMultiApplySummary(cmd.OutOrStdout(), result, envelope)
 }
@@ -691,6 +696,9 @@ func batchAttentionLines(target addTargetResult) []string {
 		if phase == usecase.GroupTargetManagedUnknown {
 			return []string{"Managed commit state is unknown; run agentplugins doctor before retrying."}
 		}
+		if batchFailureNeedsDoctor(target) {
+			return []string{"Installation state could not be saved safely; run agentplugins doctor before retrying."}
+		}
 		if target.Error != nil && strings.TrimSpace(target.Error.Message) != "" {
 			return []string{target.Error.Message}
 		}
@@ -731,11 +739,18 @@ func countBatchTarget(result *addMultiResult, target addTargetResult) {
 	}
 }
 
-func batchRetrySource(envelope domain.PackageEnvelope, public string) string {
-	// Prefer repository identity so retries never echo host-local absolute paths
-	// that publicPackageSource intentionally hides.
-	if strings.TrimSpace(envelope.Source.Repository) != "" {
-		return publicPackageSource(envelope.Source)
+func batchRetrySource(envelope domain.PackageEnvelope, origin domain.OriginMode, public string) string {
+	// Directory retries must keep the safe product selector (for example context7),
+	// not a reconstructed repository//path that changes provenance.
+	if origin == domain.OriginModeDirectory {
+		if source := strings.TrimSpace(envelope.Source.RequestedSource); isBatchRetryableSource(source) {
+			return source
+		}
+		return ""
+	}
+	// Direct GitHub retries require an immutable owner/repo@FULL_SHA[//path] selector.
+	if repo := strings.TrimSpace(envelope.Source.Repository); repo != "" {
+		return batchRetryGitHubSource(envelope.Source)
 	}
 	if source := strings.TrimSpace(envelope.Source.RequestedSource); isBatchRetryableSource(source) {
 		return source
@@ -744,6 +759,22 @@ func batchRetrySource(envelope domain.PackageEnvelope, public string) string {
 		return source
 	}
 	return ""
+}
+
+func batchRetryGitHubSource(source domain.SourceIdentity) string {
+	repo := strings.TrimSpace(source.Repository)
+	rev := publicImmutableRevision(strings.TrimSpace(source.ResolvedRevision))
+	if repo == "" || rev == "" {
+		return ""
+	}
+	value := repo + "@" + rev
+	if sub := strings.TrimSpace(source.PackageSubpath); sub != "" {
+		value += "//" + sub
+	}
+	if !isBatchRetrySafeArg(value) {
+		return ""
+	}
+	return value
 }
 
 func isBatchPresentationSource(source string) bool {
@@ -775,7 +806,7 @@ func isLocalFilesystemSource(source string) bool {
 }
 
 func batchRetryCommandFor(target addTargetResult, source string) string {
-	if strings.TrimSpace(source) == "" {
+	if strings.TrimSpace(source) == "" || batchFailureNeedsDoctor(target) {
 		return ""
 	}
 	switch target.Output.Result.GroupPhase {
@@ -784,6 +815,13 @@ func batchRetryCommandFor(target addTargetResult, source string) string {
 	default:
 		return ""
 	}
+}
+
+func batchFailureNeedsDoctor(target addTargetResult) bool {
+	if target.Error == nil {
+		return false
+	}
+	return target.Error.Stage == "persist"
 }
 
 func batchRetryCommand(source string, target domain.ClientID) string {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
@@ -6,19 +6,29 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"io"
+	"path/filepath"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
+	"github.com/777genius/plugin-kit-ai/cli/internal/agentpluginscli/prompt"
+	"github.com/777genius/plugin-kit-ai/cli/internal/terminaltheme"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/domain"
 	"github.com/777genius/plugin-kit-ai/install/integrationctl/agentplugins/usecase"
 	"github.com/spf13/cobra"
 )
 
 type addTargetResult struct {
-	Target     string        `json:"target"`
-	Status     string        `json:"status"`
-	NextAction string        `json:"next_action,omitempty"`
-	Output     addResultData `json:"output"`
+	Target       string                      `json:"target"`
+	Status       string                      `json:"status"`
+	NextAction   string                      `json:"next_action,omitempty"`
+	Error        *usecase.GroupTargetFailure `json:"error,omitempty"`
+	RetryCommand string                      `json:"retry_command,omitempty"`
+	Output       addResultData               `json:"output"`
+	displayName  string
 }
 
 type addMultiResult struct {
@@ -27,6 +37,7 @@ type addMultiResult struct {
 	Status         string                     `json:"status"`
 	Succeeded      int                        `json:"succeeded"`
 	Failed         int                        `json:"failed"`
+	ActionRequired int                        `json:"action_required,omitempty"`
 	Plugin         string                     `json:"plugin"`
 	Version        string                     `json:"version,omitempty"`
 	Source         string                     `json:"source"`
@@ -40,6 +51,17 @@ type addMultiResult struct {
 	Acquisition    *addAcquisitionProof       `json:"acquisition,omitempty"`
 	TargetOutcomes map[string]addTargetProof  `json:"target_outcomes,omitempty"`
 }
+
+type batchPresentationKind string
+
+const (
+	batchPresentationInstalled      batchPresentationKind = "Installed"
+	batchPresentationSetupRequired  batchPresentationKind = "Setup required"
+	batchPresentationSignInRequired batchPresentationKind = "Sign-in required"
+	batchPresentationFailed         batchPresentationKind = "Failed"
+	batchPresentationNotCompleted   batchPresentationKind = "Not completed"
+	batchPresentationRolledBack     batchPresentationKind = "Rolled back"
+)
 
 type addAcquisitionProof struct {
 	AcquisitionID    string `json:"acquisition_id"`
@@ -93,13 +115,16 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 	}
 	deferredChatGPT := loaded.chatGPTPreparation && loaded.localChatGPTMapping == nil && containsClientID(targets, domain.ClientChatGPT)
 	if deferredChatGPT && len(targets) == 1 {
+		// Setup-required ChatGPT registration is not an install failure.
 		action := chatGPTRegistrationResumeAction(cmd, loaded.envelope.Source.RequestedSource, []domain.ClientID{domain.ClientChatGPT})
 		if opts.format == "json" {
-			if err := writeJSONResult(cmd.OutOrStdout(), "add", outputResultFailure, map[string]any{"status": "action_required", "target": "chatgpt", "mcp_url": domain.Context7ChatGPTURL, "authentication": "none", "next_action": action, "remote_verified": true, "mutated": false}); err != nil {
-				return err
-			}
+			return writeJSONResult(cmd.OutOrStdout(), "add", outputResultSuccess, map[string]any{
+				"status": "action_required", "target": "chatgpt", "mcp_url": domain.Context7ChatGPTURL,
+				"authentication": "none", "next_action": action, "remote_verified": true, "mutated": false,
+			})
 		}
-		return fmt.Errorf("action_required: %s", action)
+		_, err := fmt.Fprintln(cmd.OutOrStdout(), action)
+		return err
 	}
 	executionTargets := targets
 	if deferredChatGPT {
@@ -160,7 +185,10 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 	for index, result := range planned.Targets {
 		output := newAddResultData(inputs[index].Envelope, result, true)
 		output.OperationID = operationID
-		combined.Targets = append(combined.Targets, addTargetResult{Target: string(selected[index].ClientID), Status: groupTargetStatus(result), Output: output, NextAction: nextLifecycleAction(result)})
+		combined.Targets = append(combined.Targets, addTargetResult{
+			Target: string(selected[index].ClientID), Status: groupTargetStatus(result), Output: output,
+			NextAction: nextLifecycleAction(result), displayName: clientDisplayName(selected[index]),
+		})
 		combined.setTargetProof(selected[index].ClientID, "not_run")
 	}
 	combined.Succeeded = len(planned.Targets)
@@ -203,37 +231,61 @@ func runAddManyLoaded(ctx context.Context, cmd *cobra.Command, app App, opts *op
 	writeProgress(app, opts.format, "Applying the completely preflighted multi-target plan...")
 	groupInput.DryRun, groupInput.Confirmed = false, true
 	applied, err := service.AddGroup(ctx, groupInput)
-	combined.Status, combined.Targets, combined.Succeeded = string(applied.Phase), combined.Targets[:0], 0
+	if len(applied.Targets) != len(selected) || len(applied.Targets) != len(inputs) {
+		if err != nil {
+			return fmt.Errorf("group apply returned %d targets for %d selected clients: %w", len(applied.Targets), len(selected), err)
+		}
+		return fmt.Errorf("group apply returned %d targets for %d selected clients", len(applied.Targets), len(selected))
+	}
+	combined.Status, combined.Targets, combined.Succeeded, combined.Failed, combined.ActionRequired = string(applied.Phase), combined.Targets[:0], 0, 0, 0
+	sourceArg := batchRetrySource(loaded.envelope, combined.Source)
 	for index, result := range applied.Targets {
 		output := newAddResultData(inputs[index].Envelope, result, false)
 		output.OperationID = operationID
-		combined.Targets = append(combined.Targets, addTargetResult{Target: string(selected[index].ClientID), Status: groupTargetStatus(result), Output: output, NextAction: nextLifecycleAction(result)})
-		combined.setTargetProof(selected[index].ClientID, addTargetProofOutcome(result))
-		if result.GroupPhase == usecase.GroupTargetExternalCompleted {
-			combined.Succeeded++
+		entry := addTargetResult{
+			Target: string(selected[index].ClientID), Status: groupTargetStatus(result), Output: output,
+			NextAction: nextLifecycleAction(result), displayName: clientDisplayName(selected[index]),
+			Error: result.Failure,
 		}
+		if retry := batchRetryCommandFor(entry, sourceArg); retry != "" {
+			entry.RetryCommand = retry
+		}
+		combined.Targets = append(combined.Targets, entry)
+		combined.setTargetProof(selected[index].ClientID, addTargetProofOutcome(result))
+		countBatchTarget(&combined, entry)
 	}
 	if err != nil {
 		if applied.Phase == usecase.GroupPhasePlanned && !applied.Mutated {
-			combined.Status, combined.Failed, combined.Succeeded = "preflight_failed", len(inputs), 0
+			combined.Status, combined.Failed, combined.Succeeded, combined.ActionRequired = "preflight_failed", len(inputs), 0, 0
 			setPreflightNextActions(combined.Targets)
 			_ = renderAddMultiResult(cmd, opts, combined, loaded.envelope)
 			return fmt.Errorf("group apply preflight failed; no target was changed (selected targets: %v): %w%s", targets, err, addGroupNextAction(combined.Targets))
 		}
 		combined.Status = groupFailureStatus(applied.Phase)
-		combined.Failed = len(inputs) - combined.Succeeded
+		// Always report selected ChatGPT setup, even when installable peers failed.
+		if deferredChatGPT {
+			appendDeferredChatGPT(&combined, cmd, loaded)
+		}
 		_ = renderAddMultiResult(cmd, opts, combined, loaded.envelope)
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		if applied.Phase == usecase.GroupPhaseManagedActivationFailed || applied.Phase == usecase.GroupPhaseExternalPartialFailure {
+			return batchActivationAggregateError(combined)
+		}
 		return err
 	}
 	if deferredChatGPT {
-		// The manual ChatGPT registration is intentionally outside the atomic
-		// local-client group. Report it after every installable peer succeeds.
+		// Manual ChatGPT registration stays outside the atomic local-client group.
 		appendDeferredChatGPT(&combined, cmd, loaded)
 	}
 	if err := renderAddMultiResult(cmd, opts, combined, loaded.envelope); err != nil {
 		return err
 	}
-	if app.Terminal && opts.format == "human" && len(applied.Targets) == 1 {
+	if combined.Failed > 0 {
+		return batchActivationAggregateError(combined)
+	}
+	if app.Terminal && opts.format == "human" && len(applied.Targets) == 1 && !deferredChatGPT {
 		input := inputs[0]
 		input.DryRun = false
 		input.InstallationID = applied.Targets[0].InstallationID
@@ -263,11 +315,18 @@ func withoutClientID(targets []domain.ClientID, excluded domain.ClientID) []doma
 
 func appendDeferredChatGPT(result *addMultiResult, cmd *cobra.Command, loaded loadedPackage) {
 	action := chatGPTRegistrationResumeAction(cmd, loaded.envelope.Source.RequestedSource, []domain.ClientID{domain.ClientChatGPT})
-	result.Status = "completed_with_action_required"
 	if result.DryRun {
 		result.Status = "planned_with_action_required"
+	} else if result.Failed == 0 {
+		// Preserve failure statuses such as external_partial_failure.
+		result.Status = "completed_with_action_required"
 	}
-	result.Targets = append(result.Targets, addTargetResult{Target: string(domain.ClientChatGPT), Status: "action_required", NextAction: action})
+	entry := addTargetResult{
+		Target: string(domain.ClientChatGPT), Status: "action_required", NextAction: action,
+		displayName: "ChatGPT",
+	}
+	result.Targets = append(result.Targets, entry)
+	countBatchTarget(result, entry)
 	result.setTargetProof(domain.ClientChatGPT, "not_run")
 }
 
@@ -354,6 +413,8 @@ func addTargetProofOutcome(result usecase.AddResult) string {
 		return "unknown"
 	case usecase.GroupTargetExternalPartial:
 		return "partial"
+	case usecase.GroupTargetExternalNotAttempted:
+		return "not_completed"
 	default:
 		return "not_completed"
 	}
@@ -408,7 +469,7 @@ func cloneLoadedPackage(source loadedPackage) loadedPackage {
 func renderAddMultiResult(cmd *cobra.Command, opts *options, result addMultiResult, envelope domain.PackageEnvelope) error {
 	if opts.format == "json" {
 		overall := "success"
-		if result.Failed > 0 {
+		if result.Failed > 0 || batchStatusIndicatesFailure(result.Status) {
 			overall = "failure"
 		}
 		return writeJSONResult(cmd.OutOrStdout(), "add", overall, result)
@@ -429,37 +490,364 @@ func renderAddMultiResult(cmd *cobra.Command, opts *options, result addMultiResu
 	if len(result.Targets) == 1 {
 		return renderAddResult(cmd.OutOrStdout(), "human", envelope, result.Targets[0].Output.Result, result.DryRun)
 	}
-	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Plugin: %s %s\n", result.Plugin, result.Version); err != nil {
+	if result.DryRun {
+		return renderAddMultiDryRun(cmd.OutOrStdout(), result)
+	}
+	return renderAddMultiApplySummary(cmd.OutOrStdout(), result, envelope)
+}
+
+func renderAddMultiDryRun(writer io.Writer, result addMultiResult) error {
+	if _, err := fmt.Fprintf(writer, "Plugin: %s %s\n", result.Plugin, result.Version); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Targets: %s\n", addResultTargets(result.Targets)); err != nil {
+	if _, err := fmt.Fprintf(writer, "Targets: %s\n", addResultTargets(result.Targets)); err != nil {
 		return err
 	}
 	for _, target := range result.Targets {
 		if target.Status == "action_required" {
-			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  %s: setup required\n    Next: %s\n", target.Target, target.NextAction); err != nil {
+			if _, err := fmt.Fprintf(writer, "  %s: setup required\n    Next: %s\n", target.Target, target.NextAction); err != nil {
 				return err
 			}
 			continue
 		}
-		if err := renderOpenCodeRuntimeNotice(cmd.OutOrStdout(), target.Output.Result); err != nil {
+		if err := renderOpenCodeRuntimeNotice(writer, target.Output.Result); err != nil {
 			return err
 		}
-		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  %s: %s\n", target.Target, target.Status); err != nil {
+		if _, err := fmt.Fprintf(writer, "  %s: %s\n", target.Target, target.Status); err != nil {
 			return err
 		}
 		if target.NextAction != "" && !fullyInstalled(target.Output.Result.Activation) {
-			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "    Next: %s\n", localTargetLifecycleAction(target.Output.Result, target.NextAction)); err != nil {
+			if _, err := fmt.Fprintf(writer, "    Next: %s\n", localTargetLifecycleAction(target.Output.Result, target.NextAction)); err != nil {
 				return err
 			}
 		}
 	}
-	if result.DryRun {
-		if _, err := fmt.Fprintln(cmd.OutOrStdout(), "No changes made (dry run)."); err != nil {
+	if _, err := fmt.Fprintln(writer, "No changes made (dry run)."); err != nil {
+		return err
+	}
+	return nil
+}
+
+func renderAddMultiApplySummary(writer io.Writer, result addMultiResult, envelope domain.PackageEnvelope) error {
+	theme := terminaltheme.For(writer)
+	title := batchApplyHeadline(result, envelope)
+	if _, err := fmt.Fprintln(writer, theme.Text(terminaltheme.Label, title)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(writer); err != nil {
+		return err
+	}
+	width := utf8.RuneCountInString("Client")
+	for _, target := range result.Targets {
+		if name := batchTargetLabel(target); utf8.RuneCountInString(name) > width {
+			width = utf8.RuneCountInString(name)
+		}
+	}
+	if _, err := fmt.Fprintf(writer, "%-*s  %s\n", width, "Client", "Result"); err != nil {
+		return err
+	}
+	for _, target := range result.Targets {
+		label := batchTargetLabel(target)
+		kind := classifyBatchPresentation(target)
+		if _, err := fmt.Fprintf(writer, "%-*s  %s\n", width, prompt.SafeText(label), theme.Text(batchResultTone(kind), string(kind))); err != nil {
 			return err
 		}
 	}
+	attention := make([]addTargetResult, 0, len(result.Targets))
+	for _, target := range result.Targets {
+		switch classifyBatchPresentation(target) {
+		case batchPresentationSetupRequired, batchPresentationSignInRequired, batchPresentationFailed, batchPresentationNotCompleted, batchPresentationRolledBack:
+			attention = append(attention, target)
+		}
+	}
+	if len(attention) == 0 {
+		return nil
+	}
+	if _, err := fmt.Fprintln(writer); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(writer, theme.Text(terminaltheme.Warning, "Needs attention")); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(writer); err != nil {
+		return err
+	}
+	for index, target := range attention {
+		if index > 0 {
+			if _, err := fmt.Fprintln(writer); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintln(writer, prompt.SafeText(batchTargetLabel(target))); err != nil {
+			return err
+		}
+		if err := renderOpenCodeRuntimeNotice(writer, target.Output.Result); err != nil {
+			return err
+		}
+		for _, line := range batchAttentionLines(target) {
+			for _, part := range strings.Split(line, "\n") {
+				if strings.TrimSpace(part) == "" {
+					continue
+				}
+				if _, err := fmt.Fprintf(writer, "  %s\n", prompt.SafeText(part)); err != nil {
+					return err
+				}
+			}
+		}
+		if target.RetryCommand != "" {
+			if _, err := fmt.Fprintln(writer, "  Retry:"); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintf(writer, "    %s\n", prompt.SafeText(target.RetryCommand)); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
+}
+
+func batchApplyHeadline(result addMultiResult, envelope domain.PackageEnvelope) string {
+	name := strings.TrimSpace(envelope.Manifest.Name)
+	if name == "" {
+		name = result.Plugin
+	}
+	switch {
+	case result.Failed > 0 && result.Succeeded > 0:
+		return name + " installation finished with issues"
+	case result.Failed > 0:
+		return name + " installation failed"
+	case result.ActionRequired > 0:
+		return name + " installation prepared"
+	default:
+		return name + " installation completed"
+	}
+}
+
+func batchTargetLabel(target addTargetResult) string {
+	if strings.TrimSpace(target.displayName) != "" {
+		return target.displayName
+	}
+	if definition, ok := domain.ClientDefinitionFor(domain.ClientID(target.Target)); ok && definition.DisplayName != "" {
+		return definition.DisplayName
+	}
+	return target.Target
+}
+
+func classifyBatchPresentation(target addTargetResult) batchPresentationKind {
+	if target.Status == "action_required" {
+		return batchPresentationSetupRequired
+	}
+	phase := target.Output.Result.GroupPhase
+	switch phase {
+	case usecase.GroupTargetManagedRolledBack:
+		return batchPresentationRolledBack
+	case usecase.GroupTargetExternalNotAttempted:
+		return batchPresentationNotCompleted
+	case usecase.GroupTargetExternalFailed, usecase.GroupTargetExternalPartial, usecase.GroupTargetManagedUnknown:
+		return batchPresentationFailed
+	}
+	activation := target.Output.Result.Activation
+	if target.Error != nil || activation.Activation == domain.ActivationFailed || activation.Authentication == domain.AuthenticationFailed || activation.Verification == domain.VerificationFailed {
+		return batchPresentationFailed
+	}
+	if activation.Authentication == domain.AuthenticationPending {
+		return batchPresentationSignInRequired
+	}
+	if fullyInstalled(activation) {
+		return batchPresentationInstalled
+	}
+	if activation.Authentication == domain.AuthenticationNotChecked {
+		return batchPresentationSetupRequired
+	}
+	if activation.Activation == domain.ActivationPrepared || activation.Activation == domain.ActivationManual || target.Status == string(usecase.GroupTargetExternalCompleted) {
+		return batchPresentationSetupRequired
+	}
+	if phase == usecase.GroupTargetExternalCompleted {
+		return batchPresentationSetupRequired
+	}
+	return batchPresentationFailed
+}
+
+func batchResultTone(kind batchPresentationKind) terminaltheme.Role {
+	switch kind {
+	case batchPresentationInstalled:
+		return terminaltheme.Success
+	case batchPresentationSetupRequired, batchPresentationSignInRequired:
+		return terminaltheme.Warning
+	case batchPresentationFailed, batchPresentationNotCompleted, batchPresentationRolledBack:
+		return terminaltheme.Error
+	default:
+		return terminaltheme.Muted
+	}
+}
+
+func batchAttentionLines(target addTargetResult) []string {
+	kind := classifyBatchPresentation(target)
+	phase := target.Output.Result.GroupPhase
+	switch kind {
+	case batchPresentationRolledBack:
+		return []string{"Managed installation was rolled back; no client changes were kept."}
+	case batchPresentationFailed, batchPresentationNotCompleted:
+		if phase == usecase.GroupTargetManagedUnknown {
+			return []string{"Managed commit state is unknown; run agentplugins doctor before retrying."}
+		}
+		if target.Error != nil && strings.TrimSpace(target.Error.Message) != "" {
+			return []string{target.Error.Message}
+		}
+		if action := localTargetLifecycleAction(target.Output.Result, target.NextAction); action != "" {
+			return []string{action}
+		}
+		if kind == batchPresentationNotCompleted {
+			return []string{"Client installation was not attempted."}
+		}
+		return []string{"Client installation failed."}
+	default:
+		action := localTargetLifecycleAction(target.Output.Result, target.NextAction)
+		if action == "" {
+			action = nextLifecycleAction(target.Output.Result)
+		}
+		if action == "" {
+			return []string{"Finish setup in the selected client."}
+		}
+		return []string{action}
+	}
+}
+
+func countBatchTarget(result *addMultiResult, target addTargetResult) {
+	switch classifyBatchPresentation(target) {
+	case batchPresentationInstalled:
+		result.Succeeded++
+	case batchPresentationSetupRequired, batchPresentationSignInRequired:
+		// Deferred ChatGPT (status action_required, no group phase) is reported
+		// separately and must not inflate succeeded beyond prepared peers.
+		if target.Output.Result.GroupPhase == usecase.GroupTargetExternalCompleted || fullyInstalled(target.Output.Result.Activation) {
+			result.Succeeded++
+		}
+		result.ActionRequired++
+	case batchPresentationFailed, batchPresentationNotCompleted, batchPresentationRolledBack:
+		result.Failed++
+	default:
+		result.Failed++
+	}
+}
+
+func batchRetrySource(envelope domain.PackageEnvelope, public string) string {
+	// Prefer repository identity so retries never echo host-local absolute paths
+	// that publicPackageSource intentionally hides.
+	if strings.TrimSpace(envelope.Source.Repository) != "" {
+		return publicPackageSource(envelope.Source)
+	}
+	if source := strings.TrimSpace(envelope.Source.RequestedSource); isBatchRetryableSource(source) {
+		return source
+	}
+	if source := strings.TrimSpace(public); isBatchRetryableSource(source) {
+		return source
+	}
+	return ""
+}
+
+func isBatchPresentationSource(source string) bool {
+	switch strings.TrimSpace(source) {
+	case "", "direct local source", "direct immutable source":
+		return true
+	default:
+		return false
+	}
+}
+
+func isBatchRetryableSource(source string) bool {
+	source = strings.TrimSpace(source)
+	if source == "" || isBatchPresentationSource(source) || isLocalFilesystemSource(source) {
+		return false
+	}
+	return true
+}
+
+func isLocalFilesystemSource(source string) bool {
+	source = strings.TrimSpace(source)
+	if source == "" || strings.Contains(source, "://") {
+		return false
+	}
+	if strings.HasPrefix(source, ".") || strings.HasPrefix(source, "~") {
+		return true
+	}
+	return filepath.IsAbs(source)
+}
+
+func batchRetryCommandFor(target addTargetResult, source string) string {
+	if strings.TrimSpace(source) == "" {
+		return ""
+	}
+	switch target.Output.Result.GroupPhase {
+	case usecase.GroupTargetExternalFailed, usecase.GroupTargetExternalNotAttempted:
+		return batchRetryCommand(source, domain.ClientID(target.Target))
+	default:
+		return ""
+	}
+}
+
+func batchRetryCommand(source string, target domain.ClientID) string {
+	source = strings.TrimSpace(source)
+	targetID := strings.TrimSpace(string(target))
+	if source == "" || targetID == "" {
+		return ""
+	}
+	// Emit only shell-safe unquoted args so the same command works under npx on
+	// POSIX shells and Windows CMD without POSIX-only quoting.
+	if !isBatchRetrySafeArg(source) || !isBatchRetrySafeArg(targetID) {
+		return ""
+	}
+	return "npx universal-agent-plugins add " + source + " --target " + targetID
+}
+
+func isBatchRetrySafeArg(value string) bool {
+	return value != "" && strings.IndexFunc(value, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r) && !strings.ContainsRune("_./:@,+-=", r)
+	}) == -1
+}
+
+func batchActivationAggregateError(result addMultiResult) error {
+	// Exclude deferred ChatGPT (and similar action_required-only rows) from the
+	// denominator so partial-failure messaging stays tied to installable peers.
+	total := result.Succeeded + result.Failed
+	if total == 0 {
+		total = countInstallableBatchTargets(result.Targets)
+	}
+	if total == 0 {
+		return fmt.Errorf("client installations failed; see results above")
+	}
+	return fmt.Errorf("%d of %d client installations failed; see results above", result.Failed, total)
+}
+
+func countInstallableBatchTargets(targets []addTargetResult) int {
+	count := 0
+	for _, target := range targets {
+		if target.Status == "action_required" && target.Output.Result.GroupPhase == "" {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+func batchStatusIndicatesFailure(status string) bool {
+	switch status {
+	case "", string(usecase.GroupPhaseCompleted), string(usecase.GroupPhasePlanned),
+		"completed_with_action_required", "planned_with_action_required", "action_required":
+		return false
+	default:
+		return true
+	}
+}
+
+func clientDisplayName(client domain.DetectedClient) string {
+	if strings.TrimSpace(client.DisplayName) != "" {
+		return client.DisplayName
+	}
+	if definition, ok := domain.ClientDefinitionFor(client.ClientID); ok {
+		return definition.DisplayName
+	}
+	return string(client.ClientID)
 }
 
 func addResultTargets(results []addTargetResult) string {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/add_multi.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path/filepath"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -694,10 +693,10 @@ func batchAttentionLines(target addTargetResult) []string {
 		return []string{"Managed installation was rolled back; no client changes were kept."}
 	case batchPresentationFailed, batchPresentationNotCompleted:
 		if phase == usecase.GroupTargetManagedUnknown {
-			return []string{"Managed commit state is unknown; run agentplugins doctor before retrying."}
+			return []string{"Managed commit state is unknown; run npx universal-agent-plugins doctor before retrying."}
 		}
 		if batchFailureNeedsDoctor(target) {
-			return []string{"Installation state could not be saved safely; run agentplugins doctor before retrying."}
+			return []string{"Installation state could not be saved safely; run npx universal-agent-plugins doctor before retrying."}
 		}
 		if target.Error != nil && strings.TrimSpace(target.Error.Message) != "" {
 			return []string{target.Error.Message}
@@ -799,10 +798,12 @@ func isLocalFilesystemSource(source string) bool {
 	if source == "" || strings.Contains(source, "://") {
 		return false
 	}
-	if strings.HasPrefix(source, ".") || strings.HasPrefix(source, "~") {
+	// Match acquisition's portable local-path detector so Windows spellings such
+	// as d:/plugin are suppressed on every host, not only on Windows.
+	if strings.HasPrefix(source, "~") {
 		return true
 	}
-	return filepath.IsAbs(source)
+	return explicitLocalPath(source)
 }
 
 func batchRetryCommandFor(target addTargetResult, source string) string {

--- a/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_guidance_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_guidance_test.go
@@ -20,7 +20,7 @@ func TestContext7InteractivePreparationChoice(t *testing.T) {
 	f.app.Detector = staticDetector{clients: []domain.DetectedClient{fixtureClient(t, domain.ClientChatGPT)}}
 	before, _ := json.Marshal(d.bundle)
 	out, _, err := f.executeInput(true, "\n", "add", "context7-alias", "--plain")
-	if err == nil || !strings.Contains(err.Error(), "action_required") || !strings.Contains(out, "prepare personal marketplace") {
+	if err != nil || !strings.Contains(out, "prepare personal marketplace") || !strings.Contains(out, "npx universal-agent-plugins") {
 		t.Fatalf("choice/guidance: %s %v", out, err)
 	}
 	if a.verifiedCalls != 1 || a.directGitCalls != 0 || a.localCalls != 0 {
@@ -31,7 +31,7 @@ func TestContext7InteractivePreparationChoice(t *testing.T) {
 	if len(state.Installations) != 0 || string(before) != string(after) {
 		t.Fatal("registration changed state or signed metadata")
 	}
-	command := emittedRegistrationCommand(t, err.Error())
+	command := emittedRegistrationCommand(t, out)
 	if !strings.Contains(command, "context7-alias") {
 		t.Fatal(command)
 	}
@@ -44,6 +44,52 @@ func TestContext7InteractivePreparationChoice(t *testing.T) {
 	if b.ClientID != "chatgpt" || b.InstallIntent != domain.InstallIntentPrepare || b.Activation != domain.ActivationPrepared {
 		t.Fatalf("intent not retained: %+v", b)
 	}
+}
+
+
+func TestContext7ChatGPTOnlyActionRequiredIsSuccess(t *testing.T) {
+	f, d, a := context7GuidedFixture(t)
+	f.app.Detector = staticDetector{clients: []domain.DetectedClient{fixtureClient(t, domain.ClientChatGPT)}}
+	before, _ := json.Marshal(d.bundle)
+	out, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--format", "json")
+	if err != nil {
+		t.Fatalf("chatgpt-only setup should exit zero: %s %v", out, err)
+	}
+	if !strings.Contains(out, `"result":"success"`) || !strings.Contains(out, `"status":"action_required"`) || !strings.Contains(out, `"target":"chatgpt"`) {
+		t.Fatalf("chatgpt-only json = %s", out)
+	}
+	if a.verifiedCalls != 1 {
+		t.Fatalf("acquisition calls = %d", a.verifiedCalls)
+	}
+	state, _ := f.store.Load()
+	after, _ := json.Marshal(d.bundle)
+	if len(state.Installations) != 0 || string(before) != string(after) {
+		t.Fatal("chatgpt-only setup mutated state")
+	}
+}
+
+func TestContext7DeferredChatGPTSurvivesPeerActivationFailure(t *testing.T) {
+	f, _, _ := context7GuidedFixture(t)
+	f.app.Detector = staticDetector{clients: []domain.DetectedClient{fixtureClient(t, domain.ClientKiro), fixtureClient(t, domain.ClientChatGPT)}}
+	f.app.Lifecycle.Activator = &failAllCLIGroupActivator{}
+	out, _, err := f.execute(false, "add", "context7", "--target", "kiro,chatgpt")
+	if err == nil {
+		t.Fatal("expected kiro activation failure")
+	}
+	if !strings.Contains(out, "ChatGPT") || !strings.Contains(out, "Setup required") || !strings.Contains(out, "npx universal-agent-plugins") {
+		t.Fatalf("deferred chatgpt missing after peer failure: %s", out)
+	}
+}
+
+type failAllCLIGroupActivator struct{ calls int }
+
+func (activator *failAllCLIGroupActivator) Activate(context.Context, domain.ActivationRequest) (domain.ActivationOutcome, error) {
+	activator.calls++
+	return domain.ActivationOutcome{Activation: domain.ActivationFailed, Authentication: domain.AuthenticationNotRequired, Policy: domain.PolicyAllowed, Verification: domain.VerificationFailed}, fmt.Errorf("injected peer activation failure")
+}
+
+func (*failAllCLIGroupActivator) Deactivate(context.Context, domain.DeactivationRequest) (domain.DeactivationOutcome, error) {
+	return domain.DeactivationOutcome{Activation: domain.ActivationNotRequired, ArtifactRemovalAllowed: true, ExternalRemovalComplete: true}, nil
 }
 
 func emittedRegistrationCommand(t *testing.T, action string) string {
@@ -172,7 +218,7 @@ func TestContext7InteractiveSelectionOnlyAppliesSelectedIntent(t *testing.T) {
 			}
 			out, _, err := f.executeInput(true, "", "add", "context7", "--plain")
 			if chooseChatGPT {
-				if err != nil || !strings.Contains(out, "chatgpt: setup required") {
+				if err != nil || !strings.Contains(out, "Setup required") || !strings.Contains(out, "ChatGPT") {
 					t.Fatalf("%s %v", out, err)
 				}
 				command := emittedRegistrationCommand(t, out)
@@ -328,7 +374,7 @@ func TestContext7GuidedSelectionKeepsEligibleCodex(t *testing.T) {
 		confirmFn: func() (prompt.ConfirmationResult, error) { return prompt.ConfirmationResult{Accepted: true}, nil },
 	}
 	out, _, err := f.executeInput(true, "", "add", "context7", "--plain")
-	if err != nil || !strings.Contains(out, "chatgpt: setup required") {
+	if err != nil || !strings.Contains(out, "Setup required") || !strings.Contains(out, "ChatGPT") {
 		t.Fatalf("registration: %s %v", out, err)
 	}
 	command := emittedRegistrationCommand(t, out)

--- a/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_guidance_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_guidance_test.go
@@ -46,7 +46,6 @@ func TestContext7InteractivePreparationChoice(t *testing.T) {
 	}
 }
 
-
 func TestContext7ChatGPTOnlyActionRequiredIsSuccess(t *testing.T) {
 	f, d, a := context7GuidedFixture(t)
 	f.app.Detector = staticDetector{clients: []domain.DetectedClient{fixtureClient(t, domain.ClientChatGPT)}}

--- a/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_prepare_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/chatgpt_prepare_test.go
@@ -58,7 +58,7 @@ func TestContext7GuidedMissingRegistrationAndResume(t *testing.T) {
 	var response struct {
 		Data map[string]any `json:"data"`
 	}
-	if json.Unmarshal([]byte(out), &response) != nil || response.Data["status"] != "completed_with_action_required" || response.Data["succeeded"] != float64(1) || !strings.Contains(out, `"target":"chatgpt"`) || !strings.Contains(out, `"status":"action_required"`) {
+	if json.Unmarshal([]byte(out), &response) != nil || response.Data["status"] != "completed_with_action_required" || response.Data["failed"] != float64(0) || response.Data["succeeded"] != float64(1) || response.Data["action_required"] != float64(2) || !strings.Contains(out, `"target":"chatgpt"`) || !strings.Contains(out, `"status":"action_required"`) {
 		t.Fatalf("action response %s: %v", out, err)
 	}
 	state, _ := f.store.Load()
@@ -274,8 +274,13 @@ func TestContext7GuidedReceiptMigratesLegacyRegistrationOnlyWithExplicitID(t *te
 	if err := f.store.Save(state); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := f.execute(false, "add", "context7", "--target", "chatgpt"); err == nil || !strings.Contains(err.Error(), "action_required") {
-		t.Fatalf("legacy receipt did not require a new explicit ID: %v", err)
+	out, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--format", "json")
+	if err != nil || !strings.Contains(out, `"result":"success"`) || !strings.Contains(out, `"status":"action_required"`) {
+		t.Fatalf("legacy receipt did not require a new explicit ID via action_required success: %s %v", out, err)
+	}
+	mid, loadErr := f.store.Load()
+	if loadErr != nil || mid.Installations[0].LocalChatGPTMapping == nil || mid.Installations[0].LocalChatGPTMapping.URL != domain.Context7OAuthURL {
+		t.Fatalf("action_required setup mutated legacy receipt early: %+v %v", mid.Installations, loadErr)
 	}
 	if out, _, err := f.execute(false, "add", "context7", "--target", "chatgpt", "--chatgpt-app-id", fixturePersonalAppID); err != nil {
 		t.Fatalf("legacy receipt migration failed: %s %v", out, err)

--- a/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
+++ b/cli/plugin-kit-ai/internal/agentpluginscli/cli_test.go
@@ -678,7 +678,7 @@ func TestGroupedPartialFailureDoesNotMarkEveryTargetPassed(t *testing.T) {
 	fixture := newCLIFixture(t, []domain.DetectedClient{fixtureClient(t, domain.ClientCodex), fixtureClient(t, domain.ClientCursor), fixtureClient(t, domain.ClientKiro)})
 	fixture.app.Lifecycle.Activator = &failSecondCLIGroupActivator{}
 	stdout, _, err := fixture.execute(false, "add", writeCLIPlugin(t), "--target", "codex,cursor,kiro", "--format", "json")
-	if err == nil || !strings.Contains(err.Error(), "injected grouped activation failure") {
+	if err == nil || !strings.Contains(err.Error(), "1 of 3 client installations failed; see results above") {
 		t.Fatalf("grouped partial failure = %v", err)
 	}
 	var output struct {
@@ -696,8 +696,25 @@ func TestGroupedPartialFailureDoesNotMarkEveryTargetPassed(t *testing.T) {
 			t.Fatalf("failed target %s lost acquisition binding: %+v", target, targetProof)
 		}
 	}
-	if len(output.Data.TargetOutcomes) != 3 || passed != 1 || output.Data.TargetOutcomes["cursor"].Outcome != "failed" || output.Data.TargetOutcomes["kiro"].Outcome == "passed" {
+	if len(output.Data.TargetOutcomes) != 3 || passed != 2 || output.Data.TargetOutcomes["cursor"].Outcome != "failed" || output.Data.TargetOutcomes["kiro"].Outcome != "passed" {
 		t.Fatalf("partial failure target outcomes = %+v", output.Data.TargetOutcomes)
+	}
+	if output.Data.Failed != 1 || output.Data.Succeeded != 2 {
+		t.Fatalf("counts succeeded=%d failed=%d", output.Data.Succeeded, output.Data.Failed)
+	}
+	var failedTarget *addTargetResult
+	for index := range output.Data.Targets {
+		if output.Data.Targets[index].Target == "cursor" {
+			failedTarget = &output.Data.Targets[index]
+			break
+		}
+	}
+	if failedTarget == nil || failedTarget.Status != string(usecase.GroupTargetExternalFailed) || failedTarget.Error == nil {
+		t.Fatalf("failed target JSON = %+v", failedTarget)
+	}
+	// Local fixture paths must not leak into retry_command; remote-safe retries are covered elsewhere.
+	if failedTarget.RetryCommand != "" {
+		t.Fatalf("local fixture emitted filesystem retry: %q", failedTarget.RetryCommand)
 	}
 }
 

--- a/install/integrationctl/agentplugins/usecase/group.go
+++ b/install/integrationctl/agentplugins/usecase/group.go
@@ -759,13 +759,18 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 
 func groupTargetFailureFromActivation(err error, outcome domain.ActivationOutcome) *GroupTargetFailure {
 	stage := "activation"
-	// Providers often set VerificationFailed together with ActivationFailed.
-	// Prefer activation unless verification is the only failed dimension.
-	if outcome.Activation != domain.ActivationFailed && outcome.Verification == domain.VerificationFailed {
-		stage = "verification"
-	}
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+	switch {
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 		stage = "canceled"
+	case outcome.Authentication == domain.AuthenticationFailed &&
+		outcome.Activation != domain.ActivationFailed &&
+		outcome.Verification != domain.VerificationFailed:
+		stage = "authentication"
+	case outcome.Verification == domain.VerificationFailed &&
+		outcome.Activation != domain.ActivationFailed:
+		// Providers often set VerificationFailed together with ActivationFailed.
+		// Prefer activation unless verification is the only failed dimension.
+		stage = "verification"
 	}
 	message := "activation failed"
 	if err != nil {

--- a/install/integrationctl/agentplugins/usecase/group.go
+++ b/install/integrationctl/agentplugins/usecase/group.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -47,14 +48,22 @@ const (
 type GroupTargetPhase string
 
 const (
-	GroupTargetPlanned           GroupTargetPhase = "planned"
-	GroupTargetManagedRolledBack GroupTargetPhase = "managed_rolled_back"
-	GroupTargetManagedCommitted  GroupTargetPhase = "managed_committed"
-	GroupTargetManagedUnknown    GroupTargetPhase = "managed_commit_unknown"
-	GroupTargetExternalCompleted GroupTargetPhase = "external_completed"
-	GroupTargetExternalFailed    GroupTargetPhase = "external_failed"
-	GroupTargetExternalPartial   GroupTargetPhase = "external_completed_managed_incomplete"
+	GroupTargetPlanned              GroupTargetPhase = "planned"
+	GroupTargetManagedRolledBack    GroupTargetPhase = "managed_rolled_back"
+	GroupTargetManagedCommitted     GroupTargetPhase = "managed_committed"
+	GroupTargetManagedUnknown       GroupTargetPhase = "managed_commit_unknown"
+	GroupTargetExternalCompleted    GroupTargetPhase = "external_completed"
+	GroupTargetExternalFailed       GroupTargetPhase = "external_failed"
+	GroupTargetExternalPartial      GroupTargetPhase = "external_completed_managed_incomplete"
+	GroupTargetExternalNotAttempted GroupTargetPhase = "external_not_attempted"
 )
+
+// GroupTargetFailure records why one logical surface failed or was skipped
+// during external activation. Retry commands belong in CLI presentation.
+type GroupTargetFailure struct {
+	Stage   string `json:"stage"`
+	Message string `json:"message"`
+}
 
 func (service Service) AddGroup(ctx context.Context, input GroupInput) (GroupResult, error) {
 	return service.applyGroup(ctx, input, false)
@@ -615,7 +624,31 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 		planned[index].dataCreated = false
 	}
 	externalCompleted := 0
-	for _, target := range planned {
+	externalFailed := 0
+	logicalTotal := len(result.Targets)
+	var firstActivationErr error
+	markRemainingNotAttempted := func(fromIndex int, stage, message string) {
+		for index := fromIndex; index < len(planned); index++ {
+			target := planned[index]
+			for _, resultIndex := range target.resultIndexes {
+				result.Targets[resultIndex].GroupPhase = GroupTargetExternalNotAttempted
+				result.Targets[resultIndex].Failure = &GroupTargetFailure{Stage: stage, Message: message}
+			}
+		}
+	}
+	classifyActivationFailure := func() {
+		if externalCompleted > 0 {
+			result.Phase = GroupPhaseExternalPartialFailure
+			return
+		}
+		result.Phase = GroupPhaseManagedActivationFailed
+	}
+	for plannedIndex, target := range planned {
+		if err := ctx.Err(); err != nil {
+			classifyActivationFailure()
+			markRemainingNotAttempted(plannedIndex, "canceled", "processing stopped because the operation was canceled before remaining clients could be activated safely")
+			return result, fmt.Errorf("%d of %d client activations failed: %w", externalFailed+countNotAttempted(result.Targets), logicalTotal, err)
+		}
 		delivery := target.delivery
 		if target.noChange && target.managed != nil {
 			delivery = domain.StagedDelivery{
@@ -635,6 +668,22 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 			VerifyOnly: target.noChange, ActivationComplete: target.input.ActivationComplete})
 		if input.Repair && target.managed != nil {
 			outcome = preserveManagedAuthentication(outcome, target.managed.Authentication)
+		}
+		if activationErr == nil && outcome.Activation == "" {
+			if err := ctx.Err(); err != nil {
+				activationErr = err
+			} else {
+				activationErr = fmt.Errorf("activator returned an empty activation outcome")
+			}
+		}
+		if activationErr == nil && (outcome.Activation == domain.ActivationFailed || outcome.Verification == domain.VerificationFailed || outcome.Authentication == domain.AuthenticationFailed) {
+			activationErr = fmt.Errorf("activator reported a failed activation outcome without an error")
+		}
+		if activationErr != nil && outcome.Activation == "" {
+			outcome = domain.ActivationOutcome{
+				Activation: domain.ActivationFailed, Authentication: target.plan.Authentication,
+				Policy: domain.PolicyAllowed, Verification: domain.VerificationFailed,
+			}
 		}
 		if target.noChange && target.managed != nil {
 			if activationErr == nil && !clientVerifierAvailable(target.input, target.plan) && target.managed.Activation == domain.ActivationActive && target.managed.Verification == domain.VerificationInstalled {
@@ -662,28 +711,77 @@ func (service Service) applyGroup(ctx context.Context, input GroupInput, replace
 			if lifecycleChanged {
 				result.Targets[resultIndex].NoChange = false
 			}
-			if activationErr == nil && persistErr == nil {
-				result.Targets[resultIndex].GroupPhase = GroupTargetExternalCompleted
-			} else {
+			switch {
+			case persistErr != nil:
 				result.Targets[resultIndex].GroupPhase = GroupTargetExternalFailed
+				result.Targets[resultIndex].Failure = &GroupTargetFailure{Stage: "persist", Message: persistErr.Error()}
+			case activationErr != nil:
+				result.Targets[resultIndex].GroupPhase = GroupTargetExternalFailed
+				result.Targets[resultIndex].Failure = groupTargetFailureFromActivation(activationErr, outcome)
+			default:
+				result.Targets[resultIndex].GroupPhase = GroupTargetExternalCompleted
 			}
-		}
-		if activationErr != nil {
-			if externalCompleted > 0 {
-				result.Phase = GroupPhaseExternalPartialFailure
-			} else {
-				result.Phase = GroupPhaseManagedActivationFailed
-			}
-			return result, activationErr
 		}
 		if persistErr != nil {
-			result.Phase = GroupPhaseManagedActivationFailed
-			return result, persistErr
+			externalFailed += len(target.resultIndexes)
+			classifyActivationFailure()
+			markRemainingNotAttempted(plannedIndex+1, "persist", "processing stopped because installation state could not be saved safely")
+			return result, fmt.Errorf("%d of %d client activations failed: %w", externalFailed+countNotAttempted(result.Targets), logicalTotal, persistErr)
+		}
+		if activationErr != nil {
+			externalFailed += len(target.resultIndexes)
+			if firstActivationErr == nil {
+				firstActivationErr = activationErr
+			}
+			if errors.Is(activationErr, context.Canceled) || errors.Is(activationErr, context.DeadlineExceeded) || ctx.Err() != nil {
+				classifyActivationFailure()
+				markRemainingNotAttempted(plannedIndex+1, "canceled", "processing stopped because the operation was canceled before remaining clients could be activated safely")
+				cause := activationErr
+				if ctxErr := ctx.Err(); ctxErr != nil && !errors.Is(activationErr, context.Canceled) && !errors.Is(activationErr, context.DeadlineExceeded) {
+					cause = ctxErr
+				}
+				return result, fmt.Errorf("%d of %d client activations failed: %w", externalFailed+countNotAttempted(result.Targets), logicalTotal, cause)
+			}
+			continue
 		}
 		externalCompleted += len(target.resultIndexes)
 	}
+	if externalFailed > 0 {
+		classifyActivationFailure()
+		if firstActivationErr != nil {
+			return result, fmt.Errorf("%d of %d client activations failed: %w", externalFailed, logicalTotal, firstActivationErr)
+		}
+		return result, fmt.Errorf("%d of %d client activations failed", externalFailed, logicalTotal)
+	}
 	result.Phase = GroupPhaseCompleted
 	return result, nil
+}
+
+func groupTargetFailureFromActivation(err error, outcome domain.ActivationOutcome) *GroupTargetFailure {
+	stage := "activation"
+	// Providers often set VerificationFailed together with ActivationFailed.
+	// Prefer activation unless verification is the only failed dimension.
+	if outcome.Activation != domain.ActivationFailed && outcome.Verification == domain.VerificationFailed {
+		stage = "verification"
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		stage = "canceled"
+	}
+	message := "activation failed"
+	if err != nil {
+		message = err.Error()
+	}
+	return &GroupTargetFailure{Stage: stage, Message: message}
+}
+
+func countNotAttempted(targets []AddResult) int {
+	count := 0
+	for _, target := range targets {
+		if target.GroupPhase == GroupTargetExternalNotAttempted {
+			count++
+		}
+	}
+	return count
 }
 
 func preservedGroupAuthentication(planned, current domain.AuthenticationState) domain.AuthenticationState {

--- a/install/integrationctl/agentplugins/usecase/group_test.go
+++ b/install/integrationctl/agentplugins/usecase/group_test.go
@@ -696,18 +696,21 @@ func TestGroupRecoveryPostApplyVerifyChecksEveryRecoveringTargetOnce(t *testing.
 func TestGroupedAddReportsCommittedActivationAndExternalPartialFailuresFromReceipts(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {
-		name      string
-		failCall  int
-		wantPhase GroupPhase
-		wantFirst GroupTargetPhase
+		name       string
+		failCall   int
+		wantPhase  GroupPhase
+		wantFirst  GroupTargetPhase
+		wantSecond GroupTargetPhase
+		wantCalls  int
 	}{
-		{name: "first activation", failCall: 1, wantPhase: GroupPhaseManagedActivationFailed, wantFirst: GroupTargetExternalFailed},
-		{name: "second activation", failCall: 2, wantPhase: GroupPhaseExternalPartialFailure, wantFirst: GroupTargetExternalCompleted},
+		{name: "first activation", failCall: 1, wantPhase: GroupPhaseExternalPartialFailure, wantFirst: GroupTargetExternalFailed, wantSecond: GroupTargetExternalCompleted, wantCalls: 2},
+		{name: "second activation", failCall: 2, wantPhase: GroupPhaseExternalPartialFailure, wantFirst: GroupTargetExternalCompleted, wantSecond: GroupTargetExternalFailed, wantCalls: 2},
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			service, store, cursor := serviceFixture(t)
-			service.Activator = &failNthGroupActivator{failCall: test.failCall}
+			activator := &failNthGroupActivator{failCall: test.failCall}
+			service.Activator = activator
 			kiro := domain.DetectedClient{ClientID: domain.ClientKiro, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".kiro")}
 			result, err := service.AddGroup(context.Background(), GroupInput{Targets: []AddInput{
 				addInput(t, cursor, "https://example.com/phase-aware"),
@@ -716,11 +719,17 @@ func TestGroupedAddReportsCommittedActivationAndExternalPartialFailuresFromRecei
 			if err == nil {
 				t.Fatal("activation failure was ignored")
 			}
-			if result.Phase != test.wantPhase || len(result.Receipts) != 2 || result.Targets[0].GroupPhase != test.wantFirst {
+			if !strings.Contains(err.Error(), "of 2 client activations failed") {
+				t.Fatalf("aggregate error = %v", err)
+			}
+			if result.Phase != test.wantPhase || len(result.Receipts) != 2 || result.Targets[0].GroupPhase != test.wantFirst || result.Targets[1].GroupPhase != test.wantSecond {
 				t.Fatalf("phase-aware result = %+v", result)
 			}
-			if result.Targets[test.failCall-1].GroupPhase != GroupTargetExternalFailed {
-				t.Fatalf("failed target outcome = %+v", result.Targets[test.failCall-1])
+			if result.Targets[test.failCall-1].Failure == nil || result.Targets[test.failCall-1].Failure.Message == "" {
+				t.Fatalf("failed target missing failure detail: %+v", result.Targets[test.failCall-1])
+			}
+			if activator.calls != test.wantCalls {
+				t.Fatalf("Activate calls = %d, want %d", activator.calls, test.wantCalls)
 			}
 			state, loadErr := store.Load()
 			if loadErr != nil {
@@ -730,6 +739,252 @@ func TestGroupedAddReportsCommittedActivationAndExternalPartialFailuresFromRecei
 				t.Fatalf("managed commit was not authoritative: %+v", state)
 			}
 		})
+	}
+}
+
+func TestGroupedAddContinuesActivationAcrossClientFailures(t *testing.T) {
+	t.Parallel()
+	t.Run("middle failure keeps neighbors", func(t *testing.T) {
+		service, store, cursor := serviceFixture(t)
+		activator := &failNthGroupActivator{failCall: 2}
+		service.Activator = activator
+		codex := domain.DetectedClient{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".codex")}
+		kiro := domain.DetectedClient{ClientID: domain.ClientKiro, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".kiro")}
+		result, err := service.AddGroup(context.Background(), GroupInput{Targets: []AddInput{
+			addInput(t, cursor, "https://example.com/batch-middle"),
+			addInput(t, codex, "https://example.com/batch-middle"),
+			addInput(t, kiro, "https://example.com/batch-middle"),
+		}, OperationGroupID: "batch-middle", Confirmed: true})
+		if err == nil || result.Phase != GroupPhaseExternalPartialFailure || activator.calls != 3 {
+			t.Fatalf("middle failure = phase=%s calls=%d err=%v", result.Phase, activator.calls, err)
+		}
+		if result.Targets[0].GroupPhase != GroupTargetExternalCompleted || result.Targets[1].GroupPhase != GroupTargetExternalFailed || result.Targets[2].GroupPhase != GroupTargetExternalCompleted {
+			t.Fatalf("target phases = %+v", result.Targets)
+		}
+		if result.Targets[1].Failure == nil || !strings.Contains(result.Targets[1].Failure.Message, "injected activation failure") {
+			t.Fatalf("failure detail = %+v", result.Targets[1].Failure)
+		}
+		state, loadErr := store.Load()
+		if loadErr != nil {
+			t.Fatal(loadErr)
+		}
+		if len(state.Installations) != 1 || len(state.Installations[0].Clients) != 3 {
+			t.Fatalf("state = %+v", state)
+		}
+	})
+	t.Run("all targets fail still activate each", func(t *testing.T) {
+		service, _, cursor := serviceFixture(t)
+		activator := &failNthGroupActivator{failSet: map[int]bool{1: true, 2: true, 3: true}}
+		service.Activator = activator
+		codex := domain.DetectedClient{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".codex")}
+		kiro := domain.DetectedClient{ClientID: domain.ClientKiro, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".kiro")}
+		result, err := service.AddGroup(context.Background(), GroupInput{Targets: []AddInput{
+			addInput(t, cursor, "https://example.com/batch-all-fail"),
+			addInput(t, codex, "https://example.com/batch-all-fail"),
+			addInput(t, kiro, "https://example.com/batch-all-fail"),
+		}, OperationGroupID: "batch-all-fail", Confirmed: true})
+		if err == nil || result.Phase != GroupPhaseManagedActivationFailed || activator.calls != 3 {
+			t.Fatalf("all-fail = phase=%s calls=%d err=%v", result.Phase, activator.calls, err)
+		}
+		for index, target := range result.Targets {
+			if target.GroupPhase != GroupTargetExternalFailed || target.Failure == nil {
+				t.Fatalf("target %d = %+v", index, target)
+			}
+		}
+	})
+	t.Run("context cancel stops remaining", func(t *testing.T) {
+		service, _, cursor := serviceFixture(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		activator := &cancelAfterFirstGroupActivator{cancel: cancel}
+		service.Activator = activator
+		codex := domain.DetectedClient{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".codex")}
+		kiro := domain.DetectedClient{ClientID: domain.ClientKiro, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".kiro")}
+		result, err := service.AddGroup(ctx, GroupInput{Targets: []AddInput{
+			addInput(t, cursor, "https://example.com/batch-cancel"),
+			addInput(t, codex, "https://example.com/batch-cancel"),
+			addInput(t, kiro, "https://example.com/batch-cancel"),
+		}, OperationGroupID: "batch-cancel", Confirmed: true})
+		if err == nil || activator.calls != 1 {
+			t.Fatalf("cancel result calls=%d err=%v", activator.calls, err)
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("cancel error lost context cause: %v", err)
+		}
+		if result.Targets[0].GroupPhase != GroupTargetExternalFailed {
+			t.Fatalf("first target = %+v", result.Targets[0])
+		}
+		if result.Targets[1].GroupPhase != GroupTargetExternalNotAttempted || result.Targets[2].GroupPhase != GroupTargetExternalNotAttempted {
+			t.Fatalf("remaining targets = %+v", result.Targets)
+		}
+		if result.Targets[1].Failure == nil || result.Targets[1].Failure.Stage != "canceled" || !strings.Contains(result.Targets[1].Failure.Message, "canceled") {
+			t.Fatalf("not-attempted failure = %+v", result.Targets[1].Failure)
+		}
+		if result.Targets[0].Failure == nil || result.Targets[0].Failure.Stage != "canceled" {
+			t.Fatalf("canceled first target stage = %+v", result.Targets[0].Failure)
+		}
+	})
+	t.Run("state store failure stops remaining", func(t *testing.T) {
+		service, store, cursor := serviceFixture(t)
+		calls := 0
+		failing := &failPersistAfterActivateStore{StateStore: store, activated: &calls}
+		service.StateStore = failing
+		service.Kernel.StateStore = failing
+		service.Activator = &countingGroupActivator{calls: &calls}
+		codex := domain.DetectedClient{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".codex")}
+		kiro := domain.DetectedClient{ClientID: domain.ClientKiro, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".kiro")}
+		result, err := service.AddGroup(context.Background(), GroupInput{Targets: []AddInput{
+			addInput(t, cursor, "https://example.com/batch-persist"),
+			addInput(t, codex, "https://example.com/batch-persist"),
+			addInput(t, kiro, "https://example.com/batch-persist"),
+		}, OperationGroupID: "batch-persist", Confirmed: true})
+		if err == nil {
+			t.Fatal("expected state store failure")
+		}
+		if calls != 1 {
+			t.Fatalf("Activate calls = %d, want 1", calls)
+		}
+		if result.Targets[0].GroupPhase != GroupTargetExternalFailed || result.Targets[0].Failure == nil || result.Targets[0].Failure.Stage != "persist" {
+			t.Fatalf("first target = %+v", result.Targets[0])
+		}
+		if result.Targets[1].GroupPhase != GroupTargetExternalNotAttempted || result.Targets[2].GroupPhase != GroupTargetExternalNotAttempted {
+			t.Fatalf("remaining targets = %+v", result.Targets)
+		}
+	})
+	t.Run("shared copilot vscode activates once", func(t *testing.T) {
+		service, _, _ := serviceFixture(t)
+		activator := &failNthGroupActivator{failCall: 1}
+		service.Activator = activator
+		copilot := domain.DetectedClient{ClientID: domain.ClientCopilot, DisplayName: "Copilot", Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".copilot"), ExecutablePath: filepath.Join(t.TempDir(), "bin", "copilot")}
+		vscode := domain.DetectedClient{ClientID: domain.ClientVSCode, DisplayName: "VS Code", Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".vscode")}
+		result, err := service.AddGroup(context.Background(), GroupInput{Targets: []AddInput{
+			addInput(t, copilot, "https://example.com/batch-shared"),
+			addInput(t, vscode, "https://example.com/batch-shared"),
+		}, OperationGroupID: "batch-shared", Confirmed: true})
+		if err == nil || activator.calls != 1 {
+			t.Fatalf("shared backend calls=%d err=%v", activator.calls, err)
+		}
+		if result.Phase != GroupPhaseManagedActivationFailed {
+			t.Fatalf("phase = %s", result.Phase)
+		}
+		for index, target := range result.Targets {
+			if target.GroupPhase != GroupTargetExternalFailed || target.Failure == nil {
+				t.Fatalf("shared target %d = %+v", index, target)
+			}
+		}
+	})
+	t.Run("empty successful outcome is rejected", func(t *testing.T) {
+		service, _, cursor := serviceFixture(t)
+		service.Activator = &emptyOutcomeGroupActivator{}
+		kiro := domain.DetectedClient{ClientID: domain.ClientKiro, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".kiro")}
+		result, err := service.AddGroup(context.Background(), GroupInput{Targets: []AddInput{
+			addInput(t, cursor, "https://example.com/batch-empty"),
+			addInput(t, kiro, "https://example.com/batch-empty"),
+		}, OperationGroupID: "batch-empty", Confirmed: true})
+		if err == nil || !strings.Contains(err.Error(), "empty activation outcome") {
+			t.Fatalf("empty outcome err = %v", err)
+		}
+		if result.Targets[0].GroupPhase != GroupTargetExternalFailed || result.Targets[0].Activation.Activation != domain.ActivationFailed {
+			t.Fatalf("first target = %+v", result.Targets[0])
+		}
+		if result.Targets[1].GroupPhase != GroupTargetExternalFailed {
+			t.Fatalf("second target = %+v", result.Targets[1])
+		}
+	})
+	t.Run("failed outcome without error is rejected", func(t *testing.T) {
+		service, _, cursor := serviceFixture(t)
+		service.Activator = &failedOutcomeWithoutErrGroupActivator{}
+		kiro := domain.DetectedClient{ClientID: domain.ClientKiro, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".kiro")}
+		result, err := service.AddGroup(context.Background(), GroupInput{Targets: []AddInput{
+			addInput(t, cursor, "https://example.com/batch-failed-silent"),
+			addInput(t, kiro, "https://example.com/batch-failed-silent"),
+		}, OperationGroupID: "batch-failed-silent", Confirmed: true})
+		if err == nil || !strings.Contains(err.Error(), "failed activation outcome without an error") {
+			t.Fatalf("silent failure err = %v", err)
+		}
+		if result.Phase != GroupPhaseManagedActivationFailed {
+			t.Fatalf("phase = %s", result.Phase)
+		}
+		for index, target := range result.Targets {
+			if target.GroupPhase != GroupTargetExternalFailed || target.Failure == nil {
+				t.Fatalf("target %d = %+v", index, target)
+			}
+		}
+	})
+	t.Run("deadline exceeded stops remaining", func(t *testing.T) {
+		service, _, cursor := serviceFixture(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		activator := &deadlineAfterFirstGroupActivator{cancel: cancel}
+		service.Activator = activator
+		codex := domain.DetectedClient{ClientID: domain.ClientCodex, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".codex")}
+		kiro := domain.DetectedClient{ClientID: domain.ClientKiro, Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".kiro")}
+		result, err := service.AddGroup(ctx, GroupInput{Targets: []AddInput{
+			addInput(t, cursor, "https://example.com/batch-deadline"),
+			addInput(t, codex, "https://example.com/batch-deadline"),
+			addInput(t, kiro, "https://example.com/batch-deadline"),
+		}, OperationGroupID: "batch-deadline", Confirmed: true})
+		if err == nil || activator.calls != 1 {
+			t.Fatalf("deadline result calls=%d err=%v", activator.calls, err)
+		}
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("deadline error lost cause: %v", err)
+		}
+		if result.Targets[0].GroupPhase != GroupTargetExternalFailed {
+			t.Fatalf("first target = %+v", result.Targets[0])
+		}
+		if result.Targets[1].GroupPhase != GroupTargetExternalNotAttempted || result.Targets[2].GroupPhase != GroupTargetExternalNotAttempted {
+			t.Fatalf("remaining targets = %+v", result.Targets)
+		}
+	})
+	t.Run("shared copilot vscode success propagates", func(t *testing.T) {
+		service, store, _ := serviceFixture(t)
+		activator := &failNthGroupActivator{}
+		service.Activator = activator
+		copilot := domain.DetectedClient{ClientID: domain.ClientCopilot, DisplayName: "Copilot", Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".copilot"), ExecutablePath: filepath.Join(t.TempDir(), "bin", "copilot")}
+		vscode := domain.DetectedClient{ClientID: domain.ClientVSCode, DisplayName: "VS Code", Status: domain.DetectionDetected, ConfigRoot: filepath.Join(t.TempDir(), ".vscode")}
+		result, err := service.AddGroup(context.Background(), GroupInput{Targets: []AddInput{
+			addInput(t, copilot, "https://example.com/batch-shared-ok"),
+			addInput(t, vscode, "https://example.com/batch-shared-ok"),
+		}, OperationGroupID: "batch-shared-ok", Confirmed: true})
+		if err != nil || activator.calls != 1 {
+			t.Fatalf("shared success calls=%d err=%v", activator.calls, err)
+		}
+		if result.Phase != GroupPhaseCompleted {
+			t.Fatalf("phase = %s", result.Phase)
+		}
+		for index, target := range result.Targets {
+			if target.GroupPhase != GroupTargetExternalCompleted || target.Activation.Activation != domain.ActivationActive {
+				t.Fatalf("shared target %d = %+v", index, target)
+			}
+		}
+		state, loadErr := store.Load()
+		if loadErr != nil || len(state.Installations) != 1 || len(state.Installations[0].Clients) != 1 {
+			t.Fatalf("shared backend state = %+v err=%v", state, loadErr)
+		}
+	})
+}
+
+
+func TestGroupTargetFailureStageClassification(t *testing.T) {
+	t.Parallel()
+	activationAndVerification := groupTargetFailureFromActivation(errors.New("boom"), domain.ActivationOutcome{
+		Activation: domain.ActivationFailed, Verification: domain.VerificationFailed,
+	})
+	if activationAndVerification.Stage != "activation" {
+		t.Fatalf("combined failure stage = %q", activationAndVerification.Stage)
+	}
+	verificationOnly := groupTargetFailureFromActivation(errors.New("verify boom"), domain.ActivationOutcome{
+		Activation: domain.ActivationActive, Verification: domain.VerificationFailed,
+	})
+	if verificationOnly.Stage != "verification" {
+		t.Fatalf("verification-only stage = %q", verificationOnly.Stage)
+	}
+	canceled := groupTargetFailureFromActivation(context.Canceled, domain.ActivationOutcome{
+		Activation: domain.ActivationFailed, Verification: domain.VerificationFailed,
+	})
+	if canceled.Stage != "canceled" {
+		t.Fatalf("canceled stage = %q", canceled.Stage)
 	}
 }
 
@@ -973,13 +1228,18 @@ func (stager *failNthVerificationStager) Verify(ctx context.Context, root, expec
 type failNthGroupActivator struct {
 	calls    int
 	failCall int
+	failSet  map[int]bool
 }
 
 func (activator *failNthGroupActivator) Activate(context.Context, domain.ActivationRequest) (domain.ActivationOutcome, error) {
 	activator.calls++
 	outcome := domain.ActivationOutcome{Activation: domain.ActivationActive, Authentication: domain.AuthenticationNotRequired,
 		Policy: domain.PolicyAllowed, Verification: domain.VerificationInstalled}
-	if activator.calls == activator.failCall {
+	fail := activator.calls == activator.failCall
+	if activator.failSet != nil {
+		fail = activator.failSet[activator.calls]
+	}
+	if fail {
 		outcome.Activation = domain.ActivationFailed
 		outcome.Verification = domain.VerificationFailed
 		return outcome, errors.New("injected activation failure")
@@ -988,6 +1248,115 @@ func (activator *failNthGroupActivator) Activate(context.Context, domain.Activat
 }
 
 func (*failNthGroupActivator) Deactivate(context.Context, domain.DeactivationRequest) (domain.DeactivationOutcome, error) {
+	return domain.DeactivationOutcome{Activation: domain.ActivationNotRequired, ArtifactRemovalAllowed: true, ExternalRemovalComplete: true}, nil
+}
+
+type cancelAfterFirstGroupActivator struct {
+	cancel context.CancelFunc
+	calls  int
+}
+
+func (activator *cancelAfterFirstGroupActivator) Activate(ctx context.Context, _ domain.ActivationRequest) (domain.ActivationOutcome, error) {
+	activator.calls++
+	outcome := domain.ActivationOutcome{Activation: domain.ActivationActive, Authentication: domain.AuthenticationNotRequired,
+		Policy: domain.PolicyAllowed, Verification: domain.VerificationInstalled}
+	if activator.calls == 1 {
+		activator.cancel()
+		outcome.Activation = domain.ActivationFailed
+		outcome.Verification = domain.VerificationFailed
+		return outcome, context.Canceled
+	}
+	return outcome, nil
+}
+
+func (*cancelAfterFirstGroupActivator) Deactivate(context.Context, domain.DeactivationRequest) (domain.DeactivationOutcome, error) {
+	return domain.DeactivationOutcome{Activation: domain.ActivationNotRequired, ArtifactRemovalAllowed: true, ExternalRemovalComplete: true}, nil
+}
+
+type failAfterInstallSaveStore struct {
+	transaction.StateStore
+	afterInstallSaves int
+	failAt            int
+}
+
+func (store *failAfterInstallSaveStore) Save(state domain.StateFileV2) error {
+	if len(state.Installations) > 0 {
+		store.afterInstallSaves++
+		if store.failAt > 0 && store.afterInstallSaves >= store.failAt {
+			return errors.New("injected state store failure")
+		}
+	}
+	return store.StateStore.Save(state)
+}
+
+type failPersistAfterActivateStore struct {
+	transaction.StateStore
+	activated *int
+}
+
+func (store *failPersistAfterActivateStore) Save(state domain.StateFileV2) error {
+	if store.activated != nil && *store.activated > 0 {
+		return errors.New("injected state store failure")
+	}
+	return store.StateStore.Save(state)
+}
+
+type countingGroupActivator struct {
+	calls *int
+}
+
+func (activator *countingGroupActivator) Activate(context.Context, domain.ActivationRequest) (domain.ActivationOutcome, error) {
+	*activator.calls++
+	return domain.ActivationOutcome{Activation: domain.ActivationActive, Authentication: domain.AuthenticationNotRequired,
+		Policy: domain.PolicyAllowed, Verification: domain.VerificationInstalled}, nil
+}
+
+func (*countingGroupActivator) Deactivate(context.Context, domain.DeactivationRequest) (domain.DeactivationOutcome, error) {
+	return domain.DeactivationOutcome{Activation: domain.ActivationNotRequired, ArtifactRemovalAllowed: true, ExternalRemovalComplete: true}, nil
+}
+
+type emptyOutcomeGroupActivator struct{}
+
+func (*emptyOutcomeGroupActivator) Activate(context.Context, domain.ActivationRequest) (domain.ActivationOutcome, error) {
+	return domain.ActivationOutcome{}, nil
+}
+
+func (*emptyOutcomeGroupActivator) Deactivate(context.Context, domain.DeactivationRequest) (domain.DeactivationOutcome, error) {
+	return domain.DeactivationOutcome{Activation: domain.ActivationNotRequired, ArtifactRemovalAllowed: true, ExternalRemovalComplete: true}, nil
+}
+
+type failedOutcomeWithoutErrGroupActivator struct{}
+
+func (*failedOutcomeWithoutErrGroupActivator) Activate(context.Context, domain.ActivationRequest) (domain.ActivationOutcome, error) {
+	return domain.ActivationOutcome{
+		Activation: domain.ActivationFailed, Authentication: domain.AuthenticationNotRequired,
+		Policy: domain.PolicyAllowed, Verification: domain.VerificationFailed,
+	}, nil
+}
+
+func (*failedOutcomeWithoutErrGroupActivator) Deactivate(context.Context, domain.DeactivationRequest) (domain.DeactivationOutcome, error) {
+	return domain.DeactivationOutcome{Activation: domain.ActivationNotRequired, ArtifactRemovalAllowed: true, ExternalRemovalComplete: true}, nil
+}
+
+type deadlineAfterFirstGroupActivator struct {
+	cancel context.CancelFunc
+	calls  int
+}
+
+func (activator *deadlineAfterFirstGroupActivator) Activate(ctx context.Context, _ domain.ActivationRequest) (domain.ActivationOutcome, error) {
+	activator.calls++
+	outcome := domain.ActivationOutcome{Activation: domain.ActivationActive, Authentication: domain.AuthenticationNotRequired,
+		Policy: domain.PolicyAllowed, Verification: domain.VerificationInstalled}
+	if activator.calls == 1 {
+		activator.cancel()
+		outcome.Activation = domain.ActivationFailed
+		outcome.Verification = domain.VerificationFailed
+		return outcome, context.DeadlineExceeded
+	}
+	return outcome, nil
+}
+
+func (*deadlineAfterFirstGroupActivator) Deactivate(context.Context, domain.DeactivationRequest) (domain.DeactivationOutcome, error) {
 	return domain.DeactivationOutcome{Activation: domain.ActivationNotRequired, ArtifactRemovalAllowed: true, ExternalRemovalComplete: true}, nil
 }
 

--- a/install/integrationctl/agentplugins/usecase/group_test.go
+++ b/install/integrationctl/agentplugins/usecase/group_test.go
@@ -965,7 +965,6 @@ func TestGroupedAddContinuesActivationAcrossClientFailures(t *testing.T) {
 	})
 }
 
-
 func TestGroupTargetFailureStageClassification(t *testing.T) {
 	t.Parallel()
 	activationAndVerification := groupTargetFailureFromActivation(errors.New("boom"), domain.ActivationOutcome{
@@ -985,6 +984,12 @@ func TestGroupTargetFailureStageClassification(t *testing.T) {
 	})
 	if canceled.Stage != "canceled" {
 		t.Fatalf("canceled stage = %q", canceled.Stage)
+	}
+	authOnly := groupTargetFailureFromActivation(errors.New("auth boom"), domain.ActivationOutcome{
+		Activation: domain.ActivationActive, Authentication: domain.AuthenticationFailed, Verification: domain.VerificationInstalled,
+	})
+	if authOnly.Stage != "authentication" {
+		t.Fatalf("authentication-only stage = %q", authOnly.Stage)
 	}
 }
 

--- a/install/integrationctl/agentplugins/usecase/service.go
+++ b/install/integrationctl/agentplugins/usecase/service.go
@@ -105,6 +105,7 @@ type AddResult struct {
 	NoChange             bool                     `json:"no_change,omitempty"`
 	Receipt              domain.MutationReceipt   `json:"-"`
 	GroupPhase           GroupTargetPhase         `json:"group_phase,omitempty"`
+	Failure              *GroupTargetFailure      `json:"failure,omitempty"`
 }
 
 func (service Service) Add(ctx context.Context, input AddInput) (AddResult, error) {


### PR DESCRIPTION
## Summary
- Continue activating remaining clients after a per-client activation failure; abort only on persist/cancel with `external_not_attempted`.
- Apply-only two-column human summary (including single-target failures) with safe `npx` retries, Directory selectors / immutable GitHub SHA sources, and doctor guidance for uncertain state.
- Treat ChatGPT-only setup as success/`action_required`, always surface deferred ChatGPT even when peers fail, and classify failure stages accurately (`activation` / `verification` / `authentication` / `canceled` / `persist`).

## Test plan
- [x] `go test` usecase batch/group activation cases
- [x] `go test` agentpluginscli BatchActivation + Context7 guidance/prepare cases
- [x] `go vet` both packages
- [x] `gofmt` / `git diff --check` clean
- [ ] CI on PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed batch activation summaries with per-target statuses, failure details, and aggregate success/failure counts.
  * Activation now continues across independent target failures and identifies targets that were not attempted.
  * Added retry commands and improved dry-run and apply-summary presentation.
  * JSON output now includes actionable statuses such as `action_required` and structured failure details.

* **Bug Fixes**
  * Deferred ChatGPT setup is reported as successful with required follow-up guidance instead of a failure.
  * ChatGPT guidance remains available when another target fails, without prematurely changing saved configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->