### PR TITLE
fix(ci): prepare authoring inputs for Pages docs

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -43,7 +43,7 @@ jobs:
           go-version: "1.25.13"
           cache: false
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.0.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -43,6 +43,10 @@ jobs:
           go-version: "1.25.13"
           cache: false
 
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
       - name: Install landing toolchain
         working-directory: landing
         run: pnpm install --frozen-lockfile
@@ -52,6 +56,29 @@ jobs:
         run: |
           export PATH="${{ steps.pnpm-docs.outputs.bin_dest }}:$PATH"
           pnpm install --frozen-lockfile
+
+      - name: Install pinned docs generators
+        run: |
+          python -m venv "${RUNNER_TEMP}/docs-tools-root/python-venv"
+          "${RUNNER_TEMP}/docs-tools-root/python-venv/bin/pip" install --require-hashes -r "${GITHUB_WORKSPACE}/website/tools/pydoc-markdown-requirements.txt"
+          mkdir -p "${RUNNER_TEMP}/docs-tools-root/bin"
+          GOBIN="${RUNNER_TEMP}/docs-tools-root/bin" go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@v1.1.0
+
+      - name: Prepare immutable authoring source
+        run: |
+          source_sha=$(node --input-type=module -e 'import { acceptedAuthoringSHA } from "./website/tools/lib/source-contract.mjs"; process.stdout.write(acceptedAuthoringSHA)')
+          git clone --no-local --no-checkout . "${RUNNER_TEMP}/docs-authoring-source"
+          git -C "${RUNNER_TEMP}/docs-authoring-source" checkout --quiet --detach "$source_sha"
+          chmod -R a-w "${RUNNER_TEMP}/docs-authoring-source"
+          echo "DOCS_AUTHORING_CHECKOUT=${RUNNER_TEMP}/docs-authoring-source" >> "$GITHUB_ENV"
+
+      - name: Warm Go module cache for offline docs generation
+        env:
+          GOCACHE: ${{ runner.temp }}/docs-consumer-gocache
+          GOMODCACHE: ${{ runner.temp }}/docs-consumer-gomodcache
+        run: |
+          cd "$DOCS_AUTHORING_CHECKOUT"
+          GOWORK="$DOCS_AUTHORING_CHECKOUT/go.work" go build -p 2 -o "$RUNNER_TEMP/docs-authoring-preflight" ./cli/plugin-kit-ai/tools/authoring-docs
 
       # Keep the renamed CLI Pages site self-contained: every deployment carries
       # a verified, byte-exact compatibility copy of the registry feeds. This
@@ -90,6 +117,17 @@ jobs:
         env:
           DOCS_BASE_PATH: /universal-agent-plugins/docs/
           DOCS_HOSTNAME: https://777genius.github.io
+          GOCACHE: ${{ runner.temp }}/docs-consumer-gocache
+          GOMODCACHE: ${{ runner.temp }}/docs-consumer-gomodcache
+          DOCS_TOOLS_ROOT: ${{ runner.temp }}/docs-tools-root
+          DOCS_GOMARKDOC: ${{ runner.temp }}/docs-tools-root/bin/gomarkdoc
+          TMPDIR: ${{ runner.temp }}
+          GOWORK: ${{ github.workspace }}/go.work
+          GOPROXY: "off"
+          GOSUMDB: "off"
+          GOENV: "off"
+          GOTOOLCHAIN: "local"
+          GOMAXPROCS: "2"
         working-directory: website
         run: |
           export PATH="${{ steps.pnpm-docs.outputs.bin_dest }}:$PATH"

--- a/.github/workflows/registry-compatibility-mirror.yml
+++ b/.github/workflows/registry-compatibility-mirror.yml
@@ -58,6 +58,10 @@ jobs:
           node-version: "22.21.1"
           package-manager-cache: false
 
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.0.0
+        with:
+          python-version: "3.12"
+
       - name: Resolve registry source
         id: source
         env:
