### PR TITLE
feat(release): protect Milestone A paired promotion

### DIFF
--- a/.github/workflows/agentplugins-release.yml
+++ b/.github/workflows/agentplugins-release.yml
@@ -20,6 +20,7 @@ on:
           - binary-only
           - paired-preparation
           - paired-promotion
+          - milestone-a-paired-promotion
           - paired-input-provenance
       source_sha:
         description: Exact source and workflow SHA (required for paired preparation)
@@ -49,6 +50,12 @@ on:
           - reconcile
       promotion_record:
         description: Fixed canonical promotion record bindings; unsupported native contracts reject
+        required: false
+      milestone_a_run:
+        description: Exact successful Authoring Milestone A E2E run ID
+        required: false
+      milestone_a_attempt:
+        description: Exact successful Authoring Milestone A E2E run attempt
         required: false
 
 permissions:
@@ -83,7 +90,7 @@ jobs:
           export PATH="/usr/local/bin:${PATH}"
           [[ "${GITHUB_EVENT_NAME}" == workflow_dispatch ]]
           case "${PRODUCER_MODE}" in
-            binary-only|paired-preparation|paired-promotion) exit 0 ;;
+            binary-only|paired-preparation|paired-promotion|milestone-a-paired-promotion) exit 0 ;;
             paired-input-provenance) [[ -z "${PROMOTION_RECORD}" && "${PROMOTION_OPERATION}" == promote ]] ;;
             *) exit 1 ;;
           esac
@@ -785,6 +792,134 @@ jobs:
         run: |
           case "${PROMOTION_OPERATION}" in promote|reconcile) ;; *) exit 1 ;; esac
           node npm/agentplugins/scripts/authoring-promotion.js "${PROMOTION_OPERATION}" "${PROMOTION_ROOT}/options.json"
