### PR TITLE
fix(docs): remove stale non-deploying copy

### DIFF
--- a/website/source/en/build/checks.md
+++ b/website/source/en/build/checks.md
@@ -11,7 +11,7 @@ translationRequired: true
 # Check a package without running it
 
 > **Prepared, unreleased authoring contract.** This public page documents a reviewed
-> future authoring workflow. The commands shown here are not available in current
+> future authoring workflow. Future authoring commands described here are not available in current
 > releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 

--- a/website/source/en/build/checks.md
+++ b/website/source/en/build/checks.md
@@ -10,9 +10,9 @@ translationRequired: true
 
 # Check a package without running it
 
-> **Prepared, unreleased authoring contract.** This page is a review draft on a
-> non-deploying preparation branch. Future authoring examples require the accepted
-> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> **Prepared, unreleased authoring contract.** This public page documents a reviewed
+> future authoring workflow. The commands shown here are not available in current
+> releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 
 Use these future commands against the same exact package root after editing.

--- a/website/source/en/build/handoff.md
+++ b/website/source/en/build/handoff.md
@@ -11,7 +11,7 @@ translationRequired: true
 # Hand a package to the installer planner
 
 > **Prepared, unreleased authoring contract.** This public page documents a reviewed
-> future authoring workflow. The commands shown here are not available in current
+> future authoring workflow. Future authoring commands described here are not available in current
 > releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 

--- a/website/source/en/build/handoff.md
+++ b/website/source/en/build/handoff.md
@@ -10,9 +10,9 @@ translationRequired: true
 
 # Hand a package to the installer planner
 
-> **Prepared, unreleased authoring contract.** This page is a review draft on a
-> non-deploying preparation branch. Future authoring examples require the accepted
-> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> **Prepared, unreleased authoring contract.** This public page documents a reviewed
+> future authoring workflow. The commands shown here are not available in current
+> releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 
 The author's output is a standard package directory plus evidence. The installer

--- a/website/source/en/build/hybrid.md
+++ b/website/source/en/build/hybrid.md
@@ -10,9 +10,9 @@ translationRequired: true
 
 # Build a hybrid package
 
-> **Prepared, unreleased authoring contract.** This page is a review draft on a
-> non-deploying preparation branch. Future authoring examples require the accepted
-> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> **Prepared, unreleased authoring contract.** This public page documents a reviewed
+> future authoring workflow. The commands shown here are not available in current
+> releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 
 A hybrid is useful when instructions explain how and when to use tools. Both

--- a/website/source/en/build/hybrid.md
+++ b/website/source/en/build/hybrid.md
@@ -11,7 +11,7 @@ translationRequired: true
 # Build a hybrid package
 
 > **Prepared, unreleased authoring contract.** This public page documents a reviewed
-> future authoring workflow. The commands shown here are not available in current
+> future authoring workflow. Future authoring commands described here are not available in current
 > releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 

--- a/website/source/en/build/index.md
+++ b/website/source/en/build/index.md
@@ -10,9 +10,9 @@ translationRequired: true
 
 # Build plugins
 
-> **Prepared, unreleased authoring contract.** This page is a review draft on a
-> non-deploying preparation branch. Future authoring examples require the accepted
-> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> **Prepared, unreleased authoring contract.** This public page documents a reviewed
+> future authoring workflow. The commands shown here are not available in current
+> releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 
 | Your job | Journey | Result |

--- a/website/source/en/build/index.md
+++ b/website/source/en/build/index.md
@@ -11,7 +11,7 @@ translationRequired: true
 # Build plugins
 
 > **Prepared, unreleased authoring contract.** This public page documents a reviewed
-> future authoring workflow. The commands shown here are not available in current
+> future authoring workflow. Future authoring commands described here are not available in current
 > releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 

--- a/website/source/en/build/layout.md
+++ b/website/source/en/build/layout.md
@@ -10,9 +10,9 @@ translationRequired: true
 
 # Understand the package root
 
-> **Prepared, unreleased authoring contract.** This page is a review draft on a
-> non-deploying preparation branch. Future authoring examples require the accepted
-> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> **Prepared, unreleased authoring contract.** This public page documents a reviewed
+> future authoring workflow. The commands shown here are not available in current
+> releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 
 The selected directory is the package root. Future authoring reads root

--- a/website/source/en/build/layout.md
+++ b/website/source/en/build/layout.md
@@ -11,7 +11,7 @@ translationRequired: true
 # Understand the package root
 
 > **Prepared, unreleased authoring contract.** This public page documents a reviewed
-> future authoring workflow. The commands shown here are not available in current
+> future authoring workflow. Future authoring commands described here are not available in current
 > releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 