@@ -80,6 +84,29 @@ jobs:
         run: |
           export PATH="${{ steps.pnpm-docs.outputs.bin_dest }}:$PATH"
           pnpm install --frozen-lockfile
+
+      - name: Install pinned docs generators
+        run: |
+          python -m venv "${RUNNER_TEMP}/docs-tools-root/python-venv"
+          "${RUNNER_TEMP}/docs-tools-root/python-venv/bin/pip" install --require-hashes -r "${GITHUB_WORKSPACE}/website/tools/pydoc-markdown-requirements.txt"
+          mkdir -p "${RUNNER_TEMP}/docs-tools-root/bin"
+          GOBIN="${RUNNER_TEMP}/docs-tools-root/bin" go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@v1.1.0
+
+      - name: Prepare immutable authoring source
+        run: |
+          source_sha=$(node --input-type=module -e 'import { acceptedAuthoringSHA } from "./website/tools/lib/source-contract.mjs"; process.stdout.write(acceptedAuthoringSHA)')
+          git clone --no-local --no-checkout . "${RUNNER_TEMP}/docs-authoring-source"
+          git -C "${RUNNER_TEMP}/docs-authoring-source" checkout --quiet --detach "$source_sha"
+          chmod -R a-w "${RUNNER_TEMP}/docs-authoring-source"
+          echo "DOCS_AUTHORING_CHECKOUT=${RUNNER_TEMP}/docs-authoring-source" >> "$GITHUB_ENV"
+
+      - name: Warm Go module cache for offline docs generation
+        env:
+          GOCACHE: ${{ runner.temp }}/docs-consumer-gocache
+          GOMODCACHE: ${{ runner.temp }}/docs-consumer-gomodcache
+        run: |
+          cd "$DOCS_AUTHORING_CHECKOUT"
+          GOWORK="$DOCS_AUTHORING_CHECKOUT/go.work" go build -p 2 -o "$RUNNER_TEMP/docs-authoring-preflight" ./cli/plugin-kit-ai/tools/authoring-docs
 
       - name: Verify and stage signed feeds
         env:
@@ -114,6 +141,17 @@ jobs:
         env:
           DOCS_BASE_PATH: /universal-agent-plugins/docs/
           DOCS_HOSTNAME: https://777genius.github.io
+          GOCACHE: ${{ runner.temp }}/docs-consumer-gocache
+          GOMODCACHE: ${{ runner.temp }}/docs-consumer-gomodcache
+          DOCS_TOOLS_ROOT: ${{ runner.temp }}/docs-tools-root
+          DOCS_GOMARKDOC: ${{ runner.temp }}/docs-tools-root/bin/gomarkdoc
+          TMPDIR: ${{ runner.temp }}
+          GOWORK: ${{ github.workspace }}/go.work
+          GOPROXY: "off"
+          GOSUMDB: "off"
+          GOENV: "off"
+          GOTOOLCHAIN: "local"
+          GOMAXPROCS: "2"
         working-directory: website
         run: |
           export PATH="${{ steps.pnpm-docs.outputs.bin_dest }}:$PATH"


### PR DESCRIPTION
The merged Milestone A Pages workflow reaches the public docs build without preparing the immutable authoring checkout or pinned offline generators, so run 34706850531 fails before deployment.

This applies the already-green Docs/Landing generation contract to both Pages producers:
- prepare the accepted immutable authoring source
- install hash-pinned Python docs tooling and pinned gomarkdoc
- warm the Go module cache before switching generation offline
- pass the complete fail-closed generation environment

Validation:
- git diff --check
- focused structural assertion for every required generation input
- GitHub Actions will run the real Pages and docs gates on the exact PR head

Refs #216
Refs #208


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved documentation build reliability and consistency through pinned tooling and reproducible build environments.
  * Documentation generation now works with prepared local dependencies, reducing reliance on external network access.
  * Added safeguards to keep documentation builds resource-conscious and predictable across supported workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->