+
+  milestone-a-promotion-admission:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.producer_mode == 'milestone-a-paired-promotion' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Validate fixed manual cut identity before checkout
+        shell: bash
+        env:
+          TAG: ${{ inputs.tag }}
+          KIT_VERSION: ${{ inputs.plugin_kit_version }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          WORKFLOW_SHA: ${{ github.sha }}
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          test "${TAG}" = agentplugins-v0.1.60
+          test "${KIT_VERSION}" = 2.0.0
+          [[ "${SOURCE_SHA}" =~ ^[0-9a-f]{40}$ && ! "${SOURCE_SHA}" =~ ^0{40}$ ]]
+          test "${SOURCE_SHA}" = "${WORKFLOW_SHA}"
+          test "${WORKFLOW_REF}" = refs/tags/agentplugins-v0.1.60
+          test "${GITHUB_REPOSITORY}" = 777genius/universal-agent-plugins
+          [[ "${{ inputs.milestone_a_run }}" =~ ^[1-9][0-9]{0,15}$ ]]
+          [[ "${{ inputs.milestone_a_attempt }}" =~ ^[1-9][0-9]{0,3}$ ]]
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.source_sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: '22.23.2'
+          package-manager-cache: false
+      - name: Independently admit preparation and authenticated Milestone A evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PROMOTION_RECORD: ${{ inputs.promotion_record }}
+          PREPARATION_RUN: ${{ inputs.preparation_run }}
+          PREPARATION_ATTEMPT: ${{ inputs.preparation_attempt }}
+          PREPARATION_ARTIFACT: ${{ inputs.preparation_artifact }}
+          PREPARATION_DIGEST: ${{ inputs.preparation_digest }}
+          MILESTONE_A_RUN: ${{ inputs.milestone_a_run }}
+          MILESTONE_A_ATTEMPT: ${{ inputs.milestone_a_attempt }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs'), path = require('node:path');
+          const p = require('./npm/agentplugins/scripts/authoring-promotion');
+          const scratch = fs.mkdtempSync(path.join(process.env.RUNNER_TEMP, 'milestone-a-admission-'));
+          const record = path.join(scratch, 'authoring-promotion.json');
+          fs.writeFileSync(record, Buffer.from(process.env.PROMOTION_RECORD), {flag: 'wx', mode: 0o400});
+          const selected = {tag: 'agentplugins-v0.1.60', ref: 'refs/tags/agentplugins-v0.1.60', source: process.env.SOURCE_SHA,
+            versions: {agentplugins: '0.1.60', 'plugin-kit-ai': '2.0.0'}};
+          const number = name => Number(process.env[name]);
+          require('./npm/agentplugins/scripts/milestone-a-release-admission').admit({record, scratch,
+            workflow_sha: process.env.SOURCE_SHA, selected,
+            preparation: {run_id: number('PREPARATION_RUN'), run_attempt: number('PREPARATION_ATTEMPT'),
+              artifact_id: number('PREPARATION_ARTIFACT'), artifact_sha256: process.env.PREPARATION_DIGEST},
+            milestone_a: {run_id: number('MILESTONE_A_RUN'), run_attempt: number('MILESTONE_A_ATTEMPT')}}});
+          NODE
+
+  milestone-a-sign-and-promote:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.producer_mode == 'milestone-a-paired-promotion' }}
+    needs: milestone-a-promotion-admission
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment: agentplugins-release
+    permissions:
+      contents: write
+      actions: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.source_sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: '22.23.2'
+          package-manager-cache: false
+      - name: Reacquire and re-admit the exact frozen pair and Milestone A run
+        id: admission
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PROMOTION_RECORD: ${{ inputs.promotion_record }}
+          PREPARATION_RUN: ${{ inputs.preparation_run }}
+          PREPARATION_ATTEMPT: ${{ inputs.preparation_attempt }}
+          PREPARATION_ARTIFACT: ${{ inputs.preparation_artifact }}
+          PREPARATION_DIGEST: ${{ inputs.preparation_digest }}
+          MILESTONE_A_RUN: ${{ inputs.milestone_a_run }}
+          MILESTONE_A_ATTEMPT: ${{ inputs.milestone_a_attempt }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs'), path = require('node:path');
+          const scratch = fs.mkdtempSync(path.join(process.env.RUNNER_TEMP, 'milestone-a-promotion-'));
+          const record = path.join(scratch, 'authoring-promotion.json');
+          fs.writeFileSync(record, Buffer.from(process.env.PROMOTION_RECORD), {flag: 'wx', mode: 0o400});
+          const n = name => Number(process.env[name]);
+          const options = {record, scratch, workflow_sha: process.env.SOURCE_SHA,
+            selected: {tag: 'agentplugins-v0.1.60', ref: 'refs/tags/agentplugins-v0.1.60', source: process.env.SOURCE_SHA,
+              versions: {agentplugins: '0.1.60', 'plugin-kit-ai': '2.0.0'}},
+            preparation: {run_id: n('PREPARATION_RUN'), run_attempt: n('PREPARATION_ATTEMPT'),
+              artifact_id: n('PREPARATION_ARTIFACT'), artifact_sha256: process.env.PREPARATION_DIGEST},
+            milestone_a: {run_id: n('MILESTONE_A_RUN'), run_attempt: n('MILESTONE_A_ATTEMPT')}};
+          const file = path.join(scratch, 'options.json'); fs.writeFileSync(file, JSON.stringify(options), {flag: 'wx', mode: 0o400});
+          const state = require('./npm/agentplugins/scripts/milestone-a-release-admission').admit(options);
+          fs.appendFileSync(process.env.GITHUB_ENV, `MILESTONE_A_PROMOTION=${file}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `subjects<<PATHS\n${state.subjects.map(s => s.file).join('\n')}\nPATHS\n`);
+          NODE
+      - uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6
+        with:
+          subject-path: ${{ steps.admission.outputs.subjects }}
+      - name: Reverify provenance and publish or reconcile both native releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PROMOTION_OPERATION: ${{ inputs.promotion_operation }}
+        run: |
+          case "${PROMOTION_OPERATION}" in
+            promote) command=milestone-a-promote ;;
+            reconcile) command=milestone-a-reconcile ;;
+            *) exit 1 ;;
+          esac
+          node npm/agentplugins/scripts/authoring-promotion.js "${command}" "${MILESTONE_A_PROMOTION}"
 
   paired_input_admission:
     name: paired_input_admission

--- a/.github/workflows/agentplugins-release.yml
+++ b/.github/workflows/agentplugins-release.yml
@@ -809,6 +809,8 @@ jobs:
           SOURCE_SHA: ${{ inputs.source_sha }}
           WORKFLOW_SHA: ${{ github.sha }}
           WORKFLOW_REF: ${{ github.ref }}
+          MILESTONE_A_RUN: ${{ inputs.milestone_a_run }}
+          MILESTONE_A_ATTEMPT: ${{ inputs.milestone_a_attempt }}
         run: |
           set -euo pipefail
           test "${TAG}" = agentplugins-v0.1.60
@@ -817,8 +819,10 @@ jobs:
           test "${SOURCE_SHA}" = "${WORKFLOW_SHA}"
           test "${WORKFLOW_REF}" = refs/tags/agentplugins-v0.1.60
           test "${GITHUB_REPOSITORY}" = 777genius/universal-agent-plugins
-          [[ "${{ inputs.milestone_a_run }}" =~ ^[1-9][0-9]{0,15}$ ]]
-          [[ "${{ inputs.milestone_a_attempt }}" =~ ^[1-9][0-9]{0,3}$ ]]
+          [[ "${MILESTONE_A_RUN}" =~ ^[1-9][0-9]{0,15}$ ]]
+          [[ "${MILESTONE_A_ATTEMPT}" =~ ^[1-9][0-9]{0,3}$ ]]
+          (( MILESTONE_A_RUN <= 9007199254740991 ))
+          (( MILESTONE_A_ATTEMPT <= 1000 ))
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ inputs.source_sha }}
@@ -847,12 +851,18 @@ jobs:
           fs.writeFileSync(record, Buffer.from(process.env.PROMOTION_RECORD), {flag: 'wx', mode: 0o400});
           const selected = {tag: 'agentplugins-v0.1.60', ref: 'refs/tags/agentplugins-v0.1.60', source: process.env.SOURCE_SHA,
             versions: {agentplugins: '0.1.60', 'plugin-kit-ai': '2.0.0'}};
-          const number = name => Number(process.env[name]);
+          const number = (name, maximum = Number.MAX_SAFE_INTEGER) => {
+            const value = process.env[name];
+            if (typeof value !== 'string' || !/^[1-9][0-9]{0,15}$/.test(value)) throw Error(`invalid ${name}`);
+            const parsed = Number(value);
+            if (!Number.isSafeInteger(parsed) || parsed > maximum) throw Error(`invalid ${name}`);
+            return parsed;
+          };
           require('./npm/agentplugins/scripts/milestone-a-release-admission').admit({record, scratch,
             workflow_sha: process.env.SOURCE_SHA, selected,
             preparation: {run_id: number('PREPARATION_RUN'), run_attempt: number('PREPARATION_ATTEMPT'),
               artifact_id: number('PREPARATION_ARTIFACT'), artifact_sha256: process.env.PREPARATION_DIGEST},
-            milestone_a: {run_id: number('MILESTONE_A_RUN'), run_attempt: number('MILESTONE_A_ATTEMPT')}}});
+            milestone_a: {run_id: number('MILESTONE_A_RUN'), run_attempt: number('MILESTONE_A_ATTEMPT', 1000)}}});
           NODE
 
   milestone-a-sign-and-promote:
@@ -894,13 +904,19 @@ jobs:
           const scratch = fs.mkdtempSync(path.join(process.env.RUNNER_TEMP, 'milestone-a-promotion-'));
           const record = path.join(scratch, 'authoring-promotion.json');
           fs.writeFileSync(record, Buffer.from(process.env.PROMOTION_RECORD), {flag: 'wx', mode: 0o400});
-          const n = name => Number(process.env[name]);
+          const n = (name, maximum = Number.MAX_SAFE_INTEGER) => {
+            const value = process.env[name];
+            if (typeof value !== 'string' || !/^[1-9][0-9]{0,15}$/.test(value)) throw Error(`invalid ${name}`);
+            const parsed = Number(value);
+            if (!Number.isSafeInteger(parsed) || parsed > maximum) throw Error(`invalid ${name}`);
+            return parsed;
+          };
           const options = {record, scratch, workflow_sha: process.env.SOURCE_SHA,
             selected: {tag: 'agentplugins-v0.1.60', ref: 'refs/tags/agentplugins-v0.1.60', source: process.env.SOURCE_SHA,
               versions: {agentplugins: '0.1.60', 'plugin-kit-ai': '2.0.0'}},
             preparation: {run_id: n('PREPARATION_RUN'), run_attempt: n('PREPARATION_ATTEMPT'),
               artifact_id: n('PREPARATION_ARTIFACT'), artifact_sha256: process.env.PREPARATION_DIGEST},
-            milestone_a: {run_id: n('MILESTONE_A_RUN'), run_attempt: n('MILESTONE_A_ATTEMPT')}};
+            milestone_a: {run_id: n('MILESTONE_A_RUN'), run_attempt: n('MILESTONE_A_ATTEMPT', 1000)}};
           const file = path.join(scratch, 'options.json'); fs.writeFileSync(file, JSON.stringify(options), {flag: 'wx', mode: 0o400});
           const state = require('./npm/agentplugins/scripts/milestone-a-release-admission').admit(options);
           fs.appendFileSync(process.env.GITHUB_ENV, `MILESTONE_A_PROMOTION=${file}\n`);

--- a/cli/plugin-kit-ai/cmd/agentplugins/main_test.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins/main_test.go
@@ -175,6 +175,7 @@ func TestOfflinePublicInstallerSecurityBoundary(t *testing.T) {
 		}
 	}
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	t.Setenv("CODEX_HOME", client)
 	t.Setenv("AGENTPLUGINS_HOME", state)
 	t.Setenv("PATH", home)

--- a/cli/plugin-kit-ai/cmd/agentplugins/release_workflow_test.go
+++ b/cli/plugin-kit-ai/cmd/agentplugins/release_workflow_test.go
@@ -213,13 +213,13 @@ func TestReleaseWorkflowRunnerCacheContext(t *testing.T) {
 func TestReleasePairedPreparationReadOnlyGraph(t *testing.T) {
 	w := readProducerWorkflow(t, "agentplugins-release.yml")
 	mode := w.On.Dispatch.Inputs["producer_mode"]
-	if mode.Default != "binary-only" || strings.Join(mode.Options, ",") != "binary-only,paired-preparation,paired-promotion,paired-input-provenance" {
+	if mode.Default != "binary-only" || strings.Join(mode.Options, ",") != "binary-only,paired-preparation,paired-promotion,milestone-a-paired-promotion,paired-input-provenance" {
 		t.Fatal("default binary-only dispatch contract changed")
 	}
 	if len(w.Permissions) != 1 || w.Permissions["contents"] != "read" {
 		t.Fatal("workflow must default to contents-read")
 	}
-	if len(w.Jobs) != 12 {
+	if len(w.Jobs) != 14 {
 		t.Fatal("review every new producer job for preparation reachability")
 	}
 	for name, job := range w.Jobs {
@@ -229,6 +229,12 @@ func TestReleasePairedPreparationReadOnlyGraph(t *testing.T) {
 		if name == "paired-promotion-admission" || name == "paired-sign-and-promote" {
 			if job.If != "${{ github.event_name == 'workflow_dispatch' && inputs.producer_mode == 'paired-promotion' }}" {
 				t.Fatalf("%s loses explicit promotion isolation", name)
+			}
+			continue
+		}
+		if name == "milestone-a-promotion-admission" || name == "milestone-a-sign-and-promote" {
+			if job.If != "${{ github.event_name == 'workflow_dispatch' && inputs.producer_mode == 'milestone-a-paired-promotion' }}" {
+				t.Fatalf("%s loses explicit Milestone A promotion isolation", name)
 			}
 			continue
 		}
@@ -557,10 +563,10 @@ func TestReleasePairedPromotionProtectedGraph(t *testing.T) {
 
 func TestReleasePairedPromotionShellSyntax(t *testing.T) {
 	w := readProducerWorkflow(t, "agentplugins-release.yml")
-	if len(w.On.Dispatch.Inputs) != 11 {
+	if len(w.On.Dispatch.Inputs) != 13 {
 		t.Fatal("review dispatch input limit and closed input contract")
 	}
-	for _, name := range []string{"paired-promotion-admission", "paired-sign-and-promote"} {
+	for _, name := range []string{"paired-promotion-admission", "paired-sign-and-promote", "milestone-a-promotion-admission", "milestone-a-sign-and-promote"} {
 		for _, step := range w.Jobs[name].Steps {
 			if step.Run == "" {
 				continue
@@ -571,6 +577,46 @@ func TestReleasePairedPromotionShellSyntax(t *testing.T) {
 			cmd.Stdin = strings.NewReader(step.Run)
 			if output, err := cmd.CombinedOutput(); err != nil {
 				t.Fatalf("%s: %v %s", step.Name, err, output)
+			}
+		}
+	}
+}
+
+func TestReleaseMilestoneAPromotionProtectedGraph(t *testing.T) {
+	w := readProducerWorkflow(t, "agentplugins-release.yml")
+	condition := "${{ github.event_name == 'workflow_dispatch' && inputs.producer_mode == 'milestone-a-paired-promotion' }}"
+	admission := w.Jobs["milestone-a-promotion-admission"]
+	signing := w.Jobs["milestone-a-sign-and-promote"]
+	if admission.If != condition || admission.Needs != nil || admission.Environment != nil ||
+		!reflect.DeepEqual(admission.Permissions, map[string]string{"contents": "read", "actions": "read"}) {
+		t.Fatal("Milestone A admission must remain an isolated read-only dispatch job")
+	}
+	if signing.If != condition || signing.Needs != "milestone-a-promotion-admission" || signing.Environment != "agentplugins-release" ||
+		!reflect.DeepEqual(signing.Permissions, map[string]string{"contents": "write", "actions": "read", "id-token": "write", "attestations": "write", "artifact-metadata": "write"}) {
+		t.Fatal("Milestone A publication must remain behind admission and the protected release environment")
+	}
+	if len(admission.Steps) == 0 || admission.Steps[0].Name != "Validate fixed manual cut identity before checkout" || admission.Steps[0].Uses != "" {
+		t.Fatal("Milestone A fixed identity must reject before checkout or provider effects")
+	}
+	for _, name := range []string{"milestone-a-promotion-admission", "milestone-a-sign-and-promote"} {
+		job := w.Jobs[name]
+		body := ""
+		hasMilestoneEnv := false
+		for _, step := range job.Steps {
+			body += step.Run
+			if strings.Contains(step.Run, "${{ inputs.milestone_a_") {
+				t.Fatalf("%s interpolates untrusted dispatch input directly into shell", name)
+			}
+			if step.Env["MILESTONE_A_RUN"] == "${{ inputs.milestone_a_run }}" && step.Env["MILESTONE_A_ATTEMPT"] == "${{ inputs.milestone_a_attempt }}" {
+				hasMilestoneEnv = true
+			}
+		}
+		if !hasMilestoneEnv {
+			t.Fatalf("%s lacks environment-bound Milestone A run selection", name)
+		}
+		for _, required := range []string{"agentplugins-v0.1.60", "2.0.0", "milestone-a-release-admission"} {
+			if !strings.Contains(body, required) {
+				t.Fatalf("%s lacks fixed release binding %q", name, required)
 			}
 		}
 	}
@@ -870,7 +916,7 @@ func c1Contract(w producerWorkflow, name string, stage, signer bool) error {
 }
 func TestC1InputProvenanceWorkflowContract(t *testing.T) {
 	w := readProducerWorkflow(t, "agentplugins-release.yml")
-	if len(w.Jobs) != 12 || len(w.On.Dispatch.Inputs) != 11 || w.On.Dispatch.Inputs["producer_mode"].Type != "choice" || !w.On.Dispatch.Inputs["producer_mode"].Required {
+	if len(w.Jobs) != 14 || len(w.On.Dispatch.Inputs) != 13 || w.On.Dispatch.Inputs["producer_mode"].Type != "choice" || !w.On.Dispatch.Inputs["producer_mode"].Required {
 		t.Fatal("closed release inputs/jobs")
 	}
 	for _, name := range []string{"paired_input_admission", "paired_input_attestation"} {
@@ -919,14 +965,16 @@ func TestC1PublicStageWorkflowContract(t *testing.T) {
 func TestC1WorkflowFailureReachability(t *testing.T) {
 	for _, file := range []string{"agentplugins-release.yml", "agentplugins-npm-publish.yml"} {
 		w := readProducerWorkflow(t, file)
-		modes := []string{"binary-only", "paired-preparation", "paired-promotion", "paired-input-provenance", "legacy", "paired-stage", "unknown"}
+		modes := []string{"binary-only", "paired-preparation", "paired-promotion", "milestone-a-paired-promotion", "paired-input-provenance", "legacy", "paired-stage", "unknown"}
 		legacyPermissions := map[string]map[string]string{
 			"dispatch_contract": {"contents": "read"}, "validate": {"checks": "read", "contents": "read", "pull-requests": "read"},
 			"build": {"contents": "read"}, "stage-draft": {"contents": "write", "id-token": "write", "attestations": "write", "artifact-metadata": "write"},
 			"platform-proof": {"contents": "read", "attestations": "read"}, "promote-release": {"contents": "write", "attestations": "read"},
 			"paired-preparation": {"contents": "read"}, "paired-promotion-admission": {"contents": "read", "actions": "read"},
-			"paired-sign-and-promote": {"contents": "write", "actions": "read", "id-token": "write", "attestations": "write", "artifact-metadata": "write"},
-			"prepare":                 {"contents": "read", "attestations": "read"}, "publish": {"contents": "read", "id-token": "write"},
+			"paired-sign-and-promote":         {"contents": "write", "actions": "read", "id-token": "write", "attestations": "write", "artifact-metadata": "write"},
+			"milestone-a-promotion-admission": {"contents": "read", "actions": "read"},
+			"milestone-a-sign-and-promote":    {"contents": "write", "actions": "read", "id-token": "write", "attestations": "write", "artifact-metadata": "write"},
+			"prepare":                         {"contents": "read", "attestations": "read"}, "publish": {"contents": "read", "id-token": "write"},
 			"verify-public": {"contents": "read", "attestations": "read"},
 		}
 		for name, job := range w.Jobs {
@@ -955,6 +1003,12 @@ func TestC1WorkflowFailureReachability(t *testing.T) {
 							}
 							if (status != "success") && reachable {
 								t.Fatalf("%s reachable after %s", name, status)
+							}
+							if name == "milestone-a-promotion-admission" || name == "milestone-a-sign-and-promote" {
+								expected := status == "success" && event == "workflow_dispatch" && mode == "milestone-a-paired-promotion"
+								if reachable != expected {
+									t.Fatalf("Milestone A reachability %s %s %s %s", name, mode, event, status)
+								}
 							}
 							if strings.HasPrefix(name, "paired_input_") || strings.HasPrefix(name, "paired_stage") {
 								expected := status == "success" && event == "workflow_dispatch" && ((strings.HasPrefix(name, "paired_input_") && mode == "paired-input-provenance") || (strings.HasPrefix(name, "paired_stage") && mode == "paired-stage" && !publish))

--- a/docs/STANDARD_FIRST_AUTHORING_ENGINE_IMPLEMENTATION_PLAN.md
+++ b/docs/STANDARD_FIRST_AUTHORING_ENGINE_IMPLEMENTATION_PLAN.md
@@ -182,6 +182,33 @@ This checkpoint does not complete phases 0-11 or release the new authoring CLI.
 
 ## Status
 
+### Milestone A paired release cut (2026-09-13)
+
+The first public cut is fixed to the paired GitHub-native releases
+`agentplugins-v0.1.60` and `v2.0.0` from one exact source SHA. A protected manual
+promotion may use the accelerated Milestone A evidence gate above: the complete
+Linux amd64 journey and packaged launcher/init/validate smoke on Windows amd64
+and macOS arm64. It must independently read back one exact authenticated,
+successful `Authoring Milestone A E2E` workflow-dispatch attempt, reacquire the
+run's retained receipts, and verify their exact source and engine-revision
+contract for both packaged entrypoints. Those behavioral receipts deliberately
+stage synthetic `universal-agent-plugins@0.1.91` with `plugin-kit-ai@2.0.0`;
+they are not evidence that `universal-agent-plugins@0.1.60` was packaged or
+published. Promotion remains separately and exactly bound to the frozen release
+pair `0.1.60` + `2.0.0`, and its final public-channel readback must report those
+exact versions. The promotion must also reacquire the
+exact digest-pinned paired preparation, verify its frozen identity, checksums and
+provenance, and reverify signed subjects before any release mutation. Both tags
+must already resolve to that same SHA. Drafts, interrupted partial publication,
+idempotent replay, and final public readback remain fail-closed and reconcilable.
+
+This is an additional narrow admission route, not a relaxation or replacement
+of the existing thirteen-lane/eighteen-cell qualification path. That path and
+all legacy code remain available unchanged. Neither route may execute in a real
+user project, and workflow dispatch alone never implies publication approval;
+the protected `agentplugins-release` environment remains the explicit manual
+effect boundary.
+
 - Decision: accelerated Milestone A delivered on 2026-09-12; phases 7-11 remain
   deferred to later bounded plans and PRs.
 - Implementation: Milestone A and its truthful public-documentation checkpoint

--- a/npm/agentplugins/scripts/authoring-promotion.js
+++ b/npm/agentplugins/scripts/authoring-promotion.js
@@ -640,6 +640,20 @@ function verifyAll(state) {
 function promote(input, reconciliation = false) {
   return promotePair(() => { const state = admittedInputs(input); verifyAll(state); return state; }, reconciliation);
 }
+function milestoneAState(input) {
+  const state = require("./milestone-a-release-admission").admit(input);
+  const runId = callerNumber("GITHUB_RUN_ID"), runAttempt = callerNumber("GITHUB_RUN_ATTEMPT", 1000);
+  for (const subject of state.subjects) verifySubject(subject.file, {
+    name: path.basename(subject.file), sha256: subject.sha256, source: state.record.identity.commit,
+    workflow_sha: state.o.workflow_sha, ref: `refs/tags/${tag(state.record.identity, "agentplugins")}`,
+    run_id: runId, run_attempt: runAttempt,
+    subjects: state.subjects.map(s => ({ name: path.basename(s.file), digest: { sha256: s.sha256 } }))
+  }, state.o.scratch);
+  return state;
+}
+function promoteMilestoneA(input, reconciliation = false) {
+  return promotePair(() => milestoneAState(input), reconciliation);
+}
 // Private sequencing seam: the only production caller supplies fresh admission
 // AND signature verification. It is not exported or configurable through input.
 function promotePair(recheck, reconciliation) {
@@ -705,9 +719,17 @@ function promotePair(recheck, reconciliation) {
   return { status: "qualified-for-promotion", public_readback: observed.states };
 }
 function main(args) {
-  if (args.length !== 2 || !["admit", "admit-reconciliation", "promote", "reconcile", "check-contracts"].includes(args[0]) || !path.isAbsolute(args[1])) fail("usage: authoring-promotion.js <check-contracts|admit|admit-reconciliation|promote|reconcile> <absolute-config.json>");
+  if (args.length !== 2 || !["admit", "admit-reconciliation", "promote", "reconcile", "milestone-a-admit", "milestone-a-promote", "milestone-a-reconcile", "check-contracts"].includes(args[0]) || !path.isAbsolute(args[1])) fail("usage: authoring-promotion.js <check-contracts|admit|admit-reconciliation|promote|reconcile|milestone-a-admit|milestone-a-promote|milestone-a-reconcile> <absolute-config.json>");
   const value = JSON.parse(c.readFile(args[1], LIMIT));
   if (args[0] === "check-contracts") { c.keys(value, ["lanes"], "terminal contracts"); requireNativeContracts(value.lanes); }
+  if (args[0] === "milestone-a-admit") {
+    const state = require("./milestone-a-release-admission").admit(value);
+    const milestoneObserved = inspectPair(state.record, state.o.scratch);
+    return { status: milestoneObserved.reconciliation_required ? "reconciliation-required" : "qualified-for-promotion",
+      subjects: state.subjects, sign_required: true };
+  }
+  if (args[0] === "milestone-a-promote" || args[0] === "milestone-a-reconcile")
+    return promoteMilestoneA(value, args[0] === "milestone-a-reconcile");
   if (args[0] === "promote" || args[0] === "reconcile") return promote(value, args[0] === "reconcile");
   const state = admittedInputs(value);
   const observed = inspectPair(state.record, state.o.scratch);
@@ -784,4 +806,4 @@ function admitPublicEvidence(value, context) {
 module.exports = { admitPublicEvidence, inspectPublicCaller, inspectPublicAttempt, verifyPublicSubject, inspectStageCaller, workflowSelection, inspectInputCaller, checkPreparationRef, acquireCurrentStage, inspectCurrentStage, checkStageEvidence, SCHEMA, WORKFLOW, GH_VERSION, LANES, encodeRecord, decodeRecord, validateSelection, admitRecord, requireNativeContracts,
   inspectArtifact, acquireArtifact, extractArtifact, acquirePreparation, checkNativeContracts, admitNativeEvidence,
   acquireInputPreparation, readInputPreparation, checkInputTags,
-  mapVerifiedOutput, verifySubject, verifyStageSubject, frozenSubjects, releasePins, inspectPair, promote };
+  mapVerifiedOutput, verifySubject, verifyStageSubject, frozenSubjects, releasePins, inspectPair, promote, promoteMilestoneA };

--- a/npm/agentplugins/scripts/milestone-a-release-admission.js
+++ b/npm/agentplugins/scripts/milestone-a-release-admission.js
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+"use strict";
+
+// Narrow release admission for the accelerated Milestone A cut.  The older
+// thirteen-lane/eighteen-cell promotion contract remains implemented by
+// authoring-promotion.js and is deliberately not interpreted here.
+const cp = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+const { isDeepStrictEqual } = require("node:util");
+const c = require("./dual-authoring-candidate");
+
+const REPOSITORY = c.REPOSITORY;
+const WORKFLOW = ".github/workflows/authoring-milestone-a-e2e.yml";
+const RELEASE_WORKFLOW = ".github/workflows/agentplugins-release.yml";
+const TAG = "agentplugins-v0.1.60";
+const KIT_TAG = "v2.0.0";
+const GH = "/usr/bin/gh";
+const GH_VERSION = "2.83.2";
+const JOBS = Object.freeze([
+  "Exact candidate package",
+  "Milestone A / linux-amd64",
+  "Milestone A / windows-amd64",
+  "Milestone A / darwin-arm64"
+]);
+const E2E_VERSIONS = Object.freeze({ agentplugins: "0.1.91", "plugin-kit-ai": "2.0.0" });
+const PLATFORMS = Object.freeze([
+  ["linux", "amd64"], ["windows", "amd64"], ["darwin", "arm64"]
+]);
+const fail = message => { throw new Error(message); };
+const exact = (actual, expected, label) => {
+  if (!isDeepStrictEqual(actual, expected)) fail(`${label}: binding mismatch`);
+};
+const positive = (value, max = Number.MAX_SAFE_INTEGER) => {
+  if (!Number.isSafeInteger(value) || value < 1 || value > max) fail("bounded positive integer required");
+  return value;
+};
+const sha = value => {
+  if (typeof value !== "string" || !/^[0-9a-f]{40}$/.test(value) || /^0+$/.test(value)) fail("exact nonzero source SHA required");
+  return value;
+};
+function gh(args, cwd, maxBuffer = 1024 * 1024) {
+  const result = cp.spawnSync(GH, args, { cwd, env: { PATH: "/usr/local/bin:/usr/bin:/bin", GH_TOKEN: process.env.GH_TOKEN },
+    encoding: "utf8", timeout: 120000, killSignal: "SIGKILL", maxBuffer, shell: false });
+  if (result.error || result.signal || result.status !== 0) fail("trusted gh provider read failed; stop without publication");
+  return result.stdout;
+}
+function api(endpoint, cwd) {
+  return JSON.parse(gh(["api", "--hostname", "github.com", "-H", "Accept: application/vnd.github+json",
+    "-H", "X-GitHub-Api-Version: 2022-11-28", `repos/${REPOSITORY}/${endpoint}`], cwd));
+}
+function receiptContract(prepare, runs, source) {
+  sha(source);
+  exact(prepare?.schema, "milestone-a-e2e-prepare/v1", "Milestone A preparation receipt schema");
+  exact(prepare?.identity, { repository: REPOSITORY, commit: source, engine_revision: source,
+    versions: E2E_VERSIONS }, "synthetic Milestone A package identity");
+  exact(prepare?.candidate_head, source, "Milestone A prepared source");
+  exact(prepare?.publication, false, "non-public Milestone A preparation");
+  if (!Array.isArray(runs) || runs.length !== PLATFORMS.length) fail("exact three-platform Milestone A receipts required");
+  for (let i = 0; i < runs.length; i++) {
+    const receipt = runs[i], [platform, arch] = PLATFORMS[i];
+    exact([receipt?.schema, receipt?.platform, receipt?.arch, receipt?.exact_candidate, receipt?.entrypoints,
+      receipt?.commands, receipt?.cleanup, receipt?.clean_root_separation],
+    ["milestone-a-e2e-run/v1", platform, arch, true, ["agentplugins", "plugin-kit-ai"],
+      platform === "linux" ? ["init", "validate", "inspect", "test", "local-add-dry-run"] : ["init", "validate"],
+      "complete", true], `Milestone A ${platform}-${arch} receipt`);
+    for (const product of ["agentplugins", "plugin-kit-ai"])
+      exact(receipt?.provenances?.[product]?.revision, source, `${product} ${platform}-${arch} engine revision`);
+  }
+  return { source, engine_revision: source, test_versions: E2E_VERSIONS,
+    release_versions: { agentplugins: "0.1.60", "plugin-kit-ai": "2.0.0" } };
+}
+const RECEIPT_READER = String.raw`
+import json,os,re,stat,sys,zipfile
+p=sys.argv[1]; wanted=sys.argv[2]
+st=os.lstat(p)
+if not stat.S_ISREG(st.st_mode) or st.st_nlink != 1: raise ValueError('regular archive required')
+with zipfile.ZipFile(p) as z:
+ infos=z.infolist()
+ if not 1 <= len(infos) <= 4096: raise ValueError('bounded archive closure required')
+ seen=set(); total=0; chosen=[]
+ for i in infos:
+  n=i.filename.rstrip('/'); parts=n.split('/')
+  if not n or len(parts)>8 or any(not re.fullmatch(r'[A-Za-z0-9][A-Za-z0-9._-]{0,150}',x) or x in ('.','..') for x in parts): raise ValueError('unsafe member')
+  k=n.lower()
+  if k in seen: raise ValueError('duplicate member')
+  seen.add(k); mode=i.external_attr >> 16
+  if stat.S_IFMT(mode) not in (0,stat.S_IFDIR if i.is_dir() else stat.S_IFREG): raise ValueError('special member')
+  if i.file_size > 134217728 or i.file_size > 200*max(1,i.compress_size): raise ValueError('member bound')
+  total += i.file_size
+  if total > 2147483648: raise ValueError('archive bound')
+  if not i.is_dir() and n == wanted: chosen.append(i)
+ if len(chosen) != 1: raise ValueError('exact receipt required')
+ body=z.read(chosen[0])
+ if len(body)>1048576: raise ValueError('receipt bound')
+ sys.stdout.buffer.write(body)
+`;
+function readReceipt(archive, member, cwd) {
+  const result = cp.spawnSync("/usr/bin/python3", ["-B", "-c", RECEIPT_READER, archive, member],
+    { cwd, env: { PATH: "/usr/bin:/bin", HOME: cwd, PYTHONNOUSERSITE: "1" }, encoding: "utf8",
+      timeout: 120000, killSignal: "SIGKILL", maxBuffer: 1024 * 1024, shell: false });
+  if (result.error || result.signal || result.status !== 0) fail("checked Milestone A receipt extraction rejected");
+  return JSON.parse(result.stdout);
+}
+function inspectReceipts(pin, selected, cwd) {
+  const p = require("./authoring-promotion");
+  const response = api(`actions/runs/${pin.run_id}/artifacts?per_page=100`, cwd);
+  const names = [`milestone-a-exact-candidate-${pin.run_id}-${pin.run_attempt}`,
+    ...PLATFORMS.map(([platform, arch]) => `milestone-a-${platform}-${arch}-${pin.run_id}-${pin.run_attempt}`)];
+  if (response.total_count !== 4 || response.artifacts?.length !== 4) fail("exact Milestone A artifact closure required");
+  const receipts = names.map((name, index) => {
+    const rows = response.artifacts.filter(item => item.name === name);
+    if (rows.length !== 1 || rows[0].expired !== false || rows[0].workflow_run?.id !== pin.run_id ||
+        rows[0].workflow_run?.head_sha !== selected.source || !/^sha256:[0-9a-f]{64}$/.test(rows[0].digest))
+      fail("exact retained Milestone A artifact required");
+    const item = rows[0], locator = { run_id: pin.run_id, run_attempt: pin.run_attempt,
+      artifact_id: positive(item.id), artifact_sha256: item.digest.slice(7) };
+    const work = fs.mkdtempSync(path.join(cwd, `milestone-a-receipt-${index}-`));
+    const archive = p.acquireArtifact(locator, WORKFLOW, selected.source, work);
+    return readReceipt(archive, index === 0 ? "evidence/prepare.json" : "run.json", work);
+  });
+  return receiptContract(receipts[0], receipts.slice(1), selected.source);
+}
+function evidenceContract(run, jobs, selected, pin) {
+  sha(selected.source); positive(pin.run_id); positive(pin.run_attempt, 1000);
+  exact(selected, { tag: TAG, ref: `refs/tags/${TAG}`, source: selected.source,
+    versions: { agentplugins: "0.1.60", "plugin-kit-ai": "2.0.0" } }, "fixed paired release selection");
+  exact([run.id, run.run_attempt, run.repository?.full_name, run.head_repository?.full_name, run.head_sha,
+    run.path, run.event, run.head_branch, run.status, run.conclusion],
+  [pin.run_id, pin.run_attempt, REPOSITORY, REPOSITORY, selected.source, WORKFLOW,
+    "workflow_dispatch", TAG, "completed", "success"], "exact successful Milestone A invocation");
+  if (!Array.isArray(jobs) || jobs.length !== JOBS.length) fail("exact Milestone A job closure required");
+  const names = jobs.map(job => {
+    exact([job.run_id, job.run_attempt, job.head_sha, job.head_branch, job.status, job.conclusion],
+      [pin.run_id, pin.run_attempt, selected.source, TAG, "completed", "success"], "successful Milestone A job");
+    positive(job.id); return job.name;
+  });
+  exact(names.sort(), [...JOBS].sort(), "accelerated Milestone A jobs");
+  return { workflow: WORKFLOW, source: selected.source, run_id: pin.run_id, run_attempt: pin.run_attempt, jobs: [...JOBS] };
+}
+function inspectEvidence(pin, selected, cwd) {
+  const version = gh(["--version"], cwd);
+  if (!version.startsWith(`gh version ${GH_VERSION} (`)) fail(`trusted /usr/bin/gh ${GH_VERSION} required`);
+  const run = api(`actions/runs/${positive(pin.run_id)}/attempts/${positive(pin.run_attempt, 1000)}`, cwd);
+  const response = api(`actions/runs/${pin.run_id}/attempts/${pin.run_attempt}/jobs?per_page=100`, cwd);
+  if (response.total_count !== response.jobs?.length || response.jobs.length > 100) fail("complete bounded job response required");
+  const first = evidenceContract(run, response.jobs, selected, pin);
+  // Independent provider readback prevents a single stale observation from
+  // becoming publication authority.
+  const runAgain = api(`actions/runs/${pin.run_id}/attempts/${pin.run_attempt}`, cwd);
+  const jobsAgain = api(`actions/runs/${pin.run_id}/attempts/${pin.run_attempt}/jobs?per_page=100`, cwd);
+  const second = evidenceContract(runAgain, jobsAgain.jobs, selected, pin);
+  exact(second, first, "independent Milestone A readback");
+  return first;
+}
+function admit(input) {
+  const p = require("./authoring-promotion");
+  const keys = ["record", "scratch", "workflow_sha", "preparation", "selected", "milestone_a"];
+  c.keys(input, keys, "Milestone A promotion options");
+  c.safeDirectory(input.scratch);
+  if (!path.isAbsolute(input.record) || path.basename(input.record) !== "authoring-promotion.json") fail("absolute promotion record required");
+  const record = p.validateSelection(c.readFile(input.record), input.selected);
+  exact(input.workflow_sha, record.identity.commit, "release workflow source");
+  exact(record.identity.versions, { agentplugins: "0.1.60", "plugin-kit-ai": "2.0.0" }, "fixed paired versions");
+  const evidence = inspectEvidence(input.milestone_a, input.selected, input.scratch);
+  evidence.receipts = inspectReceipts(input.milestone_a, input.selected, input.scratch);
+  const prepared = p.acquirePreparation(input.preparation, record, input.scratch);
+  require("./authoring-native-qualification").readPreparation(prepared.root,
+    { identity: record.identity, candidate_sha256: record.candidate_sha256, pair_marker_sha256: record.pair_marker_sha256,
+      products: Object.fromEntries(c.PRODUCTS.map(name => [name, { manifest_sha256: record.products[name].manifest_sha256,
+        checksums_sha256: record.products[name].checksums_sha256 }])) }, prepared.preparation);
+  const subjects = p.frozenSubjects(prepared.root, record);
+  subjects.push({ file: input.record, sha256: c.digest(p.encodeRecord(record)) });
+  return { o: { ...input, root: prepared.root }, record, subjects, milestone_a: evidence };
+}
+
+module.exports = { REPOSITORY, WORKFLOW, RELEASE_WORKFLOW, TAG, KIT_TAG, JOBS, E2E_VERSIONS, PLATFORMS,
+  evidenceContract, receiptContract, inspectEvidence, inspectReceipts, admit };

--- a/npm/agentplugins/scripts/milestone-a-release-admission.js
+++ b/npm/agentplugins/scripts/milestone-a-release-admission.js
@@ -104,10 +104,22 @@ function readReceipt(archive, member, cwd) {
 }
 function inspectReceipts(pin, selected, cwd) {
   const p = require("./authoring-promotion");
+  positive(pin.run_id); positive(pin.run_attempt, 1000); sha(selected.source);
   const response = api(`actions/runs/${pin.run_id}/artifacts?per_page=100`, cwd);
   const names = [`milestone-a-exact-candidate-${pin.run_id}-${pin.run_attempt}`,
     ...PLATFORMS.map(([platform, arch]) => `milestone-a-${platform}-${arch}-${pin.run_id}-${pin.run_attempt}`)];
-  if (response.total_count !== 4 || response.artifacts?.length !== 4) fail("exact Milestone A artifact closure required");
+  // A rerun retains artifacts from earlier attempts under the same run. Require
+  // a complete provider page, then close over the four names for the explicitly
+  // selected attempt instead of treating valid earlier-attempt artifacts as an
+  // ambiguity in that selection.
+  if (!Array.isArray(response.artifacts) || response.total_count !== response.artifacts.length ||
+      response.artifacts.length > 100) fail("complete bounded Milestone A artifact response required");
+  const retainedName = new RegExp(`^milestone-a-(?:exact-candidate|${PLATFORMS.map(value => value.join("-")).join("|")})-${pin.run_id}-([1-9][0-9]{0,3})$`);
+  for (const item of response.artifacts) {
+    const match = typeof item?.name === "string" && retainedName.exec(item.name);
+    if (!match) fail("exact Milestone A artifact closure required");
+    positive(Number(match[1]), 1000);
+  }
   const receipts = names.map((name, index) => {
     const rows = response.artifacts.filter(item => item.name === name);
     if (rows.length !== 1 || rows[0].expired !== false || rows[0].workflow_run?.id !== pin.run_id ||

--- a/npm/agentplugins/test/milestone-a-release-admission.test.js
+++ b/npm/agentplugins/test/milestone-a-release-admission.test.js
@@ -1,7 +1,10 @@
 "use strict";
 
 const assert = require("node:assert/strict");
+const cp = require("node:child_process");
 const test = require("node:test");
+const os = require("node:os");
+const fs = require("node:fs");
 const a = require("../scripts/milestone-a-release-admission");
 
 const source = "a".repeat(40);
@@ -34,6 +37,53 @@ test("binds behavioral receipts to the source and synthetic 0.1.91 test package 
   assert.deepEqual(result.test_versions, { agentplugins: "0.1.91", "plugin-kit-ai": "2.0.0" });
   assert.deepEqual(result.release_versions, { agentplugins: "0.1.60", "plugin-kit-ai": "2.0.0" });
   assert.equal(result.engine_revision, source);
+});
+
+function artifactFixture(attempt) {
+  const labels = ["exact-candidate", ...a.PLATFORMS.map(value => value.join("-"))];
+  return labels.map((label, index) => ({ id: attempt * 100 + index + 1,
+    name: `milestone-a-${label}-${pin.run_id}-${attempt}`, expired: false,
+    workflow_run: { id: pin.run_id, head_sha: source }, digest: `sha256:${String(attempt).repeat(64)}` }));
+}
+
+function withMockedReceiptProvider(t, artifacts, operation) {
+  const promotion = require("../scripts/authoring-promotion");
+  const bodies = new Map();
+  artifactFixture(2).forEach((item, index) => bodies.set(item.id,
+    index === 0 ? prepareReceipt() : runReceipts()[index - 1]));
+  t.mock.method(promotion, "acquireArtifact", locator => `/provider/artifact-${locator.artifact_id}.zip`);
+  t.mock.method(cp, "spawnSync", (command, args) => {
+    if (command === "/usr/bin/gh") return { status: 0, signal: null, stdout: JSON.stringify({ total_count: artifacts.length, artifacts }) };
+    if (command === "/usr/bin/python3") {
+      const id = Number(/artifact-(\d+)\.zip$/.exec(args[3])?.[1]);
+      return { status: 0, signal: null, stdout: JSON.stringify(bodies.get(id)) };
+    }
+    throw new Error(`unexpected mocked command: ${command}`);
+  });
+  const scratch = fs.mkdtempSync(`${os.tmpdir()}/milestone-a-provider-fixture-`);
+  try { return operation(scratch); } finally { fs.rmSync(scratch, { recursive: true, force: true }); }
+}
+
+test("selects attempt 2 receipts while attempt 1 artifacts remain retained", t => {
+  const artifacts = [...artifactFixture(1), ...artifactFixture(2)];
+  const result = withMockedReceiptProvider(t, artifacts, scratch => a.inspectReceipts(pin, selected, scratch));
+  assert.equal(result.source, source);
+  assert.deepEqual(result.test_versions, a.E2E_VERSIONS);
+});
+
+test("rejects malformed or ambiguous selected-attempt artifact closure", async t => {
+  await t.test("malformed selected name leaves the canonical receipt absent", child => {
+    const artifacts = [...artifactFixture(1), ...artifactFixture(2)];
+    artifacts.at(-1).name += "-malformed";
+    assert.throws(() => withMockedReceiptProvider(child, artifacts,
+      scratch => a.inspectReceipts(pin, selected, scratch)), /exact Milestone A artifact closure required/);
+  });
+  await t.test("duplicate selected canonical name is ambiguous", child => {
+    const artifacts = [...artifactFixture(1), ...artifactFixture(2)];
+    artifacts.push({ ...artifacts.at(-1), id: 999 });
+    assert.throws(() => withMockedReceiptProvider(child, artifacts,
+      scratch => a.inspectReceipts(pin, selected, scratch)), /exact retained Milestone A artifact required/);
+  });
 });
 
 test("requires the authentic ordered Linux command receipt", () => {

--- a/npm/agentplugins/test/milestone-a-release-admission.test.js
+++ b/npm/agentplugins/test/milestone-a-release-admission.test.js
@@ -1,0 +1,85 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const a = require("../scripts/milestone-a-release-admission");
+
+const source = "a".repeat(40);
+const selected = { tag: a.TAG, ref: `refs/tags/${a.TAG}`, source,
+  versions: { agentplugins: "0.1.60", "plugin-kit-ai": "2.0.0" } };
+const pin = { run_id: 42, run_attempt: 2 };
+const run = { id: 42, run_attempt: 2, repository: { full_name: a.REPOSITORY },
+  head_repository: { full_name: a.REPOSITORY }, head_sha: source, path: a.WORKFLOW,
+  event: "workflow_dispatch", head_branch: a.TAG, status: "completed", conclusion: "success" };
+const jobs = () => a.JOBS.map((name, index) => ({ id: 100 + index, name, run_id: 42, run_attempt: 2,
+  head_sha: source, head_branch: a.TAG, status: "completed", conclusion: "success" }));
+
+test("admits exactly the accelerated Milestone A run and three-platform job closure", () => {
+  const result = a.evidenceContract(structuredClone(run), jobs(), structuredClone(selected), pin);
+  assert.deepEqual(result.jobs, a.JOBS);
+  assert.equal(result.source, source);
+});
+
+const prepareReceipt = () => ({ schema: "milestone-a-e2e-prepare/v1",
+  identity: { repository: a.REPOSITORY, commit: source, engine_revision: source, versions: { ...a.E2E_VERSIONS } },
+  candidate_head: source, publication: false });
+const runReceipts = () => a.PLATFORMS.map(([platform, arch]) => ({ schema: "milestone-a-e2e-run/v1",
+  platform, arch, exact_candidate: true, entrypoints: ["agentplugins", "plugin-kit-ai"],
+  commands: platform === "linux" ? ["init", "validate", "inspect", "test", "local-add-dry-run"] : ["init", "validate"],
+  cleanup: "complete", clean_root_separation: true,
+  provenances: { agentplugins: { revision: source }, "plugin-kit-ai": { revision: source } } }));
+
+test("binds behavioral receipts to the source and synthetic 0.1.91 test package without claiming release 0.1.60", () => {
+  const result = a.receiptContract(prepareReceipt(), runReceipts(), source);
+  assert.deepEqual(result.test_versions, { agentplugins: "0.1.91", "plugin-kit-ai": "2.0.0" });
+  assert.deepEqual(result.release_versions, { agentplugins: "0.1.60", "plugin-kit-ai": "2.0.0" });
+  assert.equal(result.engine_revision, source);
+});
+
+test("requires the authentic ordered Linux command receipt", () => {
+  const authentic = runReceipts();
+  assert.doesNotThrow(() => a.receiptContract(prepareReceipt(), authentic, source));
+
+  const omitted = runReceipts();
+  omitted[0].commands.pop();
+  assert.throws(() => a.receiptContract(prepareReceipt(), omitted, source), /linux-amd64 receipt/);
+
+  const reordered = runReceipts();
+  [reordered[0].commands[3], reordered[0].commands[4]] =
+    [reordered[0].commands[4], reordered[0].commands[3]];
+  assert.throws(() => a.receiptContract(prepareReceipt(), reordered, source), /linux-amd64 receipt/);
+});
+
+for (const [name, mutate] of [
+  ["synthetic package presented as 0.1.60", value => { value.prepare.identity.versions.agentplugins = "0.1.60"; }],
+  ["engine revision differs", value => { value.prepare.identity.engine_revision = "b".repeat(40); }],
+  ["entrypoint omitted", value => { value.runs[1].entrypoints.pop(); }],
+  ["Windows runs Linux-only commands", value => { value.runs[1].commands.push("inspect", "test"); }],
+  ["launcher provenance differs", value => { value.runs[2].provenances.agentplugins.revision = "b".repeat(40); }],
+  ["cleanup incomplete", value => { value.runs[0].cleanup = "pending"; }]
+]) test(`rejects receipt contract when ${name}`, () => {
+  const value = { prepare: prepareReceipt(), runs: runReceipts() };
+  mutate(value);
+  assert.throws(() => a.receiptContract(value.prepare, value.runs, source));
+});
+
+for (const [name, mutate] of [
+  ["wrong source", value => { value.run.head_sha = "b".repeat(40); }],
+  ["pull request run", value => { value.run.event = "pull_request"; }],
+  ["wrong ref", value => { value.run.head_branch = "main"; }],
+  ["failed Linux E2E", value => { value.jobs[1].conclusion = "failure"; }],
+  ["missing Windows smoke", value => { value.jobs.splice(2, 1); }],
+  ["extra matrix lane", value => { value.jobs.push({ ...value.jobs[0], id: 999, name: "Milestone A / linux-arm64" }); }],
+  ["stale agentplugins version", value => { value.selected.versions.agentplugins = "0.1.59"; }],
+  ["stale plugin-kit tag", value => { value.selected.versions["plugin-kit-ai"] = "2.0.1"; }]
+]) test(`rejects ${name}`, () => {
+  const value = { run: structuredClone(run), jobs: jobs(), selected: structuredClone(selected) };
+  mutate(value);
+  assert.throws(() => a.evidenceContract(value.run, value.jobs, value.selected, pin));
+});
+
+test("legacy thirteen-lane admission remains present and separate", () => {
+  const promotion = require("../scripts/authoring-promotion");
+  assert.equal(promotion.LANES.length, 13);
+  assert.throws(() => promotion.requireNativeContracts([]), /missing lanes/);
+});


### PR DESCRIPTION
The current paired authoring release path cannot publish because its original 13-lane gate remains deliberately closed, while the accepted Milestone A cut requires the smaller three-platform evidence set.

This adds a separate protected `milestone-a-paired-promotion` path for `universal-agent-plugins@0.1.60` and `plugin-kit-ai@2.0.0`. It binds one exact source SHA to the frozen paired preparation, the successful authenticated Linux/Windows/macOS Milestone A run, signed subjects, both release tags, idempotent pair publication, and public readback. The original strict promotion path and all legacy YAML code remain unchanged.

Validation:
- `node --test npm/agentplugins/test/milestone-a-release-admission.test.js`: 18/18 passed
- Authentic run receipt shape checked against workflow run 34728938845, including Linux `local-add-dry-run`
- Exact commit: `49d6b57dccf46a1f37a6c711291f8a20d19b3a71`

Refs #216
Refs #208


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a protected Milestone A paired promotion route for the fixed `agentplugins-v0.1.60` and `v2.0.0` release pair.
  * Added admission, promotion, and reconciliation options with required run and attempt details.
  * Added comprehensive verification of workflow evidence, build artifacts, receipts, provenance, and native qualification before publishing.

* **Documentation**
  * Documented the paired release process, evidence requirements, and protected manual promotion boundaries.

* **Tests**
  * Added coverage for valid admission evidence and rejection of mismatched or incomplete release data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->