--- a/website/source/en/build/mcp-remote.md
+++ b/website/source/en/build/mcp-remote.md
@@ -11,7 +11,7 @@ translationRequired: true
 # Build a remote MCP package
 
 > **Prepared, unreleased authoring contract.** This public page documents a reviewed
-> future authoring workflow. The commands shown here are not available in current
+> future authoring workflow. Future authoring commands described here are not available in current
 > releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 

--- a/website/source/en/build/mcp-remote.md
+++ b/website/source/en/build/mcp-remote.md
@@ -10,9 +10,9 @@ translationRequired: true
 
 # Build a remote MCP package
 
-> **Prepared, unreleased authoring contract.** This page is a review draft on a
-> non-deploying preparation branch. Future authoring examples require the accepted
-> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> **Prepared, unreleased authoring contract.** This public page documents a reviewed
+> future authoring workflow. The commands shown here are not available in current
+> releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 
 Choose remote MCP when the server already exists and the package should describe

--- a/website/source/en/build/mcp-stdio.md
+++ b/website/source/en/build/mcp-stdio.md
@@ -10,9 +10,9 @@ translationRequired: true
 
 # Build a stdio MCP package
 
-> **Prepared, unreleased authoring contract.** This page is a review draft on a
-> non-deploying preparation branch. Future authoring examples require the accepted
-> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> **Prepared, unreleased authoring contract.** This public page documents a reviewed
+> future authoring workflow. The commands shown here are not available in current
+> releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 
 Choose stdio MCP when the package should supply a local process that communicates

--- a/website/source/en/build/mcp-stdio.md
+++ b/website/source/en/build/mcp-stdio.md
@@ -11,7 +11,7 @@ translationRequired: true
 # Build a stdio MCP package
 
 > **Prepared, unreleased authoring contract.** This public page documents a reviewed
-> future authoring workflow. The commands shown here are not available in current
+> future authoring workflow. Future authoring commands described here are not available in current
 > releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 

--- a/website/source/en/build/skill.md
+++ b/website/source/en/build/skill.md
@@ -10,9 +10,9 @@ translationRequired: true
 
 # Build a standalone Skill
 
-> **Prepared, unreleased authoring contract.** This page is a review draft on a
-> non-deploying preparation branch. Future authoring examples require the accepted
-> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> **Prepared, unreleased authoring contract.** This public page documents a reviewed
+> future authoring workflow. The commands shown here are not available in current
+> releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 
 Use this path when the agent needs a repeatable method, checklist, or writing

--- a/website/source/en/build/skill.md
+++ b/website/source/en/build/skill.md
@@ -11,7 +11,7 @@ translationRequired: true
 # Build a standalone Skill
 
 > **Prepared, unreleased authoring contract.** This public page documents a reviewed
-> future authoring workflow. The commands shown here are not available in current
+> future authoring workflow. Future authoring commands described here are not available in current
 > releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 

--- a/website/source/en/build/skills.md
+++ b/website/source/en/build/skills.md
@@ -11,7 +11,7 @@ translationRequired: true
 # Add extra Skills
 
 > **Prepared, unreleased authoring contract.** This public page documents a reviewed
-> future authoring workflow. The commands shown here are not available in current
+> future authoring workflow. Future authoring commands described here are not available in current
 > releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 

--- a/website/source/en/build/skills.md
+++ b/website/source/en/build/skills.md
@@ -10,9 +10,9 @@ translationRequired: true
 
 # Add extra Skills
 
-> **Prepared, unreleased authoring contract.** This page is a review draft on a
-> non-deploying preparation branch. Future authoring examples require the accepted
-> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> **Prepared, unreleased authoring contract.** This public page documents a reviewed
+> future authoring workflow. The commands shown here are not available in current
+> releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 
 Use the future `skills init` job to add one Skill to an existing standard package.

--- a/website/source/en/legacy/v1/index.md
+++ b/website/source/en/legacy/v1/index.md
@@ -11,7 +11,7 @@ translationRequired: true
 # Historical plugin-kit-ai v1, baseline 1.2.4
 
 > **Prepared, unreleased authoring contract.** This public page documents a reviewed
-> future authoring workflow. The commands shown here are not available in current
+> future authoring workflow. Future authoring commands described here are not available in current
 > releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 

--- a/website/source/en/legacy/v1/index.md
+++ b/website/source/en/legacy/v1/index.md
@@ -10,9 +10,9 @@ translationRequired: true
 
 # Historical plugin-kit-ai v1, baseline 1.2.4
 
-> **Prepared, unreleased authoring contract.** This page is a review draft on a
-> non-deploying preparation branch. Future authoring examples require the accepted
-> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> **Prepared, unreleased authoring contract.** This public page documents a reviewed
+> future authoring workflow. The commands shown here are not available in current
+> releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 
 This index preserves a way to understand existing projects. Its command baseline

