### PR TITLE
test(release): keep staged package suite hermetic

### DIFF
--- a/npm/agentplugins/test/milestone-a-release-admission.test.js
+++ b/npm/agentplugins/test/milestone-a-release-admission.test.js
@@ -9,7 +9,7 @@ const path = require("node:path");
 const a = require("../scripts/milestone-a-release-admission");
 const candidate = require("../scripts/dual-authoring-candidate");
 const promotion = require("../scripts/authoring-promotion");
-const workflow = fs.readFileSync(path.resolve(__dirname, "../../../.github/workflows/agentplugins-release.yml"), "utf8");
+const workflowPath = path.resolve(__dirname, "../../../.github/workflows/agentplugins-release.yml");
 
 const source = "a".repeat(40);
 const selected = { tag: a.TAG, ref: `refs/tags/${a.TAG}`, source,
@@ -182,7 +182,9 @@ test("legacy thirteen-lane admission remains present and separate", () => {
   assert.throws(() => promotion.requireNativeContracts([]), /missing lanes/);
 });
 
-test("Milestone A admission and promotion embedded Node programs parse", () => {
+test("Milestone A admission and promotion embedded Node programs parse", t => {
+  if (!fs.existsSync(workflowPath)) return t.skip("detached npm package has no source workflow");
+  const workflow = fs.readFileSync(workflowPath, "utf8");
   for (const name of ["Independently admit preparation and authenticated Milestone A evidence",
     "Reacquire and re-admit the exact frozen pair and Milestone A run"]) {
     const start = workflow.indexOf(`      - name: ${name}\n`);


### PR DESCRIPTION
The staged npm package suite copied the new source-workflow parser test into a detached layout, where `.github/workflows/agentplugins-release.yml` intentionally does not exist. Required CI therefore failed after all 1,067 other tests passed.

This keeps the functional Milestone A admission tests active in detached staging and skips only the repository-workflow parser assertion when the source workflow tree is absent. In the source checkout all 25 tests still run; in a detached package 24 pass and the workflow-only check is explicitly skipped.

Validation:
- `node --test npm/agentplugins/test/milestone-a-release-admission.test.js` (25/25)
- detached copied package test (24 passed, 1 source-only skip)
- `git diff --check`

Refs #216
Refs #208
