### PR TITLE
fix(release): add truthful Milestone A promotion record

### DIFF
--- a/.github/workflows/agentplugins-release.yml
+++ b/.github/workflows/agentplugins-release.yml
@@ -861,7 +861,7 @@ jobs:
             workflow_sha: process.env.SOURCE_SHA, selected,
             preparation: {run_id: number('PREPARATION_RUN'), run_attempt: number('PREPARATION_ATTEMPT'),
               artifact_id: number('PREPARATION_ARTIFACT'), artifact_sha256: process.env.PREPARATION_DIGEST},
-            milestone_a: {run_id: number('MILESTONE_A_RUN'), run_attempt: number('MILESTONE_A_ATTEMPT', 1000)}}});
+            milestone_a: {run_id: number('MILESTONE_A_RUN'), run_attempt: number('MILESTONE_A_ATTEMPT', 1000)}});
           NODE
 
   milestone-a-sign-and-promote:

--- a/.github/workflows/agentplugins-release.yml
+++ b/.github/workflows/agentplugins-release.yml
@@ -49,7 +49,7 @@ on:
           - promote
           - reconcile
       promotion_record:
-        description: Fixed canonical promotion record bindings; unsupported native contracts reject
+        description: Fixed canonical promotion record; Milestone A uses milestone-a-promotion/v1
         required: false
       milestone_a_run:
         description: Exact successful Authoring Milestone A E2E run ID
@@ -845,9 +845,8 @@ jobs:
         run: |
           node <<'NODE'
           const fs = require('node:fs'), path = require('node:path');
-          const p = require('./npm/agentplugins/scripts/authoring-promotion');
           const scratch = fs.mkdtempSync(path.join(process.env.RUNNER_TEMP, 'milestone-a-admission-'));
-          const record = path.join(scratch, 'authoring-promotion.json');
+          const record = path.join(scratch, 'milestone-a-promotion.json');
           fs.writeFileSync(record, Buffer.from(process.env.PROMOTION_RECORD), {flag: 'wx', mode: 0o400});
           const selected = {tag: 'agentplugins-v0.1.60', ref: 'refs/tags/agentplugins-v0.1.60', source: process.env.SOURCE_SHA,
             versions: {agentplugins: '0.1.60', 'plugin-kit-ai': '2.0.0'}};
@@ -902,7 +901,7 @@ jobs:
           node <<'NODE'
           const fs = require('node:fs'), path = require('node:path');
           const scratch = fs.mkdtempSync(path.join(process.env.RUNNER_TEMP, 'milestone-a-promotion-'));
