### PR TITLE
fix(release): accept compatible GitHub CLI updates

### DIFF
--- a/npm/agentplugins/scripts/authoring-promotion.js
+++ b/npm/agentplugins/scripts/authoring-promotion.js
@@ -14,6 +14,7 @@ const URL = `https://github.com/${REPOSITORY}`;
 const SIGNER = `github.com/${REPOSITORY}/${WORKFLOW}`;
 const GH = "/usr/bin/gh";
 const GH_VERSION = "2.83.2";
+const GH_VERSION_PARTS = Object.freeze(GH_VERSION.split(".").map(Number));
 const MODE = "release-cli-contract-v1";
 const SCOPE = "six-platform-pair";
 const SCHEMA = "authoring-promotion/v1";
@@ -25,6 +26,18 @@ const NATIVE_WORKFLOW = ".github/workflows/authoring-frozen-native.yml";
 const NATIVE_FILES = Object.freeze(["transcripts.json", "trees.json", "build-info.json", "preservation.json",
   "preparation.json", "host.json", "scans.json", "acquisition.json", ...c.PRODUCTS.map(p => `${p}-terminal.json`)]);
 const fail = message => { throw new Error(message); };
+function compatibleGhVersion(output) {
+  if (typeof output !== "string") return false;
+  const first = output.split(/\r?\n/, 1)[0];
+  const match = /^gh version (0|[1-9][0-9]{0,5})\.(0|[1-9][0-9]{0,5})\.(0|[1-9][0-9]{0,5}) \([^\r\n]{1,200}\)$/.exec(first);
+  if (!match) return false;
+  const actual = match.slice(1).map(Number);
+  if (actual[0] !== GH_VERSION_PARTS[0]) return false;
+  for (let i = 1; i < actual.length; i++) {
+    if (actual[i] !== GH_VERSION_PARTS[i]) return actual[i] > GH_VERSION_PARTS[i];
+  }
+  return true;
+}
 const exact = (a, b, label) => { if (!equal(a, b)) fail(`${label}: binding mismatch`); };
 const sha = (v, n = 64) => {
   if (typeof v !== "string" || !new RegExp(`^[0-9a-f]{${n}}$`).test(v) || /^0+$/.test(v)) fail(`exact nonzero SHA-${n === 40 ? "1 source" : "256"} required`);
@@ -161,7 +174,7 @@ function gh(args, cwd, maximum = 4 * LIMIT, encoding = "utf8") {
   return result.stdout;
 }
 function cliVersion(cwd) {
-  if (!gh(["--version"], cwd).startsWith(`gh version ${GH_VERSION} (`)) fail(`trusted /usr/bin/gh ${GH_VERSION} required`);
+  if (!compatibleGhVersion(gh(["--version"], cwd))) fail(`trusted /usr/bin/gh ${GH_VERSION} or newer compatible 2.x required`);
 }
 function api(endpoint, cwd) {
   return JSON.parse(gh(["api", "--hostname", "github.com", "-H", "Accept: application/vnd.github+json",
@@ -822,7 +835,7 @@ function admitPublicEvidence(value, context) {
   exact(e.stage, request.stage, 'public Q original S locator');
   return admitted;
 }
-module.exports = { admitPublicEvidence, inspectPublicCaller, inspectPublicAttempt, verifyPublicSubject, inspectStageCaller, workflowSelection, inspectInputCaller, checkPreparationRef, acquireCurrentStage, inspectCurrentStage, checkStageEvidence, SCHEMA, WORKFLOW, GH_VERSION, LANES, encodeRecord, decodeRecord, validateSelection, admitRecord, requireNativeContracts,
+module.exports = { admitPublicEvidence, inspectPublicCaller, inspectPublicAttempt, verifyPublicSubject, inspectStageCaller, workflowSelection, inspectInputCaller, checkPreparationRef, acquireCurrentStage, inspectCurrentStage, checkStageEvidence, SCHEMA, WORKFLOW, GH_VERSION, compatibleGhVersion, LANES, encodeRecord, decodeRecord, validateSelection, admitRecord, requireNativeContracts,
   inspectArtifact, acquireArtifact, extractArtifact, acquirePreparation, checkNativeContracts, admitNativeEvidence,
   acquireInputPreparation, readInputPreparation, checkInputTags,
   mapVerifiedOutput, verifySubject, verifyStageSubject, frozenSubjects, releasePins, promotionRecord, acquireMilestonePreparation, inspectPair, promote, promoteMilestoneA };

--- a/npm/agentplugins/scripts/milestone-a-release-admission.js
+++ b/npm/agentplugins/scripts/milestone-a-release-admission.js
@@ -9,6 +9,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const { isDeepStrictEqual } = require("node:util");
 const c = require("./dual-authoring-candidate");
+const promotion = require("./authoring-promotion");
 
 const REPOSITORY = c.REPOSITORY;
 const WORKFLOW = ".github/workflows/authoring-milestone-a-e2e.yml";
@@ -18,7 +19,7 @@ const RECORD_FILE = "milestone-a-promotion.json";
 const TAG = "agentplugins-v0.1.60";
 const KIT_TAG = "v2.0.0";
 const GH = "/usr/bin/gh";
-const GH_VERSION = "2.83.2";
+const GH_VERSION = promotion.GH_VERSION;
 const JOBS = Object.freeze([
   "Exact candidate package",
   "Milestone A / linux-amd64",
@@ -229,7 +230,7 @@ function evidenceContract(run, jobs, selected, pin) {
 }
 function inspectEvidence(pin, selected, cwd) {
   const version = gh(["--version"], cwd);
-  if (!version.startsWith(`gh version ${GH_VERSION} (`)) fail(`trusted /usr/bin/gh ${GH_VERSION} required`);
+  if (!promotion.compatibleGhVersion(version)) fail(`trusted /usr/bin/gh ${GH_VERSION} or newer compatible 2.x required`);
   const run = api(`actions/runs/${positive(pin.run_id)}/attempts/${positive(pin.run_attempt, 1000)}`, cwd);
   const response = api(`actions/runs/${pin.run_id}/attempts/${pin.run_attempt}/jobs?per_page=100`, cwd);
   if (response.total_count !== response.jobs?.length || response.jobs.length > 100) fail("complete bounded job response required");

--- a/npm/agentplugins/scripts/stage-authoring-npm.js
+++ b/npm/agentplugins/scripts/stage-authoring-npm.js
@@ -367,7 +367,7 @@ function stageTools(o, context) {
   const tools = Object.fromEntries(Object.entries(paths).map(([name, file]) => [name, {
     version: (name === "npm" ? command(o.node, [o.npm, "--version"]) : command(file, ["--version"])).split("\n")[0],
     sha256: c.digest(c.readFile(file)) }]));
-  if (!tools.gh.version.startsWith(`gh version ${promotion.GH_VERSION} (`)) throw new Error("fixed stage gh provision required");
+  if (!promotion.compatibleGhVersion(tools.gh.version)) throw new Error("compatible stage gh provision required");
   return tools;
 }
 function toolSnapshot(o) {

--- a/npm/agentplugins/test/authoring-promotion.test.js
+++ b/npm/agentplugins/test/authoring-promotion.test.js
@@ -15,6 +15,15 @@ const hash = text => c.digest(Buffer.from(text));
 const pin = { run_id: 21, run_attempt: 2, artifact_id: 31, artifact_sha256: hash("zip fixture") };
 const url = `https://github.com/${c.REPOSITORY}`;
 
+test("GitHub CLI compatibility accepts supported 2.x updates only", () => {
+  assert.equal(p.compatibleGhVersion(`gh version ${p.GH_VERSION} (minimum)\nhttps://github.com/cli/cli/releases\n`), true);
+  assert.equal(p.compatibleGhVersion("gh version 2.84.0 (newer minor)\n"), true);
+  assert.equal(p.compatibleGhVersion("gh version 2.83.3 (newer patch)\n"), true);
+  assert.equal(p.compatibleGhVersion("gh version 2.83.1 (too old)\n"), false);
+  assert.equal(p.compatibleGhVersion("gh version 3.0.0 (unsupported major)\n"), false);
+  assert.equal(p.compatibleGhVersion("gh version latest (malformed)\n"), false);
+});
+
 // Text/ustar structural fixtures ONLY. No native compiler or subject execution,
 // no valid terminal contract and no authentic signature proof is manufactured.
 function fixture() {


### PR DESCRIPTION
Milestone A promotion reached provider admission but stopped because GitHub's hosted runner no longer ships exactly gh 2.83.2. The release code now keeps the absolute /usr/bin/gh boundary and strict version parsing while accepting compatible 2.x updates at or above 2.83.2; older, malformed, and future-major versions still fail closed.

Validation:
- focused GitHub CLI compatibility test passes
- changed scripts pass node syntax checks
- full macOS suite reaches the known source-path symlink limitation tracked separately; Required CI is the Linux/Windows exact-head gate

Evidence: failed release run https://github.com/777genius/universal-agent-plugins/actions/runs/34737082378

Refs #216
Refs #208


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - GitHub CLI checks now accept supported 2.x updates newer than the minimum required version.
  - Older releases, major-version upgrades, and invalid version strings continue to be rejected.

- **Bug Fixes**
  - Authoring and release staging workflows no longer require one exact GitHub CLI patch version, reducing unnecessary failures after compatible CLI updates.

- **Tests**
  - Added coverage for supported, outdated, major-version, and malformed GitHub CLI versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->