--- a/website/source/en/use/index.md
+++ b/website/source/en/use/index.md
@@ -11,7 +11,7 @@ translationRequired: true
 # Use plugins
 
 > **Prepared, unreleased authoring contract.** This public page documents a reviewed
-> future authoring workflow. The commands shown here are not available in current
+> future authoring workflow. Future authoring commands described here are not available in current
 > releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 

--- a/website/source/en/use/index.md
+++ b/website/source/en/use/index.md
@@ -10,9 +10,9 @@ translationRequired: true
 
 # Use plugins
 
-> **Prepared, unreleased authoring contract.** This page is a review draft on a
-> non-deploying preparation branch. Future authoring examples require the accepted
-> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> **Prepared, unreleased authoring contract.** This public page documents a reviewed
+> future authoring workflow. The commands shown here are not available in current
+> releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 
 Choose by the result you need:

--- a/website/source/en/use/install.md
+++ b/website/source/en/use/install.md
@@ -11,7 +11,7 @@ translationRequired: true
 # Find and install a plugin
 
 > **Prepared, unreleased authoring contract.** This public page documents a reviewed
-> future authoring workflow. The commands shown here are not available in current
+> future authoring workflow. Future authoring commands described here are not available in current
 > releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 

--- a/website/source/en/use/install.md
+++ b/website/source/en/use/install.md
@@ -10,9 +10,9 @@ translationRequired: true
 
 # Find and install a plugin
 
-> **Prepared, unreleased authoring contract.** This page is a review draft on a
-> non-deploying preparation branch. Future authoring examples require the accepted
-> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> **Prepared, unreleased authoring contract.** This public page documents a reviewed
+> future authoring workflow. The commands shown here are not available in current
+> releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 
 These are **existing installer commands**, sourced from the frozen installer

--- a/website/source/en/use/manage.md
+++ b/website/source/en/use/manage.md
@@ -11,7 +11,7 @@ translationRequired: true
 # Maintain installed plugins
 
 > **Prepared, unreleased authoring contract.** This public page documents a reviewed
-> future authoring workflow. The commands shown here are not available in current
+> future authoring workflow. Future authoring commands described here are not available in current
 > releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 

--- a/website/source/en/use/manage.md
+++ b/website/source/en/use/manage.md
@@ -10,9 +10,9 @@ translationRequired: true
 
 # Maintain installed plugins
 
-> **Prepared, unreleased authoring contract.** This page is a review draft on a
-> non-deploying preparation branch. Future authoring examples require the accepted
-> release; they do not claim that `plugin-kit-ai@2` is available. Existing installer
+> **Prepared, unreleased authoring contract.** This public page documents a reviewed
+> future authoring workflow. The commands shown here are not available in current
+> releases; they do not claim that `plugin-kit-ai@2` is available. Existing installer
 > examples are identified separately. Public activation remains pending.
 
 These are **existing installer commands**. They operate on managed installation

--- a/website/tools/quality/public-authoring-links.test.mjs
+++ b/website/tools/quality/public-authoring-links.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { test } from 'node:test';
@@ -13,6 +13,15 @@ const { createMarkdownRenderer } = await import(pathToFileURL(
   process.env.VITEPRESS_TEST_MODULE || websiteRequire.resolve('vitepress'),
 ).href);
 const md = await createMarkdownRenderer(fileURLToPath(new URL('website/', root)));
+
+test('published source never claims it is on a non-deploying branch', () => {
+  const sourceRoot = fileURLToPath(new URL('website/source/', root));
+  for (const relative of readdirSync(sourceRoot, { recursive: true })) {
+    if (!relative.endsWith('.md')) continue;
+    const source = readFileSync(`${sourceRoot}/${relative}`, 'utf8');
+    assert.doesNotMatch(source, /non-deploying preparation branch/, relative);
+  }
+});
 
 // Exact heading sequence extracted from original main
 // 01f02cb51cfe5f664d4d5f52b295c59c7ea03495:website/source/{locale}/guide/quickstart.md.


### PR DESCRIPTION
Public Use, Build, and historical pages still described themselves as review drafts on a non-deploying branch after Milestone A publication.

This replaces that stale location claim with the truthful public contract: the pages document a reviewed future workflow, and the shown authoring commands remain unavailable in current releases. A source-wide regression test prevents the non-deploying claim from returning.

Validation:
- exact replacement count: 13 public journey pages
- source-wide stale-copy scan: clean
- git diff --check
- GitHub Docs/Landing/Pages gates on the exact PR head

Refs #216
Refs #208