-          const record = path.join(scratch, 'authoring-promotion.json');
+          const record = path.join(scratch, 'milestone-a-promotion.json');
           fs.writeFileSync(record, Buffer.from(process.env.PROMOTION_RECORD), {flag: 'wx', mode: 0o400});
           const n = (name, maximum = Number.MAX_SAFE_INTEGER) => {
             const value = process.env[name];

--- a/npm/agentplugins/scripts/authoring-promotion.js
+++ b/npm/agentplugins/scripts/authoring-promotion.js
@@ -499,8 +499,15 @@ function mapVerifiedOutput(output, expected) {
 function mapWorkflowOutput(output, expected, workflow) {
   if (typeof output !== "string" || Buffer.byteLength(output) > 4 * LIMIT) fail("bounded verifier output required");
   const results = JSON.parse(output);
-  if (!Array.isArray(results) || results.length !== 1) fail("one verified attestation required");
-  const statement = results[0]?.verificationResult?.statement;
+  if (!Array.isArray(results) || results.length < 1 || results.length > 64) fail("bounded verified attestations required");
+  const invocationId = `${URL}/actions/runs/${expected.run_id}/attempts/${expected.run_attempt}`;
+  // A reconcile run can see signatures retained from earlier attempts over the
+  // same immutable subject set. Select the one cryptographically verified
+  // statement from this exact invocation, then apply the complete binding below.
+  const current = results.filter(result =>
+    result?.verificationResult?.statement?.predicate?.runDetails?.metadata?.invocationId === invocationId);
+  if (current.length !== 1) fail("one current-invocation verified attestation required");
+  const statement = current[0].verificationResult.statement;
   if (statement?._type !== "https://in-toto.io/Statement/v1" || statement.predicateType !== SLSA) fail("verified in-toto/SLSA type mismatch");
   // actions/attest signs the complete subject-path set in one statement. Both
   // products legitimately have a release-manifest.json/checksums.txt basename.
@@ -522,7 +529,7 @@ function mapWorkflowOutput(output, expected, workflow) {
   exact(build.externalParameters?.workflow, { ref: expected.ref, repository: URL, path: workflow }, "verified workflow");
   exact(build.resolvedDependencies, [{ uri: `git+${URL}@${expected.ref}`, digest: { gitCommit: expected.source } }], "verified source");
   const run = statement.predicate?.runDetails;
-  exact(run?.metadata?.invocationId, `${URL}/actions/runs/${expected.run_id}/attempts/${expected.run_attempt}`, "verified invocation");
+  exact(run?.metadata?.invocationId, invocationId, "verified invocation");
   exact(run?.builder?.id, "https://github.com/actions/runner/github-hosted", "verified runner");
   return statement;
 }

--- a/npm/agentplugins/scripts/authoring-promotion.js
+++ b/npm/agentplugins/scripts/authoring-promotion.js
@@ -390,6 +390,11 @@ function projectedPins(record) {
 function acquirePreparation(pin, record, scratch) {
   return acquirePreparationBinding(pin, recordShape(record), scratch);
 }
+function acquireMilestonePreparation(pin, record, scratch) {
+  const milestone = require("./milestone-a-release-admission");
+  record = milestone.recordShape(record);
+  return acquirePreparationBinding(pin, record, scratch, record.preparation.receipt_sha256);
+}
 // Shared preparation intake below Q validation. Only the Q wrapper above and
 // the canonical I adapter below supply this private binding; no synthetic Q.
 function acquirePreparationBinding(pin, record, scratch, receiptSha256) {
@@ -562,12 +567,19 @@ function frozenSubjects(root, record) {
   return verified.subjects;
 }
 function releasePins(record, p) {
+  const promotion = promotionRecord(record);
   return [...Object.values(record.products[p].assets).map(a => ({ name: a.file, sha256: a.sha256, size: a.size })),
     { name: "release-manifest.json", sha256: record.products[p].manifest_sha256 },
     { name: "checksums.txt", sha256: record.products[p].checksums_sha256 },
     { name: "candidate.json", sha256: record.candidate_sha256 },
     { name: "pair-prepared.json", sha256: record.pair_marker_sha256 },
-    { name: "authoring-promotion.json", sha256: c.digest(encodeRecord(record)) }];
+    { name: promotion.name, sha256: c.digest(promotion.body) }];
+}
+function promotionRecord(record) {
+  if (record?.schema === SCHEMA) return { name: "authoring-promotion.json", body: encodeRecord(record) };
+  const milestone = require("./milestone-a-release-admission");
+  if (record?.schema === milestone.RECORD_SCHEMA) return { name: milestone.RECORD_FILE, body: milestone.encodeRecord(record) };
+  fail("unsupported promotion record schema");
 }
 function checkTag(record, p, cwd) {
   // The commit endpoint peels annotated tags too; tag names are derived, never URLs.
@@ -680,7 +692,7 @@ function promotePair(recheck, reconciliation) {
       if (existing && !reconciliation) fail("incomplete draft requires explicit reconciliation");
       const projection = path.join(state.o.root, p);
       const files = releasePins(state.record, p).filter(pin => !existing || existing.missing_assets.includes(pin.name)).map(pin => {
-        if (pin.name === "authoring-promotion.json") return state.o.record;
+        if (pin.name === promotionRecord(state.record).name) return state.o.record;
         if (pin.name === "candidate.json") return path.join(state.o.root, "candidate", pin.name);
         if (pin.name === "pair-prepared.json") return path.join(state.o.root, pin.name);
         return path.join(projection, pin.name);
@@ -806,4 +818,4 @@ function admitPublicEvidence(value, context) {
 module.exports = { admitPublicEvidence, inspectPublicCaller, inspectPublicAttempt, verifyPublicSubject, inspectStageCaller, workflowSelection, inspectInputCaller, checkPreparationRef, acquireCurrentStage, inspectCurrentStage, checkStageEvidence, SCHEMA, WORKFLOW, GH_VERSION, LANES, encodeRecord, decodeRecord, validateSelection, admitRecord, requireNativeContracts,
   inspectArtifact, acquireArtifact, extractArtifact, acquirePreparation, checkNativeContracts, admitNativeEvidence,
   acquireInputPreparation, readInputPreparation, checkInputTags,
-  mapVerifiedOutput, verifySubject, verifyStageSubject, frozenSubjects, releasePins, inspectPair, promote, promoteMilestoneA };
+  mapVerifiedOutput, verifySubject, verifyStageSubject, frozenSubjects, releasePins, promotionRecord, acquireMilestonePreparation, inspectPair, promote, promoteMilestoneA };

--- a/npm/agentplugins/scripts/milestone-a-release-admission.js
+++ b/npm/agentplugins/scripts/milestone-a-release-admission.js
@@ -13,6 +13,8 @@ const c = require("./dual-authoring-candidate");
 const REPOSITORY = c.REPOSITORY;
 const WORKFLOW = ".github/workflows/authoring-milestone-a-e2e.yml";
 const RELEASE_WORKFLOW = ".github/workflows/agentplugins-release.yml";
+const RECORD_SCHEMA = "milestone-a-promotion/v1";
+const RECORD_FILE = "milestone-a-promotion.json";
 const TAG = "agentplugins-v0.1.60";
 const KIT_TAG = "v2.0.0";
 const GH = "/usr/bin/gh";
@@ -39,6 +41,81 @@ const sha = value => {
   if (typeof value !== "string" || !/^[0-9a-f]{40}$/.test(value) || /^0+$/.test(value)) fail("exact nonzero source SHA required");
   return value;
 };
+const hash = value => {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/.test(value) || /^0+$/.test(value)) fail("exact nonzero SHA-256 required");
+  return value;
+};
+const artifact = value => {
+  c.keys(value, ["run_id", "run_attempt", "artifact_id", "artifact_sha256", "receipt_sha256"], "Milestone A preparation pin");
+  return { run_id: positive(value.run_id), run_attempt: positive(value.run_attempt, 1000),
+    artifact_id: positive(value.artifact_id), artifact_sha256: hash(value.artifact_sha256),
+    receipt_sha256: hash(value.receipt_sha256) };
+};
+function recordShape(value) {
+  c.keys(value, ["schema", "identity", "authoring_mode", "asset_scope", "candidate_sha256",
+    "pair_marker_sha256", "products", "preparation", "milestone_a", "signer"], "Milestone A promotion record");
+  exact([value.schema, value.authoring_mode, value.asset_scope],
+    [RECORD_SCHEMA, "release-cli-contract-v1", "six-platform-pair"], "Milestone A record contract");
+  const identity = c.identity(value.identity);
+  sha(identity.commit);
+  exact(identity, { repository: REPOSITORY, commit: identity.commit, engine_revision: identity.commit,
+    versions: { agentplugins: "0.1.60", "plugin-kit-ai": "2.0.0" } }, "Milestone A record identity");
+  c.keys(value.products, c.PRODUCTS, "Milestone A products");
+  const products = {};
+  const binaries = new Set();
+  for (const product of c.PRODUCTS) {
+    const source = value.products[product];
+    c.keys(source, ["tag", "manifest_sha256", "checksums_sha256", "assets"], "Milestone A product");
+    exact(source.tag, product === "agentplugins" ? "agentplugins-v0.1.60" : "v2.0.0", "Milestone A product tag");
+    c.keys(source.assets, c.TARGETS, "Milestone A product assets");
+    const assets = {};
+    for (const target of c.TARGETS) {
+      const outer = source.assets[target];
+      c.keys(outer, ["file", "sha256", "size", "binary"], "Milestone A asset");
+      c.keys(outer.binary, ["file", "sha256", "size"], "Milestone A binary");
+      exact(outer.file, c.assetName(product, identity.versions[product], target), "Milestone A asset name");
+      exact(outer.binary.file, c.executableName(product, target), "Milestone A binary name");
+      const assetValue = { file: outer.file, sha256: hash(outer.sha256), size: positive(outer.size, 128 * 1024 * 1024),
+        binary: { file: outer.binary.file, sha256: hash(outer.binary.sha256), size: positive(outer.binary.size, 128 * 1024 * 1024) } };
+      if (product === "agentplugins") exact([assetValue.sha256, assetValue.size],
+        [assetValue.binary.sha256, assetValue.binary.size], "Milestone A raw executable");
+      if (binaries.has(assetValue.binary.sha256)) fail("distinct Milestone A binaries required");
+      binaries.add(assetValue.binary.sha256);
+      assets[target] = assetValue;
+    }
+    products[product] = { tag: source.tag, manifest_sha256: hash(source.manifest_sha256),
+      checksums_sha256: hash(source.checksums_sha256), assets };
+  }
+  const preparation = artifact(value.preparation);
+  c.keys(value.milestone_a, ["workflow", "run_id", "run_attempt"], "Milestone A evidence pin");
+  const milestone_a = { workflow: value.milestone_a.workflow, run_id: positive(value.milestone_a.run_id),
+    run_attempt: positive(value.milestone_a.run_attempt, 1000) };
+  exact(milestone_a.workflow, WORKFLOW, "Milestone A evidence workflow");
+  c.keys(value.signer, ["workflow", "source"], "Milestone A signer");
+  const signer = { workflow: value.signer.workflow, source: value.signer.source };
+  exact(signer, { workflow: RELEASE_WORKFLOW, source: identity.commit }, "Milestone A signer identity");
+  return { schema: RECORD_SCHEMA, identity, authoring_mode: value.authoring_mode, asset_scope: value.asset_scope,
+    candidate_sha256: hash(value.candidate_sha256), pair_marker_sha256: hash(value.pair_marker_sha256),
+    products, preparation, milestone_a, signer };
+}
+function encodeRecord(value) {
+  const body = c.encode(recordShape(value));
+  if (body.length > 1024 * 1024) fail("Milestone A promotion record exceeds byte bound");
+  return body;
+}
+function decodeRecord(body) {
+  if (!Buffer.isBuffer(body) || body.length === 0 || body.length > 1024 * 1024) fail("bounded Milestone A promotion bytes required");
+  const value = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(body));
+  const record = recordShape(value);
+  if (!body.equals(encodeRecord(record))) fail("noncanonical Milestone A promotion record");
+  return record;
+}
+function validateSelection(body, selected) {
+  const record = decodeRecord(body);
+  exact(selected, { tag: TAG, ref: `refs/tags/${TAG}`, source: record.identity.commit,
+    versions: record.identity.versions }, "Milestone A selected identity");
+  return record;
+}
 function gh(args, cwd, maxBuffer = 1024 * 1024) {
   const result = cp.spawnSync(GH, args, { cwd, env: { PATH: "/usr/local/bin:/usr/bin:/bin", GH_TOKEN: process.env.GH_TOKEN },
     encoding: "utf8", timeout: 120000, killSignal: "SIGKILL", maxBuffer, shell: false });
@@ -170,21 +247,23 @@ function admit(input) {
   const keys = ["record", "scratch", "workflow_sha", "preparation", "selected", "milestone_a"];
   c.keys(input, keys, "Milestone A promotion options");
   c.safeDirectory(input.scratch);
-  if (!path.isAbsolute(input.record) || path.basename(input.record) !== "authoring-promotion.json") fail("absolute promotion record required");
-  const record = p.validateSelection(c.readFile(input.record), input.selected);
+  if (!path.isAbsolute(input.record) || path.basename(input.record) !== RECORD_FILE) fail("absolute Milestone A promotion record required");
+  const record = validateSelection(c.readFile(input.record), input.selected);
   exact(input.workflow_sha, record.identity.commit, "release workflow source");
-  exact(record.identity.versions, { agentplugins: "0.1.60", "plugin-kit-ai": "2.0.0" }, "fixed paired versions");
+  exact(input.preparation, { run_id: record.preparation.run_id, run_attempt: record.preparation.run_attempt,
+    artifact_id: record.preparation.artifact_id, artifact_sha256: record.preparation.artifact_sha256 }, "record preparation selection");
+  exact(input.milestone_a, { run_id: record.milestone_a.run_id, run_attempt: record.milestone_a.run_attempt }, "record Milestone A selection");
   const evidence = inspectEvidence(input.milestone_a, input.selected, input.scratch);
   evidence.receipts = inspectReceipts(input.milestone_a, input.selected, input.scratch);
-  const prepared = p.acquirePreparation(input.preparation, record, input.scratch);
+  const prepared = p.acquireMilestonePreparation(input.preparation, record, input.scratch);
   require("./authoring-native-qualification").readPreparation(prepared.root,
     { identity: record.identity, candidate_sha256: record.candidate_sha256, pair_marker_sha256: record.pair_marker_sha256,
       products: Object.fromEntries(c.PRODUCTS.map(name => [name, { manifest_sha256: record.products[name].manifest_sha256,
         checksums_sha256: record.products[name].checksums_sha256 }])) }, prepared.preparation);
   const subjects = p.frozenSubjects(prepared.root, record);
-  subjects.push({ file: input.record, sha256: c.digest(p.encodeRecord(record)) });
+  subjects.push({ file: input.record, sha256: c.digest(encodeRecord(record)) });
   return { o: { ...input, root: prepared.root }, record, subjects, milestone_a: evidence };
 }
 
-module.exports = { REPOSITORY, WORKFLOW, RELEASE_WORKFLOW, TAG, KIT_TAG, JOBS, E2E_VERSIONS, PLATFORMS,
-  evidenceContract, receiptContract, inspectEvidence, inspectReceipts, admit };
+module.exports = { REPOSITORY, WORKFLOW, RELEASE_WORKFLOW, RECORD_SCHEMA, RECORD_FILE, TAG, KIT_TAG, JOBS, E2E_VERSIONS, PLATFORMS,
+  recordShape, encodeRecord, decodeRecord, validateSelection, evidenceContract, receiptContract, inspectEvidence, inspectReceipts, admit };

--- a/npm/agentplugins/test/authoring-promotion.test.js
+++ b/npm/agentplugins/test/authoring-promotion.test.js
@@ -216,6 +216,17 @@ test("fresh verifier subprocess binds independently selected signer revision and
   }
   assert(args.includes("--deny-self-hosted-runners"));
 });
+test("reconciliation selects one exact current invocation while retaining older attestations", () => {
+  const f = fixture(), e = expected(f);
+  const current = verified(e)[0];
+  const older = verified({ ...e, run_id: e.run_id - 1 })[0];
+  assert.deepEqual(p.mapVerifiedOutput(JSON.stringify([older, current]), e),
+    current.verificationResult.statement);
+  assert.throws(() => p.mapVerifiedOutput(JSON.stringify([current, structuredClone(current)]), e),
+    /one current-invocation verified attestation/);
+  assert.throws(() => p.mapVerifiedOutput(JSON.stringify([older]), e),
+    /one current-invocation verified attestation/);
+});
 for (const [label, mutate] of Object.entries({
   "wrong subject": s => { s.subject[0].digest.sha256 = hash("other"); }, "wrong name": s => { s.subject[0].name = "other"; },
   "predicate": s => { s.predicateType = "test/terminal"; }, "statement": s => { s._type = "wrong"; },

--- a/npm/agentplugins/test/milestone-a-release-admission.test.js
+++ b/npm/agentplugins/test/milestone-a-release-admission.test.js
@@ -5,9 +5,11 @@ const cp = require("node:child_process");
 const test = require("node:test");
 const os = require("node:os");
 const fs = require("node:fs");
+const path = require("node:path");
 const a = require("../scripts/milestone-a-release-admission");
 const candidate = require("../scripts/dual-authoring-candidate");
 const promotion = require("../scripts/authoring-promotion");
+const workflow = fs.readFileSync(path.resolve(__dirname, "../../../.github/workflows/agentplugins-release.yml"), "utf8");
 
 const source = "a".repeat(40);
 const selected = { tag: a.TAG, ref: `refs/tags/${a.TAG}`, source,
@@ -178,4 +180,15 @@ test("legacy thirteen-lane admission remains present and separate", () => {
   const promotion = require("../scripts/authoring-promotion");
   assert.equal(promotion.LANES.length, 13);
   assert.throws(() => promotion.requireNativeContracts([]), /missing lanes/);
+});
+
+test("Milestone A admission and promotion embedded Node programs parse", () => {
+  for (const name of ["Independently admit preparation and authenticated Milestone A evidence",
+    "Reacquire and re-admit the exact frozen pair and Milestone A run"]) {
+    const start = workflow.indexOf(`      - name: ${name}\n`);
+    assert.notEqual(start, -1, `missing workflow step ${name}`);
+    const block = workflow.slice(start).match(/          node <<'NODE'\n([\s\S]*?)\n          NODE/);
+    assert.ok(block, `missing embedded Node program for ${name}`);
+    assert.doesNotThrow(() => new Function(block[1].split("\n").map(line => line.slice(10)).join("\n")), name);
+  }
 });

--- a/npm/agentplugins/test/milestone-a-release-admission.test.js
+++ b/npm/agentplugins/test/milestone-a-release-admission.test.js
@@ -6,6 +6,8 @@ const test = require("node:test");
 const os = require("node:os");
 const fs = require("node:fs");
 const a = require("../scripts/milestone-a-release-admission");
+const candidate = require("../scripts/dual-authoring-candidate");
+const promotion = require("../scripts/authoring-promotion");
 
 const source = "a".repeat(40);
 const selected = { tag: a.TAG, ref: `refs/tags/${a.TAG}`, source,
@@ -16,6 +18,50 @@ const run = { id: 42, run_attempt: 2, repository: { full_name: a.REPOSITORY },
   event: "workflow_dispatch", head_branch: a.TAG, status: "completed", conclusion: "success" };
 const jobs = () => a.JOBS.map((name, index) => ({ id: 100 + index, name, run_id: 42, run_attempt: 2,
   head_sha: source, head_branch: a.TAG, status: "completed", conclusion: "success" }));
+
+function promotionRecord() {
+  let binary = 1;
+  const products = Object.fromEntries(candidate.PRODUCTS.map(product => [product, {
+    tag: product === "agentplugins" ? a.TAG : a.KIT_TAG,
+    manifest_sha256: product === "agentplugins" ? "d".repeat(64) : "e".repeat(64),
+    checksums_sha256: product === "agentplugins" ? "f".repeat(64) : "1".repeat(64),
+    assets: Object.fromEntries(candidate.TARGETS.map(target => {
+      const digest = (++binary).toString(16).repeat(64);
+      const size = 1000 + binary;
+      const binaryPin = { file: candidate.executableName(product, target), sha256: digest, size };
+      return [target, { file: candidate.assetName(product, selected.versions[product], target),
+        sha256: digest,
+        size: product === "agentplugins" ? size : size + 20, binary: binaryPin }];
+    }))
+  }]));
+  return { schema: a.RECORD_SCHEMA,
+    identity: { repository: a.REPOSITORY, commit: source, engine_revision: source, versions: selected.versions },
+    authoring_mode: "release-cli-contract-v1", asset_scope: "six-platform-pair",
+    candidate_sha256: "a".repeat(64), pair_marker_sha256: "b".repeat(64), products,
+    preparation: { run_id: 41, run_attempt: 1, artifact_id: 91,
+      artifact_sha256: "c".repeat(64), receipt_sha256: "2".repeat(64) },
+    milestone_a: { workflow: a.WORKFLOW, run_id: pin.run_id, run_attempt: pin.run_attempt },
+    signer: { workflow: a.RELEASE_WORKFLOW, source } };
+}
+
+test("uses a canonical Milestone A record without legacy qualification lanes", () => {
+  const record = promotionRecord();
+  const body = a.encodeRecord(record);
+  assert.deepEqual(a.decodeRecord(body), record);
+  assert.deepEqual(a.validateSelection(body, selected), record);
+  assert.equal(promotion.promotionRecord(record).name, a.RECORD_FILE);
+  assert.equal(promotion.releasePins(record, "agentplugins").at(-1).name, a.RECORD_FILE);
+  assert.equal(Object.hasOwn(record, "qualification"), false);
+});
+
+test("rejects legacy or invented qualification content on the Milestone A route", () => {
+  const record = promotionRecord();
+  record.qualification = { lanes: [] };
+  assert.throws(() => a.encodeRecord(record), /Milestone A promotion record/);
+  const legacy = { ...record, schema: promotion.SCHEMA };
+  delete legacy.qualification;
+  assert.throws(() => a.encodeRecord(legacy));
+});
 
 test("admits exactly the accelerated Milestone A run and three-platform job closure", () => {
   const result = a.evidenceContract(structuredClone(run), jobs(), structuredClone(selected), pin);


### PR DESCRIPTION
The accelerated Milestone A release route accepted the full `authoring-promotion/v1` record, which requires thirteen qualification lanes that Milestone A does not produce. This made a truthful promotion impossible even after the dedicated Linux, Windows, and macOS E2E passed.

This adds `milestone-a-promotion/v1`, binding the exact paired candidate, preparation artifact and receipt, actual Milestone A run/attempt, and fixed release signer workflow. The Milestone A route rejects legacy or invented qualification fields, signs the dedicated record with the same frozen 18 subjects, and publishes it as `milestone-a-promotion.json`. The existing thirteen-lane promotion path remains unchanged.

Validation:
- `node --check npm/agentplugins/scripts/milestone-a-release-admission.js`
- `node --check npm/agentplugins/scripts/authoring-promotion.js`
- `node --test npm/agentplugins/test/milestone-a-release-admission.test.js` (24/24)
- workflow YAML parse

Refs #216
Refs #208


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Milestone A promotion records with dedicated validation and evidence pinning.
  * Added milestone-specific promotion processing and record handling.
  * Milestone A promotion records are now frozen as part of release admission.

* **Bug Fixes**
  * Improved validation to reject unsupported or legacy promotion record formats.
  * Updated release workflows to use the correct Milestone A promotion record